### PR TITLE
fix: backoff v2 — real failures only, skips don't inflate window

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,63 +23,71 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Additive backoff: 1st fail → 1h, 2nd → 3h, 3rd → 5h ... cap 24h.
-          # Exits 0 + sets SKIP_SYNC=true if inside the window (so the skip
-          # itself is NOT a failure and doesn't extend the window).
-          # Manual/dispatch triggers bypass this step entirely.
+          # Additive backoff: 1st real fail → 1h, 2nd → 3h, 3rd → 5h ... cap 24h.
+          # "Real" failures = runs that lasted > 30s (actual pipeline attempts).
+          # Backoff skips last < 15s and are excluded from the count so they
+          # don't inflate the window. Manual triggers bypass entirely.
 
-          RUNS=$(gh run list --workflow=sync.yml --status=completed --limit=20 \
-            --json conclusion,createdAt \
+          RUNS=$(gh run list --workflow=sync.yml --status=completed --limit=30 \
+            --json conclusion,createdAt,updatedAt \
             --jq '[.[] | select(.conclusion == "success" or .conclusion == "failure")]' \
             2>/dev/null || echo "[]")
 
           python3 -c "
-          import json, os, sys
+          import json, sys
           from datetime import datetime, timezone, timedelta
 
           runs = json.loads('''$RUNS''')
           if not runs:
               sys.exit(0)
 
+          def parse_ts(s):
+              return datetime.fromisoformat(s.replace('Z', '+00:00'))
+
+          def duration_s(r):
+              return (parse_ts(r['updatedAt']) - parse_ts(r['createdAt'])).total_seconds()
+
+          # Count consecutive REAL failures (duration > 30s).
+          # Skip over short runs (backoff skips) — they don't count either way.
           consecutive = 0
+          last_real_failure_at = None
           for r in runs:
+              dur = duration_s(r)
+              if dur < 30:
+                  continue  # backoff skip, ignore
               if r['conclusion'] == 'failure':
                   consecutive += 1
+                  if last_real_failure_at is None:
+                      last_real_failure_at = parse_ts(r['createdAt'])
               else:
-                  break
+                  break  # hit a real success, stop counting
 
-          if consecutive == 0:
-              sys.exit(0)
+          if consecutive == 0 or last_real_failure_at is None:
+              sys.exit(0)  # no real failures, proceed
 
           backoff_h = min(2 * consecutive - 1, 24)
-          last = datetime.fromisoformat(runs[0]['createdAt'].replace('Z', '+00:00'))
-          elapsed = datetime.now(timezone.utc) - last
+          elapsed = datetime.now(timezone.utc) - last_real_failure_at
           remaining = timedelta(hours=backoff_h) - elapsed
 
           if remaining.total_seconds() > 0:
               h = remaining.total_seconds() / 3600
-              print(f'::notice::Backoff: {consecutive} failure(s), waiting {backoff_h}h ({h:.1f}h left). Manual trigger bypasses.')
-              with open(os.environ.get('GITHUB_ENV', '/dev/null'), 'a') as f:
-                  f.write('SKIP_SYNC=true\n')
-          else:
-              print(f'::notice::Backoff expired ({backoff_h}h window, {elapsed.total_seconds()/3600:.1f}h elapsed). Retrying.')
+              print(f'::notice::Backoff: {consecutive} real failure(s), waiting {backoff_h}h ({h:.1f}h left). Manual trigger bypasses.')
+              sys.exit(1)  # fail fast — keeps this run short so it's excluded from future counts
+
+          print(f'::notice::Backoff expired ({backoff_h}h window, {elapsed.total_seconds()/3600:.1f}h elapsed). Retrying.')
           "
 
       - uses: actions/checkout@v4
-        if: env.SKIP_SYNC != 'true'
 
       - uses: actions/setup-python@v5
-        if: env.SKIP_SYNC != 'true'
         with:
           python-version: '3.12'
 
       - name: Install dependencies
-        if: env.SKIP_SYNC != 'true'
         working-directory: sync
         run: pip install -e .
 
       - name: Run sync pipeline (smart — auto-detects stale dates)
-        if: env.SKIP_SYNC != 'true'
         working-directory: sync
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
v1 backoff (#47) had a bug: skipped runs exited 0 (success) which reset the failure counter, causing the next cron to retry immediately.

**Fix:** backoff skips now exit 1 (fast, <15s). The Python uses run duration (via `updatedAt - createdAt`) to tell real pipeline failures (>30s) apart from backoff skips (<30s). Only real failures count toward the additive window (1h/3h/5h/...). Skips are invisible to the counter.

Simpler workflow too — removed the `SKIP_SYNC` env var gating. The backoff step just exits 1 to fail fast, job stops, no runner minutes wasted.