### PR TITLE
feat(nutrition): Batch 2 — macro targets matrix + mode engine wiring

### DIFF
--- a/sync/migrations/006_nutrition_deficit_mode.sql
+++ b/sync/migrations/006_nutrition_deficit_mode.sql
@@ -1,0 +1,15 @@
+-- Nutrition Batch 2: add deficit_mode column for the M2 mode engine.
+-- Default 'standard' preserves current behaviour for existing rows.
+
+ALTER TABLE nutrition_profile
+    ADD COLUMN IF NOT EXISTS deficit_mode text NOT NULL DEFAULT 'standard';
+
+-- CHECK constraint matches macro-engine's Mode enum.
+ALTER TABLE nutrition_profile
+    DROP CONSTRAINT IF EXISTS nutrition_profile_deficit_mode_check;
+
+ALTER TABLE nutrition_profile
+    ADD CONSTRAINT nutrition_profile_deficit_mode_check
+    CHECK (deficit_mode IN (
+        'standard', 'aggressive', 'reverse', 'maintenance', 'bulk', 'injured'
+    ));

--- a/sync/src/nutrition_engine/generate_today.py
+++ b/sync/src/nutrition_engine/generate_today.py
@@ -147,7 +147,8 @@ def generate_today() -> None:
         cur.execute(
             "SELECT target_calories, weight_kg, goal, daily_deficit,"
             " estimated_ffm_kg, protein_g_per_kg, fat_g_per_kg,"
-            " estimated_bf_pct, target_bf_pct, target_date, age, sex, step_goal"
+            " estimated_bf_pct, target_bf_pct, target_date, age, sex, step_goal,"
+            " deficit_mode"
             " FROM nutrition_profile WHERE id = 1"
         )
         profile = cur.fetchone()
@@ -161,6 +162,7 @@ def generate_today() -> None:
             profile_ffm_kg, profile_protein_g_per_kg, profile_fat_g_per_kg,
             profile_bf_pct, profile_target_bf_pct, profile_target_date,
             profile_age, profile_sex, profile_step_goal,
+            profile_deficit_mode,
         ) = profile
 
         age = int(profile_age) if profile_age else DEFAULT_AGE
@@ -170,6 +172,7 @@ def generate_today() -> None:
         fat_g_per_kg = float(profile_fat_g_per_kg) if profile_fat_g_per_kg else 0.8
         ffm_kg = float(profile_ffm_kg) if profile_ffm_kg else None
         estimated_bf_pct = float(profile_bf_pct) if profile_bf_pct else None
