### PR TITLE
feat(nutrition): Batch 1 — foundations (Cunningham BMR + Forbes + safety rails + tier framework)

### DIFF
--- a/sync/src/nutrition_engine/bmr.py
+++ b/sync/src/nutrition_engine/bmr.py
@@ -1,0 +1,111 @@
+"""Basal Metabolic Rate (BMR) formulas.
+
+Cunningham 1980 primary for FFM-based (most accurate for trained athletes,
+validated by ten Haaf 2014 with 78% accuracy in recreational athletes).
+
+ten Haaf 2014 weight-based as fallback when FFM is unknown (~80% accuracy
+for athlete populations, better than Mifflin for lean trained).
+
+Mifflin-St Jeor 1990 as absolute fallback (best for general/obese adults).
+
+DO NOT use Garmin-reported BMR — no published validation, known to inflate
+by ~13% through an embedded ~1.1 sedentary activity multiplier.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+
+def cunningham(ffm_kg: float) -> int:
+    """Cunningham 1980: BMR = 500 + 22 × FFM_kg.
+
+    Primary formula for trained athletes. Validated by ten Haaf 2014
+    (PMID 25275434, DOI 10.1371/journal.pone.0108460).
+    """
+    if ffm_kg <= 0:
+        raise ValueError(f"ffm_kg must be positive, got {ffm_kg}")
+    return round(500 + 22 * ffm_kg)
+
+
+def mifflin_st_jeor(
+    weight_kg: float,
+    height_cm: float,
+    age: int,
+    sex: Literal["male", "female"],
+) -> int:
+    """Mifflin-St Jeor 1990: demographic-based BMR.
+
+    Best for general/obese populations. Under-predicts in lean trained men
+    because it ignores FFM.
+
+    Reference: Frankenfield 2005, DOI 10.1016/j.jada.2005.02.005
+    """
+    if weight_kg <= 0 or height_cm <= 0 or age <= 0:
+        raise ValueError("weight_kg, height_cm, and age must all be positive")
+    base = 10 * weight_kg + 6.25 * height_cm - 5 * age
+    if sex == "male":
+        return round(base + 5)
+    return round(base - 161)
+
+
+def ten_haaf_weight(
+    weight_kg: float,
+    height_cm: float,
+    age: int,
+    sex: Literal["male", "female"],
+) -> int:
+    """ten Haaf 2014 weight-based REE formula for recreational athletes.
+
+    Better than Mifflin-St Jeor for trained populations (~80% accuracy).
+    Reference: ten Haaf & Weijs 2014, PMID 25275434, DOI 10.1371/journal.pone.0108460
+
+    Formula (Table 3, kcal output):
+        REE = 11.936·w + 587.728·(h_m) - 8.129·a + 191.027·(sex_male) + 29.279
+
+    where h_m = height in meters and sex_male = 1 for male, 0 for female.
+    """
+    if weight_kg <= 0 or height_cm <= 0 or age <= 0:
+        raise ValueError("weight_kg, height_cm, and age must all be positive")
+
+    height_m = height_cm / 100.0
+    sex_male = 1 if sex == "male" else 0
+
+    ree_kcal = (
+        11.936 * weight_kg
+        + 587.728 * height_m
+        - 8.129 * age
+        + 191.027 * sex_male
+        + 29.279
+    )
+    return round(ree_kcal)
+
+
+def compute_bmr(
+    ffm_kg: float | None = None,
+    weight_kg: float | None = None,
+    height_cm: float | None = None,
+    age: int | None = None,
+    sex: Literal["male", "female"] | None = None,
+) -> int:
+    """Route to the best BMR formula given available inputs.
+
+    Priority:
+    1. Cunningham (FFM-based) — if ``ffm_kg`` provided
+    2. ten Haaf weight-based — if demographics provided
+    3. (Mifflin-St Jeor is available as a secondary fallback but ten Haaf
+       is preferred for athletic populations; callers explicitly invoke
+       ``mifflin_st_jeor`` if they want it.)
+    """
+    if ffm_kg is not None:
+        return cunningham(ffm_kg=ffm_kg)
+
+    if weight_kg is not None and height_cm is not None and age is not None and sex is not None:
+        return ten_haaf_weight(
+            weight_kg=weight_kg, height_cm=height_cm, age=age, sex=sex,
+        )
+
+    raise ValueError(
+        "compute_bmr requires either ffm_kg or full demographics "
+        "(weight_kg + height_cm + age + sex)"
+    )

--- a/sync/src/nutrition_engine/fat_floor.py
+++ b/sync/src/nutrition_engine/fat_floor.py
@@ -1,0 +1,89 @@
+"""Fat floor enforcement — hormonal protection (M1.5).
+
+Research basis:
+- Whittaker & Wu 2021 meta: <20% of calories from fat → 10-15% total T drop
+- Volek 1997, Wang 2005: hormonal disruption below ~0.6-0.8 g/kg
+- Helms 2014 contest prep: 0.8 g/kg recommended minimum
+
+Modes:
+- standard / aggressive: floor 0.8 soft / 0.6 hard (non-negotiable)
+- maintenance: 1.0 g/kg soft (real target with headroom), 0.6 hard
+- bulk: 0.8 g/kg soft (floor stays); up to 1.2 g/kg acceptable as target
+
+Fat is treated as a FLOOR, not a target. Overshoot is safe — no warnings
+when fat exceeds the soft floor (treat like protein).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+Mode = Literal["standard", "aggressive", "maintenance", "bulk"]
+
+FAT_FLOOR_SOFT_DEFAULT: float = 0.8  # g/kg
+FAT_FLOOR_HARD: float = 0.6          # g/kg (never breachable)
+FAT_TARGET_MAINTENANCE: float = 1.0  # g/kg (real target in maintenance)
+
+
+class FatBreachType(str, Enum):
+    NONE = "none"
+    SOFT = "soft"  # below soft, above hard — warning
+    HARD = "hard"  # below hard — enforced raise
+
+
+@dataclass(frozen=True)
+class FatFloorResult:
+    soft_floor_g: int
+    hard_floor_g: int
+    fat_g: int = 0
+    breach_type: FatBreachType = FatBreachType.NONE
+
+
+def _soft_floor_g_per_kg(mode: Mode) -> float:
+    if mode == "maintenance":
+        return FAT_TARGET_MAINTENANCE
+    # standard, aggressive, bulk all use 0.8 g/kg soft floor
+    return FAT_FLOOR_SOFT_DEFAULT
+
+
+def compute_fat_floor(weight_kg: float, mode: Mode) -> FatFloorResult:
+    """Compute fat floor for a given weight and mode."""
+    if mode not in ("standard", "aggressive", "maintenance", "bulk"):
+        raise ValueError(f"Unknown mode: {mode!r}")
+    if weight_kg <= 0:
+        raise ValueError(f"weight_kg must be positive, got {weight_kg}")
+
+    soft_per_kg = _soft_floor_g_per_kg(mode)
+    return FatFloorResult(
+        soft_floor_g=round(soft_per_kg * weight_kg),
+        hard_floor_g=round(FAT_FLOOR_HARD * weight_kg),
+    )
+
+
+def apply_fat_floor(fat_g: int, weight_kg: float, mode: Mode) -> FatFloorResult:
+    """Apply fat floor to a proposed fat intake.
+
+    - Above soft → NONE (no warning on overshoot)
+    - Between hard and soft → SOFT (warning, not enforced)
+    - Below hard → HARD (raised to hard floor)
+    """
+    floors = compute_fat_floor(weight_kg=weight_kg, mode=mode)
+
+    if fat_g < floors.hard_floor_g:
+        breach = FatBreachType.HARD
+        adjusted = floors.hard_floor_g
+    elif fat_g < floors.soft_floor_g:
+        breach = FatBreachType.SOFT
+        adjusted = fat_g  # warn but don't enforce
+    else:
+        breach = FatBreachType.NONE
+        adjusted = fat_g
+
+    return FatFloorResult(
+        soft_floor_g=floors.soft_floor_g,
+        hard_floor_g=floors.hard_floor_g,
+        fat_g=adjusted,
+        breach_type=breach,
+    )

