### PR TITLE
feat: integrate hevy2garmin merge mode into soma sync pipeline

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -103,4 +103,5 @@ jobs:
           VAPID_PUBLIC_KEY: ${{ secrets.VAPID_PUBLIC_KEY }}
           VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
           VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
+          MERGE_MODE: ${{ secrets.MERGE_MODE }}
         run: python -m src.pipeline

--- a/sync/src/activity_replacer.py
+++ b/sync/src/activity_replacer.py
@@ -20,6 +20,7 @@ from config import DATABASE_URL
 from db import get_connection, upsert_workout_enrichment, get_outlier_workouts
 from hevy2garmin.fit import generate_fit
 from hevy2garmin.garmin import upload_fit as h2g_upload_fit, rename_activity as h2g_rename
+from hevy2garmin.merge import attempt_merge, reset_circuit_breaker
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -326,8 +327,13 @@ def process_workout(
     dry_run: bool = False,
     fit_dir: str = DEFAULT_FIT_DIR,
     enrich_only: bool = False,
+    merge_mode: bool = False,
 ) -> dict:
     """Process a single Hevy workout: generate FIT and upload.
+
+    If merge_mode is True and a matching Garmin watch activity is found,
+    pushes Hevy exercise data into the existing activity instead of
+    generating a new FIT file. Falls back to FIT upload if no match.
 
     Returns a result dict with status and details.
     """
@@ -337,6 +343,22 @@ def process_workout(
         "date": workout.get("date", "unknown"),
         "status": "error",
     }
+
+    # ── Merge mode: try to enhance a watch-recorded activity ──
+    if merge_mode and garmin_client and not dry_run and not enrich_only:
+        try:
+            from hevy2garmin.db import get_db
+            merge_result = attempt_merge(garmin_client, workout["hevy_workout"], get_db())
+            if merge_result.merged:
+                result["status"] = "merged"
+                result["new_activity_id"] = merge_result.activity_id
+                result["sync_method"] = "merge"
+                print(f"  ⚡ Enhanced watch activity {merge_result.activity_id}")
+                return result
+            else:
+                print(f"  Merge fallback: {merge_result.fallback_reason}")
+        except Exception as e:
+            print(f"  Merge attempt failed: {e}")
 
     try:
         # 1. Generate FIT

--- a/sync/src/pipeline.py
+++ b/sync/src/pipeline.py
@@ -523,6 +523,9 @@ def _upload_enriched_to_garmin(garmin_client) -> int:
             "date": str(workout_date) if workout_date else "unknown",
         }
 
+        # Check merge mode from env or sync rules
+        merge_mode = os.environ.get("MERGE_MODE", "").lower() in ("1", "true", "yes")
+
         print(f"  Uploading {hevy_id} ({hevy_title})...")
         result = process_workout(
             workout,
@@ -530,9 +533,10 @@ def _upload_enriched_to_garmin(garmin_client) -> int:
             hr_source=hr_source or "unknown",
             garmin_client=garmin_client,
             fit_dir=DEFAULT_FIT_DIR,
+            merge_mode=merge_mode,
         )
 
-        if result["status"] == "uploaded":
+        if result["status"] in ("uploaded", "merged"):
             uploaded += 1
             fit_path = result.get("fit_path")
             if fit_path and os.path.exists(fit_path):


### PR DESCRIPTION
## Summary

- Integrates hevy2garmin's merge mode (drkostas/hevy2garmin#117) into soma's sync pipeline
- When `MERGE_MODE=true` (GitHub secret), the pipeline tries to enhance watch-recorded Garmin Strength Training activities with Hevy exercise data before falling back to FIT upload
- `activity_replacer.py`: merge branch before FIT generation via `attempt_merge()`
- `pipeline.py`: passes `merge_mode` from env, handles `"merged"` status alongside `"uploaded"`
- `sync.yml`: adds `MERGE_MODE` env var from secrets

## Test plan

- [x] Pre-existing test suite passes (24 failures are pre-existing nutrition engine tests, not related)
- [x] Merge mode OFF (default): no behavior change, existing flow untouched
- [x] Merge mode ON: calls `attempt_merge()` from hevy2garmin, falls back to FIT upload if no match
- [x] E2E merge verified on live Garmin in hevy2garmin#117