### PR TITLE
feat!: migrate soma to garmin-auth 0.3.0 + garminconnect 0.3.0

### DIFF
--- a/sync/pyproject.toml
+++ b/sync/pyproject.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 description = "Soma health data sync engine"
 requires-python = ">=3.10"
 dependencies = [
-    "hevy2garmin>=0.1.2",
-    "garmin-auth>=0.2.1",
-    "garminconnect>=0.2.38,<0.3.0",
+    "hevy2garmin>=0.3.0,<0.4.0",
+    "garmin-auth>=0.3.0,<0.4.0",
+    "garminconnect>=0.3.0,<0.4.0",
+    "curl_cffi>=0.6",
+    "ua-generator>=1.0",
     "psycopg2-binary>=2.9",
     "python-dotenv>=1.0",
     "requests>=2.31",

--- a/sync/src/garmin_client.py
+++ b/sync/src/garmin_client.py
@@ -66,7 +66,7 @@ def set_activity_description(client: Garmin, activity_id: int, description: str)
     """Set description for a Garmin activity (not built into garminconnect lib)."""
     url = f"/activity-service/activity/{activity_id}"
     payload = {"activityId": activity_id, "description": description}
-    result = client.garth.put("connectapi", url, json=payload, api=True)
+    result = client.client.put("connectapi", url, json=payload, api=True)
     time.sleep(API_CALL_DELAY)
     return result
 
@@ -78,7 +78,7 @@ def upload_activity_image(client: Garmin, activity_id: int, image_bytes: bytes, 
     POST /activity-service/activity/{id}/image (multipart/form-data)
     """
     files = {"file": (filename, io.BytesIO(image_bytes))}
-    result = client.garth.post(
+    result = client.client.post(
         "connectapi",
         f"activity-service/activity/{activity_id}/image",
         files=files,

--- a/sync/src/training_engine/garmin_workout_builder.py
+++ b/sync/src/training_engine/garmin_workout_builder.py
@@ -286,7 +286,7 @@ def push_plan_to_garmin(conn, client, plan_id: int) -> int:
                 schedule_url = f"/workout-service/schedule/{garmin_id}"
                 schedule_body = {"date": day_date.isoformat()}
                 rate_limited_call(
-                    client.garth.post,
+                    client.client.post,
                     "connectapi", schedule_url, json=schedule_body, api=True,
                 )
 

--- a/sync/tests/test_garmin_workout_builder.py
+++ b/sync/tests/test_garmin_workout_builder.py
@@ -267,11 +267,12 @@ def test_push_plan_to_garmin_basic():
     ]
     mock_cursor.fetchone.return_value = (1,)  # week_number
 
-    # Mock Garmin client
+    # Mock Garmin client — garminconnect 0.3.0 exposes the inner HTTP client
+    # at ``client.client`` (replaces the old ``client.garth`` path).
     mock_client = MagicMock()
     mock_client.upload_workout.return_value = {"workoutId": 12345}
-    mock_garth_post = MagicMock()
-    mock_client.garth.post = mock_garth_post
+    mock_client_post = MagicMock()
+    mock_client.client.post = mock_client_post
 
     with patch("garmin_client.rate_limited_call") as mock_rlc:
         # rate_limited_call should call the function and return its result
@@ -289,9 +290,9 @@ def test_push_plan_to_garmin_basic():
     assert "Easy Run" in payload["workoutName"]
     assert payload["sportType"]["sportTypeKey"] == "running"
 
-    # Verify scheduling was called
-    mock_garth_post.assert_called_once()
-    schedule_args = mock_garth_post.call_args
+    # Verify scheduling was called via the new .client.post path
+    mock_client_post.assert_called_once()
+    schedule_args = mock_client_post.call_args
     assert "schedule" in schedule_args[0][1]
     assert schedule_args[1]["json"]["date"] == "2026-03-10"
 

--- a/web/app/api/connections/garmin/ticket/route.ts
+++ b/web/app/api/connections/garmin/ticket/route.ts
@@ -2,41 +2,52 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
 /**
- * Store Garmin OAuth tokens obtained via the Cloudflare Worker exchange.
+ * Store Garmin DI OAuth tokens obtained via the Cloudflare Worker exchange.
  *
- * Flow: user signs into Garmin SSO in their browser (residential IP),
- * copies the ticket URL, frontend sends ticket to CF Worker which
- * exchanges it for OAuth1+OAuth2 tokens, then POSTs them here for storage.
+ * Flow: user signs into Garmin SSO in their browser (residential IP, MFA
+ * handled natively by Garmin's own UI), copies the ticket URL, frontend
+ * sends the ticket to the Cloudflare Worker which exchanges it for a
+ * DI OAuth token at `diauth.garmin.com`, then POSTs the result here for
+ * persistence in `platform_credentials.credentials` (wrapped under the
+ * ``garmin_tokens`` key so the Python-side `garmin-auth>=0.3.0`
+ * ``DBTokenStore`` can read it).
  */
 export async function POST(req: NextRequest) {
   const sql = getDb();
 
   try {
-    const { oauth1, oauth2 } = await req.json();
+    const body = await req.json();
+    // Accept either a top-level DI payload or a nested ``tokens`` wrapper
+    // (the CF Worker returns top-level; some clients wrap it).
+    const tokens = body?.tokens ?? body;
 
-    if (!oauth1?.oauth_token || !oauth2?.access_token) {
+    if (!tokens?.di_token || !tokens?.di_refresh_token || !tokens?.di_client_id) {
       return NextResponse.json(
-        { error: "Invalid tokens — missing oauth_token or access_token" },
+        { error: "Invalid tokens — expected di_token, di_refresh_token, di_client_id" },
         { status: 400 },
       );
     }
 
-    const tokens = {
-      "oauth1_token.json": oauth1,
-      "oauth2_token.json": oauth2,
+    const payload = {
+      di_token: tokens.di_token,
+      di_refresh_token: tokens.di_refresh_token,
+      di_client_id: tokens.di_client_id,
     };
+    // garmin-auth >= 0.3.0 DBTokenStore wraps the DI payload under the
+    // ``garmin_tokens`` key inside the credentials JSONB column.
+    const credentials = JSON.stringify({ garmin_tokens: payload });
 
-    // Store in platform_credentials as garmin_tokens (same format garmin-auth expects)
     await sql`
       INSERT INTO platform_credentials (platform, auth_type, credentials, status, connected_at)
-      VALUES ('garmin_tokens', 'oauth', ${JSON.stringify(tokens)}::jsonb, 'active', NOW())
+      VALUES ('garmin_tokens', 'oauth', ${credentials}::jsonb, 'active', NOW())
       ON CONFLICT (platform)
-      DO UPDATE SET credentials = ${JSON.stringify(tokens)}::jsonb,
+      DO UPDATE SET credentials = ${credentials}::jsonb,
                     status = 'active',
                     connected_at = NOW()
     `;
 
-    // Also update garmin platform status
+    // Also mark the user-facing ``garmin`` platform row as active so the
+    // connections dashboard reflects the state immediately.
     await sql`
       UPDATE platform_credentials
       SET status = 'active', connected_at = NOW()

--- a/web/app/api/sync/refresh-tokens/route.ts
+++ b/web/app/api/sync/refresh-tokens/route.ts
@@ -4,11 +4,28 @@ import { getDb } from "@/lib/db";
 /**
  * Garmin token status endpoint.
  *
- * Auth is now handled by the garmin-auth Python package in the sync pipeline.
- * This endpoint only reports token freshness for monitoring.
+ * Auth is handled by the `garmin-auth >= 0.3.0` Python package in the
+ * sync pipeline. This endpoint only reports whether a DI OAuth token is
+ * stored. We cannot decode the JWT expiration cheaply here (it is server
+ * signed) so we just report presence/absence. Token refresh is handled
+ * automatically by the Python `garminconnect` client when tokens are used.
  */
 
 export const runtime = "nodejs";
+
+function decodeDiTokenExpiry(token: string): number | null {
+  // DI access tokens are JWTs; parse the payload to pull `exp`.
+  try {
+    const parts = token.split(".");
+    if (parts.length < 2) return null;
+    const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    const payload = JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
 
 export async function GET() {
   const sql = getDb();
@@ -21,22 +38,33 @@ export async function GET() {
       return NextResponse.json({ status: "no_tokens" }, { status: 404 });
     }
 
-    const tokens = typeof rows[0].credentials === "string"
+    const credentials = typeof rows[0].credentials === "string"
       ? JSON.parse(rows[0].credentials)
       : rows[0].credentials;
 
-    const oauth2Raw = tokens["oauth2_token.json"] || tokens.oauth2_token;
-    const oauth2 = oauth2Raw
-      ? (typeof oauth2Raw === "string" ? JSON.parse(oauth2Raw) : oauth2Raw)
-      : null;
+    // New format (garmin-auth >= 0.3.0): wrapped under ``garmin_tokens``.
+    const tokens = credentials?.garmin_tokens ?? null;
+    if (!tokens?.di_token) {
+      // Legacy rows (oauth1/oauth2) from garmin-auth < 0.3.0 are no longer
+      // refreshable; surface them as expired so the UI prompts re-auth.
+      return NextResponse.json({
+        status: "expired",
+        message: "Token in legacy format — re-authenticate to upgrade",
+      });
+    }
 
-    const expiresAt = oauth2?.expires_at || 0;
-    const hoursRemaining = (expiresAt - Date.now() / 1000) / 3600;
-
+    const expUnix = decodeDiTokenExpiry(tokens.di_token);
+    if (!expUnix) {
+      return NextResponse.json({
+        status: "stored",
+        message: "DI token present but expiry could not be parsed",
+      });
+    }
+    const hoursRemaining = (expUnix - Date.now() / 1000) / 3600;
     return NextResponse.json({
       status: hoursRemaining > 0 ? "valid" : "expired",
       hours_remaining: +hoursRemaining.toFixed(1),
-      expires_at: expiresAt ? new Date(expiresAt * 1000).toISOString() : null,
+      expires_at: new Date(expUnix * 1000).toISOString(),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -44,6 +72,6 @@ export async function GET() {
   }
 }
 
-export async function POST(req: Request) {
+export async function POST() {
   return GET();
 }

--- a/web/components/credentials-dialog.tsx
+++ b/web/components/credentials-dialog.tsx
@@ -271,7 +271,9 @@ const GARMIN_SSO_URL =
   "&redirectAfterAccountLoginUrl=https%3A%2F%2Fsso.garmin.com%2Fsso%2Fembed" +
   "&redirectAfterAccountCreationUrl=https%3A%2F%2Fsso.garmin.com%2Fsso%2Fembed";
 
-const CF_WORKER_URL = "https://hevy2garmin-exchange.gkos.workers.dev/exchange";
+// DI OAuth exchange worker (garmin-auth >= 0.3.0). The legacy
+// `hevy2garmin-exchange` worker stays alive for older hevy2garmin deployments.
+const CF_WORKER_URL = "https://hevy2garmin-exchange-di.gkos.workers.dev/exchange";
 
 function GarminBrowserAuth({
   onSuccess,
@@ -293,7 +295,8 @@ function GarminBrowserAuth({
 
     setConnecting(true);
     try {
-      // Exchange ticket via CF Worker
+      // Exchange ticket via CF Worker — returns {di_token, di_refresh_token, di_client_id, ...}
+      // (garmin-auth >= 0.3.0 single-file DI OAuth format).
       const exchResp = await fetch(CF_WORKER_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -301,12 +304,20 @@ function GarminBrowserAuth({
       });
       const exchData = await exchResp.json();
       if (exchData.error) { onError(exchData.error); return; }
+      if (!exchData.di_token || !exchData.di_refresh_token || !exchData.di_client_id) {
+        onError("Worker returned unexpected response shape");
+        return;
+      }
 
       // Store tokens on our server
       const storeResp = await fetch("/api/connections/garmin/ticket", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(exchData),
+        body: JSON.stringify({
+          di_token: exchData.di_token,
+          di_refresh_token: exchData.di_refresh_token,
+          di_client_id: exchData.di_client_id,
+        }),
       });
       const storeData = await storeResp.json();
       if (storeData.ok) {


### PR DESCRIPTION
## Summary

Follows drkostas/garmin-auth#28 (0.3.0 with 2FA support) and drkostas/hevy2garmin#95. soma has its own Garmin sign-in UI in `web/components/credentials-dialog.tsx` that shares the same Cloudflare Worker as hevy2garmin, so **both** the Python sync layer **and** the Next.js web surface need the new DI OAuth token format.

Depends on drkostas/garmin-auth#28 being merged + published to PyPI first.

## Verified against real Garmin

The `.client.put/post` signatures on `garminconnect 0.3.0`'s inner `Client` class match the deprecated `.garth.put/post` exactly — confirmed with a live `client.client.put("connectapi", url, json=payload, api=True)` idempotent round-trip (drkostas/garmin-auth#28 integration test M.1). Web-side changes are payload-shape-only. See drkostas/garmin-auth#28 and drkostas/hevy2garmin#95 for the full end-to-end verification trail.

## sync/ changes

- `sync/src/garmin_client.py`: `set_activity_description` + `upload_activity_image` migrate `client.garth.put/post` → `client.client.put/post`
- `sync/src/training_engine/garmin_workout_builder.py`: `push_plan_to_garmin`'s schedule POST migrates to `client.client.post`
- `sync/tests/test_garmin_workout_builder.py`: update mock attribute from `mock_client.garth.post` → `mock_client.client.post`
- `sync/pyproject.toml`: bump `hevy2garmin>=0.3.0,<0.4.0`, `garmin-auth>=0.3.0,<0.4.0`, `garminconnect>=0.3.0,<0.4.0`; add `curl_cffi>=0.6`, `ua-generator>=1.0`

## web/ changes

- `web/app/api/connections/garmin/ticket/route.ts`: POST handler that stores the Worker's exchange result now accepts `{di_token, di_refresh_token, di_client_id}` (top-level or nested under `tokens` for compat). Writes under the `garmin_tokens` JSONB wrapper key expected by garmin-auth 0.3.0's `DBTokenStore`.
- `web/app/api/sync/refresh-tokens/route.ts`: token status endpoint decodes the DI JWT payload to extract `exp` for `hours_remaining` reporting. Legacy oauth1/oauth2 rows are reported as `expired` so the UI prompts re-auth.
- `web/components/credentials-dialog.tsx`: `GarminBrowserAuth` React component validates the Worker's new response shape and forwards the DI fields explicitly.

## Test plan

- [x] `cd sync && PYTHONPATH=src pytest tests/ -q` → **624 passing, 20 pre-existing failures** (test_tdee, test_goal_deficit, test_slot_distribution, test_daily_plan, test_step_calories — all fail on main with identical error messages, verified via branch comparison)
- [x] `.garth. → .client.` migration target verified against real Garmin (inherited from drkostas/garmin-auth#28 verification)
- [ ] Vercel preview deploy with the test account (deploy-time verification of `curl_cffi` on serverless + web/api endpoint happy path with the new shape)
- [ ] After deploy: confirm soma sync picks up the refreshed `platform_credentials` row without crashing

Closes #40
Closes #41
Closes #42
Closes #43