--- a/sync/src/nutrition_engine/floor.py
+++ b/sync/src/nutrition_engine/floor.py
@@ -1,0 +1,110 @@
+"""BMR + RED-S Energy Availability floor enforcement.
+
+Safety rails for target_calories. Based on:
+- Cunningham 1980 BMR (primary soft floor)
+- Mountjoy 2018 IOC RED-S consensus (EA hard floor: 25 kcal/kg FFM + exercise)
+
+Modes:
+- Standard: soft = Cunningham; hard = max(Cunningham, 25·FFM + ex_kcal). Both enforced.
+- Aggressive: soft = Cunningham (advisory); hard = 25·FFM + ex_kcal. Only hard enforced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+from nutrition_engine.bmr import cunningham
+
+# Mountjoy 2018 RED-S consensus threshold
+REDS_EA_COEFFICIENT: int = 25  # kcal per kg FFM per day
+
+Mode = Literal["standard", "aggressive"]
+
+
+class FloorBreachType(str, Enum):
+    NONE = "none"
+    SOFT = "soft"
+    HARD = "hard"
+
+
+@dataclass(frozen=True)
+class FloorResult:
+    """Floor computation result."""
+    soft_floor: int
+    hard_floor: int
+    target_kcal: int = 0
+    breach_type: FloorBreachType = FloorBreachType.NONE
+
+
+def compute_floor(
+    ffm_kg: float,
+    exercise_kcal: float,
+    mode: Mode,
+) -> FloorResult:
+    """Compute soft + hard floors for a given FFM, exercise level, and mode.
+
+    Standard mode:
+        soft = Cunningham(FFM)
+        hard = max(Cunningham, 25·FFM + exercise)
+
+    Aggressive mode:
+        soft = Cunningham(FFM)  [advisory only]
+        hard = 25·FFM + exercise  [Cunningham dropped]
+    """
+    if mode not in ("standard", "aggressive"):
+        raise ValueError(f"Unknown mode: {mode!r}. Use 'standard' or 'aggressive'.")
+    if ffm_kg <= 0:
+        raise ValueError(f"ffm_kg must be positive, got {ffm_kg}")
+    if exercise_kcal < 0:
+        raise ValueError(f"exercise_kcal must be non-negative, got {exercise_kcal}")
+
+    soft = cunningham(ffm_kg=ffm_kg)
+    ea_threshold = round(REDS_EA_COEFFICIENT * ffm_kg + exercise_kcal)
+
+    if mode == "standard":
+        hard = max(soft, ea_threshold)
+    else:  # aggressive
+        hard = ea_threshold
+
+    return FloorResult(soft_floor=soft, hard_floor=hard)
+
+
+def apply_floor(
+    target_kcal: int,
+    ffm_kg: float,
+    exercise_kcal: float,
+    mode: Mode,
+) -> FloorResult:
+    """Apply floor to a proposed target_kcal.
+
+    Returns FloorResult with:
+    - ``target_kcal`` adjusted to hard_floor if it was breached
+    - ``breach_type`` indicating NONE, SOFT, or HARD
+
+    Semantics:
+    - Standard mode: target below soft == target below hard (soft=hard in this mode
+      when soft dominates). Both breach types can fire.
+    - Aggressive mode: target below Cunningham but above hard = SOFT breach (warning),
+      target below hard = HARD breach (enforced raise).
+    """
+    floors = compute_floor(ffm_kg=ffm_kg, exercise_kcal=exercise_kcal, mode=mode)
+
+    if target_kcal < floors.hard_floor:
+        breach = FloorBreachType.HARD
+        adjusted = floors.hard_floor
+    elif target_kcal < floors.soft_floor:
+        # Only reachable in aggressive mode (hard < soft).
+        breach = FloorBreachType.SOFT
+        adjusted = target_kcal  # allowed to stay below soft in aggressive
+    else:
+        breach = FloorBreachType.NONE
+        adjusted = target_kcal
+
+    return FloorResult(
+        soft_floor=floors.soft_floor,
+        hard_floor=floors.hard_floor,
+        target_kcal=adjusted,
+        breach_type=breach,
+    )

--- a/sync/src/nutrition_engine/forbes.py
+++ b/sync/src/nutrition_engine/forbes.py
@@ -1,0 +1,51 @@
+"""Forbes partitioning of body-weight change into FFM and FM (M3.1).
+
+Research basis:
+- Forbes 2000 FFM-FM curve: `dFFM/dBW = 10.4 / (10.4 + FM)`
+- Recomp multiplier: concurrent resistance training + ≥1.8 g/kg protein
+  biases partitioning toward muscle gain / spares FFM during a cut. We apply
+  a 0.6× scalar to the baseline FFM fraction per V2 §8.1 (MATADOR / Helms
+  recomp reviews).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# Forbes 2000 curve constant — do not change without revisiting the research.
+_FORBES_K: float = 10.4
+
+# V2 §8.1 recomp multiplier on the FFM fraction.
+_RECOMP_MULTIPLIER: float = 0.6
+
+
+@dataclass(frozen=True)
+class ForbesResult:
+    d_ffm_kg: float
+    d_fm_kg: float
+    ffm_fraction: float
+
+
+def partition_weight_change(
+    d_bw_kg: float,
+    fm_kg: float,
+    *,
+    recomp: bool = False,
+) -> ForbesResult:
+    """Split a body-weight change into FFM and FM components via Forbes.
+
+    The fat-mass variable is the *current* FM, not the target. Callers that
+    want an integrated prediction across a multi-day window should integrate
+    in small steps and re-estimate `fm_kg` each step.
+    """
+    if fm_kg < 0:
+        raise ValueError(f"fm_kg must be non-negative, got {fm_kg}")
+
+    base_fraction = _FORBES_K / (_FORBES_K + fm_kg)
+    ffm_fraction = base_fraction * _RECOMP_MULTIPLIER if recomp else base_fraction
+
+    d_ffm = d_bw_kg * ffm_fraction
+    d_fm = d_bw_kg - d_ffm
+
+    return ForbesResult(d_ffm_kg=d_ffm, d_fm_kg=d_fm, ffm_fraction=ffm_fraction)

--- a/sync/src/nutrition_engine/protein_floor.py
+++ b/sync/src/nutrition_engine/protein_floor.py
@@ -1,0 +1,95 @@
+"""Protein floor warning + per-meal quality thresholds (M1.6 + V9.1).
+
+Research basis:
+- Morton 2018 meta: 1.6 g/kg plateau for resistance-training FFM gains
+- Schoenfeld & Aragon 2018: per-meal 0.4 g/kg as optimal
+- Trommelen 2023: 100g doses have extended anabolic effect — no upper cap
+
+Behavior:
+- Daily intake floor: 1.6 × weight_kg
+- Amber warning banner when intake < floor for 3+ consecutive days
+- Per-meal quality levels for MPS signaling (informational, not enforced)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+PROTEIN_FLOOR_G_PER_KG: float = 1.6
+
+# Per-meal thresholds (g)
+_PER_MEAL_RED_MAX: int = 14       # <15g = RED
+_PER_MEAL_AMBER_MAX: int = 24     # 15-24 = AMBER
+_PER_MEAL_YELLOW_MAX: int = 29    # 25-29 = YELLOW
+_PER_MEAL_GREEN_MAX: int = 55     # 30-55 = GREEN; >55 = NO_WARNING
+
+
+class ProteinFloorStatus(str, Enum):
+    GREEN = "green"
+    AMBER = "amber"
+
+
+class PerMealProteinLevel(str, Enum):
+    RED = "red"
+    AMBER = "amber"
+    YELLOW = "yellow"
+    GREEN = "green"
+    NO_WARNING = "no_warning"
+
+
+@dataclass(frozen=True)
+class ProteinFloorResult:
+    floor_g: int
+    days_below_floor: int  # consecutive streak at end of history
+    status: ProteinFloorStatus
+
+
+def compute_protein_floor(weight_kg: float) -> int:
+    """Return the daily protein floor in grams for a given body weight."""
+    if weight_kg <= 0:
+        raise ValueError(f"weight_kg must be positive, got {weight_kg}")
+    return round(PROTEIN_FLOOR_G_PER_KG * weight_kg)
+
+
+def check_protein_floor(
+    recent_intakes: list[float],
+    weight_kg: float,
+) -> ProteinFloorResult:
+    """Check if protein intake has been below floor for 3+ consecutive recent days.
+
+    Args:
+        recent_intakes: daily protein totals in grams, oldest first, newest last.
+        weight_kg: user weight.
+
+    Returns AMBER when the trailing streak (days ending at most recent) is >= 3.
+    """
+    floor = compute_protein_floor(weight_kg=weight_kg)
+
+    # Count consecutive days below floor ending at the most recent day
+    streak = 0
+    for intake in reversed(recent_intakes):
+        if intake < floor:
+            streak += 1
+        else:
+            break
+
+    status = ProteinFloorStatus.AMBER if streak >= 3 else ProteinFloorStatus.GREEN
+    return ProteinFloorResult(
+        floor_g=floor,
+        days_below_floor=streak,
+        status=status,
+    )
+
+
+def check_per_meal_protein(protein_g: int) -> PerMealProteinLevel:
+    """Classify a single meal's protein content per V9.1 MPS quality thresholds."""
+    if protein_g <= _PER_MEAL_RED_MAX:
+        return PerMealProteinLevel.RED
+    if protein_g <= _PER_MEAL_AMBER_MAX:
+        return PerMealProteinLevel.AMBER
+    if protein_g <= _PER_MEAL_YELLOW_MAX:
+        return PerMealProteinLevel.YELLOW
+    if protein_g <= _PER_MEAL_GREEN_MAX:
+        return PerMealProteinLevel.GREEN
+    return PerMealProteinLevel.NO_WARNING

