### PR TITLE
fix: isolate training engine steps with per-step DB connections

### DIFF
--- a/sync/src/training_engine/run_engine.py
+++ b/sync/src/training_engine/run_engine.py
@@ -13,59 +13,37 @@ logger = logging.getLogger(__name__)
 def run_full_engine():
     import psycopg2
     from config import DATABASE_URL, today_nyc
-    from training_engine.runner import run_training_engine, _compute_hevy_loads
+    from training_engine.runner import run_training_engine, _run_step
     from training_engine.load_stream import backfill_load_from_history, compute_and_store_pmc
     from training_engine.readiness_stream import compute_daily_readiness
     from training_engine.fitness_stream import update_fitness_trajectory
 
-    conn = psycopg2.connect(DATABASE_URL)
-    conn.autocommit = False
     today = today_nyc()
 
     # 1. Backfill loads
     logger.info("=== Step 1: Backfill activity loads ===")
-    try:
-        loads = backfill_load_from_history(conn)
-        logger.info("Activity loads: %d inserted", len(loads))
-    except Exception as e:
-        logger.error("Load backfill failed: %s", e)
-        conn.rollback()
-
-    try:
-        _compute_hevy_loads(conn)
-        logger.info("Hevy strength loads computed")
-    except Exception as e:
-        logger.error("Hevy loads failed: %s", e)
-        conn.rollback()
+    loads = _run_step("load backfill", backfill_load_from_history) or []
+    logger.info("Activity loads: %d inserted", len(loads))
 
     # 2. PMC
     logger.info("=== Step 2: Compute PMC ===")
-    try:
-        pmc = compute_and_store_pmc(conn)
-        logger.info("PMC: %d days computed", len(pmc))
-        if pmc:
-            last = pmc[-1]
-            logger.info("Latest PMC: CTL=%.1f ATL=%.1f TSB=%.1f", last["ctl"], last["atl"], last["tsb"])
-    except Exception as e:
-        logger.error("PMC failed: %s", e)
-        conn.rollback()
+    pmc = _run_step("PMC", compute_and_store_pmc) or []
+    if pmc:
+        last = pmc[-1]
+        logger.info("PMC: %d days, latest: CTL=%.1f ATL=%.1f TSB=%.1f",
+                     len(pmc), last["ctl"], last["atl"], last["tsb"])
 
     # 3. Readiness for last 30 days
     logger.info("=== Step 3: Compute readiness (last 30 days) ===")
     readiness_count = 0
     for i in range(30):
         target = today - timedelta(days=i)
-        try:
-            result = compute_daily_readiness(conn, target)
-            if result and result.get("traffic_light"):
-                readiness_count += 1
-                if i == 0:
-                    logger.info("Today: light=%s, composite=%.2f, flags=%s",
-                                result["traffic_light"], result["composite_score"], result.get("flags", []))
-        except Exception as e:
-            conn.rollback()
+        result = _run_step(f"readiness {target}", compute_daily_readiness, target)
+        if result and result.get("traffic_light"):
+            readiness_count += 1
             if i == 0:
-                logger.error("Readiness failed for %s: %s", target, e)
+                logger.info("Today: light=%s, composite=%.2f, flags=%s",
+                            result["traffic_light"], result["composite_score"], result.get("flags", []))
     logger.info("Readiness computed for %d days", readiness_count)
 
     # 4. Fitness trajectory for last 90 days (weekly samples)
@@ -73,30 +51,19 @@ def run_full_engine():
     fitness_count = 0
     for i in range(0, 90, 7):
         target = today - timedelta(days=i)
-        try:
-            result = update_fitness_trajectory(conn, target)
-            if result:
-                fitness_count += 1
-                if i == 0:
-                    logger.info("Today: VO2max=%s, EF=%s, decoupling=%s%%",
-                                result.get("vo2max"), result.get("efficiency_factor"),
-                                result.get("decoupling_pct"))
-        except Exception as e:
-            conn.rollback()
+        result = _run_step(f"fitness {target}", update_fitness_trajectory, target)
+        if result:
+            fitness_count += 1
             if i == 0:
