### PR TITLE
feat(nutrition): Batch 3 — adaptive TDEE + deficit duration + Forbes weight prediction

### DIFF
--- a/sync/migrations/006_nutrition_deficit_mode.sql
+++ b/sync/migrations/006_nutrition_deficit_mode.sql
@@ -1,0 +1,15 @@
+-- Nutrition Batch 2: add deficit_mode column for the M2 mode engine.
+-- Default 'standard' preserves current behaviour for existing rows.
+
+ALTER TABLE nutrition_profile
+    ADD COLUMN IF NOT EXISTS deficit_mode text NOT NULL DEFAULT 'standard';
+
+-- CHECK constraint matches macro-engine's Mode enum.
+ALTER TABLE nutrition_profile
+    DROP CONSTRAINT IF EXISTS nutrition_profile_deficit_mode_check;
+
+ALTER TABLE nutrition_profile
+    ADD CONSTRAINT nutrition_profile_deficit_mode_check
+    CHECK (deficit_mode IN (
+        'standard', 'aggressive', 'reverse', 'maintenance', 'bulk', 'injured'
+    ));

--- a/sync/migrations/007_nutrition_deficit_phase.sql
+++ b/sync/migrations/007_nutrition_deficit_phase.sql
@@ -1,0 +1,8 @@
+-- Nutrition Batch 3: add deficit_phase_start_date column for the M5.3
+-- diet-break recommender + M1.7 deficit duration counter.
+--
+-- Null means "not currently in an explicit deficit phase" (the counter
+-- returns 0). Set to the date the user began a new cut to start the clock.
+
+ALTER TABLE nutrition_profile
+    ADD COLUMN IF NOT EXISTS deficit_phase_start_date date;

--- a/sync/src/nutrition_engine/adaptive.py
+++ b/sync/src/nutrition_engine/adaptive.py
@@ -1,0 +1,257 @@
+"""M5 Phase A — Adaptive Systems core (V2 §4).
+
+Four adaptive subsystems that react to the user's actual observed data
+rather than relying on fixed formulas:
+
+M5.1 Adaptive TDEE — reconcile predicted TDEE with actual intake + weight change
+M5.2 Refeed Pressure Score — composite 0-100 trigger for suggesting a refeed
+M5.3 Diet Break level — 4-level suggestion ramp based on deficit duration
+M5.4 Plateau Detection — gated on adaptive-TDEE stability, with type classifier
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+from nutrition_engine.tier import Tier
+from nutrition_engine.weight_prediction import DayPoint
+
+
+# ---------------------------------------------------------------------------
+# M5.1 Adaptive TDEE
+# ---------------------------------------------------------------------------
+
+_KCAL_PER_KG_BW: float = 7700.0  # V2 §4.1 reconciliation constant
+_ADAPTIVE_TDEE_MIN_DAYS: int = 7
+_ADAPTIVE_TDEE_WINDOW_DAYS: int = 14
+_DRIFT_THRESHOLD_PCT: float = 10.0
+
+
+@dataclass(frozen=True)
+class AdaptiveTdeeResult:
+    effective_tdee: float
+    reported_tdee: float
+    discrepancy_pct: float
+    drift_flag: bool
+
+
+def compute_adaptive_tdee(
+    days: list[DayPoint],
+    *,
+    window_days: int = _ADAPTIVE_TDEE_WINDOW_DAYS,
+    min_days: int = _ADAPTIVE_TDEE_MIN_DAYS,
+) -> AdaptiveTdeeResult | None:
+    """Reconcile a user's reported TDEE with observed intake + weight change.
+
+    effective_tdee = avg_intake - (weight_delta_kg × 7700 / days)
+    A positive weight_delta (weight loss) adds kcal back to explain the loss.
+    Returns None when fewer than min_days of data are available.
+    """
+    if len(days) < min_days:
+        return None
+
+    window = days[-window_days:]
+    n = len(window)
+    avg_intake = sum(d.intake_kcal for d in window) / n
+    weight_delta = window[0].weight_kg - window[-1].weight_kg  # positive if losing
+    days_span = max(1, n - 1)
+    effective_tdee = avg_intake + (weight_delta * _KCAL_PER_KG_BW / days_span)
+
+    # Average reported TDEE across the window
+    reported = sum(d.tdee_kcal for d in window) / n
+    if reported <= 0:
+        return None
+
+    discrepancy_pct = abs(effective_tdee - reported) / reported * 100
+
+    # Drift flag: discrepancy > 10% on 5+ of the last 7 days. We approximate
+    # "last 7 days" as a trailing 7-day window of day-level comparisons.
+    drift_flag = False
+    if n >= 7:
+        recent = window[-7:]
+        drift_count = 0
+        for i, d in enumerate(recent):
+            if d.tdee_kcal <= 0:
+                continue
+            # Per-day effective TDEE: use the 14-day window total applied
+            # day-wise for a stable per-day metric.
+            day_discrepancy = abs(effective_tdee - d.tdee_kcal) / d.tdee_kcal * 100
+            if day_discrepancy > _DRIFT_THRESHOLD_PCT:
+                drift_count += 1
+        drift_flag = drift_count >= 5
+
+    return AdaptiveTdeeResult(
+        effective_tdee=effective_tdee,
+        reported_tdee=reported,
+        discrepancy_pct=discrepancy_pct,
+        drift_flag=drift_flag,
+    )
+
+
+# ---------------------------------------------------------------------------
+# M5.2 Refeed Pressure Score
+# ---------------------------------------------------------------------------
+
+
+def compute_refeed_pressure_score(
+    *,
+    deficit_days: int,
+    weight_stall_days: int,
+    hrv_7d_trend_pct: float,
+    readiness_avg: float,
+    bf_tier: Tier,
+    weight_loss_velocity_pct_per_wk: float,
+) -> int:
+    """Composite 0-100 score that triggers app-suggested refeed at ≥ 60.
+
+    Each signal contributes up to its weighted max; the final sum is clamped
+    to [0, 100]. Weights from V2 §4.2.
+    """
+    score = 0.0
+
+    # Deficit-days: 25 points ramped linearly from 0 → 56 days
+    score += min(25.0, deficit_days / 56 * 25)
+
+    # Weight stall: 20 points ramped linearly from 0 → 14 days
+    score += min(20.0, weight_stall_days / 14 * 20)
+
+    # HRV down-trend: 15 points if 7d trend ≤ -5%, ramps up to -15% for max
+    if hrv_7d_trend_pct <= -5:
+        score += min(15.0, abs(hrv_7d_trend_pct) / 15 * 15)
+
+    # Readiness below 60: up to 10 points (lower readiness = more pressure)
+    if readiness_avg < 60:
+        score += min(10.0, (60 - readiness_avg) / 30 * 10)
+
+    # BF tier: leaner tiers add pressure (MPS/metabolic adaptation risk)
+    tier_bonus = {Tier.T1: 0, Tier.T2: 0, Tier.T3: 5, Tier.T4: 10, Tier.T5: 10}
+    score += tier_bonus[bf_tier]
+
+    # Weight-loss velocity: 20 points if > 1.0%/wk (generic hard-cap proxy)
+    if weight_loss_velocity_pct_per_wk > 1.0:
+        score += min(20.0, (weight_loss_velocity_pct_per_wk - 1.0) / 1.0 * 20)
+
+    return max(0, min(100, round(score)))
+
+
+# ---------------------------------------------------------------------------
+# M5.3 Diet Break level
+# ---------------------------------------------------------------------------
+
+
+class DietBreakLevel(str, Enum):
+    NONE = "none"
+    SUGGESTED = "suggested"
+    STRONG = "strong"
+    MANDATORY = "mandatory"
+
+
+def recommend_diet_break(deficit_duration_days: int) -> DietBreakLevel:
+    """Days-in-deficit → escalating diet-break recommendation level."""
+    if deficit_duration_days < 56:
+        return DietBreakLevel.NONE
+    if deficit_duration_days < 84:
+        return DietBreakLevel.SUGGESTED
+    if deficit_duration_days < 112:
+        return DietBreakLevel.STRONG
+    return DietBreakLevel.MANDATORY
+
+
+# ---------------------------------------------------------------------------
+# M5.4 Plateau detection
+# ---------------------------------------------------------------------------
+
+_PLATEAU_MIN_DAYS: int = 21
+_PLATEAU_SLOPE_THRESHOLD_KG_PER_WK: float = 0.185
+_PLATEAU_WATER_DAYS: int = 14
+
+
+class PlateauType(str, Enum):
+    ADAPTATION = "adaptation"
+    INTAKE_CREEP = "intake_creep"
+    WATER = "water"
+    RECOMP = "recomp"
+
+
+@dataclass(frozen=True)
+class PlateauResult:
+    is_plateau: bool
+    ema_slope_kg_per_wk: float
+    type: PlateauType | None
+    days_stalled: int
+
+
+def _linear_slope_kg_per_day(weights: list[float]) -> float:
+    """Simple least-squares slope of weight vs. day-index."""
+    n = len(weights)
+    if n < 2:
+        return 0.0
+    x_mean = (n - 1) / 2
+    y_mean = sum(weights) / n
+    num = 0.0
+    den = 0.0
+    for i, w in enumerate(weights):
+        num += (i - x_mean) * (w - y_mean)
+        den += (i - x_mean) ** 2
+    return num / den if den else 0.0
+
+
+def detect_plateau(
+    weight_days: list[DayPoint],
+    *,
+    hunger_elevated: bool = False,
+    strength_improving: bool = False,
+    tdee_stable: bool,
+) -> PlateauResult:
+    """Identify a plateau from weight history + subjective training signals.
+
+    Gates: need ≥ 21 days of data AND a stable adaptive-TDEE signal (else we
+    can't distinguish a true plateau from a data artifact).
+    """
+    if len(weight_days) < _PLATEAU_MIN_DAYS:
+        return PlateauResult(
+            is_plateau=False, ema_slope_kg_per_wk=0.0,
+            type=None, days_stalled=0,
+        )
+
+    slope_per_day = _linear_slope_kg_per_day([d.weight_kg for d in weight_days])
+    slope_per_wk = slope_per_day * 7
+
+    # Count days since last weight decrease of more than half a sigma
+    days_stalled = len(weight_days)  # approximation — all data points count
+
+    if strength_improving:
+        # Recomp: body comp changing even though weight isn't → not a plateau.
+        return PlateauResult(
+            is_plateau=False, ema_slope_kg_per_wk=slope_per_wk,
+            type=PlateauType.RECOMP, days_stalled=days_stalled,
+        )
+
+    if not tdee_stable:
+        return PlateauResult(
+            is_plateau=False, ema_slope_kg_per_wk=slope_per_wk,
+            type=None, days_stalled=days_stalled,
+        )
+
+    # Must be stalling: slope must be shallower than -0.185 kg/wk (i.e.
+    # losing LESS than 0.185/wk means it's a plateau).
+    if abs(slope_per_wk) > _PLATEAU_SLOPE_THRESHOLD_KG_PER_WK:
+        return PlateauResult(
+            is_plateau=False, ema_slope_kg_per_wk=slope_per_wk,
+            type=None, days_stalled=days_stalled,
+        )
+
+    # Classify type from subjective signals
+    if hunger_elevated:
+        plateau_type = PlateauType.ADAPTATION
+    elif days_stalled < _PLATEAU_WATER_DAYS:
+        plateau_type = PlateauType.WATER
+    else:
+        plateau_type = PlateauType.INTAKE_CREEP
+
+    return PlateauResult(
+        is_plateau=True, ema_slope_kg_per_wk=slope_per_wk,
+        type=plateau_type, days_stalled=days_stalled,
+    )

--- a/sync/src/nutrition_engine/bmr.py
+++ b/sync/src/nutrition_engine/bmr.py
@@ -1,0 +1,111 @@
+"""Basal Metabolic Rate (BMR) formulas.
+
+Cunningham 1980 primary for FFM-based (most accurate for trained athletes,
+validated by ten Haaf 2014 with 78% accuracy in recreational athletes).
+
+ten Haaf 2014 weight-based as fallback when FFM is unknown (~80% accuracy
+for athlete populations, better than Mifflin for lean trained).
+
+Mifflin-St Jeor 1990 as absolute fallback (best for general/obese adults).
+
+DO NOT use Garmin-reported BMR — no published validation, known to inflate
+by ~13% through an embedded ~1.1 sedentary activity multiplier.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+
+def cunningham(ffm_kg: float) -> int:
+    """Cunningham 1980: BMR = 500 + 22 × FFM_kg.
+
+    Primary formula for trained athletes. Validated by ten Haaf 2014
+    (PMID 25275434, DOI 10.1371/journal.pone.0108460).
+    """
+    if ffm_kg <= 0:
+        raise ValueError(f"ffm_kg must be positive, got {ffm_kg}")
+    return round(500 + 22 * ffm_kg)
+
+
+def mifflin_st_jeor(
+    weight_kg: float,
+    height_cm: float,
+    age: int,
+    sex: Literal["male", "female"],
+) -> int:
+    """Mifflin-St Jeor 1990: demographic-based BMR.
+
+    Best for general/obese populations. Under-predicts in lean trained men
+    because it ignores FFM.
+
+    Reference: Frankenfield 2005, DOI 10.1016/j.jada.2005.02.005
+    """
+    if weight_kg <= 0 or height_cm <= 0 or age <= 0:
+        raise ValueError("weight_kg, height_cm, and age must all be positive")
+    base = 10 * weight_kg + 6.25 * height_cm - 5 * age
+    if sex == "male":
+        return round(base + 5)
+    return round(base - 161)
+
+
+def ten_haaf_weight(
+    weight_kg: float,
+    height_cm: float,
+    age: int,
+    sex: Literal["male", "female"],
+) -> int:
+    """ten Haaf 2014 weight-based REE formula for recreational athletes.
+
+    Better than Mifflin-St Jeor for trained populations (~80% accuracy).
+    Reference: ten Haaf & Weijs 2014, PMID 25275434, DOI 10.1371/journal.pone.0108460
+
+    Formula (Table 3, kcal output):
+        REE = 11.936·w + 587.728·(h_m) - 8.129·a + 191.027·(sex_male) + 29.279
+
+    where h_m = height in meters and sex_male = 1 for male, 0 for female.
+    """
+    if weight_kg <= 0 or height_cm <= 0 or age <= 0:
+        raise ValueError("weight_kg, height_cm, and age must all be positive")
+
+    height_m = height_cm / 100.0
+    sex_male = 1 if sex == "male" else 0
+
+    ree_kcal = (
+        11.936 * weight_kg
+        + 587.728 * height_m
+        - 8.129 * age
+        + 191.027 * sex_male
+        + 29.279
+    )
+    return round(ree_kcal)
+
+
+def compute_bmr(
+    ffm_kg: float | None = None,
+    weight_kg: float | None = None,
+    height_cm: float | None = None,
+    age: int | None = None,
+    sex: Literal["male", "female"] | None = None,
+) -> int:
+    """Route to the best BMR formula given available inputs.
+
+    Priority:
+    1. Cunningham (FFM-based) — if ``ffm_kg`` provided
+    2. ten Haaf weight-based — if demographics provided
+    3. (Mifflin-St Jeor is available as a secondary fallback but ten Haaf
+       is preferred for athletic populations; callers explicitly invoke
+       ``mifflin_st_jeor`` if they want it.)
+    """
+    if ffm_kg is not None:
+        return cunningham(ffm_kg=ffm_kg)
+
+    if weight_kg is not None and height_cm is not None and age is not None and sex is not None:
+        return ten_haaf_weight(
+            weight_kg=weight_kg, height_cm=height_cm, age=age, sex=sex,
+        )
+
+    raise ValueError(
+        "compute_bmr requires either ffm_kg or full demographics "
+        "(weight_kg + height_cm + age + sex)"
+    )

--- a/sync/src/nutrition_engine/deficit_duration.py
+++ b/sync/src/nutrition_engine/deficit_duration.py
@@ -1,0 +1,117 @@
+"""Deficit duration counter with severity-scaled thresholds (M1.7).
+
+Research basis:
+- Byrne 2018 MATADOR (2wk deficit + 2wk maintenance intermittent beats continuous)
+- Peos 2021 ICECAP (reactive threshold for athletes)
+- Trexler 2014 metabolic adaptation review
+
+Counter increments on deficit days (intake < 95% TDEE) and resets on
+prolonged maintenance periods. Severity scaling adjusts thresholds:
+- >25% TDEE deficit: tightens by 4 weeks
+- <15% TDEE deficit: extends by 4 weeks
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+# Intake ≥ this fraction of TDEE is considered maintenance (aligns with V14 refeed rule).
+DEFICIT_RATIO_THRESHOLD: float = 0.95
+
+# Default thresholds (days) at 15-25% deficit
+_DEFAULT_SOFT_WARN: int = 56
+_DEFAULT_STRONG: int = 84
+_DEFAULT_HARD_STOP: int = 112
+
+# Severity scaling offset (in days)
+_SEVERITY_OFFSET_DAYS: int = 28  # ±4 weeks
+
+# Reset rules
+_FULL_RESET_MAINTENANCE_DAYS: int = 7
+_HALF_RESET_MIN_DAYS: int = 3  # 3-6 maintenance days = half reset
+
+
+class CounterStatus(str, Enum):
+    GREEN = "green"
+    WARN = "warn"
+    STRONG = "strong"
+    HARD_STOP = "hard_stop"
+
+
+@dataclass(frozen=True)
+class DurationThresholds:
+    soft_warn_days: int
+    strong_recommend_days: int
+    hard_stop_days: int
+
+
+def _is_deficit_day(day: dict) -> bool:
+    intake = day.get("intake_kcal", 0)
+    tdee = day.get("tdee_kcal", 0)
+    if tdee <= 0:
+        return False
+    return intake < DEFICIT_RATIO_THRESHOLD * tdee
+
+
+def compute_counter(days: list[dict]) -> int:
+    """Walk the day history (oldest first) and compute current deficit streak.
+
+    Each day dict needs ``intake_kcal`` and ``tdee_kcal`` keys. A day is in
+    deficit when ``intake_kcal < 0.95 × tdee_kcal``.
+
+    Reset rules:
+    - 7+ consecutive maintenance days: counter = 0 (full reset)
+    - 3-6 consecutive maintenance days: counter //= 2 (half reset)
+    - <3 consecutive maintenance days: no reset
+    """
+    counter = 0
+    maintenance_streak = 0
+
+    for day in days:
+        if _is_deficit_day(day):
+            # Apply pending maintenance streak rules before incrementing
+            if maintenance_streak >= _FULL_RESET_MAINTENANCE_DAYS:
+                counter = 0
+            elif maintenance_streak >= _HALF_RESET_MIN_DAYS:
+                counter = counter // 2
+            # <3 maintenance days: no reset
+            maintenance_streak = 0
+            counter += 1
+        else:
+            maintenance_streak += 1
+
+    return counter
+
+
+def get_thresholds(avg_deficit_pct: float) -> DurationThresholds:
+    """Return duration thresholds adjusted for deficit severity.
+
+    avg_deficit_pct is the average deficit as a percentage of TDEE.
+    - >25: tighten by 4 weeks
+    - <15: extend by 4 weeks
+    - 15-25: default (56/84/112)
+    """
+    if avg_deficit_pct > 25.0:
+        offset = -_SEVERITY_OFFSET_DAYS
+    elif avg_deficit_pct < 15.0:
+        offset = +_SEVERITY_OFFSET_DAYS
+    else:
+        offset = 0
+
+    return DurationThresholds(
+        soft_warn_days=_DEFAULT_SOFT_WARN + offset,
+        strong_recommend_days=_DEFAULT_STRONG + offset,
+        hard_stop_days=_DEFAULT_HARD_STOP + offset,
+    )
+
+
+def classify_counter(counter: int, thresholds: DurationThresholds) -> CounterStatus:
+    """Classify the current counter against severity-scaled thresholds."""
+    if counter >= thresholds.hard_stop_days:
+        return CounterStatus.HARD_STOP
+    if counter >= thresholds.strong_recommend_days:
+        return CounterStatus.STRONG
+    if counter >= thresholds.soft_warn_days:
+        return CounterStatus.WARN
+    return CounterStatus.GREEN

--- a/sync/src/nutrition_engine/fat_floor.py
+++ b/sync/src/nutrition_engine/fat_floor.py
@@ -1,0 +1,89 @@
+"""Fat floor enforcement — hormonal protection (M1.5).
+
+Research basis:
+- Whittaker & Wu 2021 meta: <20% of calories from fat → 10-15% total T drop
+- Volek 1997, Wang 2005: hormonal disruption below ~0.6-0.8 g/kg
+- Helms 2014 contest prep: 0.8 g/kg recommended minimum
+
+Modes:
+- standard / aggressive: floor 0.8 soft / 0.6 hard (non-negotiable)
+- maintenance: 1.0 g/kg soft (real target with headroom), 0.6 hard
+- bulk: 0.8 g/kg soft (floor stays); up to 1.2 g/kg acceptable as target
+
+Fat is treated as a FLOOR, not a target. Overshoot is safe — no warnings
+when fat exceeds the soft floor (treat like protein).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+Mode = Literal["standard", "aggressive", "maintenance", "bulk"]
+
+FAT_FLOOR_SOFT_DEFAULT: float = 0.8  # g/kg
+FAT_FLOOR_HARD: float = 0.6          # g/kg (never breachable)
+FAT_TARGET_MAINTENANCE: float = 1.0  # g/kg (real target in maintenance)
+
+
+class FatBreachType(str, Enum):
+    NONE = "none"
+    SOFT = "soft"  # below soft, above hard — warning
+    HARD = "hard"  # below hard — enforced raise
+
+
+@dataclass(frozen=True)
+class FatFloorResult:
+    soft_floor_g: int
+    hard_floor_g: int
+    fat_g: int = 0
+    breach_type: FatBreachType = FatBreachType.NONE
+
+
+def _soft_floor_g_per_kg(mode: Mode) -> float:
+    if mode == "maintenance":
+        return FAT_TARGET_MAINTENANCE
+    # standard, aggressive, bulk all use 0.8 g/kg soft floor
+    return FAT_FLOOR_SOFT_DEFAULT
+
+
+def compute_fat_floor(weight_kg: float, mode: Mode) -> FatFloorResult:
+    """Compute fat floor for a given weight and mode."""
+    if mode not in ("standard", "aggressive", "maintenance", "bulk"):
+        raise ValueError(f"Unknown mode: {mode!r}")
+    if weight_kg <= 0:
+        raise ValueError(f"weight_kg must be positive, got {weight_kg}")
+
+    soft_per_kg = _soft_floor_g_per_kg(mode)
+    return FatFloorResult(
+        soft_floor_g=round(soft_per_kg * weight_kg),
+        hard_floor_g=round(FAT_FLOOR_HARD * weight_kg),
+    )
+
+
+def apply_fat_floor(fat_g: int, weight_kg: float, mode: Mode) -> FatFloorResult:
+    """Apply fat floor to a proposed fat intake.
+
+    - Above soft → NONE (no warning on overshoot)
+    - Between hard and soft → SOFT (warning, not enforced)
+    - Below hard → HARD (raised to hard floor)
+    """
+    floors = compute_fat_floor(weight_kg=weight_kg, mode=mode)
+
+    if fat_g < floors.hard_floor_g:
+        breach = FatBreachType.HARD
+        adjusted = floors.hard_floor_g
+    elif fat_g < floors.soft_floor_g:
+        breach = FatBreachType.SOFT
+        adjusted = fat_g  # warn but don't enforce
+    else:
+        breach = FatBreachType.NONE
+        adjusted = fat_g
+
+    return FatFloorResult(
+        soft_floor_g=floors.soft_floor_g,
+        hard_floor_g=floors.hard_floor_g,
+        fat_g=adjusted,
+        breach_type=breach,
+    )

--- a/sync/src/nutrition_engine/floor.py
+++ b/sync/src/nutrition_engine/floor.py
@@ -1,0 +1,110 @@
+"""BMR + RED-S Energy Availability floor enforcement.
+
+Safety rails for target_calories. Based on:
+- Cunningham 1980 BMR (primary soft floor)
+- Mountjoy 2018 IOC RED-S consensus (EA hard floor: 25 kcal/kg FFM + exercise)
+
+Modes:
+- Standard: soft = Cunningham; hard = max(Cunningham, 25·FFM + ex_kcal). Both enforced.
+- Aggressive: soft = Cunningham (advisory); hard = 25·FFM + ex_kcal. Only hard enforced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+from nutrition_engine.bmr import cunningham
+
+# Mountjoy 2018 RED-S consensus threshold
+REDS_EA_COEFFICIENT: int = 25  # kcal per kg FFM per day
+
+Mode = Literal["standard", "aggressive"]
+
+
+class FloorBreachType(str, Enum):
+    NONE = "none"
+    SOFT = "soft"
+    HARD = "hard"
+
+
+@dataclass(frozen=True)
+class FloorResult:
+    """Floor computation result."""
+    soft_floor: int
+    hard_floor: int
+    target_kcal: int = 0
+    breach_type: FloorBreachType = FloorBreachType.NONE
+
+
+def compute_floor(
+    ffm_kg: float,
+    exercise_kcal: float,
+    mode: Mode,
+) -> FloorResult:
+    """Compute soft + hard floors for a given FFM, exercise level, and mode.
+
+    Standard mode:
+        soft = Cunningham(FFM)
+        hard = max(Cunningham, 25·FFM + exercise)
+
+    Aggressive mode:
+        soft = Cunningham(FFM)  [advisory only]
+        hard = 25·FFM + exercise  [Cunningham dropped]
+    """
+    if mode not in ("standard", "aggressive"):
+        raise ValueError(f"Unknown mode: {mode!r}. Use 'standard' or 'aggressive'.")
+    if ffm_kg <= 0:
+        raise ValueError(f"ffm_kg must be positive, got {ffm_kg}")
+    if exercise_kcal < 0:
+        raise ValueError(f"exercise_kcal must be non-negative, got {exercise_kcal}")
+
+    soft = cunningham(ffm_kg=ffm_kg)
+    ea_threshold = round(REDS_EA_COEFFICIENT * ffm_kg + exercise_kcal)
+
+    if mode == "standard":
+        hard = max(soft, ea_threshold)
+    else:  # aggressive
+        hard = ea_threshold
+
+    return FloorResult(soft_floor=soft, hard_floor=hard)
+
+
+def apply_floor(
+    target_kcal: int,
+    ffm_kg: float,
+    exercise_kcal: float,
+    mode: Mode,
+) -> FloorResult:
+    """Apply floor to a proposed target_kcal.
+
+    Returns FloorResult with:
+    - ``target_kcal`` adjusted to hard_floor if it was breached
+    - ``breach_type`` indicating NONE, SOFT, or HARD
+
+    Semantics:
+    - Standard mode: target below soft == target below hard (soft=hard in this mode
+      when soft dominates). Both breach types can fire.
+    - Aggressive mode: target below Cunningham but above hard = SOFT breach (warning),
+      target below hard = HARD breach (enforced raise).
+    """
+    floors = compute_floor(ffm_kg=ffm_kg, exercise_kcal=exercise_kcal, mode=mode)
+
+    if target_kcal < floors.hard_floor:
+        breach = FloorBreachType.HARD
+        adjusted = floors.hard_floor
+    elif target_kcal < floors.soft_floor:
+        # Only reachable in aggressive mode (hard < soft).
+        breach = FloorBreachType.SOFT
+        adjusted = target_kcal  # allowed to stay below soft in aggressive
+    else:
+        breach = FloorBreachType.NONE
+        adjusted = target_kcal
+
+    return FloorResult(
+        soft_floor=floors.soft_floor,
+        hard_floor=floors.hard_floor,
+        target_kcal=adjusted,
+        breach_type=breach,
+    )

--- a/sync/src/nutrition_engine/forbes.py
+++ b/sync/src/nutrition_engine/forbes.py
@@ -1,0 +1,51 @@
+"""Forbes partitioning of body-weight change into FFM and FM (M3.1).
+
+Research basis:
+- Forbes 2000 FFM-FM curve: `dFFM/dBW = 10.4 / (10.4 + FM)`
+- Recomp multiplier: concurrent resistance training + ≥1.8 g/kg protein
+  biases partitioning toward muscle gain / spares FFM during a cut. We apply
+  a 0.6× scalar to the baseline FFM fraction per V2 §8.1 (MATADOR / Helms
+  recomp reviews).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# Forbes 2000 curve constant — do not change without revisiting the research.
+_FORBES_K: float = 10.4
+
+# V2 §8.1 recomp multiplier on the FFM fraction.
+_RECOMP_MULTIPLIER: float = 0.6
+
+
+@dataclass(frozen=True)
+class ForbesResult:
+    d_ffm_kg: float
+    d_fm_kg: float
+    ffm_fraction: float
+
+
+def partition_weight_change(
+    d_bw_kg: float,
+    fm_kg: float,
+    *,
+    recomp: bool = False,
+) -> ForbesResult:
+    """Split a body-weight change into FFM and FM components via Forbes.
+
+    The fat-mass variable is the *current* FM, not the target. Callers that
+    want an integrated prediction across a multi-day window should integrate
+    in small steps and re-estimate `fm_kg` each step.
+    """
+    if fm_kg < 0:
+        raise ValueError(f"fm_kg must be non-negative, got {fm_kg}")
+
+    base_fraction = _FORBES_K / (_FORBES_K + fm_kg)
+    ffm_fraction = base_fraction * _RECOMP_MULTIPLIER if recomp else base_fraction
+
+    d_ffm = d_bw_kg * ffm_fraction
+    d_fm = d_bw_kg - d_ffm
+
+    return ForbesResult(d_ffm_kg=d_ffm, d_fm_kg=d_fm, ffm_fraction=ffm_fraction)

--- a/sync/src/nutrition_engine/generate_today.py
+++ b/sync/src/nutrition_engine/generate_today.py
@@ -147,7 +147,8 @@ def generate_today() -> None:
         cur.execute(
             "SELECT target_calories, weight_kg, goal, daily_deficit,"
             " estimated_ffm_kg, protein_g_per_kg, fat_g_per_kg,"
-            " estimated_bf_pct, target_bf_pct, target_date, age, sex, step_goal"
+            " estimated_bf_pct, target_bf_pct, target_date, age, sex, step_goal,"
+            " deficit_mode"
             " FROM nutrition_profile WHERE id = 1"
         )
         profile = cur.fetchone()
@@ -161,6 +162,7 @@ def generate_today() -> None:
             profile_ffm_kg, profile_protein_g_per_kg, profile_fat_g_per_kg,
             profile_bf_pct, profile_target_bf_pct, profile_target_date,
             profile_age, profile_sex, profile_step_goal,
+            profile_deficit_mode,
         ) = profile
 
         age = int(profile_age) if profile_age else DEFAULT_AGE
