### PR TITLE
fix: route soma sync Garmin login through CF Worker auth broker

### DIFF
--- a/sync/pyproject.toml
+++ b/sync/pyproject.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 description = "Soma health data sync engine"
 requires-python = ">=3.10"
 dependencies = [
-    "hevy2garmin>=0.1.2",
-    "garmin-auth>=0.2.1",
-    "garminconnect>=0.2.38,<0.3.0",
+    "hevy2garmin>=0.3.0,<0.4.0",
+    "garmin-auth>=0.3.0,<0.4.0",
+    "garminconnect>=0.3.0,<0.4.0",
+    "curl_cffi>=0.6",
+    "ua-generator>=1.0",
     "psycopg2-binary>=2.9",
     "python-dotenv>=1.0",
     "requests>=2.31",

--- a/sync/src/garmin_client.py
+++ b/sync/src/garmin_client.py
@@ -66,7 +66,7 @@ def set_activity_description(client: Garmin, activity_id: int, description: str)
     """Set description for a Garmin activity (not built into garminconnect lib)."""
     url = f"/activity-service/activity/{activity_id}"
     payload = {"activityId": activity_id, "description": description}
-    result = client.garth.put("connectapi", url, json=payload, api=True)
+    result = client.client.put("connectapi", url, json=payload, api=True)
     time.sleep(API_CALL_DELAY)
     return result
 
@@ -78,7 +78,7 @@ def upload_activity_image(client: Garmin, activity_id: int, image_bytes: bytes, 
     POST /activity-service/activity/{id}/image (multipart/form-data)
     """
     files = {"file": (filename, io.BytesIO(image_bytes))}
-    result = client.garth.post(
+    result = client.client.post(
         "connectapi",
         f"activity-service/activity/{activity_id}/image",
         files=files,

--- a/sync/src/garmin_client.py
+++ b/sync/src/garmin_client.py
@@ -1,4 +1,4 @@
-"""Garmin Connect API client wrapper — backed by garmin-auth package.
+"""Garmin Connect API client wrapper — backed by garmin-auth + CF Worker auth broker.
 
 Public API (unchanged — all existing imports continue to work):
     init_garmin() -> Garmin client
@@ -9,8 +9,12 @@ Public API (unchanged — all existing imports continue to work):
 """
 
 import io
+import json
+import logging
 import os
 import time
+import urllib.request
+import urllib.error
 
 from garminconnect import Garmin
 
@@ -19,42 +23,143 @@ from garmin_auth.storage import DBTokenStore, FileTokenStore
 
 from config import GARMINTOKENS, DATABASE_URL, get_garmin_credentials
 
+logger = logging.getLogger("garmin_client")
+
 # Delay between API calls to avoid rate limiting (seconds)
 API_CALL_DELAY = 1.0
+
+# The Cloudflare Worker that handles Garmin login from a non-blocked IP.
+# Same worker hevy2garmin's setup wizard uses. Shared across the soma
+# ecosystem so any component can authenticate without being blocked by
+# Garmin's cloud-IP detection on sso.garmin.com.
+CF_WORKER_LOGIN_URL = os.environ.get(
+    "GARMIN_CF_WORKER_URL",
+    "https://hevy2garmin-exchange-di.gkos.workers.dev/login",
+)
+CF_WORKER_MFA_URL = os.environ.get(
+    "GARMIN_CF_WORKER_MFA_URL",
+    "https://hevy2garmin-exchange-di.gkos.workers.dev/login-mfa",
+)
 
 
 def init_garmin() -> Garmin:
     """Initialize Garmin client, reusing cached tokens when possible.
 
-    Uses garmin-auth package with dual storage (file + DB) for token persistence.
+    Strategy:
+        1. Load cached DI tokens from the DB (via garmin-auth DBTokenStore).
+           If the tokens are valid (or auto-refresh succeeds), return immediately.
+        2. If no cached tokens (first run, or legacy format rejected), authenticate
+           via the Cloudflare Worker broker instead of calling Garmin directly.
+           GitHub Actions / Vercel IPs are blocked by Garmin's Cloudflare; the
+           Worker runs from Cloudflare's edge which Garmin accepts.
+        3. Store the resulting DI tokens in the DB for future runs.
     """
     email, password = get_garmin_credentials()
-
-    # Use DB as primary store (survives CI ephemeral runners),
-    # /tmp for garth token files on read-only filesystems (Vercel, GitHub Actions)
     store = DBTokenStore(DATABASE_URL)
-    garth_dir = "/tmp/.garminconnect" if not os.path.isdir(GARMINTOKENS) else GARMINTOKENS
+    token_dir = "/tmp/.garminconnect" if not os.path.isdir(GARMINTOKENS) else GARMINTOKENS
 
+    # Strategy 1: try cached tokens (garmin-auth handles DI refresh internally)
     auth = GarminAuth(
         email=email,
         password=password,
         store=store,
-        token_dir=garth_dir,
+        token_dir=token_dir,
+    )
+    try:
+        client = auth.login()
+        # If we got here without an exception, cached tokens worked.
+        _persist_tokens(auth, store)
+        return client
+    except Exception as e:
+        logger.info("Cached token login failed (%s), trying CF Worker auth broker", e)
+
+    # Strategy 2: authenticate via the Cloudflare Worker
+    tokens = _login_via_cf_worker(email, password)
+    store.save(tokens)
+    logger.info("Fresh DI tokens obtained via CF Worker and saved to DB")
+
+    # Now load through garmin-auth so we get a proper Garmin client
+    auth2 = GarminAuth(store=store, token_dir=token_dir)
+    client = auth2.login()
+    _persist_tokens(auth2, store)
+    return client
+
+
+def _login_via_cf_worker(email: str, password: str) -> dict:
+    """Call the hevy2garmin Cloudflare Worker to authenticate with Garmin.
+
+    The Worker runs on Cloudflare's edge network which Garmin does not block.
+    It POSTs credentials to Garmin's portal/mobile login API and returns
+    DI OAuth tokens.
+
+    Raises RuntimeError if the Worker returns an error or MFA is required
+    (MFA can't be handled in a non-interactive pipeline — the user needs
+    to re-authenticate via the hevy2garmin dashboard instead).
+    """
+    body = json.dumps({"email": email, "password": password}).encode()
+    req = urllib.request.Request(
+        CF_WORKER_LOGIN_URL,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/131.0.0.0 Safari/537.36"
+            ),
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(
+            f"CF Worker login failed (HTTP {e.code}): {e.read().decode()[:300]}"
+        ) from e
+
+    status = data.get("status")
+
+    if status == "success":
+        return {
+            "di_token": data["di_token"],
+            "di_refresh_token": data["di_refresh_token"],
+            "di_client_id": data["di_client_id"],
+        }
+
+    if status == "needs_mfa":
+        raise RuntimeError(
+            "Garmin account has MFA enabled. The sync pipeline can't handle "
+            "MFA codes non-interactively. Please re-authenticate via the "
+            "hevy2garmin dashboard (which has an inline MFA code input), "
+            "then the tokens will be shared with soma via the database."
+        )
+
+    if status == "invalid_credentials":
+        raise RuntimeError(
+            "Garmin login failed: invalid email or password. "
+            "Check GARMIN_EMAIL and GARMIN_PASSWORD in your GitHub secrets."
+        )
+
+    if status == "rate_limited":
+        raise RuntimeError(
+            "Garmin rate-limited the login. Wait 30-60 minutes and retry. "
+            "The sync circuit breaker will auto-resume on the next successful run."
+        )
+
+    raise RuntimeError(
+        f"CF Worker login returned unexpected status: {data}"
     )
 
-    client = auth.login()
 
-    # Also save to DB after successful login (garmin-auth saves to its store,
-    # but we want to ensure both file and DB are in sync)
+def _persist_tokens(auth: GarminAuth, store: DBTokenStore) -> None:
+    """Save the current tokens back to the DB store."""
     try:
-        file_store = FileTokenStore(GARMINTOKENS)
-        tokens = file_store.load()
+        tokens = auth._client.client.dumps() if auth._client else None
         if tokens:
             store.save(tokens)
     except Exception:
         pass
-
-    return client
 
 
 def rate_limited_call(func, *args, **kwargs):

--- a/sync/src/training_engine/garmin_workout_builder.py
+++ b/sync/src/training_engine/garmin_workout_builder.py
@@ -286,7 +286,7 @@ def push_plan_to_garmin(conn, client, plan_id: int) -> int:
                 schedule_url = f"/workout-service/schedule/{garmin_id}"
                 schedule_body = {"date": day_date.isoformat()}
                 rate_limited_call(
-                    client.garth.post,
+                    client.client.post,
                     "connectapi", schedule_url, json=schedule_body, api=True,
                 )
 

--- a/sync/tests/test_garmin_workout_builder.py
+++ b/sync/tests/test_garmin_workout_builder.py
@@ -267,11 +267,12 @@ def test_push_plan_to_garmin_basic():
     ]
     mock_cursor.fetchone.return_value = (1,)  # week_number
 
-    # Mock Garmin client
+    # Mock Garmin client — garminconnect 0.3.0 exposes the inner HTTP client
+    # at ``client.client`` (replaces the old ``client.garth`` path).
     mock_client = MagicMock()
     mock_client.upload_workout.return_value = {"workoutId": 12345}
-    mock_garth_post = MagicMock()
-    mock_client.garth.post = mock_garth_post
+    mock_client_post = MagicMock()
+    mock_client.client.post = mock_client_post
 
     with patch("garmin_client.rate_limited_call") as mock_rlc:
         # rate_limited_call should call the function and return its result
@@ -289,9 +290,9 @@ def test_push_plan_to_garmin_basic():
     assert "Easy Run" in payload["workoutName"]
     assert payload["sportType"]["sportTypeKey"] == "running"
 
-    # Verify scheduling was called
-    mock_garth_post.assert_called_once()
-    schedule_args = mock_garth_post.call_args
+    # Verify scheduling was called via the new .client.post path
+    mock_client_post.assert_called_once()
+    schedule_args = mock_client_post.call_args
     assert "schedule" in schedule_args[0][1]
     assert schedule_args[1]["json"]["date"] == "2026-03-10"
 

--- a/web/app/api/connections/garmin/ticket/route.ts
+++ b/web/app/api/connections/garmin/ticket/route.ts
@@ -2,41 +2,52 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
 /**
- * Store Garmin OAuth tokens obtained via the Cloudflare Worker exchange.
+ * Store Garmin DI OAuth tokens obtained via the Cloudflare Worker exchange.
  *
- * Flow: user signs into Garmin SSO in their browser (residential IP),
- * copies the ticket URL, frontend sends ticket to CF Worker which
- * exchanges it for OAuth1+OAuth2 tokens, then POSTs them here for storage.
+ * Flow: user signs into Garmin SSO in their browser (residential IP, MFA
+ * handled natively by Garmin's own UI), copies the ticket URL, frontend
+ * sends the ticket to the Cloudflare Worker which exchanges it for a
+ * DI OAuth token at `diauth.garmin.com`, then POSTs the result here for
+ * persistence in `platform_credentials.credentials` (wrapped under the
+ * ``garmin_tokens`` key so the Python-side `garmin-auth>=0.3.0`
+ * ``DBTokenStore`` can read it).
  */
 export async function POST(req: NextRequest) {
   const sql = getDb();
 
   try {
-    const { oauth1, oauth2 } = await req.json();
+    const body = await req.json();
+    // Accept either a top-level DI payload or a nested ``tokens`` wrapper
+    // (the CF Worker returns top-level; some clients wrap it).
+    const tokens = body?.tokens ?? body;
 
-    if (!oauth1?.oauth_token || !oauth2?.access_token) {
+    if (!tokens?.di_token || !tokens?.di_refresh_token || !tokens?.di_client_id) {
       return NextResponse.json(
-        { error: "Invalid tokens — missing oauth_token or access_token" },
+        { error: "Invalid tokens — expected di_token, di_refresh_token, di_client_id" },
         { status: 400 },
       );
     }
 
-    const tokens = {
-      "oauth1_token.json": oauth1,
-      "oauth2_token.json": oauth2,
+    const payload = {
+      di_token: tokens.di_token,
+      di_refresh_token: tokens.di_refresh_token,
+      di_client_id: tokens.di_client_id,
     };
+    // garmin-auth >= 0.3.0 DBTokenStore wraps the DI payload under the
+    // ``garmin_tokens`` key inside the credentials JSONB column.
+    const credentials = JSON.stringify({ garmin_tokens: payload });
 
-    // Store in platform_credentials as garmin_tokens (same format garmin-auth expects)
     await sql`
       INSERT INTO platform_credentials (platform, auth_type, credentials, status, connected_at)
-      VALUES ('garmin_tokens', 'oauth', ${JSON.stringify(tokens)}::jsonb, 'active', NOW())
+      VALUES ('garmin_tokens', 'oauth', ${credentials}::jsonb, 'active', NOW())
       ON CONFLICT (platform)
-      DO UPDATE SET credentials = ${JSON.stringify(tokens)}::jsonb,
+      DO UPDATE SET credentials = ${credentials}::jsonb,
                     status = 'active',
                     connected_at = NOW()
     `;
 
-    // Also update garmin platform status
+    // Also mark the user-facing ``garmin`` platform row as active so the
+    // connections dashboard reflects the state immediately.
     await sql`
       UPDATE platform_credentials
       SET status = 'active', connected_at = NOW()

--- a/web/app/api/sync/refresh-tokens/route.ts
+++ b/web/app/api/sync/refresh-tokens/route.ts
@@ -4,11 +4,28 @@ import { getDb } from "@/lib/db";
 /**
  * Garmin token status endpoint.
  *
- * Auth is now handled by the garmin-auth Python package in the sync pipeline.
- * This endpoint only reports token freshness for monitoring.
+ * Auth is handled by the `garmin-auth >= 0.3.0` Python package in the
+ * sync pipeline. This endpoint only reports whether a DI OAuth token is
+ * stored. We cannot decode the JWT expiration cheaply here (it is server
+ * signed) so we just report presence/absence. Token refresh is handled
+ * automatically by the Python `garminconnect` client when tokens are used.
  */
 
 export const runtime = "nodejs";
+
+function decodeDiTokenExpiry(token: string): number | null {
+  // DI access tokens are JWTs; parse the payload to pull `exp`.
+  try {
+    const parts = token.split(".");
+    if (parts.length < 2) return null;
+    const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    const payload = JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
 
 export async function GET() {
   const sql = getDb();
@@ -21,22 +38,33 @@ export async function GET() {
       return NextResponse.json({ status: "no_tokens" }, { status: 404 });
     }
 
-    const tokens = typeof rows[0].credentials === "string"
+    const credentials = typeof rows[0].credentials === "string"
       ? JSON.parse(rows[0].credentials)
       : rows[0].credentials;
 
-    const oauth2Raw = tokens["oauth2_token.json"] || tokens.oauth2_token;
-    const oauth2 = oauth2Raw
-      ? (typeof oauth2Raw === "string" ? JSON.parse(oauth2Raw) : oauth2Raw)
-      : null;
+    // New format (garmin-auth >= 0.3.0): wrapped under ``garmin_tokens``.
+    const tokens = credentials?.garmin_tokens ?? null;
+    if (!tokens?.di_token) {
+      // Legacy rows (oauth1/oauth2) from garmin-auth < 0.3.0 are no longer
+      // refreshable; surface them as expired so the UI prompts re-auth.
+      return NextResponse.json({
+        status: "expired",
+        message: "Token in legacy format — re-authenticate to upgrade",
+      });
+    }
 
-    const expiresAt = oauth2?.expires_at || 0;
-    const hoursRemaining = (expiresAt - Date.now() / 1000) / 3600;
-
+    const expUnix = decodeDiTokenExpiry(tokens.di_token);
+    if (!expUnix) {
+      return NextResponse.json({
+        status: "stored",
+        message: "DI token present but expiry could not be parsed",
+      });
+    }
+    const hoursRemaining = (expUnix - Date.now() / 1000) / 3600;
     return NextResponse.json({
       status: hoursRemaining > 0 ? "valid" : "expired",
       hours_remaining: +hoursRemaining.toFixed(1),
-      expires_at: expiresAt ? new Date(expiresAt * 1000).toISOString() : null,
+      expires_at: new Date(expUnix * 1000).toISOString(),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -44,6 +72,6 @@ export async function GET() {
   }
 }
 
-export async function POST(req: Request) {
+export async function POST() {
   return GET();
 }

--- a/web/components/credentials-dialog.tsx
+++ b/web/components/credentials-dialog.tsx
@@ -271,7 +271,9 @@ const GARMIN_SSO_URL =
   "&redirectAfterAccountLoginUrl=https%3A%2F%2Fsso.garmin.com%2Fsso%2Fembed" +
   "&redirectAfterAccountCreationUrl=https%3A%2F%2Fsso.garmin.com%2Fsso%2Fembed";
 
-const CF_WORKER_URL = "https://hevy2garmin-exchange.gkos.workers.dev/exchange";
+// DI OAuth exchange worker (garmin-auth >= 0.3.0). The legacy
+// `hevy2garmin-exchange` worker stays alive for older hevy2garmin deployments.
+const CF_WORKER_URL = "https://hevy2garmin-exchange-di.gkos.workers.dev/exchange";
 
 function GarminBrowserAuth({
   onSuccess,
@@ -293,7 +295,8 @@ function GarminBrowserAuth({
 
     setConnecting(true);
     try {
-      // Exchange ticket via CF Worker
+      // Exchange ticket via CF Worker — returns {di_token, di_refresh_token, di_client_id, ...}
+      // (garmin-auth >= 0.3.0 single-file DI OAuth format).
       const exchResp = await fetch(CF_WORKER_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -301,12 +304,20 @@ function GarminBrowserAuth({
       });
       const exchData = await exchResp.json();
       if (exchData.error) { onError(exchData.error); return; }
+      if (!exchData.di_token || !exchData.di_refresh_token || !exchData.di_client_id) {
+        onError("Worker returned unexpected response shape");
+        return;
+      }
 
       // Store tokens on our server
       const storeResp = await fetch("/api/connections/garmin/ticket", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(exchData),
+        body: JSON.stringify({
+          di_token: exchData.di_token,
+          di_refresh_token: exchData.di_refresh_token,
+          di_client_id: exchData.di_client_id,
+        }),
       });
       const storeData = await storeResp.json();
       if (storeData.ok) {


### PR DESCRIPTION
## Summary

The soma sync pipeline runs on GitHub Actions whose IPs are blocked by Garmin's Cloudflare. After soma#44 merged, the old garth-era tokens were rejected by garmin-auth 0.3.0, and the fallback direct login fails with 429/403 from cloud IPs. Every cron run since the merge has failed.

**Fix:** `init_garmin()` now uses the same hevy2garmin Cloudflare Worker auth broker (`hevy2garmin-exchange-di.gkos.workers.dev/login`) as a fallback when cached tokens aren't available. The Worker runs from Cloudflare's edge network which Garmin accepts.

## How it works

1. Try cached DI tokens from the DB (garmin-auth handles auto-refresh via `diauth.garmin.com`, which is NOT blocked from GH Actions)
2. If no tokens / legacy format → call the CF Worker with `GARMIN_EMAIL` + `GARMIN_PASSWORD`
3. Worker does the portal/mobile login from Cloudflare's edge → returns DI tokens → saved to DB
4. Future runs load from cache → auto-refresh keeps tokens alive indefinitely

For MFA-enabled accounts: the pipeline raises a clear error directing the user to re-authenticate via the hevy2garmin dashboard (which has inline MFA code input). Tokens are shared via the same Postgres DB.

## Test plan

- [x] Garmin workout builder tests: 15 passing (4 pre-existing failures unchanged from main)
- [x] DI token refresh from non-Cloudflare IP: verified works (both curl_cffi and plain requests)
- [ ] Production sync run after rate limit clears (will self-heal on next successful cron run)