-                logger.error("Fitness failed for %s: %s", target, e)
+                logger.info("Today: VO2max=%s, EF=%s, decoupling=%s%%",
+                            result.get("vo2max"), result.get("efficiency_factor"),
+                            result.get("decoupling_pct"))
     logger.info("Fitness trajectory computed for %d dates", fitness_count)
 
-    # 5. Run merge for today
+    # 5. Run full training engine (merge step)
     logger.info("=== Step 5: Merge ===")
-    try:
-        run_training_engine(conn)
-    except Exception as e:
-        logger.error("Merge failed: %s", e)
-        conn.rollback()
+    _run_step("merge", lambda conn: run_training_engine())
 
-    conn.commit()
-    conn.close()
     logger.info("=== Done ===")
 
 

--- a/sync/src/training_engine/runner.py
+++ b/sync/src/training_engine/runner.py
@@ -156,22 +156,36 @@ def _compute_hevy_loads(conn):
     conn.commit()
 
 
-def run_training_engine(conn):
+def _fresh_conn():
+    """Get a fresh DB connection. Each step gets its own to prevent transaction cascade failures."""
+    import psycopg2
+    from config import DATABASE_URL
+    return psycopg2.connect(DATABASE_URL)
+
+
+def _run_step(name, func, *args):
+    """Run a training engine step with its own connection. Commits on success, rolls back on failure."""
+    conn = _fresh_conn()
+    try:
+        result = func(conn, *args)
+        conn.commit()
+        return result
+    except Exception as e:
+        conn.rollback()
+        logger.error("Training engine: %s failed: %s", name, e)
+        return None
+    finally:
+        conn.close()
+
+
+def run_training_engine(conn=None):
     """
     Run all training engine streams and merge.
     Called from pipeline.py after parsing.
 
-    Steps:
-    1. Compute load for any new activities (backfill_load_from_history)
-    1b. Compute strength loads from Hevy workouts
-    2. Recompute PMC (compute_and_store_pmc)
-    3. Compute today's readiness (compute_daily_readiness)
-    4. Update fitness trajectory (update_fitness_trajectory)
-    5. Update body comp (update_body_comp)
-    6. Merge all stream outputs
-    7. Log results
-
-    Each step is wrapped in try/except so one failure doesn't block others.
+    Each step uses its own DB connection so a failure in one step
+    doesn't put the transaction in an aborted state for subsequent steps.
+    The conn parameter is accepted for backwards compatibility but ignored.
     """
     from training_engine.load_stream import backfill_load_from_history, compute_and_store_pmc
     from training_engine.readiness_stream import compute_daily_readiness
@@ -182,146 +196,118 @@ def run_training_engine(conn):
     today = today_nyc()
 
     # 1. Compute loads for new activities
-    try:
-        loads = backfill_load_from_history(conn)
+    loads = _run_step("load computation", backfill_load_from_history) or []
+    if loads:
         logger.info("Training engine: %d activity loads computed", len(loads))
-    except Exception as e:
-        logger.error("Training engine: load computation failed: %s", e)
-        loads = []
 
     # 1b. Compute strength loads from Hevy workouts
-    try:
-        _compute_hevy_loads(conn)
-        logger.info("Training engine: strength loads computed")
-    except Exception as e:
-        logger.error("Training engine: strength load computation failed: %s", e)
+    _run_step("strength loads", lambda conn: _compute_hevy_loads(conn))
 
     # 2. Recompute PMC
-    pmc = []
-    try:
-        pmc = compute_and_store_pmc(conn)
+    pmc = _run_step("PMC", compute_and_store_pmc) or []
+    if pmc:
         logger.info("Training engine: PMC computed for %d days", len(pmc))
-    except Exception as e:
-        logger.error("Training engine: PMC computation failed: %s", e)
 
     # 2b. Try Banister fitting for personal tau values
-    banister_params = None
     try:
         from training_engine.banister import fit_from_db, _DEFAULT_PARAMS
-        banister_params = fit_from_db(conn)
+        banister_params = _run_step("Banister fitting", fit_from_db)
         if banister_params and abs(banister_params.tau1 - _DEFAULT_PARAMS.tau1) > 0.5:
-            logger.info("Training engine: Banister fitted — τ1=%.1f, τ2=%.1f",
-                        banister_params.tau1, banister_params.tau2)
-            # Re-run PMC with personal tau
-            pmc = compute_and_store_pmc(conn, tau_ctl=banister_params.tau1, tau_atl=banister_params.tau2)
-            logger.info("Training engine: PMC re-computed with personal τ values")
+            logger.info("Training engine: Banister fitted, re-running PMC with personal tau")
+            pmc = _run_step("PMC (personal tau)", compute_and_store_pmc,
+                            banister_params.tau1, banister_params.tau2) or pmc
     except Exception as e:
         logger.error("Training engine: Banister fitting failed (using defaults): %s", e)
 
     # 3. Today's readiness
-    readiness = None
-    try:
-        readiness = compute_daily_readiness(conn, today)
-        if readiness:
-            logger.info("Training engine: readiness=%s (z=%.2f)",
-                        readiness.get("traffic_light"), readiness.get("composite_score", 0))
-        else:
-            logger.info("Training engine: insufficient data for readiness")
-    except Exception as e:
-        logger.error("Training engine: readiness computation failed: %s", e)
+    readiness = _run_step("readiness", compute_daily_readiness, today)
+    if readiness:
+        logger.info("Training engine: readiness=%s (z=%.2f)",
+                    readiness.get("traffic_light"), readiness.get("composite_score", 0))
+    else:
+        logger.info("Training engine: insufficient data for readiness")
 
     # 3b. Advance calibration
     try:
         from training_engine.calibration import advance_calibration, CalibrationState
 
-        # Load persisted calibration state from DB, fall back to defaults
-        calib_state = None
-        try:
-            with conn.cursor() as cur:
-                cur.execute("""
-                    SELECT phase, data_days, weights, correlations, force_equal
-                    FROM calibration_state
-                    WHERE id = 1
-                """)
-                row = cur.fetchone()
-            if row:
-                db_phase, db_data_days, db_weights, db_correlations, db_force_equal = row
-                if isinstance(db_weights, str):
-                    db_weights = json.loads(db_weights)
-                if isinstance(db_correlations, str):
-                    db_correlations = json.loads(db_correlations)
+        def _run_calibration(conn):
+            calib_state = None
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("""
+                        SELECT phase, data_days, weights, correlations, force_equal
+                        FROM calibration_state WHERE id = 1
+                    """)
+                    row = cur.fetchone()
+                if row:
+                    db_phase, db_data_days, db_weights, db_correlations, db_force_equal = row
+                    if isinstance(db_weights, str):
+                        db_weights = json.loads(db_weights)
+                    if isinstance(db_correlations, str):
+                        db_correlations = json.loads(db_correlations)
+                    calib_state = CalibrationState(
+                        phase=db_phase, data_days=db_data_days, weights=db_weights,
+                        correlations=db_correlations, force_equal=db_force_equal,
+                    )
+            except Exception:
+                pass
+            if calib_state is None:
                 calib_state = CalibrationState(
-                    phase=db_phase,
-                    data_days=db_data_days,
-                    weights=db_weights,
-                    correlations=db_correlations,
-                    force_equal=db_force_equal,
+                    phase=1, data_days=0,
+                    weights={"hrv": 0.25, "sleep": 0.25, "rhr": 0.25, "bb": 0.25},
+                    force_equal=False,
                 )
-                logger.info("Training engine: loaded calibration state from DB (phase=%d, data_days=%d)",
-                            db_phase, db_data_days)
-        except Exception:
-            # Table may not exist yet; advance_calibration will create it
-            pass
+            return advance_calibration(conn, calib_state)
 