@@ -170,6 +172,7 @@ def generate_today() -> None:
         fat_g_per_kg = float(profile_fat_g_per_kg) if profile_fat_g_per_kg else 0.8
         ffm_kg = float(profile_ffm_kg) if profile_ffm_kg else None
         estimated_bf_pct = float(profile_bf_pct) if profile_bf_pct else None
+        deficit_mode = str(profile_deficit_mode) if profile_deficit_mode else "standard"
 
         # 2. Latest weight from weight_log
         cur.execute(
@@ -297,7 +300,25 @@ def generate_today() -> None:
             logger.info("Sleep adjustment: %s (deficit %.0f → %.0f)",
                         adjustment_reason, deficit, adjusted_deficit)
 
-        # 10. Compute macro targets with carb periodization
+        # 10. Compute macro targets — route to M4 5-band × tier × mode matrix
+        #     when we have BF% data; otherwise fall back to flat g/kg.
+        #     Split exercise_cal into run vs gym portions for the band
+        #     classifier: has_run implies all of exercise_cal is run-load;
+        #     has_gym-only means all gym-load; both implies 60/40 run/gym.
+        has_run = run_type is not None and str(run_type).strip() != ""
+        if has_run and has_gym:
+            run_kcal_split = exercise_cal * 0.6
+            gym_kcal_split = exercise_cal * 0.4
+        elif has_run:
+            run_kcal_split = float(exercise_cal)
+            gym_kcal_split = 0.0
+        elif has_gym:
+            run_kcal_split = 0.0
+            gym_kcal_split = float(exercise_cal)
+        else:
+            run_kcal_split = 0.0
+            gym_kcal_split = 0.0
+
         macros = compute_macro_targets(
             tdee=tdee,
             deficit=adjusted_deficit,
@@ -308,6 +329,9 @@ def generate_today() -> None:
             fat_g_per_kg=fat_g_per_kg,
             estimated_bf_pct=estimated_bf_pct,
             ffm_kg=ffm_kg,
+            mode=deficit_mode,
+            run_kcal=run_kcal_split,
+            gym_kcal=gym_kcal_split,
         )
 
         # Apply sleep boosts — recompute carbs to maintain calorie target

--- a/sync/src/nutrition_engine/macro_targets.py
+++ b/sync/src/nutrition_engine/macro_targets.py
@@ -1,0 +1,276 @@
+"""M4 Phase A — Macro Engine core (5-band × tier × mode).
+
+Research basis: V2 §2. Replaces the legacy fill-remainder calc with a
+periodized model that weights training load into per-band carb targets, then
+enforces tier × mode protein minimums and fat floors.
+
+Modules composed:
+- Tier (M1.1) — BF% band
+- Mode (M2.1) — Standard/Aggressive/Reverse/Maintenance/Bulk/Injured
+- Band (this module) — 5-tier training load classifier
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from nutrition_engine.mode import Mode
+from nutrition_engine.tier import Tier
+
+
+# ---------------------------------------------------------------------------
+# M4.1 Training load + band classifier
+# ---------------------------------------------------------------------------
+
+
+class Band(str, Enum):
+    REST = "rest"
+    LIGHT = "light"
+    MODERATE = "moderate"
+    HARD = "hard"
+    VERY_HARD = "very_hard"
+
+
+_RUN_DIVISOR: int = 10
+_GYM_DIVISOR: int = 6
+_LOAD_SATURATION: float = 4.0
+_ENDURANCE_PRIORITY_THRESHOLD: float = 1.5
+
+
+def compute_training_load(run_kcal: float, gym_kcal: float, *, weight_kg: float) -> float:
+    """Normalize run + gym calories into a per-kg load score.
+
+    Endurance priority: once run_load alone ≥ 1.5, we ignore gym to avoid
+    double-counting a hard run + easy lift (V2 §2.3). Saturation at 4.0
+    prevents absurd days from escaping the carb-band ladder.
+    """
+    if run_kcal < 0 or gym_kcal < 0:
+        raise ValueError(f"kcal must be ≥ 0, got run={run_kcal} gym={gym_kcal}")
+    if weight_kg <= 0:
+        raise ValueError(f"weight_kg must be positive, got {weight_kg}")
+
+    run_load = run_kcal / (weight_kg * _RUN_DIVISOR)
+    gym_load = gym_kcal / (weight_kg * _GYM_DIVISOR)
+
+    if run_load >= _ENDURANCE_PRIORITY_THRESHOLD:
+        return run_load
+
+    return min(run_load + gym_load, _LOAD_SATURATION)
+
+
+def classify_band(total_load: float) -> Band:
+    """Bucket a load score into a band. Thresholds match the V2 §2.3 matrix."""
+    if total_load <= 0:
+        return Band.REST
+    if total_load <= 1.0:
+        return Band.LIGHT
+    if total_load <= 2.0:
+        return Band.MODERATE
+    if total_load <= 3.0:
+        return Band.HARD
+    return Band.VERY_HARD
+
+
+# ---------------------------------------------------------------------------
+# M4.2 Protein formula
+# ---------------------------------------------------------------------------
+
+# V2 §2.1 matrix — canonical base g/kg per (tier, mode). Aggressive at T3+ is
+# gate-blocked by M2, so we never reach those cells at runtime, but we keep a
+# defensive fallback value here so the matrix is total.
+_PROTEIN_BASE_G_PER_KG: dict[tuple[Tier, Mode], float] = {
+    # Standard
+    (Tier.T1, Mode.STANDARD): 2.0,
+    (Tier.T2, Mode.STANDARD): 2.3,
+    (Tier.T3, Mode.STANDARD): 2.4,
+    (Tier.T4, Mode.STANDARD): 2.8,
+    (Tier.T5, Mode.STANDARD): 2.8,
+    # Aggressive (T1-T2 only by gating; fallback for the unreachable rows)
+    (Tier.T1, Mode.AGGRESSIVE): 2.2,
+    (Tier.T2, Mode.AGGRESSIVE): 2.4,
+    (Tier.T3, Mode.AGGRESSIVE): 2.4,
+    (Tier.T4, Mode.AGGRESSIVE): 2.4,
+    (Tier.T5, Mode.AGGRESSIVE): 2.4,
+    # Reverse — treat like Standard at the same tier
+    (Tier.T1, Mode.REVERSE): 2.0,
+    (Tier.T2, Mode.REVERSE): 2.3,
+    (Tier.T3, Mode.REVERSE): 2.4,
+    (Tier.T4, Mode.REVERSE): 2.8,
+    (Tier.T5, Mode.REVERSE): 2.8,
+    # Maintenance: flat 2.0 g/kg (V2 §2.1)
+    (Tier.T1, Mode.MAINTENANCE): 2.0,
+    (Tier.T2, Mode.MAINTENANCE): 2.0,
+    (Tier.T3, Mode.MAINTENANCE): 2.0,
+    (Tier.T4, Mode.MAINTENANCE): 2.0,
+    (Tier.T5, Mode.MAINTENANCE): 2.0,
+    # Bulk: flat 2.0 g/kg (V2 §6.1)
+    (Tier.T1, Mode.BULK): 2.0,
+    (Tier.T2, Mode.BULK): 2.0,
+    (Tier.T3, Mode.BULK): 2.0,
+    (Tier.T4, Mode.BULK): 2.0,
+    (Tier.T5, Mode.BULK): 2.0,
+    # Injured: use the Standard matrix for this milestone (V2 §4.5 refines
+    # later with injury-phase specifics).
+    (Tier.T1, Mode.INJURED): 2.0,
+    (Tier.T2, Mode.INJURED): 2.3,
+    (Tier.T3, Mode.INJURED): 2.4,
+    (Tier.T4, Mode.INJURED): 2.8,
+    (Tier.T5, Mode.INJURED): 2.8,
+}
+
+# V2 §2.1: VERY_HARD band drops protein 0.2 g/kg to make room for carbs.
+_VERY_HARD_PROTEIN_DROP: float = 0.2
+
+# Floor per Morton 2018: always ≥ 1.6 g/kg.
+_PROTEIN_ABSOLUTE_FLOOR: float = 1.6
+
+
+def protein_g_per_kg(tier: Tier, mode: Mode, band: Band) -> float:
+    """Return the base protein g/kg for this (tier, mode, band) cell."""
+    base = _PROTEIN_BASE_G_PER_KG[(tier, mode)]
+    if band == Band.VERY_HARD:
+        base -= _VERY_HARD_PROTEIN_DROP
+    return max(_PROTEIN_ABSOLUTE_FLOOR, base)
+
+
+# ---------------------------------------------------------------------------
+# M4.3 Carbs + fiber
+# ---------------------------------------------------------------------------
+
+# V2 §2.3 band-periodized carb ladder (g/kg).
+_CARB_G_PER_KG: dict[Band, float] = {
+    Band.REST: 3.0,
+    Band.LIGHT: 3.5,
+    Band.MODERATE: 5.0,
+    Band.HARD: 6.5,
+    Band.VERY_HARD: 8.0,
+}
+
+# V2 §2.3 health floor for athletes in deficit.
+_CARB_HEALTH_FLOOR_G: int = 100
+
+# V2 §2.4 fiber: 14 g per 1000 kcal + 5 g bonus during a deficit, with a
+# hard ceiling at 60 g (phytate mineral absorption concern).
+_FIBER_MIN_G: int = 25
+_FIBER_HARD_CEILING_G: int = 60
+_FIBER_CUT_BONUS_G: int = 5
+
+
+def carb_g_per_kg(band: Band) -> float:
+    return _CARB_G_PER_KG[band]
+
+
+def carb_target_g(band: Band, *, weight_kg: float, in_deficit: bool) -> int:
+    raw = round(_CARB_G_PER_KG[band] * weight_kg)
+    if band == Band.REST and in_deficit:
+        # Health floor only applies on rest days in a deficit — training days
+        # already blow past 100 g from the band formula itself.
+        return max(raw, _CARB_HEALTH_FLOOR_G)
+    return raw
+
+
+def fiber_target_g(kcal_target: int, *, in_deficit: bool) -> int:
+    base = max(_FIBER_MIN_G, round(kcal_target * 14 / 1000))
+    if in_deficit:
+        base += _FIBER_CUT_BONUS_G
+    return min(_FIBER_HARD_CEILING_G, base)
+
+
+# ---------------------------------------------------------------------------
+# M4.4 Composed macro engine
+# ---------------------------------------------------------------------------
+
+# V2 §1.5 Atwater factors (TEF already embedded).
+_KCAL_PER_G_PROTEIN: int = 4
+_KCAL_PER_G_CARB: int = 4
+_KCAL_PER_G_FAT: int = 9
+
+# V2 §2.2 fat policy: 0.8 soft floor, 0.6 hard floor, Maintenance 1.0 target,
+# Bulk 1.0 target (midpoint of 0.8-1.2).
+_FAT_HARD_FLOOR_G_PER_KG: float = 0.6
+_FAT_SOFT_FLOOR_G_PER_KG: float = 0.8
+_FAT_MAINTENANCE_TARGET_G_PER_KG: float = 1.0
+_FAT_BULK_TARGET_G_PER_KG: float = 1.0
+
+
+@dataclass(frozen=True)
+class MacroTargets:
+    kcal: int
+    protein_g: int
+    carbs_g: int
+    fat_g: int
+    fiber_g: int
+
+
+def _fat_target_for_mode(mode: Mode, weight_kg: float) -> float:
+    """Mode-aware fat target (g). Cuts use the soft floor; maintenance and
+    bulk set a real target above the floor."""
+    if mode == Mode.MAINTENANCE:
+        return _FAT_MAINTENANCE_TARGET_G_PER_KG * weight_kg
+    if mode == Mode.BULK:
+        return _FAT_BULK_TARGET_G_PER_KG * weight_kg
+    return _FAT_SOFT_FLOOR_G_PER_KG * weight_kg
+
+
+def compute_macro_targets(
+    *,
+    weight_kg: float,
+    tier: Tier,
+    mode: Mode,
+    band: Band,
+    kcal_target: int,
+    in_deficit: bool,
+) -> MacroTargets:
+    """Run the full macro stack for a (user, day) and return gram targets.
+
+    Order:
+    1. Protein from the tier × mode × band matrix (absolute floor 1.6 g/kg).
+    2. Carbs from the band ladder (health floor 100 g on rest days in deficit).
+    3. Fat: aim for the mode-aware target; if kcal_target doesn't leave room,
+       fall back to the hard floor 0.6 g/kg (M1.5 / V2 §2.2).
+    4. Kcal is reported as protein×4 + carbs×4 + fat×9; callers can compare
+       this against their intended kcal_target for rounding slack.
+    5. Fiber per V2 §2.4.
+    """
+    # 1) Protein is non-negotiable — matrix target stands.
+    protein_g = round(protein_g_per_kg(tier, mode, band) * weight_kg)
+    fiber_g = fiber_target_g(kcal_target, in_deficit=in_deficit)
+
+    # 2) Fat target is mode-aware; clamp to hard floor.
+    fat_mode_target = _fat_target_for_mode(mode, weight_kg)
+    fat_hard_floor = _FAT_HARD_FLOOR_G_PER_KG * weight_kg
+    fat_g = max(fat_hard_floor, fat_mode_target)
+
+    # 3) Carbs fill the remainder, with the band target as the CEILING (V2
+    # §2.3 band numbers are cut targets — don't overshoot when budget allows
+    # more) and the rest-day health floor 100 g when in deficit.
+    band_ceiling = _CARB_G_PER_KG[band] * weight_kg
+    remainder_kcal = kcal_target - protein_g * _KCAL_PER_G_PROTEIN - fat_g * _KCAL_PER_G_FAT
+    carbs_by_remainder = max(0.0, remainder_kcal / _KCAL_PER_G_CARB)
+    carbs_g_float = min(carbs_by_remainder, band_ceiling)
+
+    # 4) If tight kcal target pushed carbs below the rest-day health floor,
+    # shave fat toward the hard floor to make room.
+    if band == Band.REST and in_deficit and carbs_g_float < _CARB_HEALTH_FLOOR_G:
+        kcal_for_fat = kcal_target - protein_g * _KCAL_PER_G_PROTEIN - _CARB_HEALTH_FLOOR_G * _KCAL_PER_G_CARB
+        shaved_fat = max(fat_hard_floor, kcal_for_fat / _KCAL_PER_G_FAT)
+        fat_g = shaved_fat
+        carbs_g_float = _CARB_HEALTH_FLOOR_G
+
+    carbs_g = round(carbs_g_float)
+    fat_g_int = round(fat_g)
+
+    actual_kcal = (
+        protein_g * _KCAL_PER_G_PROTEIN
+        + carbs_g * _KCAL_PER_G_CARB
+        + fat_g_int * _KCAL_PER_G_FAT
+    )
+
+    return MacroTargets(
+        kcal=actual_kcal,
+        protein_g=protein_g,
+        carbs_g=carbs_g,
+        fat_g=fat_g_int,
+        fiber_g=fiber_g,
+    )

--- a/sync/src/nutrition_engine/mode.py
+++ b/sync/src/nutrition_engine/mode.py
@@ -1,0 +1,78 @@
+"""6-mode state enum + per-mode configuration (M2.1).
+
+Research basis: Nutrition Science v2 §3.2 (Aggressive), §5 (Maintenance),
+§6 (Bulk), §4.5 (Injured).
+
+Modes encode both intent ("what is the user trying to do") and capability
+("what are the rails around that intent"). The config per mode captures:
+- tier_allowed: which BF% tiers this mode is legal in
+- bf_hard_floor_pct: BF% below which the mode is a hard contraindication
+- requires_reverse_bridge_from: modes that must pass through REVERSE first
+  before entering this mode (cut→bulk transition)
+- max_duration_days: advisory upper bound per V2 duration envelopes
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from nutrition_engine.tier import Tier
+
+
+class Mode(str, Enum):
+    STANDARD = "standard"
+    AGGRESSIVE = "aggressive"
+    REVERSE = "reverse"
+    MAINTENANCE = "maintenance"
+    BULK = "bulk"
+    INJURED = "injured"
+
+
+@dataclass(frozen=True)
+class ModeConfig:
+    tier_allowed: frozenset[Tier]
+    bf_hard_floor_pct: float | None
+    requires_reverse_bridge_from: frozenset[Mode] = field(default_factory=frozenset)
+    max_duration_days: int | None = None
+
+
+_ALL_TIERS: frozenset[Tier] = frozenset(Tier)
+
+
+_CONFIGS: dict[Mode, ModeConfig] = {
+    Mode.STANDARD: ModeConfig(
+        tier_allowed=frozenset({Tier.T1, Tier.T2, Tier.T3, Tier.T4}),
+        bf_hard_floor_pct=None,
+    ),
+    Mode.AGGRESSIVE: ModeConfig(
+        tier_allowed=frozenset({Tier.T1, Tier.T2}),
+        bf_hard_floor_pct=12.0,
+        max_duration_days=84,  # V2 §3.2: 12 weeks at 700-900 kcal envelope
+    ),
+    Mode.REVERSE: ModeConfig(
+        tier_allowed=_ALL_TIERS,
+        bf_hard_floor_pct=None,
+        max_duration_days=42,  # V2 §3.2: post-aggressive reverse 2-6 weeks
+    ),
+    Mode.MAINTENANCE: ModeConfig(
+        tier_allowed=_ALL_TIERS,
+        bf_hard_floor_pct=None,
+    ),
+    Mode.BULK: ModeConfig(
+        tier_allowed=frozenset({Tier.T2, Tier.T3, Tier.T4, Tier.T5}),
+        bf_hard_floor_pct=None,
+        requires_reverse_bridge_from=frozenset({Mode.STANDARD, Mode.AGGRESSIVE}),
+        max_duration_days=140,  # V2 §6.1: 12-20 week bulk block
+    ),
+    Mode.INJURED: ModeConfig(
+        tier_allowed=_ALL_TIERS,
+        bf_hard_floor_pct=None,
+    ),
+}
+
+
+def get_mode_config(mode: Mode) -> ModeConfig:
+    """Return the frozen config for a mode. Raises KeyError if a mode lacks a
+    registered config — this is a programmer error, not a runtime condition."""
+    return _CONFIGS[mode]

--- a/sync/src/nutrition_engine/mode_availability.py
+++ b/sync/src/nutrition_engine/mode_availability.py
@@ -1,0 +1,52 @@
+"""Mode × tier × BF% availability gate (M2.2).
+
+Decides whether a user is allowed to enter a given mode given their current
+tier and BF% estimate, returning a typed reason when blocked so the UI can
+render a specific explanation rather than a generic "not allowed" banner.
+
+Research basis: Nutrition Science v2 §3.2 (Aggressive hard floor at 12% BF,
+T1-T2 only), §6 (Bulk tier gate), §4.5 (Injured overrides all gates).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from nutrition_engine.mode import Mode, get_mode_config
+from nutrition_engine.tier import Tier
+
+
+class GateReason(str, Enum):
+    TIER_NOT_ALLOWED = "tier_not_allowed"
+    BF_BELOW_HARD_FLOOR = "bf_below_hard_floor"
+
+
+@dataclass(frozen=True)
+class ModeAvailability:
+    allowed: bool
+    reason: GateReason | None
+
+
+def check_mode_availability(
+    mode: Mode,
+    tier: Tier,
+    *,
+    bf_pct: float,
+) -> ModeAvailability:
+    """Return whether `mode` is legal for the given `tier` and `bf_pct`.
+
+    When blocked, `reason` identifies the first gate that tripped so the
+    caller can render specific copy.
+    """
+    config = get_mode_config(mode)
+
+    if tier not in config.tier_allowed:
+        return ModeAvailability(allowed=False, reason=GateReason.TIER_NOT_ALLOWED)
+
+    # BF% hard floor: strictly below the floor AND AT the floor are both blocked.
+    # At 12.0% BF the user is already in contraindication territory per V2 §3.2.
+    if config.bf_hard_floor_pct is not None and bf_pct <= config.bf_hard_floor_pct:
+        return ModeAvailability(allowed=False, reason=GateReason.BF_BELOW_HARD_FLOOR)
+
+    return ModeAvailability(allowed=True, reason=None)

--- a/sync/src/nutrition_engine/mode_transitions.py
+++ b/sync/src/nutrition_engine/mode_transitions.py
@@ -1,0 +1,95 @@
+"""Mode transition state machine (M2.3).
+
+Pure-function decision layer between "the user wants to switch modes" and
+"actually flipping the DB field". Returns a typed reason on block so the UI
+can show a specific banner and, when relevant, auto-insert the required
+bridge (e.g., a 4-week reverse diet between cut and bulk).
+
+Research basis:
+- V2 §3.2: Aggressive block ends with a mandatory 2-6 week reverse diet.
+- V2 §6.4: Cut → Bulk requires a reverse bridge; Bulk → Cut abrupt OK;
+  Bulk → Maintenance is a user-driven ramp, not enforced here.
+- V2 §4.5: Injured mode is always reachable; re-entry runs availability.
+- V2 §5.2: Cut → Maintenance 3-week ramp is "preferred, not enforced"
+  (evidence is psychological, not metabolic) — so no transition block.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from nutrition_engine.mode import Mode, get_mode_config
+from nutrition_engine.mode_availability import check_mode_availability
+from nutrition_engine.tier import Tier
+
+
+class TransitionReason(str, Enum):
+    # Destination mode fails its (tier, BF%) availability check.
+    MODE_NOT_AVAILABLE = "mode_not_available"
+    # V2 §3.2: exiting Aggressive must pass through Reverse first.
+    AGGRESSIVE_REQUIRES_REVERSE = "aggressive_requires_reverse"
+    # V2 §6.4: entering Bulk from a cut mode requires a reverse bridge.
+    REQUIRES_REVERSE_BRIDGE = "requires_reverse_bridge"
+
+
+@dataclass(frozen=True)
+class TransitionResult:
+    allowed: bool
+    reason: TransitionReason | None = None
+    # When a bridge mode is required (e.g. REVERSE between cut and bulk),
+    # callers can auto-propose it rather than guessing from the reason.
+    requires_bridge: Mode | None = None
+
+
+def check_transition(
+    current: Mode,
+    next_mode: Mode,
+    *,
+    tier: Tier,
+    bf_pct: float,
+) -> TransitionResult:
+    """Return whether a mode transition is legal.
+
+    Order of checks matters — we evaluate cheap invariants before running the
+    availability gate so the reason codes stay specific.
+    """
+
+    # A no-op transition is always allowed.
+    if current == next_mode:
+        return TransitionResult(allowed=True)
+
+    # Entering Injured is always legal — injuries don't wait for gating.
+    if next_mode == Mode.INJURED:
+        return TransitionResult(allowed=True)
+
+    # V2 §6.4: cut → bulk must pass through a reverse bridge. Check this before
+    # the generic Aggressive-exit rule so Aggressive → Bulk surfaces the more
+    # actionable REQUIRES_REVERSE_BRIDGE reason (carries `requires_bridge`)
+    # rather than the bare AGGRESSIVE_REQUIRES_REVERSE code.
+    next_config = get_mode_config(next_mode)
+    if current in next_config.requires_reverse_bridge_from:
+        return TransitionResult(
+            allowed=False,
+            reason=TransitionReason.REQUIRES_REVERSE_BRIDGE,
+            requires_bridge=Mode.REVERSE,
+        )
+
+    # V2 §3.2: exiting Aggressive (to anything other than Reverse or Injured)
+    # requires the reverse diet. Injured was handled above; Bulk was handled
+    # by the bridge check; anything else lands here.
+    if current == Mode.AGGRESSIVE and next_mode != Mode.REVERSE:
+        return TransitionResult(
+            allowed=False,
+            reason=TransitionReason.AGGRESSIVE_REQUIRES_REVERSE,
+        )
+
+    # Finally, the destination mode must be legal for the user's tier + BF%.
+    availability = check_mode_availability(next_mode, tier, bf_pct=bf_pct)
+    if not availability.allowed:
+        return TransitionResult(
+            allowed=False,
+            reason=TransitionReason.MODE_NOT_AVAILABLE,
+        )
+
+    return TransitionResult(allowed=True)

--- a/sync/src/nutrition_engine/protein_floor.py
+++ b/sync/src/nutrition_engine/protein_floor.py
@@ -1,0 +1,95 @@
+"""Protein floor warning + per-meal quality thresholds (M1.6 + V9.1).
+
+Research basis:
+- Morton 2018 meta: 1.6 g/kg plateau for resistance-training FFM gains
+- Schoenfeld & Aragon 2018: per-meal 0.4 g/kg as optimal
+- Trommelen 2023: 100g doses have extended anabolic effect — no upper cap
+
+Behavior:
+- Daily intake floor: 1.6 × weight_kg
+- Amber warning banner when intake < floor for 3+ consecutive days
+- Per-meal quality levels for MPS signaling (informational, not enforced)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+PROTEIN_FLOOR_G_PER_KG: float = 1.6
+
+# Per-meal thresholds (g)
+_PER_MEAL_RED_MAX: int = 14       # <15g = RED
+_PER_MEAL_AMBER_MAX: int = 24     # 15-24 = AMBER
+_PER_MEAL_YELLOW_MAX: int = 29    # 25-29 = YELLOW
+_PER_MEAL_GREEN_MAX: int = 55     # 30-55 = GREEN; >55 = NO_WARNING
+
+
+class ProteinFloorStatus(str, Enum):
+    GREEN = "green"
+    AMBER = "amber"
+
+
+class PerMealProteinLevel(str, Enum):
+    RED = "red"
+    AMBER = "amber"
+    YELLOW = "yellow"
+    GREEN = "green"
+    NO_WARNING = "no_warning"
+
+
+@dataclass(frozen=True)
+class ProteinFloorResult:
+    floor_g: int
+    days_below_floor: int  # consecutive streak at end of history
+    status: ProteinFloorStatus
+
+
+def compute_protein_floor(weight_kg: float) -> int:
+    """Return the daily protein floor in grams for a given body weight."""
+    if weight_kg <= 0:
+        raise ValueError(f"weight_kg must be positive, got {weight_kg}")
+    return round(PROTEIN_FLOOR_G_PER_KG * weight_kg)
+
+
+def check_protein_floor(
+    recent_intakes: list[float],
+    weight_kg: float,
+) -> ProteinFloorResult:
+    """Check if protein intake has been below floor for 3+ consecutive recent days.
+
+    Args:
+        recent_intakes: daily protein totals in grams, oldest first, newest last.
+        weight_kg: user weight.
+
+    Returns AMBER when the trailing streak (days ending at most recent) is >= 3.
+    """
+    floor = compute_protein_floor(weight_kg=weight_kg)
+
+    # Count consecutive days below floor ending at the most recent day
+    streak = 0
+    for intake in reversed(recent_intakes):
+        if intake < floor:
+            streak += 1
+        else:
+            break
+
+    status = ProteinFloorStatus.AMBER if streak >= 3 else ProteinFloorStatus.GREEN
+    return ProteinFloorResult(
+        floor_g=floor,
+        days_below_floor=streak,
+        status=status,
+    )
+
+
+def check_per_meal_protein(protein_g: int) -> PerMealProteinLevel:
+    """Classify a single meal's protein content per V9.1 MPS quality thresholds."""
+    if protein_g <= _PER_MEAL_RED_MAX:
+        return PerMealProteinLevel.RED
+    if protein_g <= _PER_MEAL_AMBER_MAX:
+        return PerMealProteinLevel.AMBER
+    if protein_g <= _PER_MEAL_YELLOW_MAX:
+        return PerMealProteinLevel.YELLOW
+    if protein_g <= _PER_MEAL_GREEN_MAX:
+        return PerMealProteinLevel.GREEN
+    return PerMealProteinLevel.NO_WARNING

--- a/sync/src/nutrition_engine/rate_cap.py
+++ b/sync/src/nutrition_engine/rate_cap.py
@@ -1,0 +1,180 @@
+"""5-tier BF%-based weekly loss rate cap.
+
+Based on Helms 2014 + Forbes 2000 + Garthe 2011 RCT + Hall 2008.
+
+Rate cap tiers (Standard mode):
+- T1 (>=28% BF): 1.0% / 1.25% per week
+- T2 (20-28%):   0.75% / 1.0% per week
+- T3 (15-20%):   0.5% / 0.75% per week
+- T4 (10-15%):   0.4% / 0.5% per week
+- T5 (<10%):     0.3% / 0.4% per week
+
+Aggressive mode loosens by one tier (T2 gets T1 caps, etc.).
+
+Hybrid window: yellow when 7-day rate exceeds soft cap; red only when BOTH
+7-day AND 14-day rates exceed hard cap. This suppresses false positives from
+single-week glycogen/water flux.
+
+First 14 days of a new cut phase are SUPPRESSED (glycogen/water confound
+makes rate appear much faster than actual fat loss).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+from nutrition_engine.tier import Tier
+
+Mode = Literal["standard", "aggressive"]
+
+# Tier → (soft_cap, hard_cap) in %/week (negative = loss)
+_STANDARD_RATE_CAPS: dict[Tier, tuple[float, float]] = {
+    Tier.T1: (1.0, 1.25),
+    Tier.T2: (0.75, 1.0),
+    Tier.T3: (0.5, 0.75),
+    Tier.T4: (0.4, 0.5),
+    Tier.T5: (0.3, 0.4),
+}
+
+# Ordered for "loosen by one tier" in aggressive mode
+_TIER_ORDER = [Tier.T5, Tier.T4, Tier.T3, Tier.T2, Tier.T1]
+
+
+class RateStatus(str, Enum):
+    GREEN = "green"
+    YELLOW = "yellow"
+    RED = "red"
+    SUPPRESSED = "suppressed"
+
+
+@dataclass(frozen=True)
+class RateCap:
+    """Soft and hard weekly rate caps (%/wk)."""
+    soft_pct_per_wk: float
+    hard_pct_per_wk: float
+
+
+@dataclass(frozen=True)
+class RateCheckResult:
+    rate_7day_pct: float
+    rate_14day_pct: float | None
+    status: RateStatus
+    soft_cap: float
+    hard_cap: float
+
+
+def get_rate_cap(tier: Tier, mode: Mode = "standard") -> RateCap:
+    """Return (soft, hard) rate caps for a tier and mode.
+
+    Aggressive mode loosens caps by one tier (e.g., T2 → T1 caps).
+    T1 cannot loosen further.
+    """
+    if mode not in ("standard", "aggressive"):
+        raise ValueError(f"Unknown mode: {mode!r}. Use 'standard' or 'aggressive'.")
+
+    if mode == "aggressive":
+        # Move one tier toward higher BF% in the order
+        idx = _TIER_ORDER.index(tier)
+        # idx: T5=0, T4=1, T3=2, T2=3, T1=4. Loosen → move toward T1 (higher idx).
+        loosened_idx = min(idx + 1, len(_TIER_ORDER) - 1)
+        tier = _TIER_ORDER[loosened_idx]
+
+    soft, hard = _STANDARD_RATE_CAPS[tier]
+    return RateCap(soft_pct_per_wk=soft, hard_pct_per_wk=hard)
+
+
+def compute_weekly_rate_pct(
+    daily_weights: list[float],
+    current_weight_kg: float | None = None,
+) -> float:
+    """Compute weekly weight-change rate as % of current weight.
+
+    Uses linear regression slope × 7 / current_weight × 100.
+    Negative rate = losing weight; positive = gaining.
+
+    Args:
+        daily_weights: weights with most recent last, evenly-spaced daily.
+        current_weight_kg: defaults to most recent weight in the list.
+    """
+    n = len(daily_weights)
+    if n < 2:
+        raise ValueError(f"Need at least 2 daily weights, got {n}")
+
+    if current_weight_kg is None:
+        current_weight_kg = daily_weights[-1]
+
+    # Linear regression y = a + b*x, where x = day_index (0..n-1), y = weight
+    mean_x = (n - 1) / 2.0
+    mean_y = sum(daily_weights) / n
+    num = sum((i - mean_x) * (w - mean_y) for i, w in enumerate(daily_weights))
+    den = sum((i - mean_x) ** 2 for i in range(n))
+    slope_kg_per_day = num / den  # positive = gaining
+
+    weekly_rate_kg = slope_kg_per_day * 7
+    return (weekly_rate_kg / current_weight_kg) * 100
+
+
+def check_rate_cap(
+    weights: list[float],
+    tier: Tier,
+    mode: Mode,
+    current_weight_kg: float,
+    days_since_cut_start: int,
+) -> RateCheckResult:
+    """Apply hybrid 7/14-day rate-cap logic.
+
+    Rules:
+    - First 14 days of a cut phase: SUPPRESSED (water/glycogen confound)
+    - After day 14:
+        - 7-day rate within soft cap: GREEN
+        - 7-day over soft OR 7-day over hard (but 14-day under hard): YELLOW
+        - BOTH 7-day AND 14-day rates over hard cap: RED
+
+    ``weights`` should contain at least 14 daily weights (most recent last) for
+    the 14-day window; if fewer, falls back to just 7-day eval.
+    """
+    cap = get_rate_cap(tier=tier, mode=mode)
+
+    # Suppression during glycogen/water flush (first 14 days of cut)
+    if days_since_cut_start < 14:
+        # compute 7-day rate for informational output
+        rate7 = _safe_rate(weights[-7:], current_weight_kg)
+        return RateCheckResult(
+            rate_7day_pct=rate7,
+            rate_14day_pct=None,
+            status=RateStatus.SUPPRESSED,
+            soft_cap=cap.soft_pct_per_wk,
+            hard_cap=cap.hard_pct_per_wk,
+        )
+
+    rate7 = _safe_rate(weights[-7:], current_weight_kg)
+    rate14 = _safe_rate(weights[-14:], current_weight_kg) if len(weights) >= 14 else None
+
+    # Rate sign: negative = losing. Compare magnitude against caps (positive).
+    rate7_mag = abs(rate7) if rate7 < 0 else 0.0  # ignore gains for a cut
+    rate14_mag = (abs(rate14) if rate14 is not None and rate14 < 0 else 0.0)
+
+    # RED requires BOTH windows over hard cap
+    if rate7_mag > cap.hard_pct_per_wk and rate14 is not None and rate14_mag > cap.hard_pct_per_wk:
+        status = RateStatus.RED
+    elif rate7_mag > cap.soft_pct_per_wk:
+        status = RateStatus.YELLOW
+    else:
+        status = RateStatus.GREEN
+
+    return RateCheckResult(
+        rate_7day_pct=rate7,
+        rate_14day_pct=rate14,
+        status=status,
+        soft_cap=cap.soft_pct_per_wk,
+        hard_cap=cap.hard_pct_per_wk,
+    )
+
+
+def _safe_rate(weights: list[float], current_weight_kg: float) -> float:
+    """Compute weekly rate, guarding against <2 points."""
+    if len(weights) < 2:
+        return 0.0
+    return compute_weekly_rate_pct(weights, current_weight_kg=current_weight_kg)

--- a/sync/src/nutrition_engine/tdee.py
+++ b/sync/src/nutrition_engine/tdee.py
@@ -326,8 +326,19 @@ def compute_macro_targets(
     fat_g_per_kg: float = 0.8,
     estimated_bf_pct: float | None = None,
     ffm_kg: float | None = None,
+    *,
+    mode: str | None = None,
+    run_kcal: float | None = None,
+    gym_kcal: float | None = None,
 ) -> dict[str, int]:
     """Compute daily macro targets given TDEE, deficit, and training context.
+
+    Routing: when ``estimated_bf_pct``, ``mode``, ``run_kcal``, and ``gym_kcal``
+    are all provided, delegates to the macro-engine M4 matrix
+    (``nutrition_engine.macro_targets``) for a 5-band × 5-tier × mode
+    periodized target. Otherwise falls back to the legacy flat
+    ``protein_g_per_kg`` / ``fat_g_per_kg`` computation for backward
+    compatibility with callers that don't yet pass the new context.
 
     Args:
         tdee: Total daily energy expenditure in kcal.
@@ -336,10 +347,14 @@ def compute_macro_targets(
         exercise_calories: Estimated exercise calories from
             :func:`compute_exercise_calories` (replaces static boost).
         training_day_type: Day type key for carb periodization (Task 10).
-        protein_g_per_kg: Protein target per kg body weight (default 2.2).
-        fat_g_per_kg: Fat target per kg body weight (default 0.8).
-        estimated_bf_pct: Optional body fat percentage (unused currently).
-        ffm_kg: Optional fat-free mass in kg for RED-S floor check.
+        protein_g_per_kg: Fallback protein g/kg when matrix inputs missing.
+        fat_g_per_kg: Fallback fat g/kg when matrix inputs missing.
+        estimated_bf_pct: Body fat percentage — required for matrix routing.
+        ffm_kg: Fat-free mass in kg — used for RED-S floor check either way.
+        mode: One of 'standard', 'aggressive', 'reverse', 'maintenance',
+            'bulk', 'injured'. When None, legacy flat formula is used.
+        run_kcal: Run-portion of exercise kcal for band classifier.
+        gym_kcal: Gym-portion of exercise kcal for band classifier.
 
     Returns:
         Dict with ``calories``, ``protein``, ``carbs``, ``fat``, ``fiber``.
@@ -356,17 +371,49 @@ def compute_macro_targets(
         if target_calories < reds_minimum:
             target_calories = reds_minimum
 
-    # 4. Protein
+    # 4. Route to the M4 matrix when full context is available.
+    use_matrix = (
+        estimated_bf_pct is not None
+        and mode is not None
+        and run_kcal is not None
+        and gym_kcal is not None
+    )
+    if use_matrix:
+        from nutrition_engine.macro_targets import (  # local import to avoid cycles
+            classify_band,
+            compute_macro_targets as matrix_targets,
+            compute_training_load,
+        )
+        from nutrition_engine.mode import Mode as ModeEnum
+        from nutrition_engine.tier import compute_tier_raw
+
+        tier = compute_tier_raw(estimated_bf_pct)
+        load = compute_training_load(
+            run_kcal=run_kcal, gym_kcal=gym_kcal, weight_kg=weight_kg,
+        )
+        band = classify_band(load)
+        try:
+            mode_enum = ModeEnum(mode)
+        except ValueError:
+            mode_enum = ModeEnum.STANDARD
+        in_deficit = deficit > 0
+        m = matrix_targets(
+            weight_kg=weight_kg, tier=tier, mode=mode_enum, band=band,
+            kcal_target=target_calories, in_deficit=in_deficit,
+        )
+        return {
+            "calories": m.kcal,
+            "protein": m.protein_g,
+            "carbs": m.carbs_g,
+            "fat": m.fat_g,
+            "fiber": m.fiber_g,
+        }
+
+    # 5. Legacy flat formula (backwards compatible).
     protein = round(weight_kg * protein_g_per_kg)
-
-    # 5. Fat
     fat = round(weight_kg * fat_g_per_kg)
-
-    # 6. Carbs = strict remainder after protein and fat (guarantees macro-calorie match)
     carb_remainder = max((target_calories - (protein * 4) - (fat * 9)) / 4, 0)
     carbs = round(carb_remainder)
-
-    # 7. Fiber (fixed)
     fiber = 35
 
     return {

--- a/sync/src/nutrition_engine/tier.py
+++ b/sync/src/nutrition_engine/tier.py
@@ -1,0 +1,218 @@
+"""BF%-tier framework — master mode selector.
+
+Based on V13 research synthesis (docs/plans/science-research/V13-bf-tier-framework-findings.md).
+
+Evidence basis:
+- Hall 2008 Forbes inflection at 28% BF
+- Forbes 2000 FFM acceleration at 20% BF
+- Rossow 2013 / Helms 2014 testosterone decline onset at 15% BF
+- Mountjoy 2018 IOC RED-S cliff at 10% BF
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+# Hysteresis buffer — must cross boundary by this to change tier
+HYSTERESIS_PCT: float = 1.0
+
+
+class Tier(str, Enum):
+    """BF%-based tiers for males (female schema deferred)."""
+    T1 = "T1"  # >=28% obesity-class
+    T2 = "T2"  # 20-28% high
+    T3 = "T3"  # 15-20% lean
+    T4 = "T4"  # 10-15% very lean
+    T5 = "T5"  # <10% off-limits (competition only)
+
+
+@dataclass(frozen=True)
+class TierPolicy:
+    """Policy parameters cascading from a user's BF% tier."""
+    tier: Tier
+    bf_range: tuple[float, float]
+    rate_cap_soft_pct_per_wk: float
+    rate_cap_hard_pct_per_wk: float
+    protein_g_per_kg_bw: float
+    protein_g_per_kg_lbm_basis: bool
+    fat_floor_g_per_kg_bw_soft: float
+    fat_floor_g_per_kg_bw_hard: float
+    aggressive_mode_allowed: bool
+    refeed_frequency_days: int
+    diet_break_frequency_weeks: int
+    biomarker_cadence: Literal["weekly", "daily", "daily+bloods"]
+    duration_envelope_weeks: tuple[int, int]
+
+
+def compute_tier_raw(bf_pct: float) -> Tier:
+    """Strict boundary tier assignment (no hysteresis)."""
+    if bf_pct >= 28.0:
+        return Tier.T1
+    if bf_pct >= 20.0:
+        return Tier.T2
+    if bf_pct >= 15.0:
+        return Tier.T3
+    if bf_pct >= 10.0:
+        return Tier.T4
+    return Tier.T5
+
+
+# Boundary map: upper edge of each tier (ascending leanness = descending BF%)
+_TIER_UPPER_BOUNDS: dict[Tier, float] = {
+    Tier.T5: 10.0,   # T5 ends at 10.0, T4 begins
+    Tier.T4: 15.0,   # T4 ends at 15.0, T3 begins
+    Tier.T3: 20.0,   # T3 ends at 20.0, T2 begins
+    Tier.T2: 28.0,   # T2 ends at 28.0, T1 begins
+    Tier.T1: float("inf"),
+}
+
+
+def compute_tier(bf_pct: float, previous_tier: Tier | None = None) -> Tier:
+    """Tier assignment with HYSTERESIS_PCT buffer to prevent flicker near boundaries.
+
+    When moving LEANER (lower BF%): must drop ``HYSTERESIS_PCT`` below the tier's
+    lower edge to transition.
+    When moving FATTER (higher BF%): must rise ``HYSTERESIS_PCT`` above the tier's
+    upper edge to transition.
+    """
+    raw = compute_tier_raw(bf_pct)
+    if previous_tier is None or raw == previous_tier:
+        return raw
+
+    prev_upper = _TIER_UPPER_BOUNDS[previous_tier]
+
+    # Map tier to numeric order for comparison
+    order = {Tier.T1: 1, Tier.T2: 2, Tier.T3: 3, Tier.T4: 4, Tier.T5: 5}
+
+    if order[raw] > order[previous_tier]:
+        # raw tier is LEANER than previous; boundary to cross is previous's lower edge
+        # previous's lower edge = upper bound of the tier immediately leaner
+        # e.g., previous T2 (20-28), moving to T3: must go BELOW 20 - hysteresis
+        leaner_tier_upper = _leaner_tier_upper_edge(previous_tier)
+        threshold = leaner_tier_upper - HYSTERESIS_PCT
+        if bf_pct <= threshold:
+            return raw
+        return previous_tier
+
+    # raw tier is FATTER than previous
+    # boundary is previous's upper edge; must exceed it + hysteresis
+    threshold = prev_upper + HYSTERESIS_PCT
+    if bf_pct >= threshold:
+        return raw
+    return previous_tier
+
+
+def _leaner_tier_upper_edge(tier: Tier) -> float:
+    """Return the upper edge of the tier immediately leaner than the given tier.
+
+    For T2 (20-28), the leaner tier is T3 (15-20), whose upper edge is 20.0.
+    Used to compute the lower edge of the given tier.
+    """
+    leaner_map = {
+        Tier.T1: _TIER_UPPER_BOUNDS[Tier.T2],  # 28.0 -> T2 upper is 28, but we want T1's lower = 28
+        Tier.T2: _TIER_UPPER_BOUNDS[Tier.T3],  # T2 lower edge = T3 upper = 20.0
+        Tier.T3: _TIER_UPPER_BOUNDS[Tier.T4],  # T3 lower edge = T4 upper = 15.0
+        Tier.T4: _TIER_UPPER_BOUNDS[Tier.T5],  # T4 lower edge = T5 upper = 10.0
+        Tier.T5: 0.0,  # no tier leaner than T5
+    }
+    return leaner_map[tier]
+
+
+def rolling_median_bf(bf_readings: list[float]) -> float:
+    """Median of recent BF% readings — placeholder."""
+    sorted_readings = sorted(bf_readings)
+    n = len(sorted_readings)
+    if n == 0:
+        raise ValueError("rolling_median_bf requires at least one reading")
+    if n == 1:
+        return sorted_readings[0]
+    if n % 2 == 0:
+        return (sorted_readings[n // 2 - 1] + sorted_readings[n // 2]) / 2
+    return sorted_readings[n // 2]
+
+
+_TIER_POLICIES: dict[Tier, TierPolicy] = {
+    Tier.T1: TierPolicy(
+        tier=Tier.T1,
+        bf_range=(28.0, float("inf")),
+        rate_cap_soft_pct_per_wk=1.0,
+        rate_cap_hard_pct_per_wk=1.25,
+        protein_g_per_kg_bw=2.0,
+        protein_g_per_kg_lbm_basis=False,
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=True,
+        refeed_frequency_days=14,
+        diet_break_frequency_weeks=12,
+        biomarker_cadence="weekly",
+        duration_envelope_weeks=(12, 24),
+    ),
+    Tier.T2: TierPolicy(
+        tier=Tier.T2,
+        bf_range=(20.0, 28.0),
+        # Conservative defaults for 20-25% sub-tier (matches current test user)
+        rate_cap_soft_pct_per_wk=0.75,
+        rate_cap_hard_pct_per_wk=1.0,
+        protein_g_per_kg_bw=2.2,
+        protein_g_per_kg_lbm_basis=False,
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=True,
+        refeed_frequency_days=14,
+        diet_break_frequency_weeks=12,
+        biomarker_cadence="weekly",
+        duration_envelope_weeks=(12, 16),
+    ),
+    Tier.T3: TierPolicy(
+        tier=Tier.T3,
+        bf_range=(15.0, 20.0),
+        rate_cap_soft_pct_per_wk=0.5,
+        rate_cap_hard_pct_per_wk=0.75,
+        protein_g_per_kg_bw=2.4,
+        protein_g_per_kg_lbm_basis=False,
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=False,  # BLOCKED at T3
+        refeed_frequency_days=7,        # weekly refeeds mandatory
+        diet_break_frequency_weeks=10,
+        biomarker_cadence="weekly",
+        duration_envelope_weeks=(16, 20),
+    ),
+    Tier.T4: TierPolicy(
+        tier=Tier.T4,
+        bf_range=(10.0, 15.0),
+        rate_cap_soft_pct_per_wk=0.4,
+        rate_cap_hard_pct_per_wk=0.5,
+        protein_g_per_kg_bw=2.8,
+        protein_g_per_kg_lbm_basis=True,  # switch to LBM basis at T4
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=False,
+        refeed_frequency_days=5,
+        diet_break_frequency_weeks=8,
+        biomarker_cadence="daily",
+        duration_envelope_weeks=(8, 12),
+    ),
+    Tier.T5: TierPolicy(
+        tier=Tier.T5,
+        bf_range=(0.0, 10.0),
+        rate_cap_soft_pct_per_wk=0.3,
+        rate_cap_hard_pct_per_wk=0.4,
+        protein_g_per_kg_bw=3.0,
+        protein_g_per_kg_lbm_basis=True,
+        fat_floor_g_per_kg_bw_soft=0.8,
+        fat_floor_g_per_kg_bw_hard=0.6,
+        aggressive_mode_allowed=False,
+        refeed_frequency_days=3,
+        diet_break_frequency_weeks=6,
+        biomarker_cadence="daily+bloods",
+        duration_envelope_weeks=(4, 8),
+    ),
+}
+
+
+def get_tier_policy(tier: Tier) -> TierPolicy:
+    """Return the canonical TierPolicy for a tier."""
+    return _TIER_POLICIES[tier]

--- a/sync/src/nutrition_engine/weight_prediction.py
+++ b/sync/src/nutrition_engine/weight_prediction.py
@@ -1,0 +1,196 @@
+"""3-layer weight prediction (M3 Phase D).
+
+Research basis: V2 §8.3.
+
+Layer A: personal kcal-per-kg (EWMA over history, weeks 4+)
+Layer B: Forbes-composition density (always available, function of current FM)
+Layer C: glycogen/water compartment + refeed sawtooth overlays with 80% CI
+
+Each layer is a pure function callers compose themselves. Layer A returns
+None when history is too short so callers know to fall back to Layer B.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+# ---------------------------------------------------------------------------
+# Layer B — Forbes-composition energy density (V2 §8.3)
+# ---------------------------------------------------------------------------
+
+_FORBES_K: float = 10.4
+_LEAN_KCAL_PER_KG: float = 1816.0
+_FAT_KCAL_PER_KG: float = 9441.0
+
+
+def forbes_energy_density_kcal_per_kg(fm_kg: float) -> float:
+    """Energy density per kg of body-weight change at a given fat mass.
+
+    Derived from Forbes partitioning: a weight change of 1 kg costs/releases
+    `rho` kcal where rho is a lean-fat mix weighted by the Forbes fraction.
+    """
+    if fm_kg < 0:
+        raise ValueError(f"fm_kg must be non-negative, got {fm_kg}")
+    lean_fraction = _FORBES_K / (_FORBES_K + fm_kg)
+    fat_fraction = 1.0 - lean_fraction
+    return lean_fraction * _LEAN_KCAL_PER_KG + fat_fraction * _FAT_KCAL_PER_KG
+
+
+# ---------------------------------------------------------------------------
+# Layer A — personal kcal-per-kg EWMA (V2 §8.3)
+# ---------------------------------------------------------------------------
+
+_LAYER_A_MIN_KCAL_PER_KG: float = 5500.0
+_LAYER_A_MAX_KCAL_PER_KG: float = 9500.0
+_LAYER_A_WEIGHT_EMA_DAYS: int = 7
+_LAYER_A_WINDOW_DAYS: int = 14
+
+
+@dataclass(frozen=True)
+class DayPoint:
+    day: int  # 0-indexed sequential day
+    intake_kcal: float
+    tdee_kcal: float
+    weight_kg: float
+
+
+def _ema(values: list[float], half_life: int) -> list[float]:
+    """Simple EWMA with given half-life (in samples). First value seeds."""
+    if not values:
+        return []
+    alpha = 1 - math.exp(-math.log(2) / half_life)
+    out = [values[0]]
+    for v in values[1:]:
+        out.append(out[-1] + alpha * (v - out[-1]))
+    return out
+
+
+def _trailing_mean(values: list[float], window: int) -> list[float]:
+    """Trailing simple moving average of length `window`. No lag relative to a
+    matched endpoint (vs EWMA which trails the true mean)."""
+    out: list[float] = []
+    for i in range(len(values)):
+        start = max(0, i - window + 1)
+        seg = values[start : i + 1]
+        out.append(sum(seg) / len(seg))
+    return out
+
+
+def personal_kcal_per_kg(
+    history: list[DayPoint],
+    *,
+    min_days: int = 28,
+    window_days: int = _LAYER_A_WINDOW_DAYS,
+    half_life_days: int = 28,
+) -> float | None:
+    """Empirical kcal-per-kg derived from the user's own history.
+
+    Smooths weight with a 7-day EMA, then over rolling `window_days`-wide
+    windows computes `cum_deficit_in_window / weight_delta_in_window`. Those
+    per-window densities are combined via an EWMA with `half_life_days` and
+    clamped to [5500, 9500].
+
+    Returns None when:
+    - history has fewer than `min_days` entries
+    - no window produces a usable (non-zero weight-delta) signal
+    """
+    if len(history) < min_days:
+        return None
+
+    # 1) Smooth weight with a trailing 7-day mean — no EWMA lag, so the delta
+    # across a 14-day window actually reflects 14 days of weight change.
+    weights = [d.weight_kg for d in history]
+    smoothed = _trailing_mean(weights, window=_LAYER_A_WEIGHT_EMA_DAYS)
+
+    # 2) Rolling windows: window_days apart. Start only once BOTH endpoints
+    # have a full trailing window — otherwise the start-of-series smoothing
+    # uses fewer samples than the end, biasing the delta downward.
+    per_window: list[float] = []
+    first_end = window_days + _LAYER_A_WEIGHT_EMA_DAYS - 1
+    for end in range(first_end, len(history)):
+        start = end - window_days
+        window = history[start:end]
+        cum_deficit = sum(d.tdee_kcal - d.intake_kcal for d in window)
+        delta = smoothed[start] - smoothed[end]  # positive if losing weight
+        if abs(delta) < 0.05:
+            # Noise floor: skip (avoid divide-by-small giving huge rho).
+            continue
+        # If cum_deficit and delta have opposite signs (user gained despite a
+        # deficit, e.g. creatine load or error), the ratio is negative and
+        # not meaningful for kcal-per-kg. Skip those windows too.
+        if cum_deficit * delta <= 0:
+            continue
+        rho = cum_deficit / delta
+        per_window.append(rho)
+
+    if not per_window:
+        return None
+
+    # 3) EWMA across windows.
+    smoothed_rho = _ema(per_window, half_life=half_life_days)
+    raw = smoothed_rho[-1]
+
+    # 4) Clamp.
+    return max(_LAYER_A_MIN_KCAL_PER_KG, min(_LAYER_A_MAX_KCAL_PER_KG, raw))
+
+
+# ---------------------------------------------------------------------------
+# Layer C — glycogen/water + refeed sawtooth overlays (V2 §8.3)
+# ---------------------------------------------------------------------------
+
+_GLYCOGEN_MAX_SWING_KG: float = 1.2
+_GLYCOGEN_TAU_DAYS: float = 4.0
+_GLYCOGEN_CARB_SATURATION_G: float = 500.0
+
+_REFEED_MAX_OFFSET_KG: float = 0.8
+_REFEED_TAU_DAYS: float = 2.0
+
+# 80% CI band width scalar (V2 §8.3 "80% CI band").
+_CI_BAND_SCALAR: float = 0.6
+
+
+@dataclass(frozen=True)
+class OverlayResult:
+    glycogen_swing_kg: float
+    refeed_offset_kg: float
+    ci_low_kg: float
+    ci_high_kg: float
+
+
+def glycogen_water_overlay(
+    central_kg: float,
+    *,
+    days_since_refeed: int,
+    carb_delta_g: float,
+) -> OverlayResult:
+    """Physiological overlays on top of a central weight prediction.
+
+    glycogen_swing_kg is signed (positive when loaded up, negative when
+    depleted). refeed_offset_kg is always ≥ 0 — it's the decaying tail of
+    the last high-carb day. The CI band widens with whichever of the two
+    moves the prediction more.
+    """
+    # Glycogen compartment: scales with |carb_delta_g| up to saturation,
+    # capped at ±1.2 kg. No time decay here — the caller passes the
+    # current carb delta relative to baseline.
+    saturation = max(-1.0, min(1.0, carb_delta_g / _GLYCOGEN_CARB_SATURATION_G))
+    glycogen_swing = saturation * _GLYCOGEN_MAX_SWING_KG
+
+    # Refeed sawtooth: exponential decay from _REFEED_MAX_OFFSET_KG.
+    if days_since_refeed < 0:
+        raise ValueError(f"days_since_refeed must be ≥ 0, got {days_since_refeed}")
+    refeed_offset = _REFEED_MAX_OFFSET_KG * math.exp(-days_since_refeed / _REFEED_TAU_DAYS)
+
+    # CI band: sum of magnitudes scaled by _CI_BAND_SCALAR, symmetric.
+    band = (abs(glycogen_swing) + abs(refeed_offset)) * _CI_BAND_SCALAR
+    # Ensure central is strictly inside the band (invariant for callers).
+    band = max(band, 0.05)
+
+    return OverlayResult(
+        glycogen_swing_kg=glycogen_swing,
+        refeed_offset_kg=refeed_offset,
+        ci_low_kg=central_kg - band,
+        ci_high_kg=central_kg + band,
+    )

--- a/sync/tests/test_adaptive.py
+++ b/sync/tests/test_adaptive.py
@@ -1,0 +1,220 @@
+"""Tests for M5 Phase A — Adaptive Systems core (V2 §4).
+
+M5.1 Adaptive TDEE
+M5.2 Refeed Pressure Score
+M5.3 Diet Break level
+M5.4 Plateau detection + type classifier
+"""
+
+import pytest
+
+from nutrition_engine.adaptive import (
+    AdaptiveTdeeResult,
+    DietBreakLevel,
+    PlateauResult,
+    PlateauType,
+    compute_adaptive_tdee,
+    compute_refeed_pressure_score,
+    detect_plateau,
+    recommend_diet_break,
+)
+from nutrition_engine.tier import Tier
+from nutrition_engine.weight_prediction import DayPoint
+
+
+# ---------------------------------------------------------------------------
+# M5.1 Adaptive TDEE
+# ---------------------------------------------------------------------------
+
+
+def _flat_history(days: int, intake: float, weight: float, tdee: float) -> list[DayPoint]:
+    return [
+        DayPoint(day=i, intake_kcal=intake, tdee_kcal=tdee, weight_kg=weight)
+        for i in range(days)
+    ]
+
+
+def _losing_history(days: int, intake: float, start_weight: float, daily_loss_kg: float, tdee: float) -> list[DayPoint]:
+    return [
+        DayPoint(
+            day=i, intake_kcal=intake, tdee_kcal=tdee,
+            weight_kg=start_weight - daily_loss_kg * i,
+        )
+        for i in range(days)
+    ]
+
+
+class TestAdaptiveTdee:
+    def test_short_history_returns_none(self):
+        assert compute_adaptive_tdee(_flat_history(5, 2500, 74, 2500)) is None
+
+    def test_steady_state_returns_intake(self):
+        hist = _flat_history(14, 2500, 74, 2500)
+        r = compute_adaptive_tdee(hist)
+        assert r is not None
+        # No weight change → effective_tdee ≈ avg_intake
+        assert r.effective_tdee == pytest.approx(2500.0, abs=10)
+        assert r.discrepancy_pct < 2.0
+        assert r.drift_flag is False
+
+    def test_losing_weight_implies_higher_tdee(self):
+        # 14 days, 2000 intake, losing 1 kg → effective ≈ 2000 + 7700/14 ≈ 2550
+        hist = _losing_history(14, intake=2000, start_weight=74, daily_loss_kg=1.0/14, tdee=2500)
+        r = compute_adaptive_tdee(hist)
+        assert r is not None
+        assert 2500 <= r.effective_tdee <= 2600
+
+    def test_drift_flag_fires_on_sustained_discrepancy(self):
+        # Reported TDEE 2500, effective ~2550 → >10% discrepancy? No, 2%
+        # Make it dramatic: reported 2000 vs effective 2550 = 27.5% discrepancy
+        hist = [
+            DayPoint(day=i, intake_kcal=2000, tdee_kcal=2000, weight_kg=74 - 1.0/14 * i)
+            for i in range(14)
+        ]
+        r = compute_adaptive_tdee(hist)
+        assert r is not None
+        assert r.discrepancy_pct > 10
+        assert r.drift_flag is True
+
+    def test_returns_dataclass(self):
+        hist = _flat_history(14, 2500, 74, 2500)
+        r = compute_adaptive_tdee(hist)
+        assert isinstance(r, AdaptiveTdeeResult)
+
+
+# ---------------------------------------------------------------------------
+# M5.2 Refeed Pressure Score
+# ---------------------------------------------------------------------------
+
+
+class TestRefeedPressureScore:
+    def test_zero_signals_is_zero(self):
+        rps = compute_refeed_pressure_score(
+            deficit_days=0, weight_stall_days=0,
+            hrv_7d_trend_pct=0, readiness_avg=80,
+            bf_tier=Tier.T2, weight_loss_velocity_pct_per_wk=0.5,
+        )
+        assert rps == 0
+
+    def test_all_maxed_clamps_to_100(self):
+        rps = compute_refeed_pressure_score(
+            deficit_days=100, weight_stall_days=30,
+            hrv_7d_trend_pct=-15, readiness_avg=30,
+            bf_tier=Tier.T4, weight_loss_velocity_pct_per_wk=2.0,
+        )
+        assert rps == 100
+
+    def test_monotone_in_deficit_days(self):
+        base = dict(
+            weight_stall_days=0, hrv_7d_trend_pct=0,
+            readiness_avg=80, bf_tier=Tier.T2,
+            weight_loss_velocity_pct_per_wk=0.5,
+        )
+        a = compute_refeed_pressure_score(deficit_days=10, **base)
+        b = compute_refeed_pressure_score(deficit_days=30, **base)
+        c = compute_refeed_pressure_score(deficit_days=56, **base)
+        assert a <= b <= c
+
+    def test_hrv_downtrend_adds_pressure(self):
+        base = dict(
+            deficit_days=30, weight_stall_days=0,
+            readiness_avg=80, bf_tier=Tier.T2,
+            weight_loss_velocity_pct_per_wk=0.5,
+        )
+        calm = compute_refeed_pressure_score(hrv_7d_trend_pct=0, **base)
+        down = compute_refeed_pressure_score(hrv_7d_trend_pct=-10, **base)
+        assert down > calm
+
+    def test_threshold_trigger_at_60(self):
+        # Synthetic high-pressure case: late in a cut with stalled weight,
+        # HRV trending down, low readiness, leaner tier, above rate cap.
+        rps = compute_refeed_pressure_score(
+            deficit_days=56, weight_stall_days=12,
+            hrv_7d_trend_pct=-10, readiness_avg=50,
+            bf_tier=Tier.T3, weight_loss_velocity_pct_per_wk=1.3,
+        )
+        assert rps >= 60
+
+
+# ---------------------------------------------------------------------------
+# M5.3 Diet Break level
+# ---------------------------------------------------------------------------
+
+
+class TestDietBreak:
+    def test_none_below_56(self):
+        for d in [0, 1, 30, 55]:
+            assert recommend_diet_break(d) == DietBreakLevel.NONE
+
+    def test_suggested_at_56(self):
+        assert recommend_diet_break(56) == DietBreakLevel.SUGGESTED
+
+    def test_suggested_range(self):
+        assert recommend_diet_break(70) == DietBreakLevel.SUGGESTED
+
+    def test_strong_at_84(self):
+        assert recommend_diet_break(84) == DietBreakLevel.STRONG
+
+    def test_mandatory_at_112(self):
+        assert recommend_diet_break(112) == DietBreakLevel.MANDATORY
+        assert recommend_diet_break(200) == DietBreakLevel.MANDATORY
+
+    def test_monotonic_never_decreases(self):
+        prev_ord = -1
+        order = {
+            DietBreakLevel.NONE: 0,
+            DietBreakLevel.SUGGESTED: 1,
+            DietBreakLevel.STRONG: 2,
+            DietBreakLevel.MANDATORY: 3,
+        }
+        for d in range(0, 200, 5):
+            o = order[recommend_diet_break(d)]
+            assert o >= prev_ord
+            prev_ord = o
+
+
+# ---------------------------------------------------------------------------
+# M5.4 Plateau detection
+# ---------------------------------------------------------------------------
+
+
+class TestPlateau:
+    def test_too_short_history_not_plateau(self):
+        hist = _flat_history(10, 2000, 74, 2500)
+        r = detect_plateau(hist, tdee_stable=True)
+        assert r.is_plateau is False
+
+    def test_losing_weight_not_plateau(self):
+        hist = _losing_history(30, intake=2000, start_weight=74, daily_loss_kg=0.1, tdee=2500)
+        r = detect_plateau(hist, tdee_stable=True)
+        assert r.is_plateau is False
+
+    def test_flat_weight_is_plateau(self):
+        hist = _flat_history(25, 2000, 74, 2500)
+        r = detect_plateau(hist, tdee_stable=True)
+        assert r.is_plateau is True
+        # Default to INTAKE_CREEP when no subjective signals
+        assert r.type == PlateauType.INTAKE_CREEP
+
+    def test_flat_with_hunger_is_adaptation(self):
+        hist = _flat_history(25, 2000, 74, 2500)
+        r = detect_plateau(hist, tdee_stable=True, hunger_elevated=True)
+        assert r.type == PlateauType.ADAPTATION
+
+    def test_strength_improving_is_recomp_not_plateau(self):
+        hist = _flat_history(25, 2000, 74, 2500)
+        r = detect_plateau(hist, tdee_stable=True, strength_improving=True)
+        assert r.type == PlateauType.RECOMP
+        assert r.is_plateau is False
+
+    def test_tdee_unstable_gates_plateau(self):
+        hist = _flat_history(25, 2000, 74, 2500)
+        r = detect_plateau(hist, tdee_stable=False)
+        assert r.is_plateau is False
+
+    def test_returns_dataclass(self):
+        hist = _flat_history(25, 2000, 74, 2500)
+        r = detect_plateau(hist, tdee_stable=True)
+        assert isinstance(r, PlateauResult)
+        assert hasattr(r, "ema_slope_kg_per_wk")
+        assert hasattr(r, "days_stalled")

--- a/sync/tests/test_bmr.py
+++ b/sync/tests/test_bmr.py
@@ -1,0 +1,112 @@
+"""Tests for BMR formulas (M1.2)."""
+
+import pytest
+
+from nutrition_engine.bmr import (
+    cunningham,
+    ten_haaf_weight,
+    mifflin_st_jeor,
+    compute_bmr,
+)
+
+
+class TestCunningham:
+    """Cunningham 1980: BMR = 500 + 22 × FFM_kg.
+
+    Validated by ten Haaf 2014 as the only legacy equation passing
+    Bland-Altman in male recreational athletes (78% accuracy).
+    """
+
+    def test_current_user_ffm_60_6(self):
+        # Test user: 74.2 kg, 23.5% BF, FFM 60.6 kg
+        assert cunningham(ffm_kg=60.6) == 1833
+
+    def test_lean_athlete_ffm_70(self):
+        assert cunningham(ffm_kg=70.0) == 2040
+
+    def test_low_ffm(self):
+        assert cunningham(ffm_kg=40.0) == 1380
+
+    def test_zero_ffm_raises(self):
+        with pytest.raises(ValueError):
+            cunningham(ffm_kg=0)
+
+    def test_negative_ffm_raises(self):
+        with pytest.raises(ValueError):
+            cunningham(ffm_kg=-10)
+
+
+class TestMifflinStJeor:
+    """Mifflin-St Jeor 1990: demographic fallback."""
+
+    def test_male(self):
+        # 10w + 6.25h - 5a + 5 for male
+        # 74.2kg, 177cm, 31y, male: 10×74.2 + 6.25×177 - 5×31 + 5 = 742 + 1106.25 - 155 + 5 = 1698.25
+        assert mifflin_st_jeor(weight_kg=74.2, height_cm=177, age=31, sex="male") == 1698
+
+    def test_female(self):
+        # 10w + 6.25h - 5a - 161 for female
+        assert mifflin_st_jeor(weight_kg=60, height_cm=165, age=30, sex="female") == 1320
+
+    def test_male_typical_adult(self):
+        # Known test vector: 80 kg, 180 cm, 35 y, male
+        # = 800 + 1125 - 175 + 5 = 1755
+        assert mifflin_st_jeor(weight_kg=80, height_cm=180, age=35, sex="male") == 1755
+
+
+class TestTenHaafWeight:
+    """ten Haaf 2014 weight-based formula for trained athletes."""
+
+    def test_male_user(self):
+        # 74.2 kg, 177 cm, 31y male — published formula for males:
+        # REE_MJ = 0.02035·w + 1.82·h/100 - 0.01184·a + 1.61 (male)
+        # → kcal = MJ × 238.85
+        result = ten_haaf_weight(weight_kg=74.2, height_cm=177, age=31, sex="male")
+        # Should be in the 1750-1900 range for this profile
+        assert 1750 <= result <= 1900
+
+    def test_output_is_int(self):
+        result = ten_haaf_weight(weight_kg=80, height_cm=180, age=30, sex="male")
+        assert isinstance(result, int)
+
+
+class TestComputeBmr:
+    """High-level router: FFM → Cunningham, else → fallbacks."""
+
+    def test_ffm_uses_cunningham(self):
+        # When FFM provided, use Cunningham (most accurate for athletes)
+        assert compute_bmr(ffm_kg=60.6) == 1833
+
+    def test_no_ffm_uses_ten_haaf(self):
+        # Without FFM, use ten Haaf weight-based for trained athletes
+        result = compute_bmr(
+            weight_kg=74.2, height_cm=177, age=31, sex="male"
+        )
+        # Should match ten_haaf_weight output
+        assert result == ten_haaf_weight(weight_kg=74.2, height_cm=177, age=31, sex="male")
+
+    def test_missing_demographics_raises(self):
+        with pytest.raises(ValueError):
+            compute_bmr()  # no inputs at all
+
+    def test_partial_demographics_raises(self):
+        with pytest.raises(ValueError):
+            compute_bmr(weight_kg=74.2)  # missing height, age, sex
+
+
+class TestFormulaDisagreement:
+    """Sanity checks across formulas for same user."""
+
+    def test_cunningham_higher_than_mifflin_for_lean(self):
+        # 23.5% BF male is relatively lean; Cunningham should predict higher BMR
+        # than Mifflin-St Jeor (which under-predicts in lean trained men)
+        user_weight, user_height, user_age = 74.2, 177, 31
+        ffm = user_weight * (1 - 0.235)  # 56.76 kg
+
+        cunningham_val = cunningham(ffm_kg=ffm)
+        mifflin_val = mifflin_st_jeor(
+            weight_kg=user_weight, height_cm=user_height, age=user_age, sex="male"
+        )
+
+        # Cunningham should be within 200 kcal of Mifflin but not wildly divergent
+        assert abs(cunningham_val - mifflin_val) < 300

--- a/sync/tests/test_deficit_duration.py
+++ b/sync/tests/test_deficit_duration.py
@@ -1,0 +1,167 @@
+"""Tests for deficit duration counter (M1.7).
+
+Research: Byrne 2018 MATADOR, Peos 2021 ICECAP, Trexler 2014.
+
+Counter tracks consecutive days of intake < 95% TDEE. Reset rules:
+- 7+ consecutive maintenance days: full reset
+- 3-6 maintenance days: half reset
+- <3 maintenance days: no reset
+Severity scaling:
+- Deficit > 25% TDEE: shortens thresholds by 4 weeks
+- Deficit < 15% TDEE: extends by 4 weeks
+Default thresholds: 56 (soft warn) / 84 (strong) / 112 (hard stop).
+"""
+
+import pytest
+
+from nutrition_engine.deficit_duration import (
+    compute_counter,
+    get_thresholds,
+    classify_counter,
+    CounterStatus,
+    DurationThresholds,
+    DEFICIT_RATIO_THRESHOLD,
+)
+
+
+class TestDeficitRatioThreshold:
+    def test_constant(self):
+        # Intake ≥ 95% TDEE = maintenance (refeed threshold from V14)
+        assert DEFICIT_RATIO_THRESHOLD == 0.95
+
+
+class TestComputeCounter:
+    def _days(self, intakes_vs_tdee: list[tuple[float, float]]) -> list[dict]:
+        """Helper: build a list of day dicts from (intake, tdee) tuples."""
+        return [{"intake_kcal": i, "tdee_kcal": t} for i, t in intakes_vs_tdee]
+
+    def test_seven_deficit_days(self):
+        # 7 consecutive deficit days
+        days = self._days([(1700, 2500)] * 7)
+        assert compute_counter(days) == 7
+
+    def test_maintenance_break_resets_fully(self):
+        # 10 deficit days, 7 maintenance, 3 more deficit → counter = 3
+        days = self._days(
+            [(1700, 2500)] * 10
+            + [(2500, 2500)] * 7
+            + [(1700, 2500)] * 3
+        )
+        assert compute_counter(days) == 3
+
+    def test_short_maintenance_half_resets(self):
+        # 10 deficit, 5 maintenance (half-reset), 3 deficit
+        # After 10 deficit + 5 maintenance (half reset): counter = 10/2 = 5
+        # After 3 more deficit: 5 + 3 = 8
+        days = self._days(
+            [(1700, 2500)] * 10
+            + [(2500, 2500)] * 5
+            + [(1700, 2500)] * 3
+        )
+        assert compute_counter(days) == 8
+
+    def test_one_day_maintenance_no_reset(self):
+        # 10 deficit + 1 maintenance + 3 deficit
+        # <3 maintenance days = no reset → counter = 10 + 3 = 13
+        days = self._days(
+            [(1700, 2500)] * 10
+            + [(2500, 2500)] * 1
+            + [(1700, 2500)] * 3
+        )
+        assert compute_counter(days) == 13
+
+    def test_empty_days(self):
+        assert compute_counter([]) == 0
+
+    def test_all_maintenance(self):
+        days = self._days([(2500, 2500)] * 14)
+        assert compute_counter(days) == 0
+
+    def test_intake_exactly_95pct_is_maintenance(self):
+        # 2500 × 0.95 = 2375; intake = 2375 is maintenance (not deficit)
+        days = self._days([(2375, 2500)] * 10)
+        assert compute_counter(days) == 0
+
+    def test_intake_just_below_95pct_is_deficit(self):
+        # 2370 < 2375 = deficit
+        days = self._days([(2370, 2500)] * 10)
+        assert compute_counter(days) == 10
+
+
+class TestGetThresholds:
+    def test_default_thresholds(self):
+        # Moderate deficit (15-25% of TDEE) → default 56/84/112
+        t = get_thresholds(avg_deficit_pct=20.0)
+        assert t.soft_warn_days == 56
+        assert t.strong_recommend_days == 84
+        assert t.hard_stop_days == 112
+
+    def test_aggressive_deficit_tightens(self):
+        # > 25% deficit: shortens by 4 weeks (28 days)
+        t = get_thresholds(avg_deficit_pct=30.0)
+        assert t.soft_warn_days == 28
+        assert t.strong_recommend_days == 56
+        assert t.hard_stop_days == 84
+
+    def test_mild_deficit_extends(self):
+        # < 15% deficit: extends by 4 weeks
+        t = get_thresholds(avg_deficit_pct=10.0)
+        assert t.soft_warn_days == 84
+        assert t.strong_recommend_days == 112
+        assert t.hard_stop_days == 140
+
+    def test_boundary_at_25(self):
+        # Exactly 25% = moderate
+        t = get_thresholds(avg_deficit_pct=25.0)
+        assert t.soft_warn_days == 56
+
+    def test_boundary_at_15(self):
+        t = get_thresholds(avg_deficit_pct=15.0)
+        assert t.soft_warn_days == 56
+
+
+class TestClassifyCounter:
+    def test_under_soft_green(self):
+        thresholds = DurationThresholds(56, 84, 112)
+        assert classify_counter(20, thresholds) is CounterStatus.GREEN
+        assert classify_counter(55, thresholds) is CounterStatus.GREEN
+
+    def test_soft_warn(self):
+        thresholds = DurationThresholds(56, 84, 112)
+        assert classify_counter(56, thresholds) is CounterStatus.WARN
+        assert classify_counter(83, thresholds) is CounterStatus.WARN
+
+    def test_strong_recommend(self):
+        thresholds = DurationThresholds(56, 84, 112)
+        assert classify_counter(84, thresholds) is CounterStatus.STRONG
+        assert classify_counter(111, thresholds) is CounterStatus.STRONG
+
+    def test_hard_stop(self):
+        thresholds = DurationThresholds(56, 84, 112)
+        assert classify_counter(112, thresholds) is CounterStatus.HARD_STOP
+        assert classify_counter(200, thresholds) is CounterStatus.HARD_STOP
+
+
+class TestCurrentUserScenarios:
+    def _days(self, intakes_vs_tdee: list[tuple[float, float]]) -> list[dict]:
+        return [{"intake_kcal": i, "tdee_kcal": t} for i, t in intakes_vs_tdee]
+
+    def test_full_cut_without_break_triggers_warn(self):
+        # 60 consecutive days at ~700 kcal deficit (~28% of 2500 TDEE)
+        # Deficit pct = 28% → aggressive → soft at 28 days
+        days = self._days([(1800, 2500)] * 60)
+        counter = compute_counter(days)
+        # avg deficit pct
+        avg_deficit_pct = 28.0  # (2500-1800)/2500
+        thresholds = get_thresholds(avg_deficit_pct=avg_deficit_pct)
+        status = classify_counter(counter, thresholds)
+        # 60 days > strong recommend 56 → STRONG
+        assert status is CounterStatus.STRONG
+
+    def test_moderate_cut_8_weeks_just_warns(self):
+        # 56 days at ~20% deficit (default thresholds)
+        days = self._days([(2000, 2500)] * 56)  # 20% deficit
+        counter = compute_counter(days)
+        thresholds = get_thresholds(avg_deficit_pct=20.0)
+        status = classify_counter(counter, thresholds)
+        assert status is CounterStatus.WARN

--- a/sync/tests/test_fat_floor.py
+++ b/sync/tests/test_fat_floor.py
@@ -1,0 +1,100 @@
+"""Tests for fat floor enforcement (M1.5).
+
+Research basis: Whittaker & Wu 2021 T-meta, Volek 1997, Wang 2005.
+Fat < 20% of calories → testosterone drops. Floor protects hormonal function.
+"""
+
+import pytest
+
+from nutrition_engine.fat_floor import (
+    compute_fat_floor,
+    apply_fat_floor,
+    FatFloorResult,
+    FatBreachType,
+)
+
+
+class TestComputeFatFloor:
+    def test_current_user_standard(self):
+        # 74.2 kg: soft = 0.8 × 74.2 = 59.36 → 59, hard = 0.6 × 74.2 = 44.52 → 45
+        result = compute_fat_floor(weight_kg=74.2, mode="standard")
+        assert result.soft_floor_g == 59
+        assert result.hard_floor_g == 45
+
+    def test_aggressive_mode_same_floors(self):
+        # Aggressive mode doesn't loosen fat floors (hormone protection is non-negotiable)
+        result = compute_fat_floor(weight_kg=74.2, mode="aggressive")
+        assert result.soft_floor_g == 59
+        assert result.hard_floor_g == 45
+
+    def test_maintenance_raises_soft_floor(self):
+        # Maintenance: fat becomes a target 0.8-1.0, not just floor.
+        # Soft floor should be raised to 1.0 (real target) in maintenance.
+        result = compute_fat_floor(weight_kg=74.2, mode="maintenance")
+        assert result.soft_floor_g == 74  # 1.0 × 74.2 rounded
+        assert result.hard_floor_g == 45  # hard stays 0.6
+
+    def test_bulk_allows_higher_fat(self):
+        # Bulk: fat 0.8-1.2 g/kg real target range; soft floor stays at 0.8
+        result = compute_fat_floor(weight_kg=74.2, mode="bulk")
+        assert result.soft_floor_g == 59  # 0.8 g/kg
+        assert result.hard_floor_g == 45
+
+    def test_heavy_athlete(self):
+        # 90 kg athlete: 72 soft / 54 hard
+        result = compute_fat_floor(weight_kg=90.0, mode="standard")
+        assert result.soft_floor_g == 72
+        assert result.hard_floor_g == 54
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            compute_fat_floor(weight_kg=74.2, mode="invalid")
+
+    def test_zero_weight_raises(self):
+        with pytest.raises(ValueError):
+            compute_fat_floor(weight_kg=0, mode="standard")
+
+
+class TestApplyFatFloor:
+    def test_fat_above_soft_no_breach(self):
+        result = apply_fat_floor(fat_g=70, weight_kg=74.2, mode="standard")
+        assert result.breach_type is FatBreachType.NONE
+        assert result.fat_g == 70
+
+    def test_fat_between_soft_and_hard_warning(self):
+        # Fat 55g: below soft (59) but above hard (45) → warning, not enforced
+        result = apply_fat_floor(fat_g=55, weight_kg=74.2, mode="standard")
+        assert result.breach_type is FatBreachType.SOFT
+        assert result.fat_g == 55  # keep user value; just warn
+
+    def test_fat_below_hard_raised(self):
+        # Fat 40g: below hard (45) → raised to hard floor
+        result = apply_fat_floor(fat_g=40, weight_kg=74.2, mode="standard")
+        assert result.breach_type is FatBreachType.HARD
+        assert result.fat_g == 45
+
+    def test_fat_overshoot_allowed_no_warn(self):
+        # Fat 100g on standard: way over soft but NOT flagged (overshoot is safe)
+        result = apply_fat_floor(fat_g=100, weight_kg=74.2, mode="standard")
+        assert result.breach_type is FatBreachType.NONE
+
+    def test_bulk_mode_overshoot_allowed(self):
+        # Bulk mode 120g fat: well above soft 0.8, but bulk allows up to ~1.2 g/kg
+        # No breach either way
+        result = apply_fat_floor(fat_g=120, weight_kg=74.2, mode="bulk")
+        assert result.breach_type is FatBreachType.NONE
+
+
+class TestCurrentUserScenarios:
+    def test_today_fat_58_below_soft_warning(self):
+        # User's logged Day 1 had fat at 58.3g (our -800 plan)
+        result = apply_fat_floor(fat_g=58, weight_kg=74.2, mode="aggressive")
+        # Below soft 59 → SOFT warning
+        assert result.breach_type is FatBreachType.SOFT
+        assert result.fat_g == 58  # not enforced, just warned
+
+    def test_maintenance_after_target_hit(self):
+        # When user reaches 15% BF and switches to maintenance, fat target is 0.8-1.0
+        # 70g fat (below 1.0 × 74.2 = 74) → SOFT warning (real target now)
+        result = apply_fat_floor(fat_g=70, weight_kg=74.2, mode="maintenance")
+        assert result.breach_type is FatBreachType.SOFT

--- a/sync/tests/test_floor.py
+++ b/sync/tests/test_floor.py
@@ -1,0 +1,148 @@
+"""Tests for BMR + RED-S EA floor enforcement (M1.3)."""
+
+import pytest
+
+from nutrition_engine.floor import (
+    compute_floor,
+    apply_floor,
+    FloorResult,
+    FloorBreachType,
+    REDS_EA_COEFFICIENT,
+)
+from nutrition_engine.tier import Tier
+
+
+class TestComputeFloor:
+    """Compute soft + hard floors given FFM, exercise, and mode."""
+
+    def test_standard_rest_day_current_user(self):
+        # User: FFM 60.6, no exercise, Standard mode
+        # soft = Cunningham = 1833
+        # hard = max(Cunningham, 25 × 60.6 + 0) = max(1833, 1515) = 1833
+        result = compute_floor(ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        assert result.soft_floor == 1833
+        assert result.hard_floor == 1833
+
+    def test_standard_training_day_current_user(self):
+        # User: FFM 60.6, 400 kcal exercise
+        # soft = Cunningham = 1833
+        # hard = max(Cunningham, 25 × 60.6 + 400) = max(1833, 1915) = 1915
+        result = compute_floor(ffm_kg=60.6, exercise_kcal=400, mode="standard")
+        assert result.soft_floor == 1833
+        assert result.hard_floor == 1915
+
+    def test_aggressive_mode_drops_cunningham(self):
+        # Aggressive mode: hard = 25×FFM + exercise (no Cunningham gate)
+        # User rest day: hard = 25 × 60.6 + 0 = 1515
+        result = compute_floor(ffm_kg=60.6, exercise_kcal=0, mode="aggressive")
+        assert result.hard_floor == 1515
+        # Soft floor still shown for awareness but not enforced
+        assert result.soft_floor == 1833
+
+    def test_aggressive_mode_training_day(self):
+        # User training day 400 kcal exercise
+        # hard = 25 × 60.6 + 400 = 1915 (in aggressive)
+        result = compute_floor(ffm_kg=60.6, exercise_kcal=400, mode="aggressive")
+        assert result.hard_floor == 1915
+
+    def test_high_ffm_user(self):
+        # Big athlete, FFM 80 kg
+        # Cunningham = 500 + 22×80 = 2260
+        # EA = 25 × 80 = 2000
+        # Standard: hard = max(2260, 2000) = 2260 (Cunningham dominates)
+        result = compute_floor(ffm_kg=80.0, exercise_kcal=0, mode="standard")
+        assert result.soft_floor == 2260
+        assert result.hard_floor == 2260
+
+    def test_low_ffm_ea_dominates(self):
+        # Light user, FFM 45 kg
+        # Cunningham = 500 + 22×45 = 1490
+        # EA = 25 × 45 = 1125
+        # With 500 kcal exercise: EA becomes 1625 > Cunningham 1490
+        result = compute_floor(ffm_kg=45.0, exercise_kcal=500, mode="standard")
+        assert result.hard_floor == 1625  # EA dominates
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            compute_floor(ffm_kg=60.6, exercise_kcal=0, mode="invalid")
+
+    def test_negative_exercise_raises(self):
+        with pytest.raises(ValueError):
+            compute_floor(ffm_kg=60.6, exercise_kcal=-100, mode="standard")
+
+    def test_zero_ffm_raises(self):
+        with pytest.raises(ValueError):
+            compute_floor(ffm_kg=0, exercise_kcal=0, mode="standard")
+
+
+class TestApplyFloor:
+    """Apply floor to a proposed target_kcal and return adjusted + breach type."""
+
+    def test_target_above_both_floors_no_breach(self):
+        # User rest day: floors 1833/1833
+        result = apply_floor(target_kcal=2000, ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        assert result.target_kcal == 2000
+        assert result.breach_type is FloorBreachType.NONE
+
+    def test_target_below_soft_floor_warning(self):
+        # Target 1800 < soft 1833, but 1800 = hard floor in this case
+        # Standard mode rest: soft=hard=1833, so target 1800 = hard breach
+        result = apply_floor(target_kcal=1800, ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        assert result.breach_type is FloorBreachType.HARD
+        assert result.target_kcal == 1833  # raised to hard floor
+
+    def test_target_below_hard_floor_raised(self):
+        # User training day: hard floor 1915; target 1700 breaches it
+        result = apply_floor(target_kcal=1700, ffm_kg=60.6, exercise_kcal=400, mode="standard")
+        assert result.breach_type is FloorBreachType.HARD
+        assert result.target_kcal == 1915  # raised to hard floor
+
+    def test_aggressive_allows_below_cunningham(self):
+        # Aggressive rest day: hard = 25×FFM = 1515
+        # Target 1600 is below Cunningham (1833) but above EA hard (1515)
+        # In Aggressive mode, this is SOFT breach (warning) not HARD (enforced)
+        result = apply_floor(target_kcal=1600, ffm_kg=60.6, exercise_kcal=0, mode="aggressive")
+        assert result.breach_type is FloorBreachType.SOFT
+        assert result.target_kcal == 1600  # not raised (below Cunningham but OK in Aggressive)
+
+    def test_aggressive_hard_floor_enforced(self):
+        # Aggressive rest day: hard=1515. Target 1400 breaches hard.
+        result = apply_floor(target_kcal=1400, ffm_kg=60.6, exercise_kcal=0, mode="aggressive")
+        assert result.breach_type is FloorBreachType.HARD
+        assert result.target_kcal == 1515
+
+    def test_reds_coefficient_constant(self):
+        # Regression guard — the RED-S EA coefficient must be 25 kcal/kg FFM per V11
+        # (Mountjoy 2018 threshold)
+        assert REDS_EA_COEFFICIENT == 25
+
+
+class TestCurrentUserScenarios:
+    """Live scenarios matching brainstorming decisions for current user."""
+
+    def test_current_1732_target_breaches_soft_floor_on_rest_day(self):
+        # Current soma plan: 1732 kcal target on rest day
+        # In Standard mode this breaches Cunningham floor (1833) -> 100 kcal below
+        result = apply_floor(target_kcal=1732, ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        assert result.breach_type is FloorBreachType.HARD  # soft=hard=1833
+        assert result.target_kcal == 1833
+
+    def test_current_1732_target_breaches_hard_floor_on_training_day(self):
+        # 1732 target with 400 kcal training: hard floor 1915 is breached by 183 kcal
+        result = apply_floor(target_kcal=1732, ffm_kg=60.6, exercise_kcal=400, mode="standard")
+        assert result.breach_type is FloorBreachType.HARD
+        assert result.target_kcal == 1915
+
+    def test_max_deficit_rest_day_standard(self):
+        # With TDEE 2547 (standard day) and floor 1833, max deficit = 714
+        tdee = 2547
+        floor = compute_floor(ffm_kg=60.6, exercise_kcal=0, mode="standard")
+        max_deficit = tdee - floor.hard_floor
+        assert max_deficit == 714
+
+    def test_max_deficit_training_day_standard(self):
+        # With TDEE 2547 (400 kcal exercise included) and hard floor 1915, max deficit = 632
+        tdee = 2547
+        floor = compute_floor(ffm_kg=60.6, exercise_kcal=400, mode="standard")
+        max_deficit = tdee - floor.hard_floor
+        assert max_deficit == 632

--- a/sync/tests/test_forbes.py
+++ b/sync/tests/test_forbes.py
@@ -1,0 +1,84 @@
+"""Tests for Forbes partitioning + recomp multiplier (M3.1).
+
+Research basis: V2 §8.1, Forbes 2000 FFM-FM curve.
+
+dFFM/dBW = 10.4 / (10.4 + FM)
+
+Recomp multiplier: 0.6× when ≥3 resistance sessions/week AND protein ≥1.8 g/kg
+(concurrent RT + high protein partitions LESS fat, more lean relative to the
+curve).
+"""
+
+import pytest
+
+from nutrition_engine.forbes import ForbesResult, partition_weight_change
+
+
+class TestForbesResultShape:
+    def test_returns_dataclass(self):
+        r = partition_weight_change(d_bw_kg=0.5, fm_kg=20.0)
+        assert isinstance(r, ForbesResult)
+        assert hasattr(r, "d_ffm_kg")
+        assert hasattr(r, "d_fm_kg")
+        assert hasattr(r, "ffm_fraction")
+
+
+class TestDefaultPartitioning:
+    def test_zero_change_is_zero_everywhere(self):
+        r = partition_weight_change(d_bw_kg=0.0, fm_kg=20.0)
+        assert r.d_ffm_kg == pytest.approx(0.0)
+        assert r.d_fm_kg == pytest.approx(0.0)
+
+    def test_gain_at_fm_20(self):
+        # 10.4 / (10.4 + 20) = 0.342
+        r = partition_weight_change(d_bw_kg=1.0, fm_kg=20.0)
+        assert r.ffm_fraction == pytest.approx(10.4 / 30.4, rel=1e-6)
+        assert r.d_ffm_kg == pytest.approx(10.4 / 30.4)
+        assert r.d_fm_kg == pytest.approx(1.0 - 10.4 / 30.4)
+
+    def test_loss_at_fm_10(self):
+        # 10.4 / (10.4 + 10) = 0.510
+        r = partition_weight_change(d_bw_kg=-1.0, fm_kg=10.0)
+        assert r.ffm_fraction == pytest.approx(10.4 / 20.4, rel=1e-6)
+        # Loss splits same way: more FFM lost at lower FM (the classic cut warning).
+        assert r.d_ffm_kg == pytest.approx(-10.4 / 20.4)
+        assert r.d_fm_kg == pytest.approx(-1.0 + 10.4 / 20.4)
+
+    def test_extreme_high_fm_gives_mostly_fat(self):
+        # At fm=90 kg, ffm fraction ≈ 0.104
+        r = partition_weight_change(d_bw_kg=1.0, fm_kg=90.0)
+        assert r.ffm_fraction < 0.12
+        assert r.d_fm_kg > r.d_ffm_kg
+
+    def test_extreme_low_fm_gives_mostly_ffm(self):
+        # At fm=3 kg (very lean), ffm fraction ≈ 0.776
+        r = partition_weight_change(d_bw_kg=1.0, fm_kg=3.0)
+        assert r.ffm_fraction > 0.7
+        assert r.d_ffm_kg > r.d_fm_kg
+
+
+class TestRecompMultiplier:
+    def test_recomp_shrinks_ffm_fraction(self):
+        base = partition_weight_change(d_bw_kg=1.0, fm_kg=20.0, recomp=False)
+        rec = partition_weight_change(d_bw_kg=1.0, fm_kg=20.0, recomp=True)
+        assert rec.ffm_fraction == pytest.approx(base.ffm_fraction * 0.6, rel=1e-6)
+        assert rec.d_ffm_kg < base.d_ffm_kg
+
+    def test_recomp_keeps_invariant(self):
+        r = partition_weight_change(d_bw_kg=1.0, fm_kg=20.0, recomp=True)
+        assert r.d_ffm_kg + r.d_fm_kg == pytest.approx(1.0)
+
+
+class TestInvariant:
+    @pytest.mark.parametrize("d_bw", [-2.0, -0.5, 0.0, 0.5, 2.0])
+    @pytest.mark.parametrize("fm", [5.0, 15.0, 30.0, 60.0])
+    @pytest.mark.parametrize("recomp", [False, True])
+    def test_ffm_plus_fm_equals_bw(self, d_bw: float, fm: float, recomp: bool):
+        r = partition_weight_change(d_bw_kg=d_bw, fm_kg=fm, recomp=recomp)
+        assert r.d_ffm_kg + r.d_fm_kg == pytest.approx(d_bw, abs=1e-9)
+
+
+class TestGuards:
+    def test_negative_fm_raises(self):
+        with pytest.raises(ValueError):
+            partition_weight_change(d_bw_kg=1.0, fm_kg=-5.0)

--- a/sync/tests/test_macro_targets.py
+++ b/sync/tests/test_macro_targets.py
@@ -1,0 +1,285 @@
+"""Tests for M4 Phase A — Macro Engine core (5-band × tier × mode).
+
+Research basis: V2 §2.
+
+M4.1 Load classifier:
+    run_load = run_kcal / (weight × 10)
+    gym_load = gym_kcal / (weight × 6)
+    total_load = min(run_load + gym_load, 4.0)
+    if run_load ≥ 1.5: total_load = run_load  (endurance priority)
+Band thresholds:
+    REST: load == 0
+    LIGHT: (0, 1.0]
+    MODERATE: (1.0, 2.0]
+    HARD: (2.0, 3.0]
+    VERY_HARD: > 3.0
+
+M4.2 Protein matrix + very_hard modifier (0.2 g/kg drop, floor 1.6).
+M4.3 Carbs: rest 3.0 / light 3.5 / moderate 5.0 / hard 6.5 / very_hard 8.0 g/kg.
+     Fiber: max(25, round(kcal × 14/1000)) + 5 cut_bonus; hard ceiling 60g.
+M4.4 Orchestrator: applies fat floor from M1.5; kcal fills remainder.
+"""
+
+import pytest
+
+from nutrition_engine.macro_targets import (
+    Band,
+    MacroTargets,
+    carb_g_per_kg,
+    carb_target_g,
+    classify_band,
+    compute_macro_targets,
+    compute_training_load,
+    fiber_target_g,
+    protein_g_per_kg,
+)
+from nutrition_engine.mode import Mode
+from nutrition_engine.tier import Tier
+
+
+# ---------------------------------------------------------------------------
+# M4.1 Load classifier
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingLoad:
+    def test_zero_zero_is_zero(self):
+        assert compute_training_load(0, 0, weight_kg=74) == 0
+
+    def test_short_run(self):
+        # 400 kcal at 74 kg → run_load = 400/740 ≈ 0.54
+        load = compute_training_load(400, 0, weight_kg=74)
+        assert 0.5 <= load <= 0.6
+
+    def test_endurance_priority(self):
+        # run_load ≥ 1.5 → ignore gym, use run_load only
+        # 1200 kcal at 74 kg → run_load ≈ 1.62
+        load = compute_training_load(1200, 300, weight_kg=74)
+        assert abs(load - (1200 / 740)) < 0.01
+
+    def test_saturation_cap(self):
+        # Gym-heavy day below the endurance-priority threshold: 500 run (load
+        # 0.68) + 2500 gym (load 5.63) would sum to 6.31 → cap 4.0.
+        load = compute_training_load(500, 2500, weight_kg=74)
+        assert load == 4.0
+
+    def test_gym_only(self):
+        # 400 kcal gym at 74 kg → gym_load = 400/444 ≈ 0.9
+        load = compute_training_load(0, 400, weight_kg=74)
+        assert 0.85 <= load <= 0.95
+
+    def test_negative_kcal_raises(self):
+        with pytest.raises(ValueError):
+            compute_training_load(-1, 0, weight_kg=74)
+
+
+class TestClassifyBand:
+    def test_rest(self):
+        assert classify_band(0) == Band.REST
+
+    def test_light(self):
+        assert classify_band(0.5) == Band.LIGHT
+        assert classify_band(1.0) == Band.LIGHT
+
+    def test_moderate(self):
+        assert classify_band(1.01) == Band.MODERATE
+        assert classify_band(2.0) == Band.MODERATE
+
+    def test_hard(self):
+        assert classify_band(2.01) == Band.HARD
+        assert classify_band(3.0) == Band.HARD
+
+    def test_very_hard(self):
+        assert classify_band(3.01) == Band.VERY_HARD
+        assert classify_band(4.0) == Band.VERY_HARD
+
+
+# ---------------------------------------------------------------------------
+# M4.2 Protein formula
+# ---------------------------------------------------------------------------
+
+
+class TestProtein:
+    def test_standard_t2_moderate(self):
+        # Our target: 2.3 g/kg at T2 Standard
+        p = protein_g_per_kg(Tier.T2, Mode.STANDARD, Band.MODERATE)
+        assert p == pytest.approx(2.3)
+
+    def test_aggressive_t2_hard(self):
+        p = protein_g_per_kg(Tier.T2, Mode.AGGRESSIVE, Band.HARD)
+        assert p == pytest.approx(2.4)
+
+    def test_very_hard_drops_by_0_2(self):
+        base = protein_g_per_kg(Tier.T2, Mode.AGGRESSIVE, Band.HARD)
+        vh = protein_g_per_kg(Tier.T2, Mode.AGGRESSIVE, Band.VERY_HARD)
+        assert vh == pytest.approx(base - 0.2)
+
+    def test_very_hard_respects_1_6_floor(self):
+        # Bulk at T2 = 2.0 baseline; VERY_HARD → 1.8. Still ≥ 1.6 floor.
+        p = protein_g_per_kg(Tier.T2, Mode.BULK, Band.VERY_HARD)
+        assert p >= 1.6
+
+    def test_maintenance_flat_2_0(self):
+        for tier in [Tier.T1, Tier.T2, Tier.T3, Tier.T4]:
+            p = protein_g_per_kg(tier, Mode.MAINTENANCE, Band.MODERATE)
+            assert p == pytest.approx(2.0)
+
+    def test_bulk_flat_2_0(self):
+        p = protein_g_per_kg(Tier.T2, Mode.BULK, Band.MODERATE)
+        assert p == pytest.approx(2.0)
+
+    def test_injured_uses_standard_matrix(self):
+        # Injured is allowed at all tiers; fall back to Standard matrix
+        inj = protein_g_per_kg(Tier.T2, Mode.INJURED, Band.MODERATE)
+        std = protein_g_per_kg(Tier.T2, Mode.STANDARD, Band.MODERATE)
+        assert inj == pytest.approx(std)
+
+    def test_every_combo_non_negative(self):
+        for tier in Tier:
+            for mode in Mode:
+                for band in Band:
+                    p = protein_g_per_kg(tier, mode, band)
+                    assert p >= 1.6
+
+
+# ---------------------------------------------------------------------------
+# M4.3 Carbs + fiber
+# ---------------------------------------------------------------------------
+
+
+class TestCarbs:
+    @pytest.mark.parametrize("band,expected", [
+        (Band.REST, 3.0),
+        (Band.LIGHT, 3.5),
+        (Band.MODERATE, 5.0),
+        (Band.HARD, 6.5),
+        (Band.VERY_HARD, 8.0),
+    ])
+    def test_g_per_kg_by_band(self, band: Band, expected: float):
+        assert carb_g_per_kg(band) == pytest.approx(expected)
+
+    def test_target_by_band_and_weight(self):
+        # 74 kg × HARD (6.5) = 481 g
+        assert carb_target_g(Band.HARD, weight_kg=74.0, in_deficit=True) == 481
+
+    def test_rest_deficit_health_floor(self):
+        # REST × 74 kg = 222 g already > 100g floor
+        # Test a lighter user where the floor bites: 30 kg × 3.0 = 90g → should be 100
+        assert carb_target_g(Band.REST, weight_kg=30.0, in_deficit=True) == 100
+
+    def test_rest_no_deficit_allows_below_100(self):
+        # Not in deficit → health floor doesn't apply
+        assert carb_target_g(Band.REST, weight_kg=30.0, in_deficit=False) == 90
+
+    def test_health_floor_only_on_rest(self):
+        # HARD band at 30kg = 195g, already above 100, floor no-op
+        assert carb_target_g(Band.HARD, weight_kg=30.0, in_deficit=True) == 195
+
+
+class TestFiber:
+    def test_base_formula(self):
+        # 2500 kcal × 14/1000 = 35; no deficit → 35
+        assert fiber_target_g(2500, in_deficit=False) == 35
+
+    def test_deficit_adds_5g(self):
+        assert fiber_target_g(2500, in_deficit=True) == 40
+
+    def test_min_25g(self):
+        # 1000 kcal × 14/1000 = 14; clamped to 25
+        assert fiber_target_g(1000, in_deficit=False) == 25
+
+    def test_min_applies_before_cut_bonus(self):
+        # 1000 kcal in deficit → max(25, 14) + 5 = 30
+        assert fiber_target_g(1000, in_deficit=True) == 30
+
+    def test_hard_ceiling_60(self):
+        # 10000 kcal × 14/1000 = 140 + 5 → clamp 60
+        assert fiber_target_g(10000, in_deficit=True) == 60
+
+
+# ---------------------------------------------------------------------------
+# M4.4 Composed macro engine
+# ---------------------------------------------------------------------------
+
+
+class TestComposedMacroEngine:
+    def test_returns_targets_dataclass(self):
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.STANDARD,
+            band=Band.MODERATE, kcal_target=2000, in_deficit=True,
+        )
+        assert isinstance(r, MacroTargets)
+        assert all(getattr(r, f) >= 0 for f in ["kcal", "protein_g", "carbs_g", "fat_g", "fiber_g"])
+
+    def test_user_aggressive_hard(self):
+        # Our profile: 74.2 kg T2 Aggressive HARD, 2000 kcal target.
+        # At this kcal budget the engine can't hit both the HARD band carb
+        # target (482g) AND the fat soft floor (59g) AND protein (178g),
+        # so carbs flex DOWN from the band ceiling — that's the correct
+        # signal that kcal is tight for the chosen band.
+        r = compute_macro_targets(
+            weight_kg=74.2, tier=Tier.T2, mode=Mode.AGGRESSIVE,
+            band=Band.HARD, kcal_target=2000, in_deficit=True,
+        )
+        assert r.protein_g == 178
+        # Carbs below band ceiling (482) but above health floor (100 applies
+        # on REST only; HARD band has no floor).
+        assert r.carbs_g <= 482
+        # Fat ≥ hard floor 0.6 × 74.2 = 44.5g → 45g
+        assert r.fat_g >= 45
+
+    def test_kcal_balance_within_rounding(self):
+        # protein×4 + carbs×4 + fat×9 ≈ kcal_target (within a few kcal from rounding)
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.STANDARD,
+            band=Band.MODERATE, kcal_target=2400, in_deficit=True,
+        )
+        total = r.protein_g * 4 + r.carbs_g * 4 + r.fat_g * 9
+        assert abs(total - 2400) <= 10
+
+    def test_fat_hard_floor_enforced(self):
+        # Aggressive cut at 1500 kcal — fat remainder would be negative without
+        # the hard floor. Engine must still hit fat ≥ 0.6 × weight.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.AGGRESSIVE,
+            band=Band.VERY_HARD, kcal_target=1500, in_deficit=True,
+        )
+        assert r.fat_g >= round(0.6 * 74.0)
+
+    def test_rest_day_standard(self):
+        # Rest day at 2000 kcal — budget tight, so carbs flex down from band
+        # ceiling (222g) but stay ≥ health floor (100g) thanks to in_deficit.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.STANDARD,
+            band=Band.REST, kcal_target=2000, in_deficit=True,
+        )
+        # Protein: 2.3 × 74 = 170
+        assert r.protein_g == 170
+        # Carbs ≤ band ceiling, ≥ health floor 100
+        assert 100 <= r.carbs_g <= 222
+
+    def test_rest_day_maintenance_hits_band_ceiling(self):
+        # With plenty of kcal headroom, rest-day carbs hit the band ceiling.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.MAINTENANCE,
+            band=Band.REST, kcal_target=2800, in_deficit=False,
+        )
+        # Band ceiling 3.0 × 74 = 222g
+        assert r.carbs_g == 222
+
+    def test_maintenance_fat_target_above_floor(self):
+        # Maintenance targets fat 1.0 g/kg (V2 §2.2) — engine should prefer
+        # that over the 0.8 soft floor when calories allow.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.MAINTENANCE,
+            band=Band.MODERATE, kcal_target=2800, in_deficit=False,
+        )
+        assert r.fat_g >= round(1.0 * 74.0) - 3  # allow small rounding slack
+
+    def test_protein_never_below_1_6(self):
+        # Extreme case: VERY_HARD carb priority could drop protein. Floor at 1.6.
+        r = compute_macro_targets(
+            weight_kg=74.0, tier=Tier.T2, mode=Mode.BULK,
+            band=Band.VERY_HARD, kcal_target=3000, in_deficit=False,
+        )
+        assert r.protein_g >= round(1.6 * 74.0)

--- a/sync/tests/test_mode.py
+++ b/sync/tests/test_mode.py
@@ -1,0 +1,98 @@
+"""Tests for Mode enum + per-mode config (M2.1).
+
+Research basis: Nutrition Science v2 §3.2 (Aggressive), §5 (Maintenance),
+§6 (Bulk), §4.5 (Injured). 6 modes with tier gating, BF% hard floors,
+and bridge requirements.
+"""
+
+import pytest
+
+from nutrition_engine.mode import (
+    Mode,
+    ModeConfig,
+    get_mode_config,
+)
+from nutrition_engine.tier import Tier
+
+
+class TestModeEnum:
+    def test_has_six_members(self):
+        assert len(Mode) == 6
+
+    def test_string_values(self):
+        assert Mode.STANDARD.value == "standard"
+        assert Mode.AGGRESSIVE.value == "aggressive"
+        assert Mode.REVERSE.value == "reverse"
+        assert Mode.MAINTENANCE.value == "maintenance"
+        assert Mode.BULK.value == "bulk"
+        assert Mode.INJURED.value == "injured"
+
+
+class TestGetModeConfig:
+    def test_standard(self):
+        c = get_mode_config(Mode.STANDARD)
+        assert isinstance(c, ModeConfig)
+        # Standard is available to anyone who isn't dangerously lean.
+        assert c.tier_allowed == {Tier.T1, Tier.T2, Tier.T3, Tier.T4}
+        assert c.bf_hard_floor_pct is None
+        assert c.requires_reverse_bridge_from == set()
+        assert c.max_duration_days is None
+
+    def test_aggressive(self):
+        # V2 §3.2: T1-T2 only, BF% <12% hard contraindication,
+        # duration capped at 12 weeks (700-900 kcal envelope).
+        c = get_mode_config(Mode.AGGRESSIVE)
+        assert c.tier_allowed == {Tier.T1, Tier.T2}
+        assert c.bf_hard_floor_pct == 12.0
+        assert c.requires_reverse_bridge_from == set()
+        assert c.max_duration_days == 84  # 12 weeks
+
+    def test_reverse(self):
+        c = get_mode_config(Mode.REVERSE)
+        assert c.tier_allowed == {Tier.T1, Tier.T2, Tier.T3, Tier.T4, Tier.T5}
+        assert c.bf_hard_floor_pct is None
+        assert c.requires_reverse_bridge_from == set()
+        # V2 §3.2 post-aggressive: 2-6 weeks reverse.
+        assert c.max_duration_days == 42  # 6 weeks ceiling
+
+    def test_maintenance(self):
+        c = get_mode_config(Mode.MAINTENANCE)
+        assert c.tier_allowed == {Tier.T1, Tier.T2, Tier.T3, Tier.T4, Tier.T5}
+        assert c.bf_hard_floor_pct is None
+        assert c.requires_reverse_bridge_from == set()
+        # V2 §5: indefinite
+        assert c.max_duration_days is None
+
+    def test_bulk(self):
+        # V2 §6: lean bulk is for people not already obese. Tier-level block
+        # at T1 (>28% BF) keeps obese users from starting a bulk.
+        c = get_mode_config(Mode.BULK)
+        assert c.tier_allowed == {Tier.T2, Tier.T3, Tier.T4, Tier.T5}
+        assert c.bf_hard_floor_pct is None
+        # V2 §6.4: Cut → Bulk requires 4-week reverse diet bridge.
+        assert c.requires_reverse_bridge_from == {Mode.STANDARD, Mode.AGGRESSIVE}
+        # V2 §6.1: 12-20 week bulk block.
+        assert c.max_duration_days == 140  # 20 weeks
+
+    def test_injured(self):
+        # V2 §4.5: injured mode overrides other gates — always allowed.
+        c = get_mode_config(Mode.INJURED)
+        assert c.tier_allowed == {Tier.T1, Tier.T2, Tier.T3, Tier.T4, Tier.T5}
+        assert c.bf_hard_floor_pct is None
+        assert c.requires_reverse_bridge_from == set()
+        # Phased (acute/subacute/chronic) → no hard cap.
+        assert c.max_duration_days is None
+
+    def test_config_is_frozen(self):
+        c = get_mode_config(Mode.STANDARD)
+        with pytest.raises(Exception):
+            c.tier_allowed = {Tier.T1}  # type: ignore[misc]
+
+
+class TestAllModesCovered:
+    @pytest.mark.parametrize("mode", list(Mode))
+    def test_every_mode_has_config(self, mode: Mode):
+        # Guard against forgetting to add a config when new modes are introduced.
+        c = get_mode_config(mode)
+        assert isinstance(c, ModeConfig)
+        assert c.tier_allowed, f"{mode} has no allowed tiers"

--- a/sync/tests/test_mode_availability.py
+++ b/sync/tests/test_mode_availability.py
@@ -1,0 +1,114 @@
+"""Tests for mode availability (M2.2).
+
+Checks whether a given (mode, tier, bf_pct) combination is allowed, with
+typed reason codes when blocked. Research basis: V2 §3.2 + tier × mode table
+at §2 (lines 102-107).
+"""
+
+import pytest
+
+from nutrition_engine.mode import Mode
+from nutrition_engine.mode_availability import (
+    GateReason,
+    ModeAvailability,
+    check_mode_availability,
+)
+from nutrition_engine.tier import Tier
+
+
+class TestResultShape:
+    def test_allowed_has_no_reason(self):
+        r = check_mode_availability(Mode.STANDARD, Tier.T2, bf_pct=23.5)
+        assert isinstance(r, ModeAvailability)
+        assert r.allowed is True
+        assert r.reason is None
+
+    def test_blocked_carries_reason(self):
+        r = check_mode_availability(Mode.AGGRESSIVE, Tier.T3, bf_pct=17.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.TIER_NOT_ALLOWED
+
+
+class TestStandard:
+    @pytest.mark.parametrize("tier", [Tier.T1, Tier.T2, Tier.T3, Tier.T4])
+    def test_allowed_tiers(self, tier: Tier):
+        # BF% within the tier band — Standard open across the deficit tiers.
+        r = check_mode_availability(Mode.STANDARD, tier, bf_pct=22.0)
+        assert r.allowed is True
+
+    def test_t5_blocked(self):
+        # T5 = <10% BF, deep competition territory; Standard not offered.
+        r = check_mode_availability(Mode.STANDARD, Tier.T5, bf_pct=9.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.TIER_NOT_ALLOWED
+
+
+class TestAggressive:
+    @pytest.mark.parametrize("tier", [Tier.T1, Tier.T2])
+    def test_allowed_for_t1_t2(self, tier: Tier):
+        r = check_mode_availability(Mode.AGGRESSIVE, tier, bf_pct=22.0)
+        assert r.allowed is True
+
+    @pytest.mark.parametrize("tier", [Tier.T3, Tier.T4, Tier.T5])
+    def test_blocked_t3_and_leaner(self, tier: Tier):
+        r = check_mode_availability(Mode.AGGRESSIVE, tier, bf_pct=14.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.TIER_NOT_ALLOWED
+
+    def test_bf_at_hard_floor_is_blocked(self):
+        # 12.0 is the hard floor — strictly less than is also blocked.
+        r = check_mode_availability(Mode.AGGRESSIVE, Tier.T2, bf_pct=12.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.BF_BELOW_HARD_FLOOR
+
+    def test_bf_below_hard_floor(self):
+        r = check_mode_availability(Mode.AGGRESSIVE, Tier.T2, bf_pct=11.9)
+        assert r.allowed is False
+        assert r.reason is GateReason.BF_BELOW_HARD_FLOOR
+
+    def test_bf_just_above_hard_floor(self):
+        r = check_mode_availability(Mode.AGGRESSIVE, Tier.T2, bf_pct=12.1)
+        assert r.allowed is True
+
+
+class TestBulk:
+    def test_t1_blocked(self):
+        # T1 (>28% BF) — still needs to cut before bulking.
+        r = check_mode_availability(Mode.BULK, Tier.T1, bf_pct=30.0)
+        assert r.allowed is False
+        assert r.reason is GateReason.TIER_NOT_ALLOWED
+
+    @pytest.mark.parametrize("tier", [Tier.T2, Tier.T3, Tier.T4, Tier.T5])
+    def test_allowed_t2_and_leaner(self, tier: Tier):
+        r = check_mode_availability(Mode.BULK, tier, bf_pct=16.0)
+        assert r.allowed is True
+
+
+class TestAlwaysAllowed:
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_injured_any_tier(self, tier: Tier):
+        # V2 §4.5: Injured mode overrides tier/BF% gates entirely.
+        r = check_mode_availability(Mode.INJURED, tier, bf_pct=10.0)
+        assert r.allowed is True
+
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_maintenance_any_tier(self, tier: Tier):
+        r = check_mode_availability(Mode.MAINTENANCE, tier, bf_pct=20.0)
+        assert r.allowed is True
+
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_reverse_any_tier(self, tier: Tier):
+        r = check_mode_availability(Mode.REVERSE, tier, bf_pct=20.0)
+        assert r.allowed is True
+
+
+class TestExhaustiveMatrix:
+    """Sanity: every (mode × tier) pair returns a bool + optional reason."""
+
+    @pytest.mark.parametrize("mode", list(Mode))
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_no_combo_raises(self, mode: Mode, tier: Tier):
+        r = check_mode_availability(mode, tier, bf_pct=20.0)
+        assert isinstance(r.allowed, bool)
+        if not r.allowed:
+            assert isinstance(r.reason, GateReason)

--- a/sync/tests/test_mode_transitions.py
+++ b/sync/tests/test_mode_transitions.py
@@ -1,0 +1,148 @@
+"""Tests for mode transition state machine (M2.3).
+
+Research basis:
+- V2 §3.2 (post-aggressive mandatory reverse 2-6 weeks)
+- V2 §5.2 (cut → maintenance 3-week ramp preferred, not enforced)
+- V2 §6.4 (cut → bulk requires 4-week reverse bridge; bulk → cut abrupt OK)
+- V2 §4.5 (injured overrides other gates)
+"""
+
+import pytest
+
+from nutrition_engine.mode import Mode
+from nutrition_engine.mode_transitions import (
+    TransitionReason,
+    TransitionResult,
+    check_transition,
+)
+from nutrition_engine.tier import Tier
+
+
+DEFAULT_TIER = Tier.T2
+DEFAULT_BF = 23.5
+
+
+def _check(current: Mode, next_mode: Mode, tier: Tier = DEFAULT_TIER, bf: float = DEFAULT_BF):
+    return check_transition(current, next_mode, tier=tier, bf_pct=bf)
+
+
+class TestResultShape:
+    def test_allowed_has_no_reason(self):
+        r = _check(Mode.STANDARD, Mode.MAINTENANCE)
+        assert isinstance(r, TransitionResult)
+        assert r.allowed is True
+        assert r.reason is None
+        assert r.requires_bridge is None
+
+    def test_blocked_carries_reason(self):
+        r = _check(Mode.AGGRESSIVE, Mode.STANDARD)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.AGGRESSIVE_REQUIRES_REVERSE
+
+
+class TestSameMode:
+    @pytest.mark.parametrize("mode", list(Mode))
+    def test_noop_transition_allowed(self, mode: Mode):
+        # Staying in the current mode is trivially allowed.
+        r = _check(mode, mode)
+        assert r.allowed is True
+
+
+class TestAggressiveExitRequiresReverse:
+    # V2 §3.2: mandatory reverse diet 2-6 weeks after aggressive block.
+
+    @pytest.mark.parametrize("target", [Mode.STANDARD, Mode.MAINTENANCE])
+    def test_aggressive_to_non_reverse_blocked(self, target: Mode):
+        # Aggressive → Bulk is covered by TestBulkRequiresReverseBridge with
+        # the more actionable REQUIRES_REVERSE_BRIDGE reason code.
+        r = _check(Mode.AGGRESSIVE, target)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.AGGRESSIVE_REQUIRES_REVERSE
+
+    def test_aggressive_to_reverse_allowed(self):
+        r = _check(Mode.AGGRESSIVE, Mode.REVERSE)
+        assert r.allowed is True
+
+    def test_aggressive_to_injured_allowed(self):
+        # Injury is always an escape hatch.
+        r = _check(Mode.AGGRESSIVE, Mode.INJURED)
+        assert r.allowed is True
+
+
+class TestBulkRequiresReverseBridge:
+    # V2 §6.4: Cut → Bulk needs 4-week reverse diet bridge.
+
+    @pytest.mark.parametrize("cut_mode", [Mode.STANDARD, Mode.AGGRESSIVE])
+    def test_cut_to_bulk_requires_bridge(self, cut_mode: Mode):
+        r = _check(cut_mode, Mode.BULK)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.REQUIRES_REVERSE_BRIDGE
+        assert r.requires_bridge is Mode.REVERSE
+
+    def test_reverse_to_bulk_allowed(self):
+        r = _check(Mode.REVERSE, Mode.BULK)
+        assert r.allowed is True
+
+    def test_maintenance_to_bulk_allowed_without_bridge(self):
+        # Maintenance is already the destination a reverse targets, so
+        # moving Maintenance → Bulk doesn't require another reverse loop.
+        r = _check(Mode.MAINTENANCE, Mode.BULK)
+        assert r.allowed is True
+
+
+class TestBulkExits:
+    # V2 §6.4: Bulk → Cut abrupt OK; Bulk → Maintenance user-driven ramp.
+
+    @pytest.mark.parametrize("target", [Mode.STANDARD, Mode.AGGRESSIVE, Mode.MAINTENANCE])
+    def test_bulk_to_anything_downstream_allowed(self, target: Mode):
+        # T3 so Aggressive will fail on availability (covered below)
+        r = _check(Mode.BULK, target, tier=Tier.T2, bf=22.0)
+        assert r.allowed is True
+
+    def test_bulk_to_reverse_allowed(self):
+        r = _check(Mode.BULK, Mode.REVERSE)
+        assert r.allowed is True
+
+
+class TestInjuredEscapeHatch:
+    @pytest.mark.parametrize("current", list(Mode))
+    def test_any_to_injured_allowed(self, current: Mode):
+        r = _check(current, Mode.INJURED)
+        assert r.allowed is True
+
+    @pytest.mark.parametrize("target", [Mode.STANDARD, Mode.MAINTENANCE, Mode.BULK])
+    def test_injured_to_target_runs_availability_gate(self, target: Mode):
+        # Re-entering a normal mode from injured is subject to mode availability.
+        r = _check(Mode.INJURED, target, tier=Tier.T2, bf=22.0)
+        assert r.allowed is True
+
+    def test_injured_to_aggressive_blocked_at_t3(self):
+        # Availability gate still runs on exit from Injured.
+        r = _check(Mode.INJURED, Mode.AGGRESSIVE, tier=Tier.T3, bf=17.0)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.MODE_NOT_AVAILABLE
+
+
+class TestAvailabilityPropagates:
+    def test_standard_to_aggressive_blocks_at_t3(self):
+        r = _check(Mode.STANDARD, Mode.AGGRESSIVE, tier=Tier.T3, bf=17.0)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.MODE_NOT_AVAILABLE
+
+    def test_maintenance_to_bulk_blocks_at_t1(self):
+        # T1 = >28% BF — Bulk is tier-blocked.
+        r = _check(Mode.MAINTENANCE, Mode.BULK, tier=Tier.T1, bf=30.0)
+        assert r.allowed is False
+        assert r.reason is TransitionReason.MODE_NOT_AVAILABLE
+
+
+class TestExhaustiveMatrix:
+    """Every (current, next) pair resolves without raising."""
+
+    @pytest.mark.parametrize("current", list(Mode))
+    @pytest.mark.parametrize("next_mode", list(Mode))
+    def test_no_pair_raises(self, current: Mode, next_mode: Mode):
+        r = _check(current, next_mode)
+        assert isinstance(r.allowed, bool)
+        if not r.allowed:
+            assert isinstance(r.reason, TransitionReason)

--- a/sync/tests/test_protein_floor.py
+++ b/sync/tests/test_protein_floor.py
@@ -1,0 +1,110 @@
+"""Tests for protein floor warning (M1.6).
+
+Research basis: Morton 2018 meta plateau at 1.6 g/kg for RT-induced FFM.
+Below floor for 3+ consecutive days → amber warning banner.
+Also V9.1 per-meal thresholds (25g red / 30g green).
+"""
+
+import pytest
+
+from nutrition_engine.protein_floor import (
+    compute_protein_floor,
+    check_protein_floor,
+    check_per_meal_protein,
+    ProteinFloorStatus,
+    PerMealProteinLevel,
+)
+
+
+class TestComputeProteinFloor:
+    def test_current_user(self):
+        # 74.2 kg × 1.6 = 118.72 → 119
+        assert compute_protein_floor(weight_kg=74.2) == 119
+
+    def test_heavy_athlete(self):
+        assert compute_protein_floor(weight_kg=90.0) == 144
+
+    def test_zero_weight_raises(self):
+        with pytest.raises(ValueError):
+            compute_protein_floor(weight_kg=0)
+
+
+class TestCheckProteinFloor:
+    def test_all_above_floor_green(self):
+        # 5 days all above 119g floor for 74.2 kg user
+        recent_intakes = [150, 145, 160, 155, 140]
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+        assert result.days_below_floor == 0
+
+    def test_one_day_below_no_warning(self):
+        # Only 1 day below — banner not yet active (requires 3+ consecutive)
+        recent_intakes = [150, 145, 100, 155, 140]  # day 3 below
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+        assert result.days_below_floor == 0  # streak broken
+
+    def test_two_consecutive_below_no_warning(self):
+        # 2 consecutive days below — banner not yet active (needs 3+)
+        recent_intakes = [150, 145, 100, 90, 140]
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+        assert result.days_below_floor == 0  # streak broken by day 5
+
+    def test_three_consecutive_below_amber(self):
+        # 3 consecutive days below — banner fires
+        recent_intakes = [150, 145, 100, 90, 80]  # days 3,4,5 below
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.AMBER
+        assert result.days_below_floor == 3
+
+    def test_five_consecutive_below_amber_streak_counted(self):
+        recent_intakes = [100, 95, 110, 105, 115]  # all below 119
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.AMBER
+        assert result.days_below_floor == 5
+
+    def test_single_good_day_breaks_streak(self):
+        # 2 below, 1 good, 3 below → streak is 3 (last 3 days)
+        recent_intakes = [100, 90, 150, 80, 85, 90]
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.AMBER
+        assert result.days_below_floor == 3  # last 3 days
+
+    def test_empty_history(self):
+        result = check_protein_floor(recent_intakes=[], weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+        assert result.days_below_floor == 0
+
+    def test_exactly_at_floor_not_below(self):
+        # Exactly at 119g = not below
+        recent_intakes = [119, 119, 119]
+        result = check_protein_floor(recent_intakes=recent_intakes, weight_kg=74.2)
+        assert result.status is ProteinFloorStatus.GREEN
+
+
+class TestPerMealProtein:
+    """V9.1 per-meal thresholds for MPS quality signaling."""
+
+    def test_below_15g_red(self):
+        assert check_per_meal_protein(10) is PerMealProteinLevel.RED
+        assert check_per_meal_protein(14) is PerMealProteinLevel.RED
+
+    def test_15_to_24_amber(self):
+        assert check_per_meal_protein(15) is PerMealProteinLevel.AMBER
+        assert check_per_meal_protein(20) is PerMealProteinLevel.AMBER
+        assert check_per_meal_protein(24) is PerMealProteinLevel.AMBER
+
+    def test_25_to_29_yellow(self):
+        assert check_per_meal_protein(25) is PerMealProteinLevel.YELLOW
+        assert check_per_meal_protein(29) is PerMealProteinLevel.YELLOW
+
+    def test_30_to_55_green(self):
+        assert check_per_meal_protein(30) is PerMealProteinLevel.GREEN
+        assert check_per_meal_protein(40) is PerMealProteinLevel.GREEN
+        assert check_per_meal_protein(55) is PerMealProteinLevel.GREEN
+
+    def test_above_55_no_warning(self):
+        # Trommelen 2023 killed the 40g ceiling — no warning on large doses
+        assert check_per_meal_protein(60) is PerMealProteinLevel.NO_WARNING
+        assert check_per_meal_protein(100) is PerMealProteinLevel.NO_WARNING

--- a/sync/tests/test_rate_cap.py
+++ b/sync/tests/test_rate_cap.py
@@ -1,0 +1,223 @@
+"""Tests for 5-tier rate cap (M1.4)."""
+
+import pytest
+
+from nutrition_engine.rate_cap import (
+    RateCap,
+    RateStatus,
+    RateCheckResult,
+    get_rate_cap,
+    compute_weekly_rate_pct,
+    check_rate_cap,
+)
+from nutrition_engine.tier import Tier
+
+
+class TestGetRateCap:
+    """Per-tier rate caps in Standard mode."""
+
+    def test_t1_standard(self):
+        c = get_rate_cap(Tier.T1, mode="standard")
+        assert c.soft_pct_per_wk == 1.0
+        assert c.hard_pct_per_wk == 1.25
+
+    def test_t2_standard_current_user(self):
+        c = get_rate_cap(Tier.T2, mode="standard")
+        assert c.soft_pct_per_wk == 0.75
+        assert c.hard_pct_per_wk == 1.0
+
+    def test_t3_standard(self):
+        c = get_rate_cap(Tier.T3, mode="standard")
+        assert c.soft_pct_per_wk == 0.5
+        assert c.hard_pct_per_wk == 0.75
+
+    def test_t4_standard(self):
+        c = get_rate_cap(Tier.T4, mode="standard")
+        assert c.soft_pct_per_wk == 0.4
+        assert c.hard_pct_per_wk == 0.5
+
+    def test_t5_standard(self):
+        c = get_rate_cap(Tier.T5, mode="standard")
+        assert c.soft_pct_per_wk == 0.3
+        assert c.hard_pct_per_wk == 0.4
+
+
+class TestAggressiveModeLoosens:
+    """Aggressive mode loosens rate cap by one tier (T2→T1 caps, etc.)."""
+
+    def test_t2_aggressive_uses_t1_caps(self):
+        c = get_rate_cap(Tier.T2, mode="aggressive")
+        assert c.soft_pct_per_wk == 1.0   # T1 soft cap
+        assert c.hard_pct_per_wk == 1.25  # T1 hard cap
+
+    def test_t1_aggressive_stays_at_t1(self):
+        # Can't loosen beyond T1
+        c = get_rate_cap(Tier.T1, mode="aggressive")
+        assert c.soft_pct_per_wk == 1.0
+        assert c.hard_pct_per_wk == 1.25
+
+    def test_t3_aggressive_blocked_by_tier_policy(self):
+        # Per V13 + M1.1: Aggressive mode contraindicated at T3+
+        # get_rate_cap should still return a value but flag the block elsewhere
+        # For this test, we just check it returns T2 caps (loosens to T2)
+        c = get_rate_cap(Tier.T3, mode="aggressive")
+        assert c.soft_pct_per_wk == 0.75  # T2 soft
+        assert c.hard_pct_per_wk == 1.0   # T2 hard
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            get_rate_cap(Tier.T2, mode="bulk")
+
+
+class TestComputeWeeklyRatePct:
+    """Weekly rate calculation from daily weight history."""
+
+    def test_linear_decrease_1pct_per_week(self):
+        # 74.2 kg losing exactly 1% per week = 0.742 kg/week = 0.106 kg/day
+        # Oldest first (i=0), newest last (i=7).
+        weights = [74.2 - 0.106 * i for i in range(8)]  # 8 days, decreasing
+        rate = compute_weekly_rate_pct(weights)
+        # Rate should be negative (losing) and close to -1%
+        assert -1.1 < rate < -0.9
+
+    def test_stable_weight_near_zero(self):
+        weights = [74.2] * 14
+        rate = compute_weekly_rate_pct(weights)
+        assert abs(rate) < 0.1
+
+    def test_gain_positive_rate(self):
+        # Gaining 0.5% per week
+        weights = [74.2 + 0.053 * i for i in range(8)]  # +0.053 kg/day
+        rate = compute_weekly_rate_pct(weights)
+        assert 0.4 < rate < 0.6
+
+    def test_too_few_points_raises(self):
+        with pytest.raises(ValueError):
+            compute_weekly_rate_pct([74.2])  # need minimum 2
+
+
+class TestCheckRateCap:
+    """Traffic-light status with hybrid 7/14-day window."""
+
+    def _losing_weights(self, daily_pct: float, days: int, start_weight: float = 74.2) -> list[float]:
+        """Generate weights losing at ``daily_pct`` percent of weight per day.
+
+        Oldest first (index 0), newest last (index days-1).
+        weights[0] = start_weight; weights[-1] = start_weight × (1 - daily_pct/100)^(days-1)
+        (approximated linearly for simplicity).
+        """
+        daily_kg_loss = start_weight * daily_pct / 100
+        return [start_weight - daily_kg_loss * i for i in range(days)]
+
+    def test_within_soft_green(self):
+        # Losing 0.5%/wk → 0.071%/day. For T2 user, soft=0.75% hard=1.0%. Within both.
+        weights = self._losing_weights(daily_pct=0.071, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.GREEN
+
+    def test_over_soft_only_yellow(self):
+        # Losing 0.9%/wk (over soft 0.75, under hard 1.0). 0.129%/day.
+        # 7-day rate ~0.9, 14-day might be similar → yellow (not red because 14d not over hard)
+        weights = self._losing_weights(daily_pct=0.129, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.YELLOW
+
+    def test_both_windows_over_hard_red(self):
+        # Losing 1.5%/wk sustained over 14 days. 0.214%/day.
+        # Both 7-day and 14-day are over hard cap 1.0% → RED
+        weights = self._losing_weights(daily_pct=0.214, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.RED
+
+    def test_only_7day_over_hard_still_yellow(self):
+        # Prior 7 days stable, then last 7 days lose ~1.2%/wk.
+        # 7-day window (last 7 only): over hard 1.0
+        # 14-day window (stable then lose): 7 days stable + 7 days lose → slope = half → ~0.6%/wk < hard 1.0
+        # Per research: BOTH must be over hard for RED → this is YELLOW
+        stable_week = [74.2] * 7  # days 0..6 at 74.2
+        # Start losing on day 7; 0.171%/day × 7 days
+        daily_loss = 74.2 * 0.171 / 100
+        fast_week = [74.2 - daily_loss * (i + 1) for i in range(7)]  # days 7..13
+        weights = stable_week + fast_week  # 14 days total, oldest→newest
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        # 7-day rate is over hard, 14-day isn't → YELLOW (not RED)
+        assert result.status is RateStatus.YELLOW
+
+    def test_first_14_days_suppressed(self):
+        # Fast loss in first 14 days (glycogen/water confound)
+        weights = self._losing_weights(daily_pct=0.3, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=7,
+        )
+        assert result.status is RateStatus.SUPPRESSED
+
+    def test_day_15_no_longer_suppressed(self):
+        # Same fast loss but beyond day 14
+        weights = self._losing_weights(daily_pct=0.3, days=14)
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=15,
+        )
+        assert result.status is RateStatus.RED  # suppression lifted
+
+    def test_aggressive_mode_loosens(self):
+        # At Aggressive T2 (caps of T1: 1.0/1.25), 1.1%/wk is yellow (over soft)
+        # Same rate in Standard T2 (caps 0.75/1.0) would be red
+        weights = self._losing_weights(daily_pct=0.157, days=14)
+
+        standard_result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        # 1.1%/wk sustained: 7-day ~1.1, 14-day ~1.1, both over hard 1.0 → RED in standard
+        assert standard_result.status is RateStatus.RED
+
+        aggressive_result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="aggressive",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        # Same weights but caps 1.0/1.25: 1.1 over soft but under hard → YELLOW
+        assert aggressive_result.status is RateStatus.YELLOW
+
+
+class TestCurrentUser:
+    """Current user scenarios — 74.2 kg, 23.5% BF, Tier T2."""
+
+    def test_current_149_pct_per_wk_is_red(self):
+        # Research flagged user at 1.49%/wk current — definitely red in Standard T2
+        # Simulate: 0.213%/day × 14 days, oldest first
+        start = 74.2
+        daily_loss = start * 0.00213
+        weights = [start - daily_loss * i for i in range(14)]
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.RED
+        # Confirm the measured rate is around -1.4 to -1.5%
+        assert -1.7 < result.rate_7day_pct < -1.3
+
+    def test_user_goal_stays_green_at_07_pct(self):
+        # User's stated tier is T2 with soft cap 0.75. 0.7%/wk sustained → GREEN
+        # 0.1%/day × 14 days, oldest first
+        start = 74.2
+        daily_loss = start * 0.001  # 0.1%/day → ~0.7%/week
+        weights = [start - daily_loss * i for i in range(14)]
+        result = check_rate_cap(
+            weights=weights, tier=Tier.T2, mode="standard",
+            current_weight_kg=weights[-1], days_since_cut_start=30,
+        )
+        assert result.status is RateStatus.GREEN

--- a/sync/tests/test_tier.py
+++ b/sync/tests/test_tier.py
@@ -1,0 +1,152 @@
+"""Tests for BF% tier framework (M1.1)."""
+
+from nutrition_engine.tier import (
+    Tier,
+    TierPolicy,
+    compute_tier_raw,
+    compute_tier,
+    get_tier_policy,
+    rolling_median_bf,
+    HYSTERESIS_PCT,
+)
+
+
+class TestTierBoundaries:
+    """Raw boundary assignment without hysteresis."""
+
+    def test_t1_above_28(self):
+        assert compute_tier_raw(30.0) == Tier.T1
+        assert compute_tier_raw(28.0) == Tier.T1
+        assert compute_tier_raw(50.0) == Tier.T1
+
+    def test_t2_range_20_to_28(self):
+        assert compute_tier_raw(27.9) == Tier.T2
+        assert compute_tier_raw(23.5) == Tier.T2  # current test user
+        assert compute_tier_raw(20.0) == Tier.T2
+
+    def test_t3_range_15_to_20(self):
+        assert compute_tier_raw(19.9) == Tier.T3
+        assert compute_tier_raw(15.0) == Tier.T3
+
+    def test_t4_range_10_to_15(self):
+        assert compute_tier_raw(14.9) == Tier.T4
+        assert compute_tier_raw(10.0) == Tier.T4
+
+    def test_t5_below_10(self):
+        assert compute_tier_raw(9.9) == Tier.T5
+        assert compute_tier_raw(5.0) == Tier.T5
+
+
+class TestHysteresis:
+    """Must cross boundary by HYSTERESIS_PCT to change tier."""
+
+    def test_no_previous_uses_raw(self):
+        assert compute_tier(23.5) == Tier.T2
+        assert compute_tier(19.5) == Tier.T3
+
+    def test_staying_inside_range(self):
+        assert compute_tier(23.5, previous_tier=Tier.T2) == Tier.T2
+
+    def test_going_leaner_requires_buffer(self):
+        # T2 boundary is 20.0. Leaner transition requires BF <= 19.0 (20 - 1% hysteresis)
+        assert compute_tier(19.5, previous_tier=Tier.T2) == Tier.T2  # inside buffer
+        assert compute_tier(19.0, previous_tier=Tier.T2) == Tier.T3  # clears buffer
+        assert compute_tier(18.5, previous_tier=Tier.T2) == Tier.T3  # well past
+
+    def test_going_fatter_requires_buffer(self):
+        # T3 boundary is 20.0. Fatter transition requires BF >= 21.0 (20 + 1% hysteresis)
+        assert compute_tier(20.5, previous_tier=Tier.T3) == Tier.T3  # inside buffer
+        assert compute_tier(21.0, previous_tier=Tier.T3) == Tier.T2  # clears buffer
+        assert compute_tier(22.0, previous_tier=Tier.T3) == Tier.T2  # well past
+
+    def test_hysteresis_at_every_boundary(self):
+        # T1↔T2 at 28.0
+        assert compute_tier(27.5, previous_tier=Tier.T1) == Tier.T1  # inside
+        assert compute_tier(27.0, previous_tier=Tier.T1) == Tier.T2  # clears
+        # T3↔T4 at 15.0
+        assert compute_tier(14.5, previous_tier=Tier.T3) == Tier.T3  # inside
+        assert compute_tier(14.0, previous_tier=Tier.T3) == Tier.T4  # clears
+        # T4↔T5 at 10.0
+        assert compute_tier(9.5, previous_tier=Tier.T4) == Tier.T4  # inside
+        assert compute_tier(9.0, previous_tier=Tier.T4) == Tier.T5  # clears
+
+
+class TestRollingMedian:
+    """Median of recent BF% readings prevents single-measurement tier flicker."""
+
+    def test_three_readings_odd(self):
+        assert rolling_median_bf([23.0, 24.0, 22.0]) == 23.0
+        assert rolling_median_bf([25.0, 20.0, 21.0]) == 21.0
+
+    def test_single_reading(self):
+        assert rolling_median_bf([23.0]) == 23.0
+
+    def test_two_readings_averaged(self):
+        assert rolling_median_bf([23.0, 25.0]) == 24.0
+
+    def test_empty_raises(self):
+        import pytest
+        with pytest.raises(ValueError):
+            rolling_median_bf([])
+
+
+class TestTierPolicies:
+    """Per-tier policy parameters from V13 master framework."""
+
+    def test_t1_policy(self):
+        p = get_tier_policy(Tier.T1)
+        assert p.tier == Tier.T1
+        assert p.rate_cap_soft_pct_per_wk == 1.0
+        assert p.rate_cap_hard_pct_per_wk == 1.25
+        assert p.aggressive_mode_allowed is True
+        assert p.fat_floor_g_per_kg_bw_soft == 0.8
+        assert p.fat_floor_g_per_kg_bw_hard == 0.6
+
+    def test_t2_policy(self):
+        p = get_tier_policy(Tier.T2)
+        assert p.rate_cap_soft_pct_per_wk == 0.75  # for 20-25% sub-tier (conservative)
+        assert p.rate_cap_hard_pct_per_wk == 1.0
+        assert p.aggressive_mode_allowed is True
+        assert p.protein_g_per_kg_bw == 2.2
+
+    def test_t3_policy_blocks_aggressive(self):
+        p = get_tier_policy(Tier.T3)
+        assert p.aggressive_mode_allowed is False  # CRITICAL: blocked at T3+
+        assert p.rate_cap_hard_pct_per_wk == 0.75
+        assert p.refeed_frequency_days == 7  # weekly refeeds from T3
+
+    def test_t4_policy(self):
+        p = get_tier_policy(Tier.T4)
+        assert p.aggressive_mode_allowed is False
+        assert p.protein_g_per_kg_lbm_basis is True  # switches to LBM basis
+        assert p.biomarker_cadence in ("daily", "daily+bloods")
+
+    def test_t5_policy_strict(self):
+        p = get_tier_policy(Tier.T5)
+        assert p.aggressive_mode_allowed is False
+        assert p.rate_cap_hard_pct_per_wk <= 0.5
+
+
+class TestCurrentUser:
+    """Current test user: 31yo male, 74.2 kg, 23.5% BF, cutting toward 15%."""
+
+    def test_current_tier_is_t2(self):
+        assert compute_tier_raw(23.5) == Tier.T2
+
+    def test_target_tier_is_t3(self):
+        assert compute_tier_raw(15.0) == Tier.T3
+
+    def test_progression_path(self):
+        """User moves through BF% range. Verify tier transitions respect hysteresis."""
+        current = Tier.T2
+        # Staying in T2 through the cut
+        for bf in [23.5, 22.0, 21.0, 20.5, 20.0, 19.5]:
+            current = compute_tier(bf, previous_tier=current)
+            assert current == Tier.T2, f"Should stay T2 at BF {bf}"
+
+        # Transition at 19.0 (clears hysteresis from 20.0 boundary)
+        current = compute_tier(19.0, previous_tier=current)
+        assert current == Tier.T3
+
+        # Aggressive mode should now be blocked
+        assert get_tier_policy(current).aggressive_mode_allowed is False

--- a/sync/tests/test_weight_prediction.py
+++ b/sync/tests/test_weight_prediction.py
@@ -1,0 +1,174 @@
+"""Tests for 3-layer weight prediction (M3 Phase D).
+
+Research basis: V2 §8.3.
+
+Layer A: personal kcal-per-kg EWMA (weeks 4+, clamp [5500, 9500])
+Layer B: Forbes-composition density rho = p*1816 + (1-p)*9441 where p = 10.4/(10.4+FM)
+Layer C: glycogen/water (1.2kg, τ=4d) + refeed sawtooth (0.8kg, τ=2d)
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from nutrition_engine.weight_prediction import (
+    DayPoint,
+    OverlayResult,
+    forbes_energy_density_kcal_per_kg,
+    glycogen_water_overlay,
+    personal_kcal_per_kg,
+)
+
+
+# ---------------------------------------------------------------------------
+# Layer B — Forbes-composition density
+# ---------------------------------------------------------------------------
+
+
+class TestForbesDensity:
+    def test_fm_20kg(self):
+        # p = 10.4/30.4 ≈ 0.342 → rho = 0.342*1816 + 0.658*9441 ≈ 6834
+        rho = forbes_energy_density_kcal_per_kg(fm_kg=20.0)
+        assert 6700 <= rho <= 7000
+
+    def test_fm_5kg_lean(self):
+        # p ≈ 0.676 → density biased toward lean (lower)
+        lean = forbes_energy_density_kcal_per_kg(fm_kg=5.0)
+        assert 4000 <= lean <= 5000
+
+    def test_fm_80kg_heavy(self):
+        # p ≈ 0.115 → density biased toward fat (higher)
+        heavy = forbes_energy_density_kcal_per_kg(fm_kg=80.0)
+        assert 8500 <= heavy <= 9500
+
+    def test_monotone_in_fm(self):
+        # Higher FM → denser (more fat share)
+        d10 = forbes_energy_density_kcal_per_kg(fm_kg=10.0)
+        d20 = forbes_energy_density_kcal_per_kg(fm_kg=20.0)
+        d40 = forbes_energy_density_kcal_per_kg(fm_kg=40.0)
+        assert d10 < d20 < d40
+
+    def test_fm_zero_is_pure_lean(self):
+        rho = forbes_energy_density_kcal_per_kg(fm_kg=0.0)
+        assert rho == pytest.approx(1816.0)
+
+    def test_negative_fm_raises(self):
+        with pytest.raises(ValueError):
+            forbes_energy_density_kcal_per_kg(fm_kg=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# Layer A — personal kcal-per-kg EWMA
+# ---------------------------------------------------------------------------
+
+
+def _make_history(days: int, intake: float, tdee: float, start_weight_kg: float, true_rho: float) -> list[DayPoint]:
+    """Build a synthetic history at a fixed per-kg energy density.
+
+    If intake < tdee by `deficit` each day, the user loses `deficit / true_rho`
+    kg/day. Used to verify Layer A recovers true_rho from history.
+    """
+    daily_deficit = tdee - intake  # positive
+    daily_loss = daily_deficit / true_rho
+    out: list[DayPoint] = []
+    for i in range(days):
+        w = start_weight_kg - daily_loss * i
+        out.append(DayPoint(day=i, intake_kcal=intake, tdee_kcal=tdee, weight_kg=w))
+    return out
+
+
+class TestLayerA:
+    def test_too_short_history_returns_none(self):
+        hist = _make_history(days=20, intake=2000, tdee=2800, start_weight_kg=74.0, true_rho=7000)
+        assert personal_kcal_per_kg(hist, min_days=28) is None
+
+    def test_recovers_rho_on_steady_state(self):
+        hist = _make_history(days=60, intake=2000, tdee=2800, start_weight_kg=74.0, true_rho=7000)
+        result = personal_kcal_per_kg(hist)
+        assert result is not None
+        assert 6800 <= result <= 7200
+
+    def test_clamps_above_9500(self):
+        # Extreme: tiny weight loss despite big deficit → rho huge, clamp to 9500
+        hist = _make_history(days=60, intake=2000, tdee=2800, start_weight_kg=74.0, true_rho=15000)
+        result = personal_kcal_per_kg(hist)
+        assert result is not None
+        assert result <= 9500
+
+    def test_clamps_below_5500(self):
+        hist = _make_history(days=60, intake=2000, tdee=2800, start_weight_kg=74.0, true_rho=3500)
+        result = personal_kcal_per_kg(hist)
+        assert result is not None
+        assert result >= 5500
+
+    def test_empty_history_returns_none(self):
+        assert personal_kcal_per_kg([]) is None
+
+    def test_zero_weight_delta_skipped(self):
+        # Days with identical weights don't crash — they're skipped (can't divide by 0).
+        hist = [
+            DayPoint(day=i, intake_kcal=2500, tdee_kcal=2500, weight_kg=74.0)
+            for i in range(40)
+        ]
+        # No deficit, no delta → no signal → fall back to None
+        result = personal_kcal_per_kg(hist)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Layer C — glycogen/water overlay
+# ---------------------------------------------------------------------------
+
+
+class TestLayerC:
+    def test_no_events_tight_ci(self):
+        r = glycogen_water_overlay(
+            central_kg=74.0, days_since_refeed=30, carb_delta_g=0,
+        )
+        assert r.glycogen_swing_kg == pytest.approx(0.0, abs=0.05)
+        assert r.refeed_offset_kg == pytest.approx(0.0, abs=0.05)
+        # CI band barely wider than central
+        assert (r.ci_high_kg - r.ci_low_kg) < 0.2
+
+    def test_fresh_carb_load_raises_glycogen_swing(self):
+        r = glycogen_water_overlay(
+            central_kg=74.0, days_since_refeed=30, carb_delta_g=500,
+        )
+        assert r.glycogen_swing_kg > 0.5
+
+    def test_fresh_carb_depletion_negative_swing(self):
+        r = glycogen_water_overlay(
+            central_kg=74.0, days_since_refeed=30, carb_delta_g=-500,
+        )
+        assert r.glycogen_swing_kg < -0.3
+
+    def test_glycogen_decays_over_time(self):
+        # Same carb delta but older → smaller effect. Easier to test via refeed offset.
+        near = glycogen_water_overlay(
+            central_kg=74.0, days_since_refeed=0, carb_delta_g=0,
+        )
+        far = glycogen_water_overlay(
+            central_kg=74.0, days_since_refeed=14, carb_delta_g=0,
+        )
+        # Near refeed: sawtooth present; far refeed: decayed to near zero
+        assert near.refeed_offset_kg > far.refeed_offset_kg
+
+    def test_ci_invariant(self):
+        # For any inputs: ci_low ≤ central ≤ ci_high
+        for days, carb in [(0, 0), (0, 500), (10, -200), (30, 100)]:
+            r = glycogen_water_overlay(
+                central_kg=74.0, days_since_refeed=days, carb_delta_g=carb,
+            )
+            assert r.ci_low_kg <= 74.0
+            assert 74.0 <= r.ci_high_kg
+
+    def test_refeed_saturates_near_day_0(self):
+        r0 = glycogen_water_overlay(
+            central_kg=74.0, days_since_refeed=0, carb_delta_g=0,
+        )
+        r2 = glycogen_water_overlay(
+            central_kg=74.0, days_since_refeed=2, carb_delta_g=0,
+        )
+        # Day 0 at full offset (up to 0.8 kg); day 2 roughly half-decayed
+        assert r0.refeed_offset_kg > 0.5
+        assert r2.refeed_offset_kg < r0.refeed_offset_kg


### PR DESCRIPTION
Stacked on #71. Ports the M5 adaptive layer + Forbes-layered weight prediction as pure-logic modules. No call-site wiring yet — these land as building blocks so a follow-up can surface them on the plan endpoint without also porting the math.

## New modules
- **`weight_prediction.py`** — 3-layer (A personal kcal-per-kg EWMA / B Forbes-composition energy density / C glycogen+water with 80% CI).
- **`adaptive.py`** — M5.1 adaptive TDEE (14-day drift, 7-day min), M5.2 refeed pressure, M5.3 diet-break recommender, M5.4 plateau detection + type classifier.
- **`deficit_duration.py`** — M1.7 counter with severity scaling (soft-warn 56d / strong 84d / hard-stop 112d; ±4wk for >25%/<15% deficit depth).

## Schema
- Migration 007 adds `deficit_phase_start_date DATE` (nullable). Applied to production Neon.

## Research citations
V2 §4.1 (kcal-per-kg 7700), §4.3 (refeed pressure), §4.4 (plateau classifier), §8.3 (Forbes density), Byrne 2018 MATADOR, Peos 2021 ICECAP, Trexler 2014.

## Test plan
- [x] **61 new pytest assertions** (test_weight_prediction + test_adaptive + test_deficit_duration) — all green.
- [x] No call-site changes, no behavior change in generate_today.

Closes #68