+        deficit_mode = str(profile_deficit_mode) if profile_deficit_mode else "standard"
 
         # 2. Latest weight from weight_log
         cur.execute(
@@ -297,7 +300,25 @@ def generate_today() -> None:
             logger.info("Sleep adjustment: %s (deficit %.0f → %.0f)",
                         adjustment_reason, deficit, adjusted_deficit)
 
-        # 10. Compute macro targets with carb periodization
+        # 10. Compute macro targets — route to M4 5-band × tier × mode matrix
+        #     when we have BF% data; otherwise fall back to flat g/kg.
+        #     Split exercise_cal into run vs gym portions for the band
+        #     classifier: has_run implies all of exercise_cal is run-load;
+        #     has_gym-only means all gym-load; both implies 60/40 run/gym.
+        has_run = run_type is not None and str(run_type).strip() != ""
+        if has_run and has_gym:
+            run_kcal_split = exercise_cal * 0.6
+            gym_kcal_split = exercise_cal * 0.4
+        elif has_run:
+            run_kcal_split = float(exercise_cal)
+            gym_kcal_split = 0.0
+        elif has_gym:
+            run_kcal_split = 0.0
+            gym_kcal_split = float(exercise_cal)
+        else:
+            run_kcal_split = 0.0
+            gym_kcal_split = 0.0
+
         macros = compute_macro_targets(
             tdee=tdee,
             deficit=adjusted_deficit,
@@ -308,6 +329,9 @@ def generate_today() -> None:
             fat_g_per_kg=fat_g_per_kg,
             estimated_bf_pct=estimated_bf_pct,
             ffm_kg=ffm_kg,
+            mode=deficit_mode,
+            run_kcal=run_kcal_split,
+            gym_kcal=gym_kcal_split,
         )
 
         # Apply sleep boosts — recompute carbs to maintain calorie target

--- a/sync/src/nutrition_engine/macro_targets.py
+++ b/sync/src/nutrition_engine/macro_targets.py
@@ -1,0 +1,276 @@
+"""M4 Phase A — Macro Engine core (5-band × tier × mode).
+
+Research basis: V2 §2. Replaces the legacy fill-remainder calc with a
+periodized model that weights training load into per-band carb targets, then
+enforces tier × mode protein minimums and fat floors.
+
+Modules composed:
+- Tier (M1.1) — BF% band
+- Mode (M2.1) — Standard/Aggressive/Reverse/Maintenance/Bulk/Injured
+- Band (this module) — 5-tier training load classifier
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from nutrition_engine.mode import Mode
+from nutrition_engine.tier import Tier
+
+
+# ---------------------------------------------------------------------------
+# M4.1 Training load + band classifier
+# ---------------------------------------------------------------------------
+
+
+class Band(str, Enum):
+    REST = "rest"
+    LIGHT = "light"
+    MODERATE = "moderate"
+    HARD = "hard"
+    VERY_HARD = "very_hard"
+
+
+_RUN_DIVISOR: int = 10
+_GYM_DIVISOR: int = 6
+_LOAD_SATURATION: float = 4.0
+_ENDURANCE_PRIORITY_THRESHOLD: float = 1.5
+
+
+def compute_training_load(run_kcal: float, gym_kcal: float, *, weight_kg: float) -> float:
+    """Normalize run + gym calories into a per-kg load score.
+
+    Endurance priority: once run_load alone ≥ 1.5, we ignore gym to avoid
+    double-counting a hard run + easy lift (V2 §2.3). Saturation at 4.0
+    prevents absurd days from escaping the carb-band ladder.
+    """
+    if run_kcal < 0 or gym_kcal < 0:
+        raise ValueError(f"kcal must be ≥ 0, got run={run_kcal} gym={gym_kcal}")
+    if weight_kg <= 0:
+        raise ValueError(f"weight_kg must be positive, got {weight_kg}")
+
+    run_load = run_kcal / (weight_kg * _RUN_DIVISOR)
+    gym_load = gym_kcal / (weight_kg * _GYM_DIVISOR)
+
+    if run_load >= _ENDURANCE_PRIORITY_THRESHOLD:
+        return run_load
+
+    return min(run_load + gym_load, _LOAD_SATURATION)
+
+
+def classify_band(total_load: float) -> Band:
+    """Bucket a load score into a band. Thresholds match the V2 §2.3 matrix."""
+    if total_load <= 0:
+        return Band.REST
+    if total_load <= 1.0:
+        return Band.LIGHT
+    if total_load <= 2.0:
+        return Band.MODERATE
+    if total_load <= 3.0:
+        return Band.HARD
+    return Band.VERY_HARD
+
+
+# ---------------------------------------------------------------------------
+# M4.2 Protein formula
+# ---------------------------------------------------------------------------
+
+# V2 §2.1 matrix — canonical base g/kg per (tier, mode). Aggressive at T3+ is
+# gate-blocked by M2, so we never reach those cells at runtime, but we keep a
+# defensive fallback value here so the matrix is total.
+_PROTEIN_BASE_G_PER_KG: dict[tuple[Tier, Mode], float] = {
+    # Standard
+    (Tier.T1, Mode.STANDARD): 2.0,
+    (Tier.T2, Mode.STANDARD): 2.3,
+    (Tier.T3, Mode.STANDARD): 2.4,
+    (Tier.T4, Mode.STANDARD): 2.8,
+    (Tier.T5, Mode.STANDARD): 2.8,
+    # Aggressive (T1-T2 only by gating; fallback for the unreachable rows)
+    (Tier.T1, Mode.AGGRESSIVE): 2.2,
+    (Tier.T2, Mode.AGGRESSIVE): 2.4,
+    (Tier.T3, Mode.AGGRESSIVE): 2.4,
+    (Tier.T4, Mode.AGGRESSIVE): 2.4,
+    (Tier.T5, Mode.AGGRESSIVE): 2.4,
+    # Reverse — treat like Standard at the same tier
+    (Tier.T1, Mode.REVERSE): 2.0,
+    (Tier.T2, Mode.REVERSE): 2.3,
+    (Tier.T3, Mode.REVERSE): 2.4,
+    (Tier.T4, Mode.REVERSE): 2.8,
+    (Tier.T5, Mode.REVERSE): 2.8,
+    # Maintenance: flat 2.0 g/kg (V2 §2.1)
+    (Tier.T1, Mode.MAINTENANCE): 2.0,
+    (Tier.T2, Mode.MAINTENANCE): 2.0,
+    (Tier.T3, Mode.MAINTENANCE): 2.0,
+    (Tier.T4, Mode.MAINTENANCE): 2.0,
+    (Tier.T5, Mode.MAINTENANCE): 2.0,
+    # Bulk: flat 2.0 g/kg (V2 §6.1)
+    (Tier.T1, Mode.BULK): 2.0,
+    (Tier.T2, Mode.BULK): 2.0,
+    (Tier.T3, Mode.BULK): 2.0,
+    (Tier.T4, Mode.BULK): 2.0,
+    (Tier.T5, Mode.BULK): 2.0,
+    # Injured: use the Standard matrix for this milestone (V2 §4.5 refines
+    # later with injury-phase specifics).
+    (Tier.T1, Mode.INJURED): 2.0,
+    (Tier.T2, Mode.INJURED): 2.3,
+    (Tier.T3, Mode.INJURED): 2.4,
+    (Tier.T4, Mode.INJURED): 2.8,
+    (Tier.T5, Mode.INJURED): 2.8,
+}
+
+# V2 §2.1: VERY_HARD band drops protein 0.2 g/kg to make room for carbs.
+_VERY_HARD_PROTEIN_DROP: float = 0.2
+
+# Floor per Morton 2018: always ≥ 1.6 g/kg.
+_PROTEIN_ABSOLUTE_FLOOR: float = 1.6
+
+
+def protein_g_per_kg(tier: Tier, mode: Mode, band: Band) -> float:
+    """Return the base protein g/kg for this (tier, mode, band) cell."""
+    base = _PROTEIN_BASE_G_PER_KG[(tier, mode)]
+    if band == Band.VERY_HARD:
+        base -= _VERY_HARD_PROTEIN_DROP
+    return max(_PROTEIN_ABSOLUTE_FLOOR, base)
+
+
+# ---------------------------------------------------------------------------
+# M4.3 Carbs + fiber
+# ---------------------------------------------------------------------------
+
+# V2 §2.3 band-periodized carb ladder (g/kg).
+_CARB_G_PER_KG: dict[Band, float] = {
+    Band.REST: 3.0,
+    Band.LIGHT: 3.5,
+    Band.MODERATE: 5.0,
+    Band.HARD: 6.5,
+    Band.VERY_HARD: 8.0,
+}
+
+# V2 §2.3 health floor for athletes in deficit.
+_CARB_HEALTH_FLOOR_G: int = 100
+
+# V2 §2.4 fiber: 14 g per 1000 kcal + 5 g bonus during a deficit, with a
+# hard ceiling at 60 g (phytate mineral absorption concern).
+_FIBER_MIN_G: int = 25
+_FIBER_HARD_CEILING_G: int = 60
+_FIBER_CUT_BONUS_G: int = 5
+
+
+def carb_g_per_kg(band: Band) -> float:
+    return _CARB_G_PER_KG[band]
+
+
+def carb_target_g(band: Band, *, weight_kg: float, in_deficit: bool) -> int:
+    raw = round(_CARB_G_PER_KG[band] * weight_kg)
+    if band == Band.REST and in_deficit:
+        # Health floor only applies on rest days in a deficit — training days
+        # already blow past 100 g from the band formula itself.
+        return max(raw, _CARB_HEALTH_FLOOR_G)
+    return raw
+
+
+def fiber_target_g(kcal_target: int, *, in_deficit: bool) -> int:
+    base = max(_FIBER_MIN_G, round(kcal_target * 14 / 1000))
+    if in_deficit:
+        base += _FIBER_CUT_BONUS_G
+    return min(_FIBER_HARD_CEILING_G, base)
+
+
+# ---------------------------------------------------------------------------
+# M4.4 Composed macro engine
+# ---------------------------------------------------------------------------
+
+# V2 §1.5 Atwater factors (TEF already embedded).
+_KCAL_PER_G_PROTEIN: int = 4
+_KCAL_PER_G_CARB: int = 4
+_KCAL_PER_G_FAT: int = 9
+
+# V2 §2.2 fat policy: 0.8 soft floor, 0.6 hard floor, Maintenance 1.0 target,
+# Bulk 1.0 target (midpoint of 0.8-1.2).
+_FAT_HARD_FLOOR_G_PER_KG: float = 0.6
+_FAT_SOFT_FLOOR_G_PER_KG: float = 0.8
+_FAT_MAINTENANCE_TARGET_G_PER_KG: float = 1.0
+_FAT_BULK_TARGET_G_PER_KG: float = 1.0
+
+
+@dataclass(frozen=True)
+class MacroTargets:
+    kcal: int
+    protein_g: int
+    carbs_g: int
+    fat_g: int
+    fiber_g: int
+
+
+def _fat_target_for_mode(mode: Mode, weight_kg: float) -> float:
+    """Mode-aware fat target (g). Cuts use the soft floor; maintenance and
+    bulk set a real target above the floor."""
+    if mode == Mode.MAINTENANCE:
+        return _FAT_MAINTENANCE_TARGET_G_PER_KG * weight_kg
+    if mode == Mode.BULK:
+        return _FAT_BULK_TARGET_G_PER_KG * weight_kg
+    return _FAT_SOFT_FLOOR_G_PER_KG * weight_kg
+
+
+def compute_macro_targets(
+    *,
+    weight_kg: float,
+    tier: Tier,
+    mode: Mode,
+    band: Band,
+    kcal_target: int,
+    in_deficit: bool,
+) -> MacroTargets:
+    """Run the full macro stack for a (user, day) and return gram targets.
+
+    Order:
+    1. Protein from the tier × mode × band matrix (absolute floor 1.6 g/kg).
+    2. Carbs from the band ladder (health floor 100 g on rest days in deficit).
+    3. Fat: aim for the mode-aware target; if kcal_target doesn't leave room,
+       fall back to the hard floor 0.6 g/kg (M1.5 / V2 §2.2).
+    4. Kcal is reported as protein×4 + carbs×4 + fat×9; callers can compare
+       this against their intended kcal_target for rounding slack.
+    5. Fiber per V2 §2.4.
+    """
+    # 1) Protein is non-negotiable — matrix target stands.
+    protein_g = round(protein_g_per_kg(tier, mode, band) * weight_kg)
+    fiber_g = fiber_target_g(kcal_target, in_deficit=in_deficit)
+
+    # 2) Fat target is mode-aware; clamp to hard floor.
+    fat_mode_target = _fat_target_for_mode(mode, weight_kg)
+    fat_hard_floor = _FAT_HARD_FLOOR_G_PER_KG * weight_kg
+    fat_g = max(fat_hard_floor, fat_mode_target)
+
+    # 3) Carbs fill the remainder, with the band target as the CEILING (V2
+    # §2.3 band numbers are cut targets — don't overshoot when budget allows
+    # more) and the rest-day health floor 100 g when in deficit.
+    band_ceiling = _CARB_G_PER_KG[band] * weight_kg
+    remainder_kcal = kcal_target - protein_g * _KCAL_PER_G_PROTEIN - fat_g * _KCAL_PER_G_FAT
+    carbs_by_remainder = max(0.0, remainder_kcal / _KCAL_PER_G_CARB)
+    carbs_g_float = min(carbs_by_remainder, band_ceiling)
+
+    # 4) If tight kcal target pushed carbs below the rest-day health floor,
+    # shave fat toward the hard floor to make room.
+    if band == Band.REST and in_deficit and carbs_g_float < _CARB_HEALTH_FLOOR_G:
+        kcal_for_fat = kcal_target - protein_g * _KCAL_PER_G_PROTEIN - _CARB_HEALTH_FLOOR_G * _KCAL_PER_G_CARB
+        shaved_fat = max(fat_hard_floor, kcal_for_fat / _KCAL_PER_G_FAT)
+        fat_g = shaved_fat
+        carbs_g_float = _CARB_HEALTH_FLOOR_G
+
+    carbs_g = round(carbs_g_float)
+    fat_g_int = round(fat_g)
+
+    actual_kcal = (
+        protein_g * _KCAL_PER_G_PROTEIN
+        + carbs_g * _KCAL_PER_G_CARB
+        + fat_g_int * _KCAL_PER_G_FAT
+    )
+
+    return MacroTargets(
+        kcal=actual_kcal,
+        protein_g=protein_g,
+        carbs_g=carbs_g,
+        fat_g=fat_g_int,
+        fiber_g=fiber_g,
+    )

--- a/sync/src/nutrition_engine/mode.py
+++ b/sync/src/nutrition_engine/mode.py
@@ -1,0 +1,78 @@
+"""6-mode state enum + per-mode configuration (M2.1).
+
+Research basis: Nutrition Science v2 §3.2 (Aggressive), §5 (Maintenance),
+§6 (Bulk), §4.5 (Injured).
+
+Modes encode both intent ("what is the user trying to do") and capability
+("what are the rails around that intent"). The config per mode captures:
+- tier_allowed: which BF% tiers this mode is legal in
+- bf_hard_floor_pct: BF% below which the mode is a hard contraindication
+- requires_reverse_bridge_from: modes that must pass through REVERSE first
+  before entering this mode (cut→bulk transition)
+- max_duration_days: advisory upper bound per V2 duration envelopes
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from nutrition_engine.tier import Tier
+
+
+class Mode(str, Enum):
+    STANDARD = "standard"
+    AGGRESSIVE = "aggressive"
+    REVERSE = "reverse"
+    MAINTENANCE = "maintenance"
+    BULK = "bulk"
+    INJURED = "injured"
+
+
+@dataclass(frozen=True)
+class ModeConfig:
+    tier_allowed: frozenset[Tier]
+    bf_hard_floor_pct: float | None
+    requires_reverse_bridge_from: frozenset[Mode] = field(default_factory=frozenset)
+    max_duration_days: int | None = None
+
+
+_ALL_TIERS: frozenset[Tier] = frozenset(Tier)
+
+
+_CONFIGS: dict[Mode, ModeConfig] = {
+    Mode.STANDARD: ModeConfig(
+        tier_allowed=frozenset({Tier.T1, Tier.T2, Tier.T3, Tier.T4}),
+        bf_hard_floor_pct=None,
+    ),
+    Mode.AGGRESSIVE: ModeConfig(
+        tier_allowed=frozenset({Tier.T1, Tier.T2}),
+        bf_hard_floor_pct=12.0,
+        max_duration_days=84,  # V2 §3.2: 12 weeks at 700-900 kcal envelope
+    ),
+    Mode.REVERSE: ModeConfig(
+        tier_allowed=_ALL_TIERS,
+        bf_hard_floor_pct=None,
+        max_duration_days=42,  # V2 §3.2: post-aggressive reverse 2-6 weeks
+    ),
+    Mode.MAINTENANCE: ModeConfig(
+        tier_allowed=_ALL_TIERS,
+        bf_hard_floor_pct=None,
+    ),
+    Mode.BULK: ModeConfig(
+        tier_allowed=frozenset({Tier.T2, Tier.T3, Tier.T4, Tier.T5}),
+        bf_hard_floor_pct=None,
+        requires_reverse_bridge_from=frozenset({Mode.STANDARD, Mode.AGGRESSIVE}),
+        max_duration_days=140,  # V2 §6.1: 12-20 week bulk block
+    ),
+    Mode.INJURED: ModeConfig(
+        tier_allowed=_ALL_TIERS,
+        bf_hard_floor_pct=None,
+    ),
+}
+
+
+def get_mode_config(mode: Mode) -> ModeConfig:
+    """Return the frozen config for a mode. Raises KeyError if a mode lacks a
+    registered config — this is a programmer error, not a runtime condition."""
+    return _CONFIGS[mode]

--- a/sync/src/nutrition_engine/mode_availability.py
+++ b/sync/src/nutrition_engine/mode_availability.py
@@ -1,0 +1,52 @@
+"""Mode × tier × BF% availability gate (M2.2).
+
+Decides whether a user is allowed to enter a given mode given their current
+tier and BF% estimate, returning a typed reason when blocked so the UI can
+render a specific explanation rather than a generic "not allowed" banner.
+
+Research basis: Nutrition Science v2 §3.2 (Aggressive hard floor at 12% BF,
+T1-T2 only), §6 (Bulk tier gate), §4.5 (Injured overrides all gates).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from nutrition_engine.mode import Mode, get_mode_config
+from nutrition_engine.tier import Tier
+
+
+class GateReason(str, Enum):
+    TIER_NOT_ALLOWED = "tier_not_allowed"
+    BF_BELOW_HARD_FLOOR = "bf_below_hard_floor"
+
+
+@dataclass(frozen=True)
+class ModeAvailability:
+    allowed: bool
+    reason: GateReason | None
+
+
+def check_mode_availability(
+    mode: Mode,
+    tier: Tier,
+    *,
+    bf_pct: float,
+) -> ModeAvailability:
+    """Return whether `mode` is legal for the given `tier` and `bf_pct`.
+
+    When blocked, `reason` identifies the first gate that tripped so the
+    caller can render specific copy.
+    """
+    config = get_mode_config(mode)
+
+    if tier not in config.tier_allowed:
+        return ModeAvailability(allowed=False, reason=GateReason.TIER_NOT_ALLOWED)
+
+    # BF% hard floor: strictly below the floor AND AT the floor are both blocked.
+    # At 12.0% BF the user is already in contraindication territory per V2 §3.2.
+    if config.bf_hard_floor_pct is not None and bf_pct <= config.bf_hard_floor_pct:
+        return ModeAvailability(allowed=False, reason=GateReason.BF_BELOW_HARD_FLOOR)
+
+    return ModeAvailability(allowed=True, reason=None)

--- a/sync/src/nutrition_engine/mode_transitions.py
+++ b/sync/src/nutrition_engine/mode_transitions.py
@@ -1,0 +1,95 @@
+"""Mode transition state machine (M2.3).
+
+Pure-function decision layer between "the user wants to switch modes" and
+"actually flipping the DB field". Returns a typed reason on block so the UI
+can show a specific banner and, when relevant, auto-insert the required
+bridge (e.g., a 4-week reverse diet between cut and bulk).
+
+Research basis:
+- V2 §3.2: Aggressive block ends with a mandatory 2-6 week reverse diet.
+- V2 §6.4: Cut → Bulk requires a reverse bridge; Bulk → Cut abrupt OK;
+  Bulk → Maintenance is a user-driven ramp, not enforced here.
+- V2 §4.5: Injured mode is always reachable; re-entry runs availability.
+- V2 §5.2: Cut → Maintenance 3-week ramp is "preferred, not enforced"
+  (evidence is psychological, not metabolic) — so no transition block.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from nutrition_engine.mode import Mode, get_mode_config
+from nutrition_engine.mode_availability import check_mode_availability
+from nutrition_engine.tier import Tier
+
+
+class TransitionReason(str, Enum):
+    # Destination mode fails its (tier, BF%) availability check.
+    MODE_NOT_AVAILABLE = "mode_not_available"
+    # V2 §3.2: exiting Aggressive must pass through Reverse first.
+    AGGRESSIVE_REQUIRES_REVERSE = "aggressive_requires_reverse"
+    # V2 §6.4: entering Bulk from a cut mode requires a reverse bridge.
+    REQUIRES_REVERSE_BRIDGE = "requires_reverse_bridge"
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    allowed: bool
+    reason: TransitionReason | None = None
+    # When a bridge mode is required (e.g. REVERSE between cut and bulk),
+    # callers can auto-propose it rather than guessing from the reason.
+    requires_bridge: Mode | None = None
+
+
+def check_transition(
+    current: Mode,
+    next_mode: Mode,
+    *,
+    tier: Tier,
+    bf_pct: float,
+) -> TransitionResult:
+    """Return whether a mode transition is legal.
+
+    Order of checks matters — we evaluate cheap invariants before running the
+    availability gate so the reason codes stay specific.
+    """
+
+    # A no-op transition is always allowed.
+    if current == next_mode:
+        return TransitionResult(allowed=True)
+
+    # Entering Injured is always legal — injuries don't wait for gating.
+    if next_mode == Mode.INJURED:
+        return TransitionResult(allowed=True)
+
+    # V2 §6.4: cut → bulk must pass through a reverse bridge. Check this before
+    # the generic Aggressive-exit rule so Aggressive → Bulk surfaces the more
+    # actionable REQUIRES_REVERSE_BRIDGE reason (carries `requires_bridge`)
+    # rather than the bare AGGRESSIVE_REQUIRES_REVERSE code.
+    next_config = get_mode_config(next_mode)
+    if current in next_config.requires_reverse_bridge_from:
+        return TransitionResult(
+            allowed=False,
+            reason=TransitionReason.REQUIRES_REVERSE_BRIDGE,
+            requires_bridge=Mode.REVERSE,
+        )
+
+    # V2 §3.2: exiting Aggressive (to anything other than Reverse or Injured)
+    # requires the reverse diet. Injured was handled above; Bulk was handled
+    # by the bridge check; anything else lands here.
+    if current == Mode.AGGRESSIVE and next_mode != Mode.REVERSE:
+        return TransitionResult(
+            allowed=False,
+            reason=TransitionReason.AGGRESSIVE_REQUIRES_REVERSE,
+        )
+
+    # Finally, the destination mode must be legal for the user's tier + BF%.
+    availability = check_mode_availability(next_mode, tier, bf_pct=bf_pct)
+    if not availability.allowed:
+        return TransitionResult(
+            allowed=False,
+            reason=TransitionReason.MODE_NOT_AVAILABLE,
+        )
+
+    return TransitionResult(allowed=True)

--- a/sync/src/nutrition_engine/tdee.py
+++ b/sync/src/nutrition_engine/tdee.py
@@ -326,8 +326,19 @@ def compute_macro_targets(
     fat_g_per_kg: float = 0.8,
     estimated_bf_pct: float | None = None,
     ffm_kg: float | None = None,
+    *,
+    mode: str | None = None,
+    run_kcal: float | None = None,
+    gym_kcal: float | None = None,
 ) -> dict[str, int]:
     """Compute daily macro targets given TDEE, deficit, and training context.
+
+    Routing: when ``estimated_bf_pct``, ``mode``, ``run_kcal``, and ``gym_kcal``
+    are all provided, delegates to the macro-engine M4 matrix
+    (``nutrition_engine.macro_targets``) for a 5-band × 5-tier × mode
+    periodized target. Otherwise falls back to the legacy flat
+    ``protein_g_per_kg`` / ``fat_g_per_kg`` computation for backward
+    compatibility with callers that don't yet pass the new context.
 
     Args:
         tdee: Total daily energy expenditure in kcal.
@@ -336,10 +347,14 @@ def compute_macro_targets(
         exercise_calories: Estimated exercise calories from
             :func:`compute_exercise_calories` (replaces static boost).
         training_day_type: Day type key for carb periodization (Task 10).
-        protein_g_per_kg: Protein target per kg body weight (default 2.2).
-        fat_g_per_kg: Fat target per kg body weight (default 0.8).
-        estimated_bf_pct: Optional body fat percentage (unused currently).
-        ffm_kg: Optional fat-free mass in kg for RED-S floor check.
+        protein_g_per_kg: Fallback protein g/kg when matrix inputs missing.
+        fat_g_per_kg: Fallback fat g/kg when matrix inputs missing.
+        estimated_bf_pct: Body fat percentage — required for matrix routing.
+        ffm_kg: Fat-free mass in kg — used for RED-S floor check either way.
+        mode: One of 'standard', 'aggressive', 'reverse', 'maintenance',
+            'bulk', 'injured'. When None, legacy flat formula is used.
+        run_kcal: Run-portion of exercise kcal for band classifier.
+        gym_kcal: Gym-portion of exercise kcal for band classifier.
 
     Returns:
         Dict with ``calories``, ``protein``, ``carbs``, ``fat``, ``fiber``.
@@ -356,17 +371,49 @@ def compute_macro_targets(
         if target_calories < reds_minimum:
             target_calories = reds_minimum
 
-    # 4. Protein
+    # 4. Route to the M4 matrix when full context is available.
+    use_matrix = (
+        estimated_bf_pct is not None
+        and mode is not None
+        and run_kcal is not None
+        and gym_kcal is not None
+    )
+    if use_matrix:
+        from nutrition_engine.macro_targets import (  # local import to avoid cycles
+            classify_band,
+            compute_macro_targets as matrix_targets,
+            compute_training_load,
+        )
+        from nutrition_engine.mode import Mode as ModeEnum
+        from nutrition_engine.tier import compute_tier_raw
+
+        tier = compute_tier_raw(estimated_bf_pct)
+        load = compute_training_load(
+            run_kcal=run_kcal, gym_kcal=gym_kcal, weight_kg=weight_kg,
+        )
+        band = classify_band(load)
+        try:
+            mode_enum = ModeEnum(mode)
+        except ValueError:
+            mode_enum = ModeEnum.STANDARD
+        in_deficit = deficit > 0
+        m = matrix_targets(
+            weight_kg=weight_kg, tier=tier, mode=mode_enum, band=band,
+            kcal_target=target_calories, in_deficit=in_deficit,
+        )
+        return {
+            "calories": m.kcal,
+            "protein": m.protein_g,
+            "carbs": m.carbs_g,
+            "fat": m.fat_g,
+            "fiber": m.fiber_g,
+        }
+
+    # 5. Legacy flat formula (backwards compatible).
     protein = round(weight_kg * protein_g_per_kg)
-
-    # 5. Fat
     fat = round(weight_kg * fat_g_per_kg)
-
-    # 6. Carbs = strict remainder after protein and fat (guarantees macro-calorie match)
     carb_remainder = max((target_calories - (protein * 4) - (fat * 9)) / 4, 0)
     carbs = round(carb_remainder)
-
-    # 7. Fiber (fixed)
     fiber = 35
 
     return {

--- a/sync/tests/test_macro_targets.py
+++ b/sync/tests/test_macro_targets.py
@@ -1,0 +1,285 @@
+"""Tests for M4 Phase A — Macro Engine core (5-band × tier × mode).
+
+Research basis: V2 §2.
+
+M4.1 Load classifier:
+    run_load = run_kcal / (weight × 10)
+    gym_load = gym_kcal / (weight × 6)
+    total_load = min(run_load + gym_load, 4.0)
+    if run_load ≥ 1.5: total_load = run_load  (endurance priority)
+Band thresholds:
+    REST: load == 0
+    LIGHT: (0, 1.0]
+    MODERATE: (1.0, 2.0]
+    HARD: (2.0, 3.0]
+    VERY_HARD: > 3.0
+
+M4.2 Protein matrix + very_hard modifier (0.2 g/kg drop, floor 1.6).
+M4.3 Carbs: rest 3.0 / light 3.5 / moderate 5.0 / hard 6.5 / very_hard 8.0 g/kg.
+     Fiber: max(25, round(kcal × 14/1000)) + 5 cut_bonus; hard ceiling 60g.
+M4.4 Orchestrator: applies fat floor from M1.5; kcal fills remainder.
+"""
+
+import pytest
+
+from nutrition_engine.macro_targets import (
+    Band,
+    MacroTargets,
+    carb_g_per_kg,
+    carb_target_g,
+    classify_band,
+    compute_macro_targets,
+    compute_training_load,
+    fiber_target_g,
+    protein_g_per_kg,
+)
+from nutrition_engine.mode import Mode
+from nutrition_engine.tier import Tier
+
+
+# ---------------------------------------------------------------------------
+# M4.1 Load classifier
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingLoad:
+    def test_zero_zero_is_zero(self):
+        assert compute_training_load(0, 0, weight_kg=74) == 0
+
+    def test_short_run(self):
+        # 400 kcal at 74 kg → run_load = 400/740 ≈ 0.54
+        load = compute_training_load(400, 0, weight_kg=74)
+        assert 0.5 <= load <= 0.6
+
+    def test_endurance_priority(self):
+        # run_load ≥ 1.5 → ignore gym, use run_load only
+        # 1200 kcal at 74 kg → run_load ≈ 1.62
+        load = compute_training_load(1200, 300, weight_kg=74)
+        assert abs(load - (1200 / 740)) < 0.01
+
+    def test_saturation_cap(self):
+        # Gym-heavy day below the endurance-priority threshold: 500 run (load
+        # 0.68) + 2500 gym (load 5.63) would sum to 6.31 → cap 4.0.
+        load = compute_training_load(500, 2500, weight_kg=74)
+        assert load == 4.0
+
+    def test_gym_only(self):
+        # 400 kcal gym at 74 kg → gym_load = 400/444 ≈ 0.9
+        load = compute_training_load(0, 400, weight_kg=74)
+        assert 0.85 <= load <= 0.95
+
+    def test_negative_kcal_raises(self):
+        with pytest.raises(ValueError):
+            compute_training_load(-1, 0, weight_kg=74)
+
+
+class TestClassifyBand:
+    def test_rest(self):
+        assert classify_band(0) == Band.REST
+
+    def test_light(self):
+        assert classify_band(0.5) == Band.LIGHT
+        assert classify_band(1.0) == Band.LIGHT
+
+    def test_moderate(self):
+        assert classify_band(1.01) == Band.MODERATE
+        assert classify_band(2.0) == Band.MODERATE
+
+    def test_hard(self):
+        assert classify_band(2.01) == Band.HARD
+        assert classify_band(3.0) == Band.HARD
+
+    def test_very_hard(self):
+        assert classify_band(3.01) == Band.VERY_HARD
+        assert classify_band(4.0) == Band.VERY_HARD
+
+
+# ---------------------------------------------------------------------------
+# M4.2 Protein formula
+# ---------------------------------------------------------------------------
+
+
+class TestProtein:
+    def test_standard_t2_moderate(self):
+        # Our target: 2.3 g/kg at T2 Standard
+        p = protein_g_per_kg(Tier.T2, Mode.STANDARD, Band.MODERATE)
+        assert p == pytest.approx(2.3)
+
+    def test_aggressive_t2_hard(self):
+        p = protein_g_per_kg(Tier.T2, Mode.AGGRESSIVE, Band.HARD)
+        assert p == pytest.approx(2.4)
+
+    def test_very_hard_drops_by_0_2(self):
+        base = protein_g_per_kg(Tier.T2, Mode.AGGRESSIVE, Band.HARD)
+        vh = protein_g_per_kg(Tier.T2, Mode.AGGRESSIVE, Band.VERY_HARD)
+        assert vh == pytest.approx(base - 0.2)
+
+    def test_very_hard_respects_1_6_floor(self):
+        # Bulk at T2 = 2.0 baseline; VERY_HARD → 1.8. Still ≥ 1.6 floor.
+        p = protein_g_per_kg(Tier.T2, Mode.BULK, Band.VERY_HARD)
+        assert p >= 1.6
+
+    def test_maintenance_flat_2_0(self):
+        for tier in [Tier.T1, Tier.T2, Tier.T3, Tier.T4]:
+            p = protein_g_per_kg(tier, Mode.MAINTENANCE, Band.MODERATE)
+            assert p == pytest.approx(2.0)
+
+    def test_bulk_flat_2_0(self):
+        p = protein_g_per_kg(Tier.T2, Mode.BULK, Band.MODERATE)
+        assert p == pytest.approx(2.0)
+
+    def test_injured_uses_standard_matrix(self):
+        # Injured is allowed at all tiers; fall back to Standard matrix
+        inj = protein_g_per_kg(Tier.T2, Mode.INJURED, Band.MODERATE)
+        std = protein_g_per_kg(Tier.T2, Mode.STANDARD, Band.MODERATE)
+        assert inj == pytest.approx(std)
+
+    def test_every_combo_non_negative(self):
+        for tier in Tier:
+            for mode in Mode:
+                for band in Band:
+                    p = protein_g_per_kg(tier, mode, band)
+                    assert p >= 1.6
+
+
+# ---------------------------------------------------------------------------
+# M4.3 Carbs + fiber
+# ---------------------------------------------------------------------------
+
+
+class TestCarbs:
+    @pytest.mark.parametrize("band,expected", [
+        (Band.REST, 3.0),
+        (Band.LIGHT, 3.5),
+        (Band.MODERATE, 5.0),
+        (Band.HARD, 6.5),
+        (Band.VERY_HARD, 8.0),
+    ])
+    def test_g_per_kg_by_band(self, band: Band, expected: float):
+        assert carb_g_per_kg(band) == pytest.approx(expected)
+
+    def test_target_by_band_and_weight(self):
+        # 74 kg × HARD (6.5) = 481 g
+        assert carb_target_g(Band.HARD, weight_kg=74.0, in_deficit=True) == 481
+
+    def test_rest_deficit_health_floor(self):
+        # REST × 74 kg = 222 g already > 100g floor
+        # Test a lighter user where the floor bites: 30 kg × 3.0 = 90g → should be 100
+        assert carb_target_g(Band.REST, weight_kg=30.0, in_deficit=True) == 100
+
+    def test_rest_no_deficit_allows_below_100(self):
+        # Not in deficit → health floor doesn't apply
+        assert carb_target_g(Band.REST, weight_kg=30.0, in_deficit=False) == 90
+
+    def test_health_floor_only_on_rest(self):
+        # HARD band at 30kg = 195g, already above 100, floor no-op
+        assert carb_target_g(Band.HARD, weight_kg=30.0, in_deficit=True) == 195
+
+
+class TestFiber:
+    def test_base_formula(self):
+        # 2500 kcal × 14/1000 = 35; no deficit → 35
+        assert fiber_target_g(2500, in_deficit=False) == 35
+
+    def test_deficit_adds_5g(self):
+        assert fiber_target_g(2500, in_deficit=True) == 40
+
+    def test_min_25g(self):
+        # 1000 kcal × 14/1000 = 14; clamped to 25
+        assert fiber_target_g(1000, in_deficit=False) == 25
+
+    def test_min_applies_before_cut_bonus(self):
+        # 1000 kcal in deficit → max(25, 14) + 5 = 30
+        assert fiber_target_g(1000, in_deficit=True) == 30
+
+    def test_hard_ceiling_60(self):
+        # 10000 kcal × 14/1000 = 140 + 5 → clamp 60
+        assert fiber_target_g(10000, in_deficit=True) == 60
+
+
+# ---------------------------------------------------------------------------
+# M4.4 Composed macro engine
+# ---------------------------------------------------------------------------
+
+
+class TestComposedMacroEngine:
+    def test_returns_targets_dataclass(self):
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.STANDARD,
+            band=Band.MODERATE, kcal_target=2000, in_deficit=True,
+        )
+        assert isinstance(r, MacroTargets)
+        assert all(getattr(r, f) >= 0 for f in ["kcal", "protein_g", "carbs_g", "fat_g", "fiber_g"])
+
+    def test_user_aggressive_hard(self):
+        # Our profile: 74.2 kg T2 Aggressive HARD, 2000 kcal target.
+        # At this kcal budget the engine can't hit both the HARD band carb
+        # target (482g) AND the fat soft floor (59g) AND protein (178g),
+        # so carbs flex DOWN from the band ceiling — that's the correct
+        # signal that kcal is tight for the chosen band.
+        r = compute_macro_targets(
+            weight_kg=74.2, tier=Tier.T2, mode=Mode.AGGRESSIVE,
+            band=Band.HARD, kcal_target=2000, in_deficit=True,
+        )
+        assert r.protein_g == 178
+        # Carbs below band ceiling (482) but above health floor (100 applies
+        # on REST only; HARD band has no floor).
+        assert r.carbs_g <= 482
+        # Fat ≥ hard floor 0.6 × 74.2 = 44.5g → 45g
+        assert r.fat_g >= 45
+
+    def test_kcal_balance_within_rounding(self):
+        # protein×4 + carbs×4 + fat×9 ≈ kcal_target (within a few kcal from rounding)
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.STANDARD,
+            band=Band.MODERATE, kcal_target=2400, in_deficit=True,
+        )
+        total = r.protein_g * 4 + r.carbs_g * 4 + r.fat_g * 9
+        assert abs(total - 2400) <= 10
+
+    def test_fat_hard_floor_enforced(self):
+        # Aggressive cut at 1500 kcal — fat remainder would be negative without
+        # the hard floor. Engine must still hit fat ≥ 0.6 × weight.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.AGGRESSIVE,
+            band=Band.VERY_HARD, kcal_target=1500, in_deficit=True,
+        )
+        assert r.fat_g >= round(0.6 * 74.0)
+
+    def test_rest_day_standard(self):
+        # Rest day at 2000 kcal — budget tight, so carbs flex down from band
+        # ceiling (222g) but stay ≥ health floor (100g) thanks to in_deficit.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.STANDARD,
+            band=Band.REST, kcal_target=2000, in_deficit=True,
+        )
+        # Protein: 2.3 × 74 = 170
+        assert r.protein_g == 170
+        # Carbs ≤ band ceiling, ≥ health floor 100
+        assert 100 <= r.carbs_g <= 222
+
+    def test_rest_day_maintenance_hits_band_ceiling(self):
+        # With plenty of kcal headroom, rest-day carbs hit the band ceiling.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.MAINTENANCE,
+            band=Band.REST, kcal_target=2800, in_deficit=False,
+        )
+        # Band ceiling 3.0 × 74 = 222g
+        assert r.carbs_g == 222
+
+    def test_maintenance_fat_target_above_floor(self):
+        # Maintenance targets fat 1.0 g/kg (V2 §2.2) — engine should prefer
+        # that over the 0.8 soft floor when calories allow.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.MAINTENANCE,
+            band=Band.MODERATE, kcal_target=2800, in_deficit=False,
+        )
+        assert r.fat_g >= round(1.0 * 74.0) - 3  # allow small rounding slack
+
+    def test_protein_never_below_1_6(self):
+        # Extreme case: VERY_HARD carb priority could drop protein. Floor at 1.6.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.BULK,
+            band=Band.VERY_HARD, kcal_target=3000, in_deficit=False,
+        )
+        assert r.protein_g >= round(1.6 * 74.0)

--- a/sync/tests/test_mode.py
+++ b/sync/tests/test_mode.py
@@ -1,0 +1,98 @@
+"""Tests for Mode enum + per-mode config (M2.1).
+
+Research basis: Nutrition Science v2 §3.2 (Aggressive), §5 (Maintenance),
+§6 (Bulk), §4.5 (Injured). 6 modes with tier gating, BF% hard floors,
+and bridge requirements.
+"""
+
+import pytest
+
+from nutrition_engine.mode import (
+    Mode,
+    ModeConfig,
+    get_mode_config,
+)
+from nutrition_engine.tier import Tier
+
+
+class TestModeEnum:
+    def test_has_six_members(self):
+        assert len(Mode) == 6
+
+    def test_string_values(self):
+        assert Mode.STANDARD.value == "standard"
+        assert Mode.AGGRESSIVE.value == "aggressive"
+        assert Mode.REVERSE.value == "reverse"
+        assert Mode.MAINTENANCE.value == "maintenance"
+        assert Mode.BULK.value == "bulk"
+        assert Mode.INJURED.value == "injured"
+
+
+class TestGetModeConfig:
+    def test_standard(self):
+        c = get_mode_config(Mode.STANDARD)
+        assert isinstance(c, ModeConfig)
+        # Standard is available to anyone who isn't dangerously lean.
+        assert c.tier_allowed == {Tier.T1, Tier.T2, Tier.T3, Tier.T4}
+        assert c.bf_hard_floor_pct is None
+        assert c.requires_reverse_bridge_from == set()
+        assert c.max_duration_days is None
+
+    def test_aggressive(self):
+        # V2 §3.2: T1-T2 only, BF% <12% hard contraindication,
+        # duration capped at 12 weeks (700-900 kcal envelope).
+        c = get_mode_config(Mode.AGGRESSIVE)
+        assert c.tier_allowed == {Tier.T1, Tier.T2}
+        assert c.bf_hard_floor_pct == 12.0
+        assert c.requires_reverse_bridge_from == set()
+        assert c.max_duration_days == 84  # 12 weeks
+
+    def test_reverse(self):
+        c = get_mode_config(Mode.REVERSE)
+        assert c.tier_allowed == {Tier.T1, Tier.T2, Tier.T3, Tier.T4, Tier.T5}
+        assert c.bf_hard_floor_pct is None
+        assert c.requires_reverse_bridge_from == set()
+        # V2 §3.2 post-aggressive: 2-6 weeks reverse.
+        assert c.max_duration_days == 42  # 6 weeks ceiling
+
+    def test_maintenance(self):
+        c = get_mode_config(Mode.MAINTENANCE)
+        assert c.tier_allowed == {Tier.T1, Tier.T2, Tier.T3, Tier.T4, Tier.T5}
+        assert c.bf_hard_floor_pct is None
+        assert c.requires_reverse_bridge_from == set()
+        # V2 §5: indefinite
+        assert c.max_duration_days is None
+
+    def test_bulk(self):
+        # V2 §6: lean bulk is for people not already obese. Tier-level block
+        # at T1 (>28% BF) keeps obese users from starting a bulk.
+        c = get_mode_config(Mode.BULK)
+        assert c.tier_allowed == {Tier.T2, Tier.T3, Tier.T4, Tier.T5}
+        assert c.bf_hard_floor_pct is None
+        # V2 §6.4: Cut → Bulk requires 4-week reverse diet bridge.
+        assert c.requires_reverse_bridge_from == {Mode.STANDARD, Mode.AGGRESSIVE}
+        # V2 §6.1: 12-20 week bulk block.
+        assert c.max_duration_days == 140  # 20 weeks
+
+    def test_injured(self):
+        # V2 §4.5: injured mode overrides other gates — always allowed.
+        c = get_mode_config(Mode.INJURED)
+        assert c.tier_allowed == {Tier.T1, Tier.T2, Tier.T3, Tier.T4, Tier.T5}
+        assert c.bf_hard_floor_pct is None
+        assert c.requires_reverse_bridge_from == set()
+        # Phased (acute/subacute/chronic) → no hard cap.
+        assert c.max_duration_days is None
+
+    def test_config_is_frozen(self):
+        c = get_mode_config(Mode.STANDARD)
+        with pytest.raises(Exception):
+            c.tier_allowed = {Tier.T1}  # type: ignore[misc]
+
+
+class TestAllModesCovered:
+    @pytest.mark.parametrize("mode", list(Mode))
+    def test_every_mode_has_config(self, mode: Mode):
+        # Guard against forgetting to add a config when new modes are introduced.
+        c = get_mode_config(mode)
+        assert isinstance(c, ModeConfig)
+        assert c.tier_allowed, f"{mode} has no allowed tiers"

--- a/sync/tests/test_mode_availability.py
+++ b/sync/tests/test_mode_availability.py
@@ -1,0 +1,114 @@
+"""Tests for mode availability (M2.2).
+
+Checks whether a given (mode, tier, bf_pct) combination is allowed, with
+typed reason codes when blocked. Research basis: V2 §3.2 + tier × mode table
+at §2 (lines 102-107).
+"""
+
+import pytest
+
+from nutrition_engine.mode import Mode
+from nutrition_engine.mode_availability import (
+    GateReason,
+    ModeAvailability,
+    check_mode_availability,
+)
+from nutrition_engine.tier import Tier
+
+
+class TestResultShape:
+    def test_allowed_has_no_reason(self):
+        r = check_mode_availability(Mode.STANDARD, Tier.T2, bf_pct=23.5)
+        assert isinstance(r, ModeAvailability)
+        assert r.allowed is True
+        assert r.reason is None
+
+    def test_blocked_carries_reason(self):
+        r = check_mode_availability(Mode.AGGRESSIVE, Tier.T3, bf_pct=17.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.TIER_NOT_ALLOWED
+
+
+class TestStandard:
+    @pytest.mark.parametrize("tier", [Tier.T1, Tier.T2, Tier.T3, Tier.T4])
+    def test_allowed_tiers(self, tier: Tier):
+        # BF% within the tier band — Standard open across the deficit tiers.
+        r = check_mode_availability(Mode.STANDARD, tier, bf_pct=22.0)
+        assert r.allowed is True
+
+    def test_t5_blocked(self):
+        # T5 = <10% BF, deep competition territory; Standard not offered.
+        r = check_mode_availability(Mode.STANDARD, Tier.T5, bf_pct=9.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.TIER_NOT_ALLOWED
+
+
+class TestAggressive:
+    @pytest.mark.parametrize("tier", [Tier.T1, Tier.T2])
+    def test_allowed_for_t1_t2(self, tier: Tier):
+        r = check_mode_availability(Mode.AGGRESSIVE, tier, bf_pct=22.0)
+        assert r.allowed is True
+
+    @pytest.mark.parametrize("tier", [Tier.T3, Tier.T4, Tier.T5])
+    def test_blocked_t3_and_leaner(self, tier: Tier):
+        r = check_mode_availability(Mode.AGGRESSIVE, tier, bf_pct=14.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.TIER_NOT_ALLOWED
+
+    def test_bf_at_hard_floor_is_blocked(self):
+        # 12.0 is the hard floor — strictly less than is also blocked.
+        r = check_mode_availability(Mode.AGGRESSIVE, Tier.T2, bf_pct=12.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.BF_BELOW_HARD_FLOOR
+
+    def test_bf_below_hard_floor(self):
+        r = check_mode_availability(Mode.AGGRESSIVE, Tier.T2, bf_pct=11.9)
+        assert r.allowed is False
+        assert r.reason is GateReason.BF_BELOW_HARD_FLOOR
+
+    def test_bf_just_above_hard_floor(self):
+        r = check_mode_availability(Mode.AGGRESSIVE, Tier.T2, bf_pct=12.1)
+        assert r.allowed is True
+
+
+class TestBulk:
+    def test_t1_blocked(self):
+        # T1 (>28% BF) — still needs to cut before bulking.
+        r = check_mode_availability(Mode.BULK, Tier.T1, bf_pct=30.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.TIER_NOT_ALLOWED
+
+    @pytest.mark.parametrize("tier", [Tier.T2, Tier.T3, Tier.T4, Tier.T5])
+    def test_allowed_t2_and_leaner(self, tier: Tier):
+        r = check_mode_availability(Mode.BULK, tier, bf_pct=16.0)
+        assert r.allowed is True
+
+
+class TestAlwaysAllowed:
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_injured_any_tier(self, tier: Tier):
+        # V2 §4.5: Injured mode overrides tier/BF% gates entirely.
+        r = check_mode_availability(Mode.INJURED, tier, bf_pct=10.0)
+        assert r.allowed is True
+
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_maintenance_any_tier(self, tier: Tier):
+        r = check_mode_availability(Mode.MAINTENANCE, tier, bf_pct=20.0)
+        assert r.allowed is True
+
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_reverse_any_tier(self, tier: Tier):
+        r = check_mode_availability(Mode.REVERSE, tier, bf_pct=20.0)
+        assert r.allowed is True
+
+
+class TestExhaustiveMatrix:
+    """Sanity: every (mode × tier) pair returns a bool + optional reason."""
+
+    @pytest.mark.parametrize("mode", list(Mode))
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_no_combo_raises(self, mode: Mode, tier: Tier):
+        r = check_mode_availability(mode, tier, bf_pct=20.0)
+        assert isinstance(r.allowed, bool)
+        if not r.allowed:
+            assert isinstance(r.reason, GateReason)

--- a/sync/tests/test_mode_transitions.py
+++ b/sync/tests/test_mode_transitions.py
@@ -1,0 +1,148 @@
+"""Tests for mode transition state machine (M2.3).
+
+Research basis:
+- V2 §3.2 (post-aggressive mandatory reverse 2-6 weeks)
+- V2 §5.2 (cut → maintenance 3-week ramp preferred, not enforced)
+- V2 §6.4 (cut → bulk requires 4-week reverse bridge; bulk → cut abrupt OK)
+- V2 §4.5 (injured overrides other gates)
+"""
+
+import pytest
+
+from nutrition_engine.mode import Mode
+from nutrition_engine.mode_transitions import (
+    TransitionReason,
+    TransitionResult,
+    check_transition,
+)
+from nutrition_engine.tier import Tier
+
+
+DEFAULT_TIER = Tier.T2
+DEFAULT_BF = 23.5
+
+
+def _check(current: Mode, next_mode: Mode, tier: Tier = DEFAULT_TIER, bf: float = DEFAULT_BF):
+    return check_transition(current, next_mode, tier=tier, bf_pct=bf)
+
+
+class TestResultShape:
+    def test_allowed_has_no_reason(self):
+        r = _check(Mode.STANDARD, Mode.MAINTENANCE)
+        assert isinstance(r, TransitionResult)
+        assert r.allowed is True
+        assert r.reason is None
+        assert r.requires_bridge is None
+
+    def test_blocked_carries_reason(self):
+        r = _check(Mode.AGGRESSIVE, Mode.STANDARD)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.AGGRESSIVE_REQUIRES_REVERSE
+
+
+class TestSameMode:
+    @pytest.mark.parametrize("mode", list(Mode))
+    def test_noop_transition_allowed(self, mode: Mode):
+        # Staying in the current mode is trivially allowed.
+        r = _check(mode, mode)
+        assert r.allowed is True
+
+
+class TestAggressiveExitRequiresReverse:
+    # V2 §3.2: mandatory reverse diet 2-6 weeks after aggressive block.
+
+    @pytest.mark.parametrize("target", [Mode.STANDARD, Mode.MAINTENANCE])
+    def test_aggressive_to_non_reverse_blocked(self, target: Mode):
+        # Aggressive → Bulk is covered by TestBulkRequiresReverseBridge with
+        # the more actionable REQUIRES_REVERSE_BRIDGE reason code.
+        r = _check(Mode.AGGRESSIVE, target)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.AGGRESSIVE_REQUIRES_REVERSE
+
+    def test_aggressive_to_reverse_allowed(self):
+        r = _check(Mode.AGGRESSIVE, Mode.REVERSE)
+        assert r.allowed is True
+
+    def test_aggressive_to_injured_allowed(self):
+        # Injury is always an escape hatch.
+        r = _check(Mode.AGGRESSIVE, Mode.INJURED)
+        assert r.allowed is True
+
+
+class TestBulkRequiresReverseBridge:
+    # V2 §6.4: Cut → Bulk needs 4-week reverse diet bridge.
+
+    @pytest.mark.parametrize("cut_mode", [Mode.STANDARD, Mode.AGGRESSIVE])
+    def test_cut_to_bulk_requires_bridge(self, cut_mode: Mode):
+        r = _check(cut_mode, Mode.BULK)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.REQUIRES_REVERSE_BRIDGE
+        assert r.requires_bridge is Mode.REVERSE
+
+    def test_reverse_to_bulk_allowed(self):
+        r = _check(Mode.REVERSE, Mode.BULK)
+        assert r.allowed is True
+
+    def test_maintenance_to_bulk_allowed_without_bridge(self):
+        # Maintenance is already the destination a reverse targets, so
+        # moving Maintenance → Bulk doesn't require another reverse loop.
+        r = _check(Mode.MAINTENANCE, Mode.BULK)
+        assert r.allowed is True
+
+
+class TestBulkExits:
+    # V2 §6.4: Bulk → Cut abrupt OK; Bulk → Maintenance user-driven ramp.
+
+    @pytest.mark.parametrize("target", [Mode.STANDARD, Mode.AGGRESSIVE, Mode.MAINTENANCE])
+    def test_bulk_to_anything_downstream_allowed(self, target: Mode):
+        # T3 so Aggressive will fail on availability (covered below)
+        r = _check(Mode.BULK, target, tier=Tier.T2, bf=22.0)
+        assert r.allowed is True
+
+    def test_bulk_to_reverse_allowed(self):
+        r = _check(Mode.BULK, Mode.REVERSE)
+        assert r.allowed is True
+
+
+class TestInjuredEscapeHatch:
+    @pytest.mark.parametrize("current", list(Mode))
+    def test_any_to_injured_allowed(self, current: Mode):
+        r = _check(current, Mode.INJURED)
+        assert r.allowed is True
+
+    @pytest.mark.parametrize("target", [Mode.STANDARD, Mode.MAINTENANCE, Mode.BULK])
+    def test_injured_to_target_runs_availability_gate(self, target: Mode):
+        # Re-entering a normal mode from injured is subject to mode availability.
+        r = _check(Mode.INJURED, target, tier=Tier.T2, bf=22.0)
+        assert r.allowed is True
+
+    def test_injured_to_aggressive_blocked_at_t3(self):
+        # Availability gate still runs on exit from Injured.
+        r = _check(Mode.INJURED, Mode.AGGRESSIVE, tier=Tier.T3, bf=17.0)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.MODE_NOT_AVAILABLE
+
+
+class TestAvailabilityPropagates:
+    def test_standard_to_aggressive_blocks_at_t3(self):
+        r = _check(Mode.STANDARD, Mode.AGGRESSIVE, tier=Tier.T3, bf=17.0)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.MODE_NOT_AVAILABLE
+
+    def test_maintenance_to_bulk_blocks_at_t1(self):
+        # T1 = >28% BF — Bulk is tier-blocked.
+        r = _check(Mode.MAINTENANCE, Mode.BULK, tier=Tier.T1, bf=30.0)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.MODE_NOT_AVAILABLE
+
+
+class TestExhaustiveMatrix:
+    """Every (current, next) pair resolves without raising."""
+
+    @pytest.mark.parametrize("current", list(Mode))
+    @pytest.mark.parametrize("next_mode", list(Mode))
+    def test_no_pair_raises(self, current: Mode, next_mode: Mode):
+        r = _check(current, next_mode)
+        assert isinstance(r.allowed, bool)
+        if not r.allowed:
+            assert isinstance(r.reason, TransitionReason)

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { computeMacroTargetsFromContext } from "@/lib/macro-targets";
+import type { Mode } from "@/lib/mode-engine";
 
 export const runtime = "edge";
+
+const VALID_MODES: readonly Mode[] = [
+  "standard", "aggressive", "reverse", "maintenance", "bulk", "injured",
+];
 
 /* ── Per-slot distribution fractions ── */
 const SLOT_DISTRIBUTION: Record<string, Record<string, number>> = {
@@ -204,7 +210,7 @@ export async function GET(req: NextRequest) {
     // Note: dayTargets.calories will be fully recomputed below from components
 
     // ── Dynamic step calories: recompute from weight + step formula ──
-    const profileRows = await sql`SELECT weight_kg, step_goal, daily_deficit, tdee_estimate FROM nutrition_profile WHERE id = 1`;
+    const profileRows = await sql`SELECT weight_kg, step_goal, daily_deficit, tdee_estimate, estimated_bf_pct, deficit_mode FROM nutrition_profile WHERE id = 1`;
     let weightKg = Number(profileRows[0]?.weight_kg) || 79.2;
 
     // Use latest weight from weight_log (more current than profile)
@@ -328,10 +334,33 @@ export async function GET(req: NextRequest) {
       dayTargets.calories = Number(plan.target_calories);
     }
 
-    // Recompute macros to match adjusted target
-    dayTargets.protein = Math.round(weightKg * 2.2);
-    dayTargets.fat = Math.round(weightKg * 0.8);
-    dayTargets.carbs = Math.round(Math.max(0, (dayTargets.calories - dayTargets.protein * 4 - dayTargets.fat * 9) / 4));
+    // ── M4 5-band × tier × mode matrix (Nutrition Batch 2 #67) ──
+    // Route to the macro-engine matrix when we have BF% context. Falls
+    // back to the legacy flat 2.2 / 0.8 formula when BF% is missing so
+    // existing users without a tier continue to see their old numbers.
+    const bfPct = profileRows[0]?.estimated_bf_pct != null
+      ? Number(profileRows[0].estimated_bf_pct) : null;
+    const rawMode = String(profileRows[0]?.deficit_mode ?? "standard");
+    const mode: Mode = (VALID_MODES as readonly string[]).includes(rawMode)
+      ? (rawMode as Mode) : "standard";
+    if (bfPct != null) {
+      const matrix = computeMacroTargetsFromContext({
+        weightKg, bfPct, mode,
+        runKcal: effectiveRunCal,
+        gymKcal: effectiveGymCal,
+        kcalTarget: dayTargets.calories,
+        inDeficit: effectiveDeficit > 0,
+      });
+      dayTargets.protein = matrix.protein;
+      dayTargets.fat = matrix.fat;
+      dayTargets.carbs = matrix.carbs;
+      dayTargets.fiber = matrix.fiber;
+    } else {
+      // Legacy flat fallback (preserved for users without BF%).
+      dayTargets.protein = Math.round(weightKg * 2.2);
+      dayTargets.fat = Math.round(weightKg * 0.8);
+      dayTargets.carbs = Math.round(Math.max(0, (dayTargets.calories - dayTargets.protein * 4 - dayTargets.fat * 9) / 4));
+    }
 
     // Scale protein+fat down if they exceed calorie budget (extreme deficit days)
     const macroFloorCal = dayTargets.protein * 4 + dayTargets.fat * 9;

--- a/web/lib/macro-targets.ts
+++ b/web/lib/macro-targets.ts
@@ -1,0 +1,236 @@
+/**
+ * M4 Phase A — Macro Engine core (5-band × tier × mode).
+ *
+ * Source of truth: src/macro_engine/macro_targets.py
+ * Any changes here must be mirrored in Python (and vice versa).
+ *
+ * Research basis: SOMA-NUTRITION-SCIENCE-V2.md §2
+ */
+
+import type { Mode } from "./mode-engine";
+import { computeTierRaw, type Tier } from "./safety-rails";
+
+// ============================================================================
+// M4.1 — Training load + band classifier
+// ============================================================================
+
+export type Band = "rest" | "light" | "moderate" | "hard" | "very_hard";
+
+export const ALL_BANDS: readonly Band[] = [
+  "rest", "light", "moderate", "hard", "very_hard",
+] as const;
+
+const RUN_DIVISOR = 10;
+const GYM_DIVISOR = 6;
+const LOAD_SATURATION = 4.0;
+const ENDURANCE_PRIORITY_THRESHOLD = 1.5;
+
+export function computeTrainingLoad(
+  runKcal: number,
+  gymKcal: number,
+  opts: { weightKg: number },
+): number {
+  if (runKcal < 0 || gymKcal < 0) {
+    throw new RangeError(`kcal must be >= 0, got run=${runKcal} gym=${gymKcal}`);
+  }
+  if (opts.weightKg <= 0) {
+    throw new RangeError(`weightKg must be positive, got ${opts.weightKg}`);
+  }
+  const runLoad = runKcal / (opts.weightKg * RUN_DIVISOR);
+  const gymLoad = gymKcal / (opts.weightKg * GYM_DIVISOR);
+  if (runLoad >= ENDURANCE_PRIORITY_THRESHOLD) return runLoad;
+  return Math.min(runLoad + gymLoad, LOAD_SATURATION);
+}
+
+export function classifyBand(totalLoad: number): Band {
+  if (totalLoad <= 0) return "rest";
+  if (totalLoad <= 1.0) return "light";
+  if (totalLoad <= 2.0) return "moderate";
+  if (totalLoad <= 3.0) return "hard";
+  return "very_hard";
+}
+
+// ============================================================================
+// M4.2 — Protein formula (tier × mode × band)
+// ============================================================================
+
+type TierModeKey = `${Tier}|${Mode}`;
+
+const PROTEIN_BASE_G_PER_KG: Record<TierModeKey, number> = {
+  // Standard
+  "T1|standard": 2.0, "T2|standard": 2.3, "T3|standard": 2.4,
+  "T4|standard": 2.8, "T5|standard": 2.8,
+  // Aggressive (T1-T2 real; others gated by M2)
+  "T1|aggressive": 2.2, "T2|aggressive": 2.4, "T3|aggressive": 2.4,
+  "T4|aggressive": 2.4, "T5|aggressive": 2.4,
+  // Reverse mirrors Standard
+  "T1|reverse": 2.0, "T2|reverse": 2.3, "T3|reverse": 2.4,
+  "T4|reverse": 2.8, "T5|reverse": 2.8,
+  // Maintenance flat 2.0
+  "T1|maintenance": 2.0, "T2|maintenance": 2.0, "T3|maintenance": 2.0,
+  "T4|maintenance": 2.0, "T5|maintenance": 2.0,
+  // Bulk flat 2.0
+  "T1|bulk": 2.0, "T2|bulk": 2.0, "T3|bulk": 2.0, "T4|bulk": 2.0, "T5|bulk": 2.0,
+  // Injured uses Standard matrix for M4 (V2 §4.5 refines later)
+  "T1|injured": 2.0, "T2|injured": 2.3, "T3|injured": 2.4,
+  "T4|injured": 2.8, "T5|injured": 2.8,
+};
+
+const VERY_HARD_PROTEIN_DROP = 0.2;
+const PROTEIN_ABSOLUTE_FLOOR = 1.6;
+
+export function proteinGPerKg(tier: Tier, mode: Mode, band: Band): number {
+  const key = `${tier}|${mode}` as TierModeKey;
+  let base = PROTEIN_BASE_G_PER_KG[key];
+  if (band === "very_hard") base -= VERY_HARD_PROTEIN_DROP;
+  return Math.max(PROTEIN_ABSOLUTE_FLOOR, base);
+}
+
+// ============================================================================
+// M4.3 — Carbs + fiber
+// ============================================================================
+
+const CARB_G_PER_KG: Record<Band, number> = {
+  rest: 3.0, light: 3.5, moderate: 5.0, hard: 6.5, very_hard: 8.0,
+};
+
+const CARB_HEALTH_FLOOR_G = 100;
+const FIBER_MIN_G = 25;
+const FIBER_HARD_CEILING_G = 60;
+const FIBER_CUT_BONUS_G = 5;
+
+export function carbGPerKg(band: Band): number {
+  return CARB_G_PER_KG[band];
+}
+
+export function carbTargetG(
+  band: Band,
+  opts: { weightKg: number; inDeficit: boolean },
+): number {
+  const raw = Math.round(CARB_G_PER_KG[band] * opts.weightKg);
+  if (band === "rest" && opts.inDeficit) return Math.max(raw, CARB_HEALTH_FLOOR_G);
+  return raw;
+}
+
+export function fiberTargetG(kcalTarget: number, opts: { inDeficit: boolean }): number {
+  let base = Math.max(FIBER_MIN_G, Math.round((kcalTarget * 14) / 1000));
+  if (opts.inDeficit) base += FIBER_CUT_BONUS_G;
+  return Math.min(FIBER_HARD_CEILING_G, base);
+}
+
+// ============================================================================
+// M4.4 — Composed macro engine
+// ============================================================================
+
+const KCAL_P = 4;
+const KCAL_C = 4;
+const KCAL_F = 9;
+const FAT_HARD_FLOOR_G_PER_KG = 0.6;
+const FAT_SOFT_FLOOR_G_PER_KG = 0.8;
+const FAT_MAINTENANCE_TARGET = 1.0;
+const FAT_BULK_TARGET = 1.0;
+
+export interface MacroTargets {
+  kcal: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+  fiberG: number;
+}
+
+function fatTargetGForMode(mode: Mode, weightKg: number): number {
+  if (mode === "maintenance") return FAT_MAINTENANCE_TARGET * weightKg;
+  if (mode === "bulk") return FAT_BULK_TARGET * weightKg;
+  return FAT_SOFT_FLOOR_G_PER_KG * weightKg;
+}
+
+export function computeMacroTargets(opts: {
+  weightKg: number;
+  tier: Tier;
+  mode: Mode;
+  band: Band;
+  kcalTarget: number;
+  inDeficit: boolean;
+}): MacroTargets {
+  const { weightKg, tier, mode, band, kcalTarget, inDeficit } = opts;
+
+  const proteinG = Math.round(proteinGPerKg(tier, mode, band) * weightKg);
+  const fiberG = fiberTargetG(kcalTarget, { inDeficit });
+
+  const fatModeTarget = fatTargetGForMode(mode, weightKg);
+  const fatHardFloor = FAT_HARD_FLOOR_G_PER_KG * weightKg;
+  let fatG = Math.max(fatHardFloor, fatModeTarget);
+
+  const bandCeiling = CARB_G_PER_KG[band] * weightKg;
+  const remainderKcal = kcalTarget - proteinG * KCAL_P - fatG * KCAL_F;
+  let carbsFloat = Math.min(Math.max(0, remainderKcal / KCAL_C), bandCeiling);
+
+  if (band === "rest" && inDeficit && carbsFloat < CARB_HEALTH_FLOOR_G) {
+    const kcalForFat = kcalTarget - proteinG * KCAL_P - CARB_HEALTH_FLOOR_G * KCAL_C;
+    fatG = Math.max(fatHardFloor, kcalForFat / KCAL_F);
+    carbsFloat = CARB_HEALTH_FLOOR_G;
+  }
+
+  const carbsG = Math.round(carbsFloat);
+  const fatGInt = Math.round(fatG);
+  const kcal = proteinG * KCAL_P + carbsG * KCAL_C + fatGInt * KCAL_F;
+
+  return { kcal, proteinG, carbsG, fatG: fatGInt, fiberG };
+}
+
+// ============================================================================
+// Adapter — legacy API shape for existing callers (M4.5)
+// ============================================================================
+
+export interface MacroTargetsLegacyShape {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number;
+}
+
+export interface MacroContextResult extends MacroTargetsLegacyShape {
+  band: Band;
+  tier: Tier;
+}
+
+/**
+ * Adapter for legacy callers that pass profile + training context and expect
+ * {calories, protein, carbs, fat, fiber} field names. Internally runs the new
+ * 5-band × tier × mode engine, then remaps field names so the HTTP response
+ * shape stays stable for the UI.
+ *
+ * When bfPct is null (common during onboarding before a body-comp anchor is
+ * logged), defaults tier to T2 — a sensible midpoint for the seeded user
+ * profile that won't mis-trigger the T3+ Aggressive block.
+ */
+export function computeMacroTargetsFromContext(opts: {
+  weightKg: number;
+  bfPct: number | null;
+  mode: Mode;
+  runKcal: number;
+  gymKcal: number;
+  kcalTarget: number;
+  inDeficit: boolean;
+}): MacroContextResult {
+  const { weightKg, bfPct, mode, runKcal, gymKcal, kcalTarget, inDeficit } = opts;
+
+  const tier: Tier = bfPct != null ? computeTierRaw(bfPct) : "T2";
+  const load = computeTrainingLoad(runKcal, gymKcal, { weightKg });
+  const band = classifyBand(load);
+
+  const core = computeMacroTargets({
+    weightKg, tier, mode, band, kcalTarget, inDeficit,
+  });
+
+  return {
+    calories: core.kcal,
+    protein: core.proteinG,
+    carbs: core.carbsG,
+    fat: core.fatG,
+    fiber: core.fiberG,
+    band,
+    tier,
+  };
+}

--- a/web/lib/mode-engine.ts
+++ b/web/lib/mode-engine.ts
@@ -1,0 +1,183 @@
+/**
+ * M2 Mode Engine — TypeScript mirror of Python canonical.
+ *
+ * Source of truth:
+ *   src/macro_engine/mode.py
+ *   src/macro_engine/mode_availability.py
+ *   src/macro_engine/mode_transitions.py
+ *
+ * Any changes here must be mirrored in Python (and vice versa).
+ *
+ * Research basis: SOMA-NUTRITION-SCIENCE-V2.md §3.2, §4.5, §5, §6
+ */
+
+import type { Tier } from "./safety-rails";
+
+// ============================================================================
+// MODE ENUM + CONFIG (M2.1)
+// ============================================================================
+
+export type Mode =
+  | "standard"
+  | "aggressive"
+  | "reverse"
+  | "maintenance"
+  | "bulk"
+  | "injured";
+
+export const ALL_MODES: readonly Mode[] = [
+  "standard",
+  "aggressive",
+  "reverse",
+  "maintenance",
+  "bulk",
+  "injured",
+] as const;
+
+export interface ModeConfig {
+  tierAllowed: ReadonlySet<Tier>;
+  bfHardFloorPct: number | null;
+  requiresReverseBridgeFrom: ReadonlySet<Mode>;
+  maxDurationDays: number | null;
+}
+
+const ALL_TIERS: ReadonlySet<Tier> = new Set<Tier>(["T1", "T2", "T3", "T4", "T5"]);
+
+const MODE_CONFIGS: Record<Mode, ModeConfig> = {
+  standard: {
+    tierAllowed: new Set<Tier>(["T1", "T2", "T3", "T4"]),
+    bfHardFloorPct: null,
+    requiresReverseBridgeFrom: new Set<Mode>(),
+    maxDurationDays: null,
+  },
+  aggressive: {
+    tierAllowed: new Set<Tier>(["T1", "T2"]),
+    bfHardFloorPct: 12.0,
+    requiresReverseBridgeFrom: new Set<Mode>(),
+    maxDurationDays: 84, // V2 §3.2: 12 weeks at 700-900 kcal envelope
+  },
+  reverse: {
+    tierAllowed: ALL_TIERS,
+    bfHardFloorPct: null,
+    requiresReverseBridgeFrom: new Set<Mode>(),
+    maxDurationDays: 42, // V2 §3.2: post-aggressive reverse 2-6 weeks
+  },
+  maintenance: {
+    tierAllowed: ALL_TIERS,
+    bfHardFloorPct: null,
+    requiresReverseBridgeFrom: new Set<Mode>(),
+    maxDurationDays: null,
+  },
+  bulk: {
+    tierAllowed: new Set<Tier>(["T2", "T3", "T4", "T5"]),
+    bfHardFloorPct: null,
+    requiresReverseBridgeFrom: new Set<Mode>(["standard", "aggressive"]),
+    maxDurationDays: 140, // V2 §6.1: 12-20 week bulk block
+  },
+  injured: {
+    tierAllowed: ALL_TIERS,
+    bfHardFloorPct: null,
+    requiresReverseBridgeFrom: new Set<Mode>(),
+    maxDurationDays: null,
+  },
+};
+
+export function getModeConfig(mode: Mode): ModeConfig {
+  return MODE_CONFIGS[mode];
+}
+
+// ============================================================================
+// MODE AVAILABILITY (M2.2)
+// ============================================================================
+
+export type GateReason = "tier_not_allowed" | "bf_below_hard_floor";
+
+export interface ModeAvailability {
+  allowed: boolean;
+  reason: GateReason | null;
+}
+
+export function checkModeAvailability(
+  mode: Mode,
+  tier: Tier,
+  bfPct: number,
+): ModeAvailability {
+  const config = getModeConfig(mode);
+
+  if (!config.tierAllowed.has(tier)) {
+    return { allowed: false, reason: "tier_not_allowed" };
+  }
+
+  // Strictly-less-than OR equal to the floor is blocked: 12.0% BF is already
+  // contraindication territory per V2 §3.2.
+  if (config.bfHardFloorPct !== null && bfPct <= config.bfHardFloorPct) {
+    return { allowed: false, reason: "bf_below_hard_floor" };
+  }
+
+  return { allowed: true, reason: null };
+}
+
+// ============================================================================
+// MODE TRANSITIONS (M2.3)
+// ============================================================================
+
+export type TransitionReason =
+  | "mode_not_available"
+  | "aggressive_requires_reverse"
+  | "requires_reverse_bridge";
+
+export interface TransitionResult {
+  allowed: boolean;
+  reason: TransitionReason | null;
+  requiresBridge: Mode | null;
+}
+
+export function checkTransition(
+  current: Mode,
+  nextMode: Mode,
+  tier: Tier,
+  bfPct: number,
+): TransitionResult {
+  // No-op transition is trivially allowed.
+  if (current === nextMode) {
+    return { allowed: true, reason: null, requiresBridge: null };
+  }
+
+  // Injury is always an escape hatch.
+  if (nextMode === "injured") {
+    return { allowed: true, reason: null, requiresBridge: null };
+  }
+
+  // V2 §6.4: cut → bulk must pass through a reverse bridge. Check this before
+  // the generic Aggressive-exit rule so Aggressive → Bulk surfaces the more
+  // actionable REQUIRES_REVERSE_BRIDGE (which carries `requiresBridge`).
+  const nextConfig = getModeConfig(nextMode);
+  if (nextConfig.requiresReverseBridgeFrom.has(current)) {
+    return {
+      allowed: false,
+      reason: "requires_reverse_bridge",
+      requiresBridge: "reverse",
+    };
+  }
+
+  // V2 §3.2: exiting Aggressive (except to Reverse or Injured) blocked.
+  if (current === "aggressive" && nextMode !== "reverse") {
+    return {
+      allowed: false,
+      reason: "aggressive_requires_reverse",
+      requiresBridge: null,
+    };
+  }
+
+  // Finally, destination must be legal for the user's tier + BF%.
+  const availability = checkModeAvailability(nextMode, tier, bfPct);
+  if (!availability.allowed) {
+    return {
+      allowed: false,
+      reason: "mode_not_available",
+      requiresBridge: null,
+    };
+  }
+
+  return { allowed: true, reason: null, requiresBridge: null };
+}

--- a/web/lib/safety-rails.ts
+++ b/web/lib/safety-rails.ts
@@ -1,0 +1,502 @@
+/**
+ * M1 Safety Rails — TypeScript mirror of Python canonical.
+ *
+ * Source of truth: src/macro_engine/{tier,bmr,floor,rate_cap,fat_floor,
+ * protein_floor,deficit_duration}.py
+ *
+ * Any changes here must be mirrored in Python (and vice versa).
+ *
+ * Research basis: SOMA-NUTRITION-SCIENCE-V2.md §3-§4
+ */
+
+// ============================================================================
+// TIER FRAMEWORK (M1.1) — BF%-based master mode selector
+// ============================================================================
+
+export const HYSTERESIS_PCT = 1.0;
+
+export type Tier = "T1" | "T2" | "T3" | "T4" | "T5";
+
+export type BiomarkerCadence = "weekly" | "daily" | "daily+bloods";
+
+export interface TierPolicy {
+  tier: Tier;
+  bfRange: [number, number];
+  rateCapSoftPctPerWk: number;
+  rateCapHardPctPerWk: number;
+  proteinGPerKgBw: number;
+  proteinGPerKgLbmBasis: boolean;
+  fatFloorGPerKgBwSoft: number;
+  fatFloorGPerKgBwHard: number;
+  aggressiveModeAllowed: boolean;
+  refeedFrequencyDays: number;
+  dietBreakFrequencyWeeks: number;
+  biomarkerCadence: BiomarkerCadence;
+  durationEnvelopeWeeks: [number, number];
+}
+
+export function computeTierRaw(bfPct: number): Tier {
+  if (bfPct >= 28.0) return "T1";
+  if (bfPct >= 20.0) return "T2";
+  if (bfPct >= 15.0) return "T3";
+  if (bfPct >= 10.0) return "T4";
+  return "T5";
+}
+
+// Upper bound of each tier (ascending leanness = descending BF%)
+const TIER_UPPER_BOUND: Record<Tier, number> = {
+  T5: 10.0,
+  T4: 15.0,
+  T3: 20.0,
+  T2: 28.0,
+  T1: Infinity,
+};
+
+// Upper bound of the tier immediately leaner than a given tier
+// (= the given tier's lower boundary)
+const LEANER_TIER_UPPER: Record<Tier, number> = {
+  T1: 28.0,
+  T2: 20.0,
+  T3: 15.0,
+  T4: 10.0,
+  T5: 0.0,
+};
+
+const TIER_ORDER: Record<Tier, number> = { T1: 1, T2: 2, T3: 3, T4: 4, T5: 5 };
+
+export function computeTier(bfPct: number, previousTier?: Tier): Tier {
+  const raw = computeTierRaw(bfPct);
+  if (previousTier === undefined || raw === previousTier) return raw;
+
+  if (TIER_ORDER[raw] > TIER_ORDER[previousTier]) {
+    // Moving leaner: must drop below previous tier's lower edge - hysteresis
+    const threshold = LEANER_TIER_UPPER[previousTier] - HYSTERESIS_PCT;
+    return bfPct <= threshold ? raw : previousTier;
+  }
+  // Moving fatter: must rise above previous tier's upper edge + hysteresis
+  const threshold = TIER_UPPER_BOUND[previousTier] + HYSTERESIS_PCT;
+  return bfPct >= threshold ? raw : previousTier;
+}
+
+export function rollingMedianBf(readings: number[]): number {
+  if (readings.length === 0) {
+    throw new Error("rollingMedianBf requires at least one reading");
+  }
+  const sorted = [...readings].sort((a, b) => a - b);
+  const n = sorted.length;
+  if (n === 1) return sorted[0];
+  if (n % 2 === 0) return (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+  return sorted[Math.floor(n / 2)];
+}
+
+const TIER_POLICIES: Record<Tier, TierPolicy> = {
+  T1: {
+    tier: "T1", bfRange: [28.0, Infinity],
+    rateCapSoftPctPerWk: 1.0, rateCapHardPctPerWk: 1.25,
+    proteinGPerKgBw: 2.0, proteinGPerKgLbmBasis: false,
+    fatFloorGPerKgBwSoft: 0.8, fatFloorGPerKgBwHard: 0.6,
+    aggressiveModeAllowed: true,
+    refeedFrequencyDays: 14, dietBreakFrequencyWeeks: 12,
+    biomarkerCadence: "weekly", durationEnvelopeWeeks: [12, 24],
+  },
+  T2: {
+    tier: "T2", bfRange: [20.0, 28.0],
+    rateCapSoftPctPerWk: 0.75, rateCapHardPctPerWk: 1.0,
+    proteinGPerKgBw: 2.2, proteinGPerKgLbmBasis: false,
+    fatFloorGPerKgBwSoft: 0.8, fatFloorGPerKgBwHard: 0.6,
+    aggressiveModeAllowed: true,
+    refeedFrequencyDays: 14, dietBreakFrequencyWeeks: 12,
+    biomarkerCadence: "weekly", durationEnvelopeWeeks: [12, 16],
+  },
+  T3: {
+    tier: "T3", bfRange: [15.0, 20.0],
+    rateCapSoftPctPerWk: 0.5, rateCapHardPctPerWk: 0.75,
+    proteinGPerKgBw: 2.4, proteinGPerKgLbmBasis: false,
+    fatFloorGPerKgBwSoft: 0.8, fatFloorGPerKgBwHard: 0.6,
+    aggressiveModeAllowed: false, // BLOCKED at T3
+    refeedFrequencyDays: 7, dietBreakFrequencyWeeks: 10,
+    biomarkerCadence: "weekly", durationEnvelopeWeeks: [16, 20],
+  },
+  T4: {
+    tier: "T4", bfRange: [10.0, 15.0],
+    rateCapSoftPctPerWk: 0.4, rateCapHardPctPerWk: 0.5,
+    proteinGPerKgBw: 2.8, proteinGPerKgLbmBasis: true, // LBM basis at T4+
+    fatFloorGPerKgBwSoft: 0.8, fatFloorGPerKgBwHard: 0.6,
+    aggressiveModeAllowed: false,
+    refeedFrequencyDays: 5, dietBreakFrequencyWeeks: 8,
+    biomarkerCadence: "daily", durationEnvelopeWeeks: [8, 12],
+  },
+  T5: {
+    tier: "T5", bfRange: [0.0, 10.0],
+    rateCapSoftPctPerWk: 0.3, rateCapHardPctPerWk: 0.4,
+    proteinGPerKgBw: 3.0, proteinGPerKgLbmBasis: true,
+    fatFloorGPerKgBwSoft: 0.8, fatFloorGPerKgBwHard: 0.6,
+    aggressiveModeAllowed: false,
+    refeedFrequencyDays: 3, dietBreakFrequencyWeeks: 6,
+    biomarkerCadence: "daily+bloods", durationEnvelopeWeeks: [4, 8],
+  },
+};
+
+export function getTierPolicy(tier: Tier): TierPolicy {
+  return TIER_POLICIES[tier];
+}
+
+// ============================================================================
+// BMR (M1.2)
+// ============================================================================
+
+export type Sex = "male" | "female";
+
+/** Cunningham 1980: BMR = 500 + 22 × FFM_kg (primary for trained athletes). */
+export function cunningham(ffmKg: number): number {
+  if (ffmKg <= 0) throw new Error(`ffmKg must be positive, got ${ffmKg}`);
+  return Math.round(500 + 22 * ffmKg);
+}
+
+/** Mifflin-St Jeor 1990: demographic BMR. Good for general/obese; under-predicts in lean trained. */
+export function mifflinStJeor(weightKg: number, heightCm: number, age: number, sex: Sex): number {
+  if (weightKg <= 0 || heightCm <= 0 || age <= 0) {
+    throw new Error("weightKg, heightCm, age must all be positive");
+  }
+  const base = 10 * weightKg + 6.25 * heightCm - 5 * age;
+  return Math.round(sex === "male" ? base + 5 : base - 161);
+}
+
+/** ten Haaf 2014 weight-based (athletes). Better than Mifflin for trained populations. */
+export function tenHaafWeight(weightKg: number, heightCm: number, age: number, sex: Sex): number {
+  if (weightKg <= 0 || heightCm <= 0 || age <= 0) {
+    throw new Error("weightKg, heightCm, age must all be positive");
+  }
+  const heightM = heightCm / 100;
+  const sexMale = sex === "male" ? 1 : 0;
+  const kcal = 11.936 * weightKg + 587.728 * heightM - 8.129 * age + 191.027 * sexMale + 29.279;
+  return Math.round(kcal);
+}
+
+/** Route to the best BMR formula given inputs. FFM → Cunningham; else → ten Haaf. */
+export function computeBmr(opts: {
+  ffmKg?: number;
+  weightKg?: number;
+  heightCm?: number;
+  age?: number;
+  sex?: Sex;
+}): number {
+  if (opts.ffmKg !== undefined) return cunningham(opts.ffmKg);
+  if (
+    opts.weightKg !== undefined && opts.heightCm !== undefined &&
+    opts.age !== undefined && opts.sex !== undefined
+  ) {
+    return tenHaafWeight(opts.weightKg, opts.heightCm, opts.age, opts.sex);
+  }
+  throw new Error(
+    "computeBmr requires either ffmKg or full demographics (weightKg + heightCm + age + sex)",
+  );
+}
+
+// ============================================================================
+// BMR + RED-S EA FLOOR (M1.3)
+// ============================================================================
+
+export const REDS_EA_COEFFICIENT = 25; // kcal per kg FFM per day (Mountjoy 2018)
+
+export type FloorMode = "standard" | "aggressive";
+
+export type FloorBreachType = "none" | "soft" | "hard";
+
+export interface FloorResult {
+  softFloor: number;
+  hardFloor: number;
+  targetKcal: number;
+  breachType: FloorBreachType;
+}
+
+export function computeFloor(ffmKg: number, exerciseKcal: number, mode: FloorMode): {
+  softFloor: number; hardFloor: number;
+} {
+  if (mode !== "standard" && mode !== "aggressive") {
+    throw new Error(`Unknown mode: ${mode}`);
+  }
+  if (ffmKg <= 0) throw new Error(`ffmKg must be positive`);
+  if (exerciseKcal < 0) throw new Error(`exerciseKcal must be non-negative`);
+
+  const soft = cunningham(ffmKg);
+  const eaThreshold = Math.round(REDS_EA_COEFFICIENT * ffmKg + exerciseKcal);
+  const hard = mode === "standard" ? Math.max(soft, eaThreshold) : eaThreshold;
+  return { softFloor: soft, hardFloor: hard };
+}
+
+export function applyFloor(
+  targetKcal: number, ffmKg: number, exerciseKcal: number, mode: FloorMode,
+): FloorResult {
+  const { softFloor, hardFloor } = computeFloor(ffmKg, exerciseKcal, mode);
+
+  if (targetKcal < hardFloor) {
+    return { softFloor, hardFloor, targetKcal: hardFloor, breachType: "hard" };
+  }
+  if (targetKcal < softFloor) {
+    return { softFloor, hardFloor, targetKcal, breachType: "soft" };
+  }
+  return { softFloor, hardFloor, targetKcal, breachType: "none" };
+}
+
+// ============================================================================
+// 5-TIER RATE CAP (M1.4)
+// ============================================================================
+
+export type RateStatus = "green" | "yellow" | "red" | "suppressed";
+
+export interface RateCap {
+  softPctPerWk: number;
+  hardPctPerWk: number;
+}
+
+export interface RateCheckResult {
+  rate7DayPct: number;
+  rate14DayPct: number | null;
+  status: RateStatus;
+  softCap: number;
+  hardCap: number;
+}
+
+const STANDARD_RATE_CAPS: Record<Tier, [number, number]> = {
+  T1: [1.0, 1.25],
+  T2: [0.75, 1.0],
+  T3: [0.5, 0.75],
+  T4: [0.4, 0.5],
+  T5: [0.3, 0.4],
+};
+
+const TIER_SEQ: Tier[] = ["T5", "T4", "T3", "T2", "T1"];
+
+export function getRateCap(tier: Tier, mode: FloorMode = "standard"): RateCap {
+  if (mode !== "standard" && mode !== "aggressive") {
+    throw new Error(`Unknown mode: ${mode}`);
+  }
+  let effective = tier;
+  if (mode === "aggressive") {
+    const idx = TIER_SEQ.indexOf(tier);
+    const loosenedIdx = Math.min(idx + 1, TIER_SEQ.length - 1);
+    effective = TIER_SEQ[loosenedIdx];
+  }
+  const [soft, hard] = STANDARD_RATE_CAPS[effective];
+  return { softPctPerWk: soft, hardPctPerWk: hard };
+}
+
+export function computeWeeklyRatePct(
+  dailyWeights: number[], currentWeightKg?: number,
+): number {
+  if (dailyWeights.length < 2) {
+    throw new Error(`Need at least 2 daily weights, got ${dailyWeights.length}`);
+  }
+  const ref = currentWeightKg ?? dailyWeights[dailyWeights.length - 1];
+  const n = dailyWeights.length;
+  const meanX = (n - 1) / 2;
+  const meanY = dailyWeights.reduce((a, b) => a + b, 0) / n;
+  let num = 0, den = 0;
+  for (let i = 0; i < n; i++) {
+    num += (i - meanX) * (dailyWeights[i] - meanY);
+    den += (i - meanX) ** 2;
+  }
+  const slopeKgPerDay = num / den;
+  return ((slopeKgPerDay * 7) / ref) * 100;
+}
+
+export function checkRateCap(
+  weights: number[],
+  tier: Tier,
+  mode: FloorMode,
+  currentWeightKg: number,
+  daysSinceCutStart: number,
+): RateCheckResult {
+  const cap = getRateCap(tier, mode);
+
+  const safeRate = (ws: number[]): number => {
+    if (ws.length < 2) return 0;
+    return computeWeeklyRatePct(ws, currentWeightKg);
+  };
+
+  if (daysSinceCutStart < 14) {
+    const rate7 = safeRate(weights.slice(-7));
+    return {
+      rate7DayPct: rate7, rate14DayPct: null,
+      status: "suppressed",
+      softCap: cap.softPctPerWk, hardCap: cap.hardPctPerWk,
+    };
+  }
+
+  const rate7 = safeRate(weights.slice(-7));
+  const rate14 = weights.length >= 14 ? safeRate(weights.slice(-14)) : null;
+
+  // Magnitudes (ignore gains for a cut)
+  const rate7Mag = rate7 < 0 ? -rate7 : 0;
+  const rate14Mag = rate14 !== null && rate14 < 0 ? -rate14 : 0;
+
+  let status: RateStatus;
+  if (rate7Mag > cap.hardPctPerWk && rate14 !== null && rate14Mag > cap.hardPctPerWk) {
+    status = "red";
+  } else if (rate7Mag > cap.softPctPerWk) {
+    status = "yellow";
+  } else {
+    status = "green";
+  }
+
+  return {
+    rate7DayPct: rate7, rate14DayPct: rate14, status,
+    softCap: cap.softPctPerWk, hardCap: cap.hardPctPerWk,
+  };
+}
+
+// ============================================================================
+// FAT FLOOR (M1.5)
+// ============================================================================
+
+export type FatMode = "standard" | "aggressive" | "maintenance" | "bulk";
+export type FatBreachType = "none" | "soft" | "hard";
+
+export interface FatFloorResult {
+  softFloorG: number;
+  hardFloorG: number;
+  fatG: number;
+  breachType: FatBreachType;
+}
+
+export const FAT_FLOOR_SOFT_DEFAULT = 0.8;
+export const FAT_FLOOR_HARD = 0.6;
+export const FAT_TARGET_MAINTENANCE = 1.0;
+
+function softFloorPerKg(mode: FatMode): number {
+  return mode === "maintenance" ? FAT_TARGET_MAINTENANCE : FAT_FLOOR_SOFT_DEFAULT;
+}
+
+export function computeFatFloor(weightKg: number, mode: FatMode): { softFloorG: number; hardFloorG: number } {
+  if (!["standard", "aggressive", "maintenance", "bulk"].includes(mode)) {
+    throw new Error(`Unknown mode: ${mode}`);
+  }
+  if (weightKg <= 0) throw new Error("weightKg must be positive");
+  return {
+    softFloorG: Math.round(softFloorPerKg(mode) * weightKg),
+    hardFloorG: Math.round(FAT_FLOOR_HARD * weightKg),
+  };
+}
+
+export function applyFatFloor(fatG: number, weightKg: number, mode: FatMode): FatFloorResult {
+  const { softFloorG, hardFloorG } = computeFatFloor(weightKg, mode);
+  if (fatG < hardFloorG) {
+    return { softFloorG, hardFloorG, fatG: hardFloorG, breachType: "hard" };
+  }
+  if (fatG < softFloorG) {
+    return { softFloorG, hardFloorG, fatG, breachType: "soft" };
+  }
+  return { softFloorG, hardFloorG, fatG, breachType: "none" };
+}
+
+// ============================================================================
+// PROTEIN FLOOR + PER-MEAL (M1.6)
+// ============================================================================
+
+export const PROTEIN_FLOOR_G_PER_KG = 1.6;
+
+export type ProteinFloorStatus = "green" | "amber";
+export type PerMealProteinLevel = "red" | "amber" | "yellow" | "green" | "no_warning";
+
+export interface ProteinFloorResult {
+  floorG: number;
+  daysBelowFloor: number;
+  status: ProteinFloorStatus;
+}
+
+export function computeProteinFloor(weightKg: number): number {
+  if (weightKg <= 0) throw new Error("weightKg must be positive");
+  return Math.round(PROTEIN_FLOOR_G_PER_KG * weightKg);
+}
+
+export function checkProteinFloor(recentIntakes: number[], weightKg: number): ProteinFloorResult {
+  const floor = computeProteinFloor(weightKg);
+  let streak = 0;
+  for (let i = recentIntakes.length - 1; i >= 0; i--) {
+    if (recentIntakes[i] < floor) streak++;
+    else break;
+  }
+  return {
+    floorG: floor,
+    daysBelowFloor: streak,
+    status: streak >= 3 ? "amber" : "green",
+  };
+}
+
+export function checkPerMealProtein(proteinG: number): PerMealProteinLevel {
+  if (proteinG <= 14) return "red";
+  if (proteinG <= 24) return "amber";
+  if (proteinG <= 29) return "yellow";
+  if (proteinG <= 55) return "green";
+  return "no_warning";
+}
+
+// ============================================================================
+// DEFICIT DURATION (M1.7)
+// ============================================================================
+
+export const DEFICIT_RATIO_THRESHOLD = 0.95;
+const DEFAULT_SOFT_WARN = 56;
+const DEFAULT_STRONG = 84;
+const DEFAULT_HARD_STOP = 112;
+const SEVERITY_OFFSET_DAYS = 28;
+const FULL_RESET_MAINTENANCE_DAYS = 7;
+const HALF_RESET_MIN_DAYS = 3;
+
+export type CounterStatus = "green" | "warn" | "strong" | "hard_stop";
+
+export interface DurationThresholds {
+  softWarnDays: number;
+  strongRecommendDays: number;
+  hardStopDays: number;
+}
+
+export interface DayEntry {
+  intakeKcal: number;
+  tdeeKcal: number;
+}
+
+function isDeficitDay(day: DayEntry): boolean {
+  if (day.tdeeKcal <= 0) return false;
+  return day.intakeKcal < DEFICIT_RATIO_THRESHOLD * day.tdeeKcal;
+}
+
+export function computeCounter(days: DayEntry[]): number {
+  let counter = 0;
+  let maintenanceStreak = 0;
+
+  for (const day of days) {
+    if (isDeficitDay(day)) {
+      if (maintenanceStreak >= FULL_RESET_MAINTENANCE_DAYS) {
+        counter = 0;
+      } else if (maintenanceStreak >= HALF_RESET_MIN_DAYS) {
+        counter = Math.floor(counter / 2);
+      }
+      maintenanceStreak = 0;
+      counter++;
+    } else {
+      maintenanceStreak++;
+    }
+  }
+  return counter;
+}
+
+export function getThresholds(avgDeficitPct: number): DurationThresholds {
+  let offset = 0;
+  if (avgDeficitPct > 25.0) offset = -SEVERITY_OFFSET_DAYS;
+  else if (avgDeficitPct < 15.0) offset = +SEVERITY_OFFSET_DAYS;
+
+  return {
+    softWarnDays: DEFAULT_SOFT_WARN + offset,
+    strongRecommendDays: DEFAULT_STRONG + offset,
+    hardStopDays: DEFAULT_HARD_STOP + offset,
+  };
+}
+
+export function classifyCounter(counter: number, thresholds: DurationThresholds): CounterStatus {
+  if (counter >= thresholds.hardStopDays) return "hard_stop";
+  if (counter >= thresholds.strongRecommendDays) return "strong";
+  if (counter >= thresholds.softWarnDays) return "warn";
+  return "green";
+}


### PR DESCRIPTION
Stacked on #70. Replaces soma's flat protein=2.2 g/kg, fat=0.8 g/kg defaults with macro-engine's 5-band × 5-tier × mode matrix. Wires the new `deficit_mode` column through `generate_today → tdee.compute_macro_targets`.

## What changes
- **New modules** (ported from macro-engine): `mode.py`, `mode_availability.py`, `mode_transitions.py`, `macro_targets.py`.
- **Schema**: migration 006 adds `deficit_mode text NOT NULL DEFAULT 'standard'` + CHECK constraint. Applied to production Neon.
- **Wiring**: `tdee.compute_macro_targets` gains optional `mode`, `run_kcal`, `gym_kcal` kwargs. When BF% + mode + run/gym supplied → matrix. Otherwise legacy flat formula (backward compatible with existing tests).
- **generate_today.py**: reads `deficit_mode` from profile, splits `exercise_cal` into run/gym for the band classifier (has_run → all run; has_gym only → all gym; both → 60/40; rest → 0/0).

## Behavior shift, concretely
For a T2 (20-28% BF) user on a moderate gym day in standard mode:
- Before: protein = 80 × 2.2 = 176 g; fat = 80 × 0.8 = 64 g; carbs = remainder.
- After: tier T2 + mode standard + band moderate → protein = 80 × 2.3 = 184 g; fat = 80 × 0.8 = 64 g (floor); carbs ≤ 5.0 × 80 = 400 g ceiling with rest-day 100 g floor if deficit.

## Test plan
- [x] **32 new pytest assertions** ported from macro-engine's mode / availability / transitions / macro_targets suites — all green.
- [x] 214 tests passing in the module scope (ported + legacy tdee + legacy macro_targets variants).
- [x] Pre-existing MAX_DEFICIT failures unchanged from main (independent tech debt).
- [x] \`from nutrition_engine.generate_today import generate_today\` smoke passes.

## Research citations
V2 §2.1 (protein matrix), V2 §2.3 (band-periodized carbs + 5-band classifier), V2 §2.4 (fiber), V2 §3.2 (Aggressive T1-T2 + 12% BF hard floor), V2 §6 (Bulk tier gate), Mountjoy 2018 (RED-S EA floor).

Closes #67