-        if calib_state is None:
-            calib_state = CalibrationState(
-                phase=1, data_days=0,
-                weights={"hrv": 0.25, "sleep": 0.25, "rhr": 0.25, "bb": 0.25},
-                force_equal=False,
-            )
-
-        updated_calib = advance_calibration(conn, calib_state)
-        logger.info("Training engine: calibration phase=%d, data_days=%d, weights=%s",
-                     updated_calib.phase, updated_calib.data_days, updated_calib.weights)
+        updated_calib = _run_step("calibration", _run_calibration)
+        if updated_calib:
+            logger.info("Training engine: calibration phase=%d, data_days=%d, weights=%s",
+                         updated_calib.phase, updated_calib.data_days, updated_calib.weights)
     except Exception as e:
         logger.error("Training engine: calibration failed: %s", e)
 
-    # 3c. Sequencing enforcement — apply z-penalty for leg day conflicts
+    # 3c. Sequencing enforcement
     try:
         from training_engine.sequencing import check_leg_day_conflict
-        with conn.cursor() as cur:
-            cur.execute("""
-                SELECT day_date, gym_workout FROM training_plan_day
-                WHERE plan_id = (SELECT id FROM training_plan WHERE status = 'active' LIMIT 1)
-                  AND gym_workout IS NOT NULL
-                  AND day_date BETWEEN %s - interval '3 days' AND %s
-            """, (today, today))
-            recent_gym = [{"date": r[0], "gym_workout": r[1]} for r in cur.fetchall()]
 
-            cur.execute("""
-                SELECT run_type FROM training_plan_day
-                WHERE plan_id = (SELECT id FROM training_plan WHERE status = 'active' LIMIT 1)
-                  AND day_date = %s
-            """, (today,))
-            today_run = cur.fetchone()
+        def _run_sequencing(conn):
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT day_date, gym_workout FROM training_plan_day
+                    WHERE plan_id = (SELECT id FROM training_plan WHERE status = 'active' LIMIT 1)
+                      AND gym_workout IS NOT NULL
+                      AND day_date BETWEEN %s - interval '3 days' AND %s
+                """, (today, today))
+                recent_gym = [{"date": r[0], "gym_workout": r[1]} for r in cur.fetchall()]
+                cur.execute("""
+                    SELECT run_type FROM training_plan_day
+                    WHERE plan_id = (SELECT id FROM training_plan WHERE status = 'active' LIMIT 1)
+                      AND day_date = %s
+                """, (today,))
+                today_run = cur.fetchone()
+            return {"today_run": today_run, "recent_gym": recent_gym}
 
-        if today_run and recent_gym:
-            has_conflict = check_leg_day_conflict(today, today_run[0], recent_gym)
+        seq = _run_step("sequencing", _run_sequencing)
+        if seq and seq.get("today_run") and seq.get("recent_gym"):
+            has_conflict = check_leg_day_conflict(today, seq["today_run"][0], seq["recent_gym"])
             if has_conflict and readiness:
                 original_z = readiness.get("composite_score", 0)
                 readiness["composite_score"] = original_z - 0.3
-                logger.info("Training engine: sequencing conflict — z penalty applied (%.2f → %.2f)",
+                logger.info("Training engine: sequencing conflict, z penalty applied (%.2f -> %.2f)",
                             original_z, readiness["composite_score"])
     except Exception as e:
         logger.error("Training engine: sequencing check failed: %s", e)
 
     # 4. Fitness trajectory
-    fitness = None
-    try:
-        fitness = update_fitness_trajectory(conn, today)
-        if fitness:
-            logger.info("Training engine: VO2max=%s", fitness.get("vo2max"))
-    except Exception as e:
-        logger.error("Training engine: fitness update failed: %s", e)
+    fitness = _run_step("fitness trajectory", update_fitness_trajectory, today)
+    if fitness:
+        logger.info("Training engine: VO2max=%s", fitness.get("vo2max"))
 
     # 5. Body comp
-    body = None
-    try:
-        body = update_body_comp(conn, today)
-        if body:
-            logger.info("Training engine: weight=%.1f kg", body.get("weight_kg", 0))
-    except Exception as e:
-        logger.error("Training engine: body comp update failed: %s", e)
+    body = _run_step("body comp", update_body_comp, today)
+    if body:
+        logger.info("Training engine: weight=%.1f kg", body.get("weight_kg", 0))
 
     # 6. Merge all streams
     try:
@@ -357,42 +343,46 @@ def run_training_engine(conn):
     # 7. Compute session quality for matched plan days
     try:
         from training_engine.session_quality import compute_session_quality
-        with conn.cursor() as cur:
-            cur.execute("""
-                SELECT d.id, d.run_type,
-                       g.raw_json, d.workout_steps
-                FROM training_plan_day d
-                JOIN training_plan p ON d.plan_id = p.id
-                JOIN garmin_activity_raw g ON g.activity_id::text = d.garmin_workout_id
-                WHERE p.status = 'active'
-                  AND d.garmin_workout_id IS NOT NULL
-                  AND d.session_quality_score IS NULL
-                  AND g.endpoint_name = 'summary'
-            """)
-            matched = cur.fetchall()
 
-        count = 0
-        for day_id, run_type, raw_json, workout_steps_raw in matched:
-            if run_type == 'rest':
-                continue
-            data = raw_json if isinstance(raw_json, dict) else json.loads(raw_json)
-            actual_duration = data.get('duration', 0)
-            actual_distance = data.get('distance', 0)
-            actual_hr = data.get('averageHR')
+        def _run_session_quality(conn):
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT d.id, d.run_type,
+                           g.raw_json, d.workout_steps
+                    FROM training_plan_day d
+                    JOIN training_plan p ON d.plan_id = p.id
+                    JOIN garmin_activity_raw g ON g.activity_id::text = d.garmin_workout_id
+                    WHERE p.status = 'active'
+                      AND d.garmin_workout_id IS NOT NULL
+                      AND d.session_quality_score IS NULL
+                      AND g.endpoint_name = 'summary'
+                """)
+                matched = cur.fetchall()
 
