### PR TITLE
feat(nutrition): Batch 4 — weekly wrap-up (adherence grade + takeaway) + alcohol parity verified

### DIFF
--- a/sync/src/nutrition_engine/weekly_wrapup.py
+++ b/sync/src/nutrition_engine/weekly_wrapup.py
@@ -1,0 +1,143 @@
+"""M10 Phase A — Weekly wrap-up aggregator.
+
+Pure function over a list of per-day records → single-week snapshot with
+adherence grade + auto-generated takeaway string.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import List, Optional
+
+
+# Adherence: a closed day "hits" when |actual - target| / target <= 10%.
+_ADHERENCE_TOLERANCE: float = 0.10
+
+
+@dataclass(frozen=True)
+class DayRecord:
+    day: date
+    target_kcal: int
+    actual_kcal: int
+    protein_g: float
+    weight_kg: Optional[float] = None
+    had_training: bool = False
+    was_closed: bool = True
+
+
+@dataclass(frozen=True)
+class WeeklyWrapup:
+    week_start: Optional[date]
+    week_end: Optional[date]
+    days_total: int
+    days_closed: int
+    adherence_pct: int  # rounded integer 0-100
+    avg_kcal: int  # closed-day average, 0 if no closed days
+    avg_protein_g: int
+    avg_protein_g_per_kg: float
+    training_days: int
+    weight_delta_kg: Optional[float]
+    grade: str = field(default="F")
+    # takeaway generated separately (expensive pure fn; keep data clean)
+
+
+def _day_hits_target(d: DayRecord) -> bool:
+    if d.target_kcal <= 0:
+        return False
+    diff = abs(d.actual_kcal - d.target_kcal) / d.target_kcal
+    return diff <= _ADHERENCE_TOLERANCE
+
+
+def adherence_grade(pct: float) -> str:
+    """A >=90, B >=80, C >=70, D >=60, F below."""
+    if pct >= 90:
+        return "A"
+    if pct >= 80:
+        return "B"
+    if pct >= 70:
+        return "C"
+    if pct >= 60:
+        return "D"
+    return "F"
+
+
+def compute_weekly_wrapup(
+    days: List[DayRecord],
+    *,
+    weight_kg: float,
+) -> WeeklyWrapup:
+    if not days:
+        return WeeklyWrapup(
+            week_start=None, week_end=None,
+            days_total=0, days_closed=0,
+            adherence_pct=0,
+            avg_kcal=0, avg_protein_g=0, avg_protein_g_per_kg=0.0,
+            training_days=0,
+            weight_delta_kg=None,
+            grade="F",
+        )
+
+    ordered = sorted(days, key=lambda d: d.day)
+    closed = [d for d in ordered if d.was_closed]
+    hits = sum(1 for d in closed if _day_hits_target(d))
+    adherence_pct = round(100 * hits / len(closed)) if closed else 0
+
+    avg_kcal = round(sum(d.actual_kcal for d in closed) / len(closed)) if closed else 0
+    avg_protein_g = round(sum(d.protein_g for d in closed) / len(closed)) if closed else 0
+    avg_protein_g_per_kg = round(
+        (avg_protein_g / weight_kg) if weight_kg > 0 else 0.0, 2,
+    )
+
+    training_days = sum(1 for d in ordered if d.had_training)
+
+    # Weight delta uses first and last days with a weight reading.
+    weights = [(d.day, d.weight_kg) for d in ordered if d.weight_kg is not None]
+    weight_delta_kg: Optional[float] = None
+    if len(weights) >= 2:
+        weight_delta_kg = round(weights[-1][1] - weights[0][1], 2)
+
+    return WeeklyWrapup(
+        week_start=ordered[0].day,
+        week_end=ordered[-1].day,
+        days_total=len(ordered),
+        days_closed=len(closed),
+        adherence_pct=adherence_pct,
+        avg_kcal=avg_kcal,
+        avg_protein_g=avg_protein_g,
+        avg_protein_g_per_kg=avg_protein_g_per_kg,
+        training_days=training_days,
+        weight_delta_kg=weight_delta_kg,
+        grade=adherence_grade(adherence_pct),
+    )
+
+
+def wrapup_takeaway(w: WeeklyWrapup) -> str:
+    """One-sentence human-readable commentary on the week."""
+    if w.days_total == 0:
+        return "Not enough data yet — close a few days to see your weekly wrap-up."
+    if w.days_closed == 0:
+        return "No closed days this week. Close a day to build your adherence score."
+
+    parts: List[str] = []
+    if w.adherence_pct >= 90:
+        parts.append("Strong week on track")
+    elif w.adherence_pct >= 80:
+        parts.append("Solid adherence")
+    elif w.adherence_pct >= 70:
+        parts.append("Mixed week")
+    else:
+        parts.append("Off track — calories ran over or under target")
+
+    if w.avg_protein_g_per_kg > 0:
+        parts.append(f"protein averaged {w.avg_protein_g_per_kg:.1f} g/kg")
+    if w.training_days > 0:
+        parts.append(f"{w.training_days} training day{'s' if w.training_days != 1 else ''}")
+    if w.weight_delta_kg is not None:
+        direction = "down" if w.weight_delta_kg < 0 else ("up" if w.weight_delta_kg > 0 else "flat")
+        if direction == "flat":
+            parts.append("weight flat")
+        else:
+            parts.append(f"weight {direction} {abs(w.weight_delta_kg):.1f} kg")
+
+    return ". ".join(parts) + "."

--- a/sync/tests/test_weekly_wrapup.py
+++ b/sync/tests/test_weekly_wrapup.py
@@ -1,0 +1,172 @@
+"""M10 Phase A — Weekly wrap-up tests."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from nutrition_engine.weekly_wrapup import (
+    DayRecord,
+    adherence_grade,
+    compute_weekly_wrapup,
+    wrapup_takeaway,
+)
+
+
+def _day(
+    offset: int,
+    *,
+    target_kcal: int = 2000,
+    actual_kcal: int = 1950,
+    protein_g: float = 140,
+    weight_kg: float | None = 75.0,
+    had_training: bool = False,
+    was_closed: bool = True,
+) -> DayRecord:
+    return DayRecord(
+        day=date(2026, 4, 1) + timedelta(days=offset),
+        target_kcal=target_kcal,
+        actual_kcal=actual_kcal,
+        protein_g=protein_g,
+        weight_kg=weight_kg,
+        had_training=had_training,
+        was_closed=was_closed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# M10A.1 aggregator
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWeeklyWrapup:
+    def test_empty_list_returns_zeros(self):
+        w = compute_weekly_wrapup([], weight_kg=75)
+        assert w.adherence_pct == 0
+        assert w.avg_kcal == 0
+        assert w.avg_protein_g == 0
+        assert w.training_days == 0
+        assert w.days_closed == 0
+        assert w.days_total == 0
+        assert w.weight_delta_kg is None
+
+    def test_all_days_in_range_hits_adherence(self):
+        # 7 days, all within ±10% of target → 100% adherence
+        days = [_day(i, actual_kcal=2050) for i in range(7)]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert w.adherence_pct == 100
+
+    def test_partial_adherence(self):
+        # 7 closed days, 5 in range + 2 way over → 5/7 ~71%
+        days = [_day(i, actual_kcal=2050) for i in range(5)] + \
+               [_day(i + 5, actual_kcal=3000) for i in range(2)]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert 70 <= w.adherence_pct <= 72
+
+    def test_open_days_skipped_from_adherence_math(self):
+        # 3 open + 4 closed (all on-target) → 4/4 = 100%
+        days = [_day(i, was_closed=False) for i in range(3)] + \
+               [_day(i + 3) for i in range(4)]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert w.adherence_pct == 100
+        assert w.days_closed == 4
+        assert w.days_total == 7
+
+    def test_avg_kcal_across_closed_days(self):
+        days = [
+            _day(0, actual_kcal=2000),
+            _day(1, actual_kcal=2100),
+            _day(2, actual_kcal=1900),
+        ]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert w.avg_kcal == 2000
+
+    def test_avg_protein_per_kg(self):
+        days = [_day(i, protein_g=150) for i in range(4)]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert w.avg_protein_g == 150
+        assert w.avg_protein_g_per_kg == 2.0
+
+    def test_training_days_counts_flagged_days(self):
+        days = [
+            _day(0, had_training=True),
+            _day(1, had_training=False),
+            _day(2, had_training=True),
+            _day(3, had_training=True),
+        ]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert w.training_days == 3
+
+    def test_weight_delta_last_minus_first(self):
+        days = [
+            _day(0, weight_kg=75.0),
+            _day(1, weight_kg=74.8),
+            _day(2, weight_kg=74.5),
+        ]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert w.weight_delta_kg == pytest.approx(-0.5, abs=0.01)
+
+    def test_weight_delta_ignores_missing_weights(self):
+        days = [
+            _day(0, weight_kg=75.0),
+            _day(1, weight_kg=None),
+            _day(2, weight_kg=74.0),
+        ]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert w.weight_delta_kg == pytest.approx(-1.0, abs=0.01)
+
+    def test_week_start_and_end(self):
+        days = [_day(i) for i in range(7)]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        assert w.week_start == date(2026, 4, 1)
+        assert w.week_end == date(2026, 4, 7)
+
+
+# ---------------------------------------------------------------------------
+# M10A.2 grade + takeaway
+# ---------------------------------------------------------------------------
+
+
+class TestAdherenceGrade:
+    def test_90_is_a(self):
+        assert adherence_grade(90) == "A"
+        assert adherence_grade(100) == "A"
+
+    def test_80_89_is_b(self):
+        assert adherence_grade(80) == "B"
+        assert adherence_grade(89) == "B"
+
+    def test_70_79_is_c(self):
+        assert adherence_grade(70) == "C"
+
+    def test_60_69_is_d(self):
+        assert adherence_grade(65) == "D"
+
+    def test_below_60_is_f(self):
+        assert adherence_grade(59) == "F"
+        assert adherence_grade(0) == "F"
+
+
+class TestWrapupTakeaway:
+    def test_strong_week_praises(self):
+        days = [_day(i, actual_kcal=2000, protein_g=165, weight_kg=75 - i * 0.08,
+                     had_training=(i % 2 == 0)) for i in range(7)]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        txt = wrapup_takeaway(w)
+        assert len(txt) > 0
+        assert any(word in txt.lower() for word in ["strong", "solid", "on track"])
+
+    def test_off_track_flags(self):
+        days = [_day(i, actual_kcal=3000, protein_g=100) for i in range(7)]
+        w = compute_weekly_wrapup(days, weight_kg=75)
+        txt = wrapup_takeaway(w)
+        assert len(txt) > 0
+        # Should mention adherence being off
+        assert any(word in txt.lower() for word in ["over", "off", "below"])
+
+    def test_no_data_returns_safe_string(self):
+        w = compute_weekly_wrapup([], weight_kg=75)
+        txt = wrapup_takeaway(w)
+        assert len(txt) > 0
+        assert "no data" in txt.lower() or "not enough" in txt.lower()


### PR DESCRIPTION
Stacked on #72. Final batch of the "port macro-engine science into soma" series (#65).

## Weekly wrap-up
Soma's web/api/nutrition has no existing weekly-adherence computation — this ports macro-engine's M10A aggregator as a pure-logic module so a future endpoint can drop it in.

- `compute_weekly_wrapup(days, weight_kg)` returns `WeeklyWrapup { week_start, week_end, days_total, days_closed, adherence_pct, avg_kcal, avg_protein_g[/kg], training_days, weight_delta_kg, grade }`.
- Grade table: A ≥ 90 / B ≥ 80 / C ≥ 70 / D ≥ 60 / F.
- Adherence uses ±10% kcal target tolerance.
- `wrapup_takeaway(w)` generates a short commentary string from adherence + protein g/kg + training days + weight delta.

## Alcohol parity
Byte-diffed soma's `nutrition_engine/alcohol.py` against macro-engine's — identical except for the `from nutrition_engine.seed_data import DRINK_DATABASE` line (already the right path). No change needed.

## Test plan
- [x] 18 new pytest assertions for `weekly_wrapup` — green.
- [x] 25 legacy `alcohol` tests remain green, unchanged.

## Batch 1-4 total new tests: 157 + 32 + 61 + 18 = **268 new pytest assertions**, all green.

Closes #69