--- a/sync/src/nutrition_engine/rate_cap.py
+++ b/sync/src/nutrition_engine/rate_cap.py
@@ -1,0 +1,180 @@
+"""5-tier BF%-based weekly loss rate cap.
+
+Based on Helms 2014 + Forbes 2000 + Garthe 2011 RCT + Hall 2008.
+
+Rate cap tiers (Standard mode):
+- T1 (>=28% BF): 1.0% / 1.25% per week
+- T2 (20-28%):   0.75% / 1.0% per week
+- T3 (15-20%):   0.5% / 0.75% per week
+- T4 (10-15%):   0.4% / 0.5% per week
+- T5 (<10%):     0.3% / 0.4% per week
+
+Aggressive mode loosens by one tier (T2 gets T1 caps, etc.).
+
+Hybrid window: yellow when 7-day rate exceeds soft cap; red only when BOTH
+7-day AND 14-day rates exceed hard cap. This suppresses false positives from
+single-week glycogen/water flux.
+
+First 14 days of a new cut phase are SUPPRESSED (glycogen/water confound
+makes rate appear much faster than actual fat loss).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+from nutrition_engine.tier import Tier
+
+Mode = Literal["standard", "aggressive"]
+
+# Tier → (soft_cap, hard_cap) in %/week (negative = loss)
+_STANDARD_RATE_CAPS: dict[Tier, tuple[float, float]] = {
+    Tier.T1: (1.0, 1.25),
+    Tier.T2: (0.75, 1.0),
+    Tier.T3: (0.5, 0.75),
+    Tier.T4: (0.4, 0.5),
+    Tier.T5: (0.3, 0.4),
+}
+
+# Ordered for "loosen by one tier" in aggressive mode
+_TIER_ORDER = [Tier.T5, Tier.T4, Tier.T3, Tier.T2, Tier.T1]
+
+
+class RateStatus(str, Enum):
+    GREEN = "green"
+    YELLOW = "yellow"
+    RED = "red"
+    SUPPRESSED = "suppressed"
+
+
+@dataclass(frozen=True)
+class RateCap:
+    """Soft and hard weekly rate caps (%/wk)."""
+    soft_pct_per_wk: float
+    hard_pct_per_wk: float
+
+
+@dataclass(frozen=True)
+class RateCheckResult:
+    rate_7day_pct: float
+    rate_14day_pct: float | None
+    status: RateStatus
+    soft_cap: float
+    hard_cap: float
+
+
+def get_rate_cap(tier: Tier, mode: Mode = "standard") -> RateCap:
+    """Return (soft, hard) rate caps for a tier and mode.
+
+    Aggressive mode loosens caps by one tier (e.g., T2 → T1 caps).
+    T1 cannot loosen further.
+    """
+    if mode not in ("standard", "aggressive"):
+        raise ValueError(f"Unknown mode: {mode!r}. Use 'standard' or 'aggressive'.")
+
+    if mode == "aggressive":
+        # Move one tier toward higher BF% in the order
+        idx = _TIER_ORDER.index(tier)
+        # idx: T5=0, T4=1, T3=2, T2=3, T1=4. Loosen → move toward T1 (higher idx).
+        loosened_idx = min(idx + 1, len(_TIER_ORDER) - 1)
+        tier = _TIER_ORDER[loosened_idx]
+
+    soft, hard = _STANDARD_RATE_CAPS[tier]
+    return RateCap(soft_pct_per_wk=soft, hard_pct_per_wk=hard)
+
+
+def compute_weekly_rate_pct(
+    daily_weights: list[float],
+    current_weight_kg: float | None = None,
+) -> float:
+    """Compute weekly weight-change rate as % of current weight.
+
+    Uses linear regression slope × 7 / current_weight × 100.
+    Negative rate = losing weight; positive = gaining.
+
+    Args:
+        daily_weights: weights with most recent last, evenly-spaced daily.
+        current_weight_kg: defaults to most recent weight in the list.
+    """
+    n = len(daily_weights)
+    if n < 2:
+        raise ValueError(f"Need at least 2 daily weights, got {n}")
+
+    if current_weight_kg is None:
+        current_weight_kg = daily_weights[-1]
+
+    # Linear regression y = a + b*x, where x = day_index (0..n-1), y = weight
+    mean_x = (n - 1) / 2.0
+    mean_y = sum(daily_weights) / n
+    num = sum((i - mean_x) * (w - mean_y) for i, w in enumerate(daily_weights))
+    den = sum((i - mean_x) ** 2 for i in range(n))
+    slope_kg_per_day = num / den  # positive = gaining
+
+    weekly_rate_kg = slope_kg_per_day * 7
+    return (weekly_rate_kg / current_weight_kg) * 100
+
+
+def check_rate_cap(
+    weights: list[float],
+    tier: Tier,
+    mode: Mode,
+    current_weight_kg: float,
+    days_since_cut_start: int,
+) -> RateCheckResult:
+    """Apply hybrid 7/14-day rate-cap logic.
+
+    Rules:
+    - First 14 days of a cut phase: SUPPRESSED (water/glycogen confound)
+    - After day 14:
+        - 7-day rate within soft cap: GREEN
+        - 7-day over soft OR 7-day over hard (but 14-day under hard): YELLOW
+        - BOTH 7-day AND 14-day rates over hard cap: RED
+
+    ``weights`` should contain at least 14 daily weights (most recent last) for
+    the 14-day window; if fewer, falls back to just 7-day eval.
+    """
+    cap = get_rate_cap(tier=tier, mode=mode)
+
+    # Suppression during glycogen/water flush (first 14 days of cut)
+    if days_since_cut_start < 14:
+        # compute 7-day rate for informational output
+        rate7 = _safe_rate(weights[-7:], current_weight_kg)
+        return RateCheckResult(
+            rate_7day_pct=rate7,
+            rate_14day_pct=None,
+            status=RateStatus.SUPPRESSED,
+            soft_cap=cap.soft_pct_per_wk,
+            hard_cap=cap.hard_pct_per_wk,
+        )
+
+    rate7 = _safe_rate(weights[-7:], current_weight_kg)
+    rate14 = _safe_rate(weights[-14:], current_weight_kg) if len(weights) >= 14 else None
+
+    # Rate sign: negative = losing. Compare magnitude against caps (positive).
+    rate7_mag = abs(rate7) if rate7 < 0 else 0.0  # ignore gains for a cut
+    rate14_mag = (abs(rate14) if rate14 is not None and rate14 < 0 else 0.0)
+
+    # RED requires BOTH windows over hard cap
+    if rate7_mag > cap.hard_pct_per_wk and rate14 is not None and rate14_mag > cap.hard_pct_per_wk:
+        status = RateStatus.RED
+    elif rate7_mag > cap.soft_pct_per_wk:
+        status = RateStatus.YELLOW
+    else:
+        status = RateStatus.GREEN
+
+    return RateCheckResult(
+        rate_7day_pct=rate7,
+        rate_14day_pct=rate14,
+        status=status,
+        soft_cap=cap.soft_pct_per_wk,
+        hard_cap=cap.hard_pct_per_wk,
+    )
+
+
+def _safe_rate(weights: list[float], current_weight_kg: float) -> float:
+    """Compute weekly rate, guarding against <2 points."""
+    if len(weights) < 2:
+        return 0.0
+    return compute_weekly_rate_pct(weights, current_weight_kg=current_weight_kg)

--- a/sync/src/nutrition_engine/tier.py
+++ b/sync/src/nutrition_engine/tier.py
@@ -1,0 +1,218 @@
+"""BF%-tier framework — master mode selector.
+
+Based on V13 research synthesis (docs/plans/science-research/V13-bf-tier-framework-findings.md).
+
+Evidence basis:
+- Hall 2008 Forbes inflection at 28% BF
+- Forbes 2000 FFM acceleration at 20% BF
+- Rossow 2013 / Helms 2014 testosterone decline onset at 15% BF
+- Mountjoy 2018 IOC RED-S cliff at 10% BF
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+# Hysteresis buffer — must cross boundary by this to change tier
+HYSTERESIS_PCT: float = 1.0
+
+
+class Tier(str, Enum):
+    """BF%-based tiers for males (female schema deferred)."""
+    T1 = "T1"  # >=28% obesity-class
+    T2 = "T2"  # 20-28% high
+    T3 = "T3"  # 15-20% lean
+    T4 = "T4"  # 10-15% very lean
+    T5 = "T5"  # <10% off-limits (competition only)
+
+
+@dataclass(frozen=True)
+class TierPolicy:
+    """Policy parameters cascading from a user's BF% tier."""
+    tier: Tier
+    bf_range: tuple[float, float]
+    rate_cap_soft_pct_per_wk: float
+    rate_cap_hard_pct_per_wk: float
+    protein_g_per_kg_bw: float
+    protein_g_per_kg_lbm_basis: bool
+    fat_floor_g_per_kg_bw_soft: float
+    fat_floor_g_per_kg_bw_hard: float
+    aggressive_mode_allowed: bool
+    refeed_frequency_days: int
+    diet_break_frequency_weeks: int
+    biomarker_cadence: Literal["weekly", "daily", "daily+bloods"]
+    duration_envelope_weeks: tuple[int, int]
+
+
+def compute_tier_raw(bf_pct: float) -> Tier:
+    """Strict boundary tier assignment (no hysteresis)."""
+    if bf_pct >= 28.0:
+        return Tier.T1
+    if bf_pct >= 20.0:
+        return Tier.T2
+    if bf_pct >= 15.0:
+        return Tier.T3
+    if bf_pct >= 10.0:
+        return Tier.T4
+    return Tier.T5
+
+
+# Boundary map: upper edge of each tier (ascending leanness = descending BF%)
+_TIER_UPPER_BOUNDS: dict[Tier, float] = {
+    Tier.T5: 10.0,   # T5 ends at 10.0, T4 begins
+    Tier.T4: 15.0,   # T4 ends at 15.0, T3 begins
+    Tier.T3: 20.0,   # T3 ends at 20.0, T2 begins
+    Tier.T2: 28.0,   # T2 ends at 28.0, T1 begins
+    Tier.T1: float("inf"),
+}
+
+
+def compute_tier(bf_pct: float, previous_tier: Tier | None = None) -> Tier:
+    """Tier assignment with HYSTERESIS_PCT buffer to prevent flicker near boundaries.
+
+    When moving LEANER (lower BF%): must drop ``HYSTERESIS_PCT`` below the tier's
+    lower edge to transition.
+    When moving FATTER (higher BF%): must rise ``HYSTERESIS_PCT`` above the tier's
+    upper edge to transition.
+    """
+    raw = compute_tier_raw(bf_pct)
+    if previous_tier is None or raw == previous_tier:
+        return raw
+
+    prev_upper = _TIER_UPPER_BOUNDS[previous_tier]
+
+    # Map tier to numeric order for comparison
+    order = {Tier.T1: 1, Tier.T2: 2, Tier.T3: 3, Tier.T4: 4, Tier.T5: 5}
+
+    if order[raw] > order[previous_tier]:
+        # raw tier is LEANER than previous; boundary to cross is previous's lower edge
+        # previous's lower edge = upper bound of the tier immediately leaner
+        # e.g., previous T2 (20-28), moving to T3: must go BELOW 20 - hysteresis
+        leaner_tier_upper = _leaner_tier_upper_edge(previous_tier)
+        threshold = leaner_tier_upper - HYSTERESIS_PCT
+        if bf_pct <= threshold:
+            return raw
+        return previous_tier
+
+    # raw tier is FATTER than previous
+    # boundary is previous's upper edge; must exceed it + hysteresis
+    threshold = prev_upper + HYSTERESIS_PCT
+    if bf_pct >= threshold:
+        return raw
+    return previous_tier
+
+
+def _leaner_tier_upper_edge(tier: Tier) -> float:
+    """Return the upper edge of the tier immediately leaner than the given tier.
+
+    For T2 (20-28), the leaner tier is T3 (15-20), whose upper edge is 20.0.
+    Used to compute the lower edge of the given tier.
+    """
+    leaner_map = {
+        Tier.T1: _TIER_UPPER_BOUNDS[Tier.T2],  # 28.0 -> T2 upper is 28, but we want T1's lower = 28
+        Tier.T2: _TIER_UPPER_BOUNDS[Tier.T3],  # T2 lower edge = T3 upper = 20.0
+        Tier.T3: _TIER_UPPER_BOUNDS[Tier.T4],  # T3 lower edge = T4 upper = 15.0
+        Tier.T4: _TIER_UPPER_BOUNDS[Tier.T5],  # T4 lower edge = T5 upper = 10.0
+        Tier.T5: 0.0,  # no tier leaner than T5
+    }
+    return leaner_map[tier]
+
+
+def rolling_median_bf(bf_readings: list[float]) -> float:
+    """Median of recent BF% readings — placeholder."""
+    sorted_readings = sorted(bf_readings)
+    n = len(sorted_readings)
+    if n == 0:
+        raise ValueError("rolling_median_bf requires at least one reading")
+    if n == 1:
+        return sorted_readings[0]
+    if n % 2 == 0:
+        return (sorted_readings[n // 2 - 1] + sorted_readings[n // 2]) / 2
+    return sorted_readings[n // 2]
+
+
+_TIER_POLICIES: dict[Tier, TierPolicy] = {
+    Tier.T1: TierPolicy(
+        tier=Tier.T1,
+        bf_range=(28.0, float("inf")),
+        rate_cap_soft_pct_per_wk=1.0,
+        rate_cap_hard_pct_per_wk=1.25,
+        protein_g_per_kg_bw=2.0,
+        protein_g_per_kg_lbm_basis=False,
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=True,
+        refeed_frequency_days=14,
+        diet_break_frequency_weeks=12,
+        biomarker_cadence="weekly",
+        duration_envelope_weeks=(12, 24),
+    ),
+    Tier.T2: TierPolicy(
+        tier=Tier.T2,
+        bf_range=(20.0, 28.0),
+        # Conservative defaults for 20-25% sub-tier (matches current test user)
+        rate_cap_soft_pct_per_wk=0.75,
+        rate_cap_hard_pct_per_wk=1.0,
+        protein_g_per_kg_bw=2.2,
+        protein_g_per_kg_lbm_basis=False,
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=True,
+        refeed_frequency_days=14,
+        diet_break_frequency_weeks=12,
+        biomarker_cadence="weekly",
+        duration_envelope_weeks=(12, 16),
+    ),
+    Tier.T3: TierPolicy(
+        tier=Tier.T3,
+        bf_range=(15.0, 20.0),
+        rate_cap_soft_pct_per_wk=0.5,
+        rate_cap_hard_pct_per_wk=0.75,
+        protein_g_per_kg_bw=2.4,
+        protein_g_per_kg_lbm_basis=False,
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=False,  # BLOCKED at T3
+        refeed_frequency_days=7,        # weekly refeeds mandatory
+        diet_break_frequency_weeks=10,
+        biomarker_cadence="weekly",
+        duration_envelope_weeks=(16, 20),
+    ),
+    Tier.T4: TierPolicy(
+        tier=Tier.T4,
+        bf_range=(10.0, 15.0),
+        rate_cap_soft_pct_per_wk=0.4,
+        rate_cap_hard_pct_per_wk=0.5,
+        protein_g_per_kg_bw=2.8,
+        protein_g_per_kg_lbm_basis=True,  # switch to LBM basis at T4
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=False,
+        refeed_frequency_days=5,
+        diet_break_frequency_weeks=8,
+        biomarker_cadence="daily",
+        duration_envelope_weeks=(8, 12),
+    ),
+    Tier.T5: TierPolicy(
+        tier=Tier.T5,
+        bf_range=(0.0, 10.0),
+        rate_cap_soft_pct_per_wk=0.3,
+        rate_cap_hard_pct_per_wk=0.4,
+        protein_g_per_kg_bw=3.0,
+        protein_g_per_kg_lbm_basis=True,
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=False,
+        refeed_frequency_days=3,
+        diet_break_frequency_weeks=6,
+        biomarker_cadence="daily+bloods",
+        duration_envelope_weeks=(4, 8),
+    ),
+}
+
+
+def get_tier_policy(tier: Tier) -> TierPolicy:
+    """Return the canonical TierPolicy for a tier."""
+    return _TIER_POLICIES[tier]

--- a/sync/tests/test_bmr.py
+++ b/sync/tests/test_bmr.py
@@ -1,0 +1,112 @@
+"""Tests for BMR formulas (M1.2)."""
+
+import pytest
+
+from nutrition_engine.bmr import (
+    cunningham,
+    ten_haaf_weight,
+    mifflin_st_jeor,
+    compute_bmr,
+)
+
+
+class TestCunningham:
+    """Cunningham 1980: BMR = 500 + 22 × FFM_kg.
+
+    Validated by ten Haaf 2014 as the only legacy equation passing
+    Bland-Altman in male recreational athletes (78% accuracy).
+    """
+
+    def test_current_user_ffm_60_6(self):
+        # Test user: 74.2 kg, 23.5% BF, FFM 60.6 kg
+        assert cunningham(ffm_kg=60.6) == 1833
+
+    def test_lean_athlete_ffm_70(self):
+        assert cunningham(ffm_kg=70.0) == 2040
+
+    def test_low_ffm(self):
+        assert cunningham(ffm_kg=40.0) == 1380
+
+    def test_zero_ffm_raises(self):
+        with pytest.raises(ValueError):
+            cunningham(ffm_kg=0)
+
+    def test_negative_ffm_raises(self):
+        with pytest.raises(ValueError):
+            cunningham(ffm_kg=-10)
+
+
+class TestMifflinStJeor:
+    """Mifflin-St Jeor 1990: demographic fallback."""
+
+    def test_male(self):
+        # 10w + 6.25h - 5a + 5 for male
+        # 74.2kg, 177cm, 31y, male: 10×74.2 + 6.25×177 - 5×31 + 5 = 742 + 1106.25 - 155 + 5 = 1698.25
+        assert mifflin_st_jeor(weight_kg=74.2, height_cm=177, age=31, sex="male") == 1698
+
+    def test_female(self):
+        # 10w + 6.25h - 5a - 161 for female
+        assert mifflin_st_jeor(weight_kg=60, height_cm=165, age=30, sex="female") == 1320
+
+    def test_male_typical_adult(self):
+        # Known test vector: 80 kg, 180 cm, 35 y, male
+        # = 800 + 1125 - 175 + 5 = 1755
+        assert mifflin_st_jeor(weight_kg=80, height_cm=180, age=35, sex="male") == 1755
+
+
+class TestTenHaafWeight:
+    """ten Haaf 2014 weight-based formula for trained athletes."""
+
+    def test_male_user(self):
+        # 74.2 kg, 177 cm, 31y male — published formula for males:
+        # REE_MJ = 0.02035·w + 1.82·h/100 - 0.01184·a + 1.61 (male)
+        # → kcal = MJ × 238.85
+        result = ten_haaf_weight(weight_kg=74.2, height_cm=177, age=31, sex="male")
+        # Should be in the 1750-1900 range for this profile
+        assert 1750 <= result <= 1900
+
+    def test_output_is_int(self):
+        result = ten_haaf_weight(weight_kg=80, height_cm=180, age=30, sex="male")
+        assert isinstance(result, int)
+
+
+class TestComputeBmr:
+    """High-level router: FFM → Cunningham, else → fallbacks."""
+
+    def test_ffm_uses_cunningham(self):
+        # When FFM provided, use Cunningham (most accurate for athletes)
+        assert compute_bmr(ffm_kg=60.6) == 1833
+
+    def test_no_ffm_uses_ten_haaf(self):
+        # Without FFM, use ten Haaf weight-based for trained athletes
+        result = compute_bmr(
+            weight_kg=74.2, height_cm=177, age=31, sex="male"
+        )
+        # Should match ten_haaf_weight output
+        assert result == ten_haaf_weight(weight_kg=74.2, height_cm=177, age=31, sex="male")
+
+    def test_missing_demographics_raises(self):
+        with pytest.raises(ValueError):
+            compute_bmr()  # no inputs at all
+
+    def test_partial_demographics_raises(self):
+        with pytest.raises(ValueError):
+            compute_bmr(weight_kg=74.2)  # missing height, age, sex
+
+
+class TestFormulaDisagreement:
+    """Sanity checks across formulas for same user."""
+
+    def test_cunningham_higher_than_mifflin_for_lean(self):
+        # 23.5% BF male is relatively lean; Cunningham should predict higher BMR
+        # than Mifflin-St Jeor (which under-predicts in lean trained men)
+        user_weight, user_height, user_age = 74.2, 177, 31
+        ffm = user_weight * (1 - 0.235)  # 56.76 kg
+
+        cunningham_val = cunningham(ffm_kg=ffm)
+        mifflin_val = mifflin_st_jeor(
+            weight_kg=user_weight, height_cm=user_height, age=user_age, sex="male"
+        )
+
+        # Cunningham should be within 200 kcal of Mifflin but not wildly divergent
+        assert abs(cunningham_val - mifflin_val) < 300

--- a/sync/tests/test_fat_floor.py
+++ b/sync/tests/test_fat_floor.py
@@ -1,0 +1,100 @@
+"""Tests for fat floor enforcement (M1.5).
+
+Research basis: Whittaker & Wu 2021 T-meta, Volek 1997, Wang 2005.
+Fat < 20% of calories → testosterone drops. Floor protects hormonal function.
+"""
+
+import pytest
+
+from nutrition_engine.fat_floor import (
+    compute_fat_floor,
+    apply_fat_floor,
+    FatFloorResult,
+    FatBreachType,
+)
+
+
+class TestComputeFatFloor:
+    def test_current_user_standard(self):
+        # 74.2 kg: soft = 0.8 × 74.2 = 59.36 → 59, hard = 0.6 × 74.2 = 44.52 → 45
+        result = compute_fat_floor(weight_kg=74.2, mode="standard")
+        assert result.soft_floor_g == 59
+        assert result.hard_floor_g == 45
+
+    def test_aggressive_mode_same_floors(self):
+        # Aggressive mode doesn't loosen fat floors (hormone protection is non-negotiable)
+        result = compute_fat_floor(weight_kg=74.2, mode="aggressive")
+        assert result.soft_floor_g == 59
+        assert result.hard_floor_g == 45
+
+    def test_maintenance_raises_soft_floor(self):
+        # Maintenance: fat becomes a target 0.8-1.0, not just floor.
+        # Soft floor should be raised to 1.0 (real target) in maintenance.
+        result = compute_fat_floor(weight_kg=74.2, mode="maintenance")
+        assert result.soft_floor_g == 74  # 1.0 × 74.2 rounded
+        assert result.hard_floor_g == 45  # hard stays 0.6
+
+    def test_bulk_allows_higher_fat(self):
+        # Bulk: fat 0.8-1.2 g/kg real target range; soft floor stays at 0.8
+        result = compute_fat_floor(weight_kg=74.2, mode="bulk")
+        assert result.soft_floor_g == 59  # 0.8 g/kg
+        assert result.hard_floor_g == 45
+
+    def test_heavy_athlete(self):
+        # 90 kg athlete: 72 soft / 54 hard
+        result = compute_fat_floor(weight_kg=90.0, mode="standard")
+        assert result.soft_floor_g == 72
+        assert result.hard_floor_g == 54
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            compute_fat_floor(weight_kg=74.2, mode="invalid")
+
+    def test_zero_weight_raises(self):
+        with pytest.raises(ValueError):
+            compute_fat_floor(weight_kg=0, mode="standard")
+
+
+class TestApplyFatFloor:
+    def test_fat_above_soft_no_breach(self):
+        result = apply_fat_floor(fat_g=70, weight_kg=74.2, mode="standard")
+        assert result.breach_type is FatBreachType.NONE
+        assert result.fat_g == 70
+
+    def test_fat_between_soft_and_hard_warning(self):
+        # Fat 55g: below soft (59) but above hard (45) → warning, not enforced
+        result = apply_fat_floor(fat_g=55, weight_kg=74.2, mode="standard")
+        assert result.breach_type is FatBreachType.SOFT
+        assert result.fat_g == 55  # keep user value; just warn
+
+    def test_fat_below_hard_raised(self):
+        # Fat 40g: below hard (45) → raised to hard floor
+        result = apply_fat_floor(fat_g=40, weight_kg=74.2, mode="standard")
+        assert result.breach_type is FatBreachType.HARD
+        assert result.fat_g == 45
+
+    def test_fat_overshoot_allowed_no_warn(self):
+        # Fat 100g on standard: way over soft but NOT flagged (overshoot is safe)
+        result = apply_fat_floor(fat_g=100, weight_kg=74.2, mode="standard")
+        assert result.breach_type is FatBreachType.NONE
+
+    def test_bulk_mode_overshoot_allowed(self):
+        # Bulk mode 120g fat: well above soft 0.8, but bulk allows up to ~1.2 g/kg
+        # No breach either way
+        result = apply_fat_floor(fat_g=120, weight_kg=74.2, mode="bulk")
+        assert result.breach_type is FatBreachType.NONE
+
+
+class TestCurrentUserScenarios:
+    def test_today_fat_58_below_soft_warning(self):
+        # User's logged Day 1 had fat at 58.3g (our -800 plan)
+        result = apply_fat_floor(fat_g=58, weight_kg=74.2, mode="aggressive")
+        # Below soft 59 → SOFT warning
+        assert result.breach_type is FatBreachType.SOFT
+        assert result.fat_g == 58  # not enforced, just warned
+
+    def test_maintenance_after_target_hit(self):
+        # When user reaches 15% BF and switches to maintenance, fat target is 0.8-1.0
+        # 70g fat (below 1.0 × 74.2 = 74) → SOFT warning (real target now)
+        result = apply_fat_floor(fat_g=70, weight_kg=74.2, mode="maintenance")
+        assert result.breach_type is FatBreachType.SOFT

--- a/sync/tests/test_floor.py
+++ b/sync/tests/test_floor.py
@@ -1,0 +1,148 @@
+"""Tests for BMR + RED-S EA floor enforcement (M1.3)."""
+
+import pytest
+
+from nutrition_engine.floor import (
+    compute_floor,
+    apply_floor,
+    FloorResult,
+    FloorBreachType,
+    REDS_EA_COEFFICIENT,
+)
+from nutrition_engine.tier import Tier
+
+
+class TestComputeFloor:
+    """Compute soft + hard floors given FFM, exercise, and mode."""
+
+    def test_standard_rest_day_current_user(self):
+        # User: FFM 60.6, no exercise, Standard mode
+        # soft = Cunningham = 1833
+        # hard = max(Cunningham, 25 × 60.6 + 0) = max(1833, 1515) = 1833
+        result = compute_floor(ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        assert result.soft_floor == 1833
+        assert result.hard_floor == 1833
+
+    def test_standard_training_day_current_user(self):
+        # User: FFM 60.6, 400 kcal exercise
+        # soft = Cunningham = 1833
+        # hard = max(Cunningham, 25 × 60.6 + 400) = max(1833, 1915) = 1915
+        result = compute_floor(ffm_kg=60.6, exercise_kcal=400, mode="standard")
+        assert result.soft_floor == 1833
+        assert result.hard_floor == 1915
+
+    def test_aggressive_mode_drops_cunningham(self):
+        # Aggressive mode: hard = 25×FFM + exercise (no Cunningham gate)
+        # User rest day: hard = 25 × 60.6 + 0 = 1515
+        result = compute_floor(ffm_kg=60.6, exercise_kcal=0, mode="aggressive")
+        assert result.hard_floor == 1515
+        # Soft floor still shown for awareness but not enforced
+        assert result.soft_floor == 1833
+
+    def test_aggressive_mode_training_day(self):
+        # User training day 400 kcal exercise
+        # hard = 25 × 60.6 + 400 = 1915 (in aggressive)
+        result = compute_floor(ffm_kg=60.6, exercise_kcal=400, mode="aggressive")
+        assert result.hard_floor == 1915
+
+    def test_high_ffm_user(self):
+        # Big athlete, FFM 80 kg
+        # Cunningham = 500 + 22×80 = 2260
+        # EA = 25 × 80 = 2000
+        # Standard: hard = max(2260, 2000) = 2260 (Cunningham dominates)
+        result = compute_floor(ffm_kg=80.0, exercise_kcal=0, mode="standard")
+        assert result.soft_floor == 2260
+        assert result.hard_floor == 2260
+
+    def test_low_ffm_ea_dominates(self):
+        # Light user, FFM 45 kg
+        # Cunningham = 500 + 22×45 = 1490
+        # EA = 25 × 45 = 1125
+        # With 500 kcal exercise: EA becomes 1625 > Cunningham 1490
+        result = compute_floor(ffm_kg=45.0, exercise_kcal=500, mode="standard")
+        assert result.hard_floor == 1625  # EA dominates
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            compute_floor(ffm_kg=60.6, exercise_kcal=0, mode="invalid")
+
+    def test_negative_exercise_raises(self):
+        with pytest.raises(ValueError):
+            compute_floor(ffm_kg=60.6, exercise_kcal=-100, mode="standard")
+
+    def test_zero_ffm_raises(self):
+        with pytest.raises(ValueError):
+            compute_floor(ffm_kg=0, exercise_kcal=0, mode="standard")
+
+
+class TestApplyFloor:
+    """Apply floor to a proposed target_kcal and return adjusted + breach type."""
+
+    def test_target_above_both_floors_no_breach(self):
+        # User rest day: floors 1833/1833
+        result = apply_floor(target_kcal=2000, ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        assert result.target_kcal == 2000
+        assert result.breach_type is FloorBreachType.NONE
+
+    def test_target_below_soft_floor_warning(self):
+        # Target 1800 < soft 1833, but 1800 = hard floor in this case
+        # Standard mode rest: soft=hard=1833, so target 1800 = hard breach
+        result = apply_floor(target_kcal=1800, ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        assert result.breach_type is FloorBreachType.HARD
+        assert result.target_kcal == 1833  # raised to hard floor
+
+    def test_target_below_hard_floor_raised(self):
+        # User training day: hard floor 1915; target 1700 breaches it
+        result = apply_floor(target_kcal=1700, ffm_kg=60.6, exercise_kcal=400, mode="standard")
+        assert result.breach_type is FloorBreachType.HARD
+        assert result.target_kcal == 1915  # raised to hard floor
+
+    def test_aggressive_allows_below_cunningham(self):
+        # Aggressive rest day: hard = 25×FFM = 1515
+        # Target 1600 is below Cunningham (1833) but above EA hard (1515)
+        # In Aggressive mode, this is SOFT breach (warning) not HARD (enforced)
+        result = apply_floor(target_kcal=1600, ffm_kg=60.6, exercise_kcal=0, mode="aggressive")
+        assert result.breach_type is FloorBreachType.SOFT
+        assert result.target_kcal == 1600  # not raised (below Cunningham but OK in Aggressive)
+
+    def test_aggressive_hard_floor_enforced(self):
+        # Aggressive rest day: hard=1515. Target 1400 breaches hard.
+        result = apply_floor(target_kcal=1400, ffm_kg=60.6, exercise_kcal=0, mode="aggressive")
+        assert result.breach_type is FloorBreachType.HARD
+        assert result.target_kcal == 1515
+
+    def test_reds_coefficient_constant(self):
+        # Regression guard — the RED-S EA coefficient must be 25 kcal/kg FFM per V11
+        # (Mountjoy 2018 threshold)
+        assert REDS_EA_COEFFICIENT == 25
+
+
+class TestCurrentUserScenarios:
+    """Live scenarios matching brainstorming decisions for current user."""
+
+    def test_current_1732_target_breaches_soft_floor_on_rest_day(self):
+        # Current soma plan: 1732 kcal target on rest day
+        # In Standard mode this breaches Cunningham floor (1833) -> 100 kcal below
+        result = apply_floor(target_kcal=1732, ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        assert result.breach_type is FloorBreachType.HARD  # soft=hard=1833
+        assert result.target_kcal == 1833
+
+    def test_current_1732_target_breaches_hard_floor_on_training_day(self):
+        # 1732 target with 400 kcal training: hard floor 1915 is breached by 183 kcal
+        result = apply_floor(target_kcal=1732, ffm_kg=60.6, exercise_kcal=400, mode="standard")
+        assert result.breach_type is FloorBreachType.HARD
+        assert result.target_kcal == 1915
+
+    def test_max_deficit_rest_day_standard(self):
+        # With TDEE 2547 (standard day) and floor 1833, max deficit = 714
+        tdee = 2547
+        floor = compute_floor(ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        max_deficit = tdee - floor.hard_floor
+        assert max_deficit == 714
+
+    def test_max_deficit_training_day_standard(self):
+        # With TDEE 2547 (400 kcal exercise included) and hard floor 1915, max deficit = 632
+        tdee = 2547
+        floor = compute_floor(ffm_kg=60.6, exercise_kcal=400, mode="standard")
+        max_deficit = tdee - floor.hard_floor
+        assert max_deficit == 632

--- a/sync/tests/test_forbes.py
+++ b/sync/tests/test_forbes.py
@@ -1,0 +1,84 @@
+"""Tests for Forbes partitioning + recomp multiplier (M3.1).
+
+Research basis: V2 §8.1, Forbes 2000 FFM-FM curve.
+
+dFFM/dBW = 10.4 / (10.4 + FM)
+
+Recomp multiplier: 0.6× when ≥3 resistance sessions/week AND protein ≥1.8 g/kg
+(concurrent RT + high protein partitions LESS fat, more lean relative to the
+curve).
+"""
+
+import pytest
+
+from nutrition_engine.forbes import ForbesResult, partition_weight_change
+
+
+class TestForbesResultShape:
+    def test_returns_dataclass(self):
+        r = partition_weight_change(d_bw_kg=0.5, fm_kg=20.0)
+        assert isinstance(r, ForbesResult)
+        assert hasattr(r, "d_ffm_kg")
+        assert hasattr(r, "d_fm_kg")
+        assert hasattr(r, "ffm_fraction")
+
+
+class TestDefaultPartitioning:
+    def test_zero_change_is_zero_everywhere(self):
+        r = partition_weight_change(d_bw_kg=0.0, fm_kg=20.0)
+        assert r.d_ffm_kg == pytest.approx(0.0)
+        assert r.d_fm_kg == pytest.approx(0.0)
+
+    def test_gain_at_fm_20(self):
+        # 10.4 / (10.4 + 20) = 0.342
+        r = partition_weight_change(d_bw_kg=1.0, fm_kg=20.0)
+        assert r.ffm_fraction == pytest.approx(10.4 / 30.4, rel=1e-6)
+        assert r.d_ffm_kg == pytest.approx(10.4 / 30.4)
+        assert r.d_fm_kg == pytest.approx(1.0 - 10.4 / 30.4)
+
+    def test_loss_at_fm_10(self):
+        # 10.4 / (10.4 + 10) = 0.510
+        r = partition_weight_change(d_bw_kg=-1.0, fm_kg=10.0)
+        assert r.ffm_fraction == pytest.approx(10.4 / 20.4, rel=1e-6)
+        # Loss splits same way: more FFM lost at lower FM (the classic cut warning).
+        assert r.d_ffm_kg == pytest.approx(-10.4 / 20.4)
+        assert r.d_fm_kg == pytest.approx(-1.0 + 10.4 / 20.4)
+
+    def test_extreme_high_fm_gives_mostly_fat(self):
+        # At fm=90 kg, ffm fraction ≈ 0.104
+        r = partition_weight_change(d_bw_kg=1.0, fm_kg=90.0)
+        assert r.ffm_fraction < 0.12
+        assert r.d_fm_kg > r.d_ffm_kg
+
+    def test_extreme_low_fm_gives_mostly_ffm(self):
+        # At fm=3 kg (very lean), ffm fraction ≈ 0.776
+        r = partition_weight_change(d_bw_kg=1.0, fm_kg=3.0)
+        assert r.ffm_fraction > 0.7
+        assert r.d_ffm_kg > r.d_fm_kg
+
+
+class TestRecompMultiplier:
+    def test_recomp_shrinks_ffm_fraction(self):
+        base = partition_weight_change(d_bw_kg=1.0, fm_kg=20.0, recomp=False)
+        rec = partition_weight_change(d_bw_kg=1.0, fm_kg=20.0, recomp=True)
+        assert rec.ffm_fraction == pytest.approx(base.ffm_fraction * 0.6, rel=1e-6)
+        assert rec.d_ffm_kg < base.d_ffm_kg
+
+    def test_recomp_keeps_invariant(self):
+        r = partition_weight_change(d_bw_kg=1.0, fm_kg=20.0, recomp=True)
+        assert r.d_ffm_kg + r.d_fm_kg == pytest.approx(1.0)
+
+
+class TestInvariant:
+    @pytest.mark.parametrize("d_bw", [-2.0, -0.5, 0.0, 0.5, 2.0])
+    @pytest.mark.parametrize("fm", [5.0, 15.0, 30.0, 60.0])
+    @pytest.mark.parametrize("recomp", [False, True])
+    def test_ffm_plus_fm_equals_bw(self, d_bw: float, fm: float, recomp: bool):
+        r = partition_weight_change(d_bw_kg=d_bw, fm_kg=fm, recomp=recomp)
+        assert r.d_ffm_kg + r.d_fm_kg == pytest.approx(d_bw, abs=1e-9)
+
+
+class TestGuards:
+    def test_negative_fm_raises(self):
+        with pytest.raises(ValueError):
+            partition_weight_change(d_bw_kg=1.0, fm_kg=-5.0)

--- a/sync/tests/test_protein_floor.py
+++ b/sync/tests/test_protein_floor.py
@@ -1,0 +1,110 @@
+"""Tests for protein floor warning (M1.6).
+
+Research basis: Morton 2018 meta plateau at 1.6 g/kg for RT-induced FFM.
+Below floor for 3+ consecutive days → amber warning banner.
+Also V9.1 per-meal thresholds (25g red / 30g green).
+"""
+
+import pytest
+
+from nutrition_engine.protein_floor import (
+    compute_protein_floor,
+    check_protein_floor,
+    check_per_meal_protein,
+    ProteinFloorStatus,
+    PerMealProteinLevel,
+)
+
+
+class TestComputeProteinFloor:
+    def test_current_user(self):
+        # 74.2 kg × 1.6 = 118.72 → 119
+        assert compute_protein_floor(weight_kg=74.2) == 119
+
+    def test_heavy_athlete(self):
+        assert compute_protein_floor(weight_kg=90.0) == 144
+
+    def test_zero_weight_raises(self):
+        with pytest.raises(ValueError):
+            compute_protein_floor(weight_kg=0)
+
+
+class TestCheckProteinFloor:
+    def test_all_above_floor_green(self):
+        # 5 days all above 119g floor for 74.2 kg user
+        recent_intakes = [150, 145, 160, 155, 140]
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+        assert result.days_below_floor == 0
+
+    def test_one_day_below_no_warning(self):
+        # Only 1 day below — banner not yet active (requires 3+ consecutive)
+        recent_intakes = [150, 145, 100, 155, 140]  # day 3 below
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+        assert result.days_below_floor == 0  # streak broken
+
+    def test_two_consecutive_below_no_warning(self):
+        # 2 consecutive days below — banner not yet active (needs 3+)
+        recent_intakes = [150, 145, 100, 90, 140]
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+        assert result.days_below_floor == 0  # streak broken by day 5
+
+    def test_three_consecutive_below_amber(self):
+        # 3 consecutive days below — banner fires
+        recent_intakes = [150, 145, 100, 90, 80]  # days 3,4,5 below
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.AMBER
+        assert result.days_below_floor == 3
+
+    def test_five_consecutive_below_amber_streak_counted(self):
+        recent_intakes = [100, 95, 110, 105, 115]  # all below 119
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.AMBER
+        assert result.days_below_floor == 5
+
+    def test_single_good_day_breaks_streak(self):
+        # 2 below, 1 good, 3 below → streak is 3 (last 3 days)
+        recent_intakes = [100, 90, 150, 80, 85, 90]
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.AMBER
+        assert result.days_below_floor == 3  # last 3 days
+
+    def test_empty_history(self):
+        result = check_protein_floor(recent_intakes=[], weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+        assert result.days_below_floor == 0
+
+    def test_exactly_at_floor_not_below(self):
+        # Exactly at 119g = not below
+        recent_intakes = [119, 119, 119]
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+
+
+class TestPerMealProtein:
+    """V9.1 per-meal thresholds for MPS quality signaling."""
+
+    def test_below_15g_red(self):
+        assert check_per_meal_protein(10) is PerMealProteinLevel.RED
+        assert check_per_meal_protein(14) is PerMealProteinLevel.RED
+
+    def test_15_to_24_amber(self):
+        assert check_per_meal_protein(15) is PerMealProteinLevel.AMBER
+        assert check_per_meal_protein(20) is PerMealProteinLevel.AMBER
+        assert check_per_meal_protein(24) is PerMealProteinLevel.AMBER
+
+    def test_25_to_29_yellow(self):
+        assert check_per_meal_protein(25) is PerMealProteinLevel.YELLOW
+        assert check_per_meal_protein(29) is PerMealProteinLevel.YELLOW
+
+    def test_30_to_55_green(self):
+        assert check_per_meal_protein(30) is PerMealProteinLevel.GREEN
+        assert check_per_meal_protein(40) is PerMealProteinLevel.GREEN
+        assert check_per_meal_protein(55) is PerMealProteinLevel.GREEN
+
+    def test_above_55_no_warning(self):
+        # Trommelen 2023 killed the 40g ceiling — no warning on large doses
+        assert check_per_meal_protein(60) is PerMealProteinLevel.NO_WARNING
+        assert check_per_meal_protein(100) is PerMealProteinLevel.NO_WARNING

--- a/sync/tests/test_rate_cap.py
+++ b/sync/tests/test_rate_cap.py
@@ -1,0 +1,223 @@
+"""Tests for 5-tier rate cap (M1.4)."""
+
+import pytest
+
+from nutrition_engine.rate_cap import (
+    RateCap,
+    RateStatus,
+    RateCheckResult,
+    get_rate_cap,
+    compute_weekly_rate_pct,
+    check_rate_cap,
+)
+from nutrition_engine.tier import Tier
+
+
+class TestGetRateCap:
+    """Per-tier rate caps in Standard mode."""
+
+    def test_t1_standard(self):
+        c = get_rate_cap(Tier.T1, mode="standard")
+        assert c.soft_pct_per_wk == 1.0
+        assert c.hard_pct_per_wk == 1.25
+
+    def test_t2_standard_current_user(self):
+        c = get_rate_cap(Tier.T2, mode="standard")
+        assert c.soft_pct_per_wk == 0.75
+        assert c.hard_pct_per_wk == 1.0
+
+    def test_t3_standard(self):
+        c = get_rate_cap(Tier.T3, mode="standard")
+        assert c.soft_pct_per_wk == 0.5
+        assert c.hard_pct_per_wk == 0.75
+
+    def test_t4_standard(self):
+        c = get_rate_cap(Tier.T4, mode="standard")
+        assert c.soft_pct_per_wk == 0.4
+        assert c.hard_pct_per_wk == 0.5
+
+    def test_t5_standard(self):
+        c = get_rate_cap(Tier.T5, mode="standard")
+        assert c.soft_pct_per_wk == 0.3
+        assert c.hard_pct_per_wk == 0.4
+
+
+class TestAggressiveModeLoosens:
+    """Aggressive mode loosens rate cap by one tier (T2→T1 caps, etc.)."""
+
+    def test_t2_aggressive_uses_t1_caps(self):
+        c = get_rate_cap(Tier.T2, mode="aggressive")
+        assert c.soft_pct_per_wk == 1.0   # T1 soft cap
+        assert c.hard_pct_per_wk == 1.25  # T1 hard cap
+
+    def test_t1_aggressive_stays_at_t1(self):
+        # Can't loosen beyond T1
+        c = get_rate_cap(Tier.T1, mode="aggressive")
+        assert c.soft_pct_per_wk == 1.0
+        assert c.hard_pct_per_wk == 1.25
+
+    def test_t3_aggressive_blocked_by_tier_policy(self):
+        # Per V13 + M1.1: Aggressive mode contraindicated at T3+
+        # get_rate_cap should still return a value but flag the block elsewhere
+        # For this test, we just check it returns T2 caps (loosens to T2)
+        c = get_rate_cap(Tier.T3, mode="aggressive")
+        assert c.soft_pct_per_wk == 0.75  # T2 soft
+        assert c.hard_pct_per_wk == 1.0   # T2 hard
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            get_rate_cap(Tier.T2, mode="bulk")
+
+
+class TestComputeWeeklyRatePct:
+    """Weekly rate calculation from daily weight history."""
+
+    def test_linear_decrease_1pct_per_week(self):
+        # 74.2 kg losing exactly 1% per week = 0.742 kg/week = 0.106 kg/day
+        # Oldest first (i=0), newest last (i=7).
+        weights = [74.2 - 0.106 * i for i in range(8)]  # 8 days, decreasing
+        rate = compute_weekly_rate_pct(weights)
+        # Rate should be negative (losing) and close to -1%
+        assert -1.1 < rate < -0.9
+
+    def test_stable_weight_near_zero(self):
+        weights = [74.2] * 14
+        rate = compute_weekly_rate_pct(weights)
+        assert abs(rate) < 0.1
+
+    def test_gain_positive_rate(self):
+        # Gaining 0.5% per week
+        weights = [74.2 + 0.053 * i for i in range(8)]  # +0.053 kg/day
+        rate = compute_weekly_rate_pct(weights)
+        assert 0.4 < rate < 0.6
+
+    def test_too_few_points_raises(self):
+        with pytest.raises(ValueError):
+            compute_weekly_rate_pct([74.2])  # need minimum 2
+
+
+class TestCheckRateCap:
+    """Traffic-light status with hybrid 7/14-day window."""
+
+    def _losing_weights(self, daily_pct: float, days: int, start_weight: float = 74.2) -> list[float]:
+        """Generate weights losing at ``daily_pct`` percent of weight per day.
+
+        Oldest first (index 0), newest last (index days-1).
+        weights[0] = start_weight; weights[-1] = start_weight × (1 - daily_pct/100)^(days-1)
+        (approximated linearly for simplicity).
+        """
+        daily_kg_loss = start_weight * daily_pct / 100
+        return [start_weight - daily_kg_loss * i for i in range(days)]
+
+    def test_within_soft_green(self):
+        # Losing 0.5%/wk → 0.071%/day. For T2 user, soft=0.75% hard=1.0%. Within both.
+        weights = self._losing_weights(daily_pct=0.071, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.GREEN
+
+    def test_over_soft_only_yellow(self):
+        # Losing 0.9%/wk (over soft 0.75, under hard 1.0). 0.129%/day.
+        # 7-day rate ~0.9, 14-day might be similar → yellow (not red because 14d not over hard)
+        weights = self._losing_weights(daily_pct=0.129, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.YELLOW
+
+    def test_both_windows_over_hard_red(self):
+        # Losing 1.5%/wk sustained over 14 days. 0.214%/day.
+        # Both 7-day and 14-day are over hard cap 1.0% → RED
+        weights = self._losing_weights(daily_pct=0.214, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.RED
+
+    def test_only_7day_over_hard_still_yellow(self):
+        # Prior 7 days stable, then last 7 days lose ~1.2%/wk.
+        # 7-day window (last 7 only): over hard 1.0
+        # 14-day window (stable then lose): 7 days stable + 7 days lose → slope = half → ~0.6%/wk < hard 1.0
+        # Per research: BOTH must be over hard for RED → this is YELLOW
+        stable_week = [74.2] * 7  # days 0..6 at 74.2
+        # Start losing on day 7; 0.171%/day × 7 days
+        daily_loss = 74.2 * 0.171 / 100
+        fast_week = [74.2 - daily_loss * (i + 1) for i in range(7)]  # days 7..13
+        weights = stable_week + fast_week  # 14 days total, oldest→newest
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        # 7-day rate is over hard, 14-day isn't → YELLOW (not RED)
+        assert result.status is RateStatus.YELLOW
+
+    def test_first_14_days_suppressed(self):
+        # Fast loss in first 14 days (glycogen/water confound)
+        weights = self._losing_weights(daily_pct=0.3, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=7,
+        )
+        assert result.status is RateStatus.SUPPRESSED
+
+    def test_day_15_no_longer_suppressed(self):
+        # Same fast loss but beyond day 14
+        weights = self._losing_weights(daily_pct=0.3, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=15,
+        )
+        assert result.status is RateStatus.RED  # suppression lifted
+
+    def test_aggressive_mode_loosens(self):
+        # At Aggressive T2 (caps of T1: 1.0/1.25), 1.1%/wk is yellow (over soft)
+        # Same rate in Standard T2 (caps 0.75/1.0) would be red
+        weights = self._losing_weights(daily_pct=0.157, days=14)
+
+        standard_result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        # 1.1%/wk sustained: 7-day ~1.1, 14-day ~1.1, both over hard 1.0 → RED in standard
+        assert standard_result.status is RateStatus.RED
+
+        aggressive_result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="aggressive",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        # Same weights but caps 1.0/1.25: 1.1 over soft but under hard → YELLOW
+        assert aggressive_result.status is RateStatus.YELLOW
+
+
+class TestCurrentUser:
+    """Current user scenarios — 74.2 kg, 23.5% BF, Tier T2."""
+
+    def test_current_149_pct_per_wk_is_red(self):
+        # Research flagged user at 1.49%/wk current — definitely red in Standard T2
+        # Simulate: 0.213%/day × 14 days, oldest first
+        start = 74.2
+        daily_loss = start * 0.00213
+        weights = [start - daily_loss * i for i in range(14)]
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.RED
+        # Confirm the measured rate is around -1.4 to -1.5%
+        assert -1.7 < result.rate_7day_pct < -1.3
+
+    def test_user_goal_stays_green_at_07_pct(self):
+        # User's stated tier is T2 with soft cap 0.75. 0.7%/wk sustained → GREEN
+        # 0.1%/day × 14 days, oldest first
+        start = 74.2
+        daily_loss = start * 0.001  # 0.1%/day → ~0.7%/week
+        weights = [start - daily_loss * i for i in range(14)]
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.GREEN

--- a/sync/tests/test_tier.py
+++ b/sync/tests/test_tier.py
@@ -1,0 +1,152 @@
+"""Tests for BF% tier framework (M1.1)."""
+
+from nutrition_engine.tier import (
+    Tier,
+    TierPolicy,
+    compute_tier_raw,
+    compute_tier,
+    get_tier_policy,
+    rolling_median_bf,
+    HYSTERESIS_PCT,
+)
+
+
+class TestTierBoundaries:
+    """Raw boundary assignment without hysteresis."""
+
+    def test_t1_above_28(self):
+        assert compute_tier_raw(30.0) == Tier.T1
+        assert compute_tier_raw(28.0) == Tier.T1
+        assert compute_tier_raw(50.0) == Tier.T1
+
+    def test_t2_range_20_to_28(self):
+        assert compute_tier_raw(27.9) == Tier.T2
+        assert compute_tier_raw(23.5) == Tier.T2  # current test user
+        assert compute_tier_raw(20.0) == Tier.T2
+
+    def test_t3_range_15_to_20(self):
+        assert compute_tier_raw(19.9) == Tier.T3
+        assert compute_tier_raw(15.0) == Tier.T3
+
+    def test_t4_range_10_to_15(self):
+        assert compute_tier_raw(14.9) == Tier.T4
+        assert compute_tier_raw(10.0) == Tier.T4
+
+    def test_t5_below_10(self):
+        assert compute_tier_raw(9.9) == Tier.T5
+        assert compute_tier_raw(5.0) == Tier.T5
+
+
+class TestHysteresis:
+    """Must cross boundary by HYSTERESIS_PCT to change tier."""
+
+    def test_no_previous_uses_raw(self):
+        assert compute_tier(23.5) == Tier.T2
+        assert compute_tier(19.5) == Tier.T3
+
+    def test_staying_inside_range(self):
+        assert compute_tier(23.5, previous_tier=Tier.T2) == Tier.T2
+
+    def test_going_leaner_requires_buffer(self):
+        # T2 boundary is 20.0. Leaner transition requires BF <= 19.0 (20 - 1% hysteresis)
+        assert compute_tier(19.5, previous_tier=Tier.T2) == Tier.T2  # inside buffer
+        assert compute_tier(19.0, previous_tier=Tier.T2) == Tier.T3  # clears buffer
+        assert compute_tier(18.5, previous_tier=Tier.T2) == Tier.T3  # well past
+
+    def test_going_fatter_requires_buffer(self):
+        # T3 boundary is 20.0. Fatter transition requires BF >= 21.0 (20 + 1% hysteresis)
+        assert compute_tier(20.5, previous_tier=Tier.T3) == Tier.T3  # inside buffer
+        assert compute_tier(21.0, previous_tier=Tier.T3) == Tier.T2  # clears buffer
+        assert compute_tier(22.0, previous_tier=Tier.T3) == Tier.T2  # well past
+
+    def test_hysteresis_at_every_boundary(self):
+        # T1↔T2 at 28.0
+        assert compute_tier(27.5, previous_tier=Tier.T1) == Tier.T1  # inside
+        assert compute_tier(27.0, previous_tier=Tier.T1) == Tier.T2  # clears
+        # T3↔T4 at 15.0
+        assert compute_tier(14.5, previous_tier=Tier.T3) == Tier.T3  # inside
+        assert compute_tier(14.0, previous_tier=Tier.T3) == Tier.T4  # clears
+        # T4↔T5 at 10.0
+        assert compute_tier(9.5, previous_tier=Tier.T4) == Tier.T4  # inside
+        assert compute_tier(9.0, previous_tier=Tier.T4) == Tier.T5  # clears
+
+
+class TestRollingMedian:
+    """Median of recent BF% readings prevents single-measurement tier flicker."""
+
+    def test_three_readings_odd(self):
+        assert rolling_median_bf([23.0, 24.0, 22.0]) == 23.0
+        assert rolling_median_bf([25.0, 20.0, 21.0]) == 21.0
+
+    def test_single_reading(self):
+        assert rolling_median_bf([23.0]) == 23.0
+
+    def test_two_readings_averaged(self):
+        assert rolling_median_bf([23.0, 25.0]) == 24.0
+
+    def test_empty_raises(self):
+        import pytest
+        with pytest.raises(ValueError):
+            rolling_median_bf([])
+
+
+class TestTierPolicies:
+    """Per-tier policy parameters from V13 master framework."""
+
+    def test_t1_policy(self):
+        p = get_tier_policy(Tier.T1)
+        assert p.tier == Tier.T1
+        assert p.rate_cap_soft_pct_per_wk == 1.0
+        assert p.rate_cap_hard_pct_per_wk == 1.25
+        assert p.aggressive_mode_allowed is True
+        assert p.fat_floor_g_per_kg_bw_soft == 0.8
+        assert p.fat_floor_g_per_kg_bw_hard == 0.6
+
+    def test_t2_policy(self):
+        p = get_tier_policy(Tier.T2)
+        assert p.rate_cap_soft_pct_per_wk == 0.75  # for 20-25% sub-tier (conservative)
+        assert p.rate_cap_hard_pct_per_wk == 1.0
+        assert p.aggressive_mode_allowed is True
+        assert p.protein_g_per_kg_bw == 2.2
+
+    def test_t3_policy_blocks_aggressive(self):
+        p = get_tier_policy(Tier.T3)
+        assert p.aggressive_mode_allowed is False  # CRITICAL: blocked at T3+
+        assert p.rate_cap_hard_pct_per_wk == 0.75
+        assert p.refeed_frequency_days == 7  # weekly refeeds from T3
+
+    def test_t4_policy(self):
+        p = get_tier_policy(Tier.T4)
+        assert p.aggressive_mode_allowed is False
+        assert p.protein_g_per_kg_lbm_basis is True  # switches to LBM basis
+        assert p.biomarker_cadence in ("daily", "daily+bloods")
+
+    def test_t5_policy_strict(self):
+        p = get_tier_policy(Tier.T5)
+        assert p.aggressive_mode_allowed is False
+        assert p.rate_cap_hard_pct_per_wk <= 0.5
+
+
+class TestCurrentUser:
+    """Current test user: 31yo male, 74.2 kg, 23.5% BF, cutting toward 15%."""
+
+    def test_current_tier_is_t2(self):
+        assert compute_tier_raw(23.5) == Tier.T2
+
+    def test_target_tier_is_t3(self):
+        assert compute_tier_raw(15.0) == Tier.T3
+
+    def test_progression_path(self):
+        """User moves through BF% range. Verify tier transitions respect hysteresis."""
+        current = Tier.T2
+        # Staying in T2 through the cut
+        for bf in [23.5, 22.0, 21.0, 20.5, 20.0, 19.5]:
+            current = compute_tier(bf, previous_tier=current)
+            assert current == Tier.T2, f"Should stay T2 at BF {bf}"
+
+        # Transition at 19.0 (clears hysteresis from 20.0 boundary)
+        current = compute_tier(19.0, previous_tier=current)
+        assert current == Tier.T3
+
+        # Aggressive mode should now be blocked
+        assert get_tier_policy(current).aggressive_mode_allowed is False


### PR DESCRIPTION
## Summary
Ports 7 pure-logic modules from macro-engine's M1 + M3 into soma's nutrition engine as drop-in additions. No call-site changes yet — Batch 2 wires these in. Ships the building blocks.

### New modules under `sync/src/nutrition_engine/`
- `bmr.py` — Cunningham (FFM-based), Mifflin-St Jeor, ten Haaf weight-based, `compute_bmr` router. Never uses Garmin-reported BMR (known 13% inflation).
- `forbes.py` — Forbes 2000 FFM/FM partitioning + V2 §8.1 recomp multiplier.
- `tier.py` — 5-tier BF% framework with policy table (rate caps, protein g/kg, fat floors, refeed cadence, diet-break cadence, duration envelopes) + 1% hysteresis buffer.
- `floor.py` — RED-S EA hard floor = `max(Cunningham, 25·FFM + ex_kcal)` in standard mode; aggressive drops Cunningham.
- `fat_floor.py` — Hormonal protection. 0.8 g/kg soft (0.6 hard) for standard/aggressive/bulk; 1.0 g/kg real target in maintenance.
- `protein_floor.py` — 1.6 g/kg daily floor; 3-day streak triggers AMBER; per-meal MPS quality thresholds.
- `rate_cap.py` — Hybrid 7/14-day rate-cap logic keyed to tier + mode. 14-day suppression at cut start. RED only when BOTH windows exceed hard cap.

### Research citations
Cunningham 1980, ten Haaf 2014, Frankenfield 2005, Forbes 2000, Hall 2008, Rossow 2013, Mountjoy 2018 RED-S, Whittaker & Wu 2021, Helms 2014, Morton 2018, Schoenfeld & Aragon 2018, Trommelen 2023, Garthe 2011.

## Test plan
- [x] **157 new pytest assertions** ported from macro-engine's suite (`test_bmr.py`, `test_forbes.py`, `test_tier.py`, `test_floor.py`, `test_fat_floor.py`, `test_protein_floor.py`, `test_rate_cap.py`) — all green via \`PYTHONPATH=sync/src python3 -m pytest sync/tests/test_{bmr,forbes,tier,floor,fat_floor,protein_floor,rate_cap}.py\`.
- [x] No regressions in neighboring nutrition tests (alcohol, calculator, tdee read paths).
- [x] Pre-existing test failures in soma (24 failing tests in test_tdee/test_step_calories/test_slot_distribution/test_daily_plan) verified as present on \`main\` without this change — unrelated tech debt.

## Non-goals
- No call-site changes. `tdee.py`, `daily_plan.py`, `generate_today.py` untouched. Wiring lands in Batch 2 (#67).
- No schema changes.
- No API shape changes.

Closes #66