-            if actual_distance > 0 and actual_duration > 0:
-                actual_pace = actual_duration / (actual_distance / 1000)
-                planned_pace = _extract_planned_pace(workout_steps_raw)
-                planned_hr = 150  # no HR targets in plan yet; keep default
+            count = 0
+            for day_id, run_type, raw_json, workout_steps_raw in matched:
+                if run_type == 'rest':
+                    continue
+                data = raw_json if isinstance(raw_json, dict) else json.loads(raw_json)
+                actual_duration = data.get('duration', 0)
+                actual_distance = data.get('distance', 0)
+                actual_hr = data.get('averageHR')
 
-                quality = compute_session_quality(planned_pace, actual_pace, planned_hr, actual_hr)
-                if quality is not None:
-                    with conn.cursor() as cur:
-                        cur.execute("""
-                            UPDATE training_plan_day SET session_quality_score = %s WHERE id = %s
-                        """, (quality, day_id))
-                    count += 1
-        conn.commit()
+                if actual_distance > 0 and actual_duration > 0:
+                    actual_pace = actual_duration / (actual_distance / 1000)
+                    planned_pace = _extract_planned_pace(workout_steps_raw)
+                    planned_hr = 150
+
+                    quality = compute_session_quality(planned_pace, actual_pace, planned_hr, actual_hr)
+                    if quality is not None:
+                        with conn.cursor() as cur:
+                            cur.execute("""
+                                UPDATE training_plan_day SET session_quality_score = %s WHERE id = %s
+                            """, (quality, day_id))
+                        count += 1
+            return count
+
+        count = _run_step("session quality", _run_session_quality) or 0
         logger.info("Training engine: session quality computed for %d matched days", count)
     except Exception as e:
         logger.error("Training engine: session quality failed: %s", e)

--- a/sync/tests/test_training_engine_runner.py
+++ b/sync/tests/test_training_engine_runner.py
@@ -1,0 +1,99 @@
+"""Tests for training engine runner transaction isolation.
+
+Verifies that _run_step gives each step its own connection so failures
+in one step don't cascade to subsequent steps.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+def _make_mock_conn():
+    """Create a mock psycopg2 connection."""
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock()
+    conn.cursor.return_value.__exit__ = MagicMock()
+    return conn
+
+
+class TestRunStep:
+    """Test that _run_step isolates each step with its own connection."""
+
+    @patch("training_engine.runner._fresh_conn")
+    def test_success_commits(self, mock_fresh):
+        from training_engine.runner import _run_step
+
+        conn = _make_mock_conn()
+        mock_fresh.return_value = conn
+
+        def my_step(c):
+            return "ok"
+
+        result = _run_step("test", my_step)
+        assert result == "ok"
+        conn.commit.assert_called_once()
+        conn.rollback.assert_not_called()
+        conn.close.assert_called_once()
+
+    @patch("training_engine.runner._fresh_conn")
+    def test_failure_rolls_back(self, mock_fresh):
+        from training_engine.runner import _run_step
+
+        conn = _make_mock_conn()
+        mock_fresh.return_value = conn
+
+        def failing_step(c):
+            raise ValueError("boom")
+
+        result = _run_step("test", failing_step)
+        assert result is None
+        conn.rollback.assert_called_once()
+        conn.commit.assert_not_called()
+        conn.close.assert_called_once()
+
+    @patch("training_engine.runner._fresh_conn")
+    def test_each_step_gets_own_connection(self, mock_fresh):
+        from training_engine.runner import _run_step
+
+        conns = [_make_mock_conn(), _make_mock_conn()]
+        mock_fresh.side_effect = conns
+
+        _run_step("step1", lambda c: "a")
+        _run_step("step2", lambda c: "b")
+
+        # Each step got its own connection
+        assert mock_fresh.call_count == 2
+        conns[0].close.assert_called_once()
+        conns[1].close.assert_called_once()
+
+    @patch("training_engine.runner._fresh_conn")
+    def test_failure_doesnt_block_next_step(self, mock_fresh):
+        from training_engine.runner import _run_step
+
+        conn1 = _make_mock_conn()
+        conn2 = _make_mock_conn()
+        mock_fresh.side_effect = [conn1, conn2]
+
+        # Step 1 fails
+        result1 = _run_step("step1", lambda c: (_ for _ in ()).throw(RuntimeError("fail")))
+        # Step 2 succeeds with its own fresh connection
+        result2 = _run_step("step2", lambda c: "ok")
+
+        assert result1 is None
+        assert result2 == "ok"
+        conn1.rollback.assert_called_once()
+        conn2.commit.assert_called_once()
+
+    @patch("training_engine.runner._fresh_conn")
+    def test_extra_args_passed_through(self, mock_fresh):
+        from training_engine.runner import _run_step
+
+        conn = _make_mock_conn()
+        mock_fresh.return_value = conn
+
+        def step_with_args(c, x, y):
+            return x + y
+
+        result = _run_step("test", step_with_args, 3, 4)
+        assert result == 7


### PR DESCRIPTION
Closes #8
Closes #27
Closes #28
Closes #29

## Problem

Training engine steps fail with "current transaction is aborted, commands ignored until end of transaction block". Each stream function (load_stream, readiness_stream, fitness_stream, etc.) calls conn.commit() independently on a shared connection with autocommit=False. When one function commits and a later one fails, conn.rollback() tries to roll back an already-committed transaction, and Postgres enters "aborted" state for all remaining queries.

## Fix

New _run_step() helper gives each step its own fresh DB connection. Commits on success, rolls back on failure, closes regardless. A failure in load computation no longer poisons PMC, readiness, fitness, body comp, or merge.

Applied to both entry points:
- runner.py:run_training_engine() (called from pipeline.py during scheduled sync)
- run_engine.py:run_full_engine() (standalone CLI runner)

## Changes
- sync/src/training_engine/runner.py: _fresh_conn(), _run_step() helpers. All steps converted from shared conn to per-step isolation.
- sync/src/training_engine/run_engine.py: rewritten to use _run_step().
- sync/tests/test_training_engine_runner.py: 5 new tests (commit on success, rollback on failure, each step gets own connection, failure doesn't block next, args passed through).

## Test plan
- [x] 5 new tests pass (mock connections verify isolation)
- [x] 620 existing tests still pass (24 pre-existing failures in nutrition/plan, unrelated)
- [x] Both runner.py and run_engine.py import cleanly
- [ ] After merge: verify training engine runs without "transaction aborted" in next scheduled sync