### PR TITLE
feat(nutrition): collapse per-meal budget to kcal-only (#81)

### DIFF
--- a/sync/src/nutrition_engine/daily_plan.py
+++ b/sync/src/nutrition_engine/daily_plan.py
@@ -173,75 +173,62 @@ def generate_daily_plan(
 
 
 # ---------------------------------------------------------------------------
-# Per-slot budget distribution
+# Per-slot kcal pacing
 # ---------------------------------------------------------------------------
+#
+# Scientific invariant: only kcal is softly paced across meal slots. Protein,
+# carbs, fat, and fiber have NO scientifically defensible per-slot allocation
+# (Schoenfeld & Aragon 2018; Trommelen 2023). Protein is instead signaled by
+# the per-meal MPS floor (≥30g per eating event), which is absolute — not a
+# proportional share of the day.
+#
+# The previous SLOT_DISTRIBUTION with per-macro fractions has been deleted.
+# If you need to display or compute anything per slot beyond kcal, reconsider.
 
-# Default per-slot distribution fractions
-SLOT_DISTRIBUTION = {
-    "breakfast":  {"kcal": 0.28, "protein": 0.25, "carbs": 0.28, "fat": 0.28, "fiber": 0.20},
-    "lunch":      {"kcal": 0.25, "protein": 0.25, "carbs": 0.25, "fat": 0.25, "fiber": 0.30},
-    "dinner":     {"kcal": 0.37, "protein": 0.32, "carbs": 0.37, "fat": 0.37, "fiber": 0.35},
-    "pre_sleep":  {"kcal": 0.10, "protein": 0.18, "carbs": 0.10, "fat": 0.10, "fiber": 0.15},
+SLOT_KCAL_DISTRIBUTION = {
+    "breakfast": 0.28,
+    "lunch":     0.25,
+    "dinner":    0.37,
+    "pre_sleep": 0.10,
 }
 
 ALL_SLOTS = ["breakfast", "lunch", "dinner", "pre_sleep"]
 
 
-def compute_slot_targets(calories: int, protein: float, carbs: float, fat: float, fiber: float) -> dict:
-    """Compute per-slot macro targets from daily totals using default distribution."""
-    targets = {}
-    for slot in ALL_SLOTS:
-        d = SLOT_DISTRIBUTION[slot]
-        targets[slot] = {
-            "calories": round(calories * d["kcal"]),
-            "protein": round(protein * d["protein"]),
-            "carbs": round(carbs * d["carbs"]),
-            "fat": round(fat * d["fat"]),
-            "fiber": round(fiber * d["fiber"]),
-        }
-    return targets
+def compute_slot_targets(calories: int) -> dict:
+    """Compute per-slot kcal targets from the daily kcal total.
 
-
-def redistribute_remaining(daily_targets: dict, eaten_by_slot: dict) -> dict:
-    """Redistribute remaining budget across unfilled slots.
-
-    After each meal is logged, the remaining macro budget is split proportionally
-    among the remaining slots. This ensures later meals adapt to earlier eating.
+    Returns a mapping {slot: {"calories": int}}. No protein / carbs / fat /
+    fiber allocation — those are day-level targets, not per-slot.
     """
-    # Sum up what's been eaten
-    total_eaten = {m: 0.0 for m in ["calories", "protein", "carbs", "fat", "fiber"]}
-    filled_slots = set()
-    for slot, macros in eaten_by_slot.items():
-        filled_slots.add(slot)
-        for m in total_eaten:
-            total_eaten[m] += macros.get(m, 0)
+    return {slot: {"calories": round(calories * frac)}
+            for slot, frac in SLOT_KCAL_DISTRIBUTION.items()}
 
-    # What's left?
-    remaining = {m: max(0, daily_targets[m] - total_eaten[m]) for m in total_eaten}
 
-    # Which slots are unfilled?
+def redistribute_remaining(daily_kcal_target: int, eaten_kcal_by_slot: dict) -> dict:
+    """Redistribute remaining daily kcal across unfilled slots.
+
+    After each meal is logged, remaining kcal is split proportionally among
+    the unfilled slots so later meals adapt to earlier eating. Non-kcal
+    macros are not split per slot.
+    """
+    total_eaten = sum(eaten_kcal_by_slot.values())
+    filled_slots = set(eaten_kcal_by_slot.keys())
+    remaining = max(0, daily_kcal_target - total_eaten)
     unfilled = [s for s in ALL_SLOTS if s not in filled_slots]
 
     if not unfilled:
-        return {s: eaten_by_slot.get(s, {m: 0 for m in total_eaten}) for s in ALL_SLOTS}
+        return {s: {"calories": round(eaten_kcal_by_slot.get(s, 0))}
+                for s in ALL_SLOTS}
 
-    # Distribute remaining proportionally to default ratios of unfilled slots
-    slot_weights = {}
-    for slot in unfilled:
-        slot_weights[slot] = SLOT_DISTRIBUTION[slot]["kcal"]
+    slot_weights = {s: SLOT_KCAL_DISTRIBUTION[s] for s in unfilled}
     total_weight = sum(slot_weights.values()) or 1.0
 
     result = {}
     for slot in ALL_SLOTS:
         if slot in filled_slots:
-            result[slot] = eaten_by_slot[slot]  # already eaten
+            result[slot] = {"calories": round(eaten_kcal_by_slot[slot])}
         else:
             frac = slot_weights[slot] / total_weight
-            result[slot] = {
-                "calories": round(remaining["calories"] * frac),
-                "protein": round(remaining["protein"] * frac),
-                "carbs": round(remaining["carbs"] * frac),
-                "fat": round(remaining["fat"] * frac),
-                "fiber": round(remaining["fiber"] * frac),
-            }
+            result[slot] = {"calories": round(remaining * frac)}
     return result

--- a/sync/tests/test_slot_distribution.py
+++ b/sync/tests/test_slot_distribution.py
@@ -1,98 +1,83 @@
-"""Tests for per-slot budget distribution — Task 13."""
+"""Tests for per-slot kcal pacing.
+
+After #81 (collapse per-meal budget to kcal-only), slot targets only allocate
+kcal. Protein / carbs / fat / fiber are day-level targets, not per-slot, so
+the functions no longer split them. The tests below enforce that shape.
+"""
 import pytest
 from nutrition_engine.daily_plan import compute_slot_targets, redistribute_remaining
 
 
 class TestComputeSlotTargets:
     def test_default_distribution(self):
-        targets = compute_slot_targets(calories=2000, protein=176, carbs=250, fat=64, fiber=35)
-        assert targets["breakfast"]["calories"] == 500   # 25%
-        assert targets["lunch"]["calories"] == 600       # 30%
-        assert targets["dinner"]["calories"] == 700      # 35%
+        targets = compute_slot_targets(calories=2000)
+        assert targets["breakfast"]["calories"] == 560   # 28%
+        assert targets["lunch"]["calories"] == 500       # 25%
+        assert targets["dinner"]["calories"] == 740      # 37%
         assert targets["pre_sleep"]["calories"] == 200   # 10%
-        # Protein distributed proportionally
-        assert sum(t["protein"] for t in targets.values()) == 176
 
-    def test_all_macros_distributed(self):
-        targets = compute_slot_targets(calories=2000, protein=176, carbs=250, fat=64, fiber=35)
-        for macro in ["calories", "protein", "carbs", "fat", "fiber"]:
-            total = sum(t[macro] for t in targets.values())
-            # Allow rounding error of ±len(ALL_SLOTS)
-            expected = {"calories": 2000, "protein": 176, "carbs": 250, "fat": 64, "fiber": 35}[macro]
-            assert abs(total - expected) <= 4, f"{macro}: {total} vs {expected}"
+    def test_only_calories_key(self):
+        targets = compute_slot_targets(calories=2000)
+        for slot, macros in targets.items():
+            assert set(macros.keys()) == {"calories"}, (
+                f"{slot} has non-kcal keys — per-slot P/C/F/Fi is the bug #81 fixed"
+            )
 
     def test_zero_calories(self):
-        targets = compute_slot_targets(calories=0, protein=0, carbs=0, fat=0, fiber=0)
+        targets = compute_slot_targets(calories=0)
         for slot in targets:
-            for macro in targets[slot]:
-                assert targets[slot][macro] == 0
+            assert targets[slot]["calories"] == 0
 
     def test_all_slots_present(self):
-        targets = compute_slot_targets(calories=2000, protein=176, carbs=250, fat=64, fiber=35)
+        targets = compute_slot_targets(calories=2000)
         assert set(targets.keys()) == {"breakfast", "lunch", "dinner", "pre_sleep"}
 
     def test_dinner_largest(self):
-        targets = compute_slot_targets(calories=2000, protein=176, carbs=250, fat=64, fiber=35)
-        assert targets["dinner"]["calories"] > targets["lunch"]["calories"]
-        assert targets["lunch"]["calories"] > targets["breakfast"]["calories"]
-        assert targets["breakfast"]["calories"] > targets["pre_sleep"]["calories"]
+        targets = compute_slot_targets(calories=2000)
+        assert targets["dinner"]["calories"] > targets["breakfast"]["calories"]
+        assert targets["breakfast"]["calories"] > targets["lunch"]["calories"]
+        assert targets["lunch"]["calories"] > targets["pre_sleep"]["calories"]
 
 
 class TestRedistributeRemaining:
-    def test_after_eating_breakfast(self):
-        """After logging 600 kcal breakfast (100 over budget), remaining slots absorb."""
-        daily = {"calories": 2000, "protein": 176, "carbs": 250, "fat": 64, "fiber": 35}
-        eaten = {"breakfast": {"calories": 600, "protein": 50, "carbs": 60, "fat": 20, "fiber": 8}}
-        remaining = redistribute_remaining(daily, eaten)
-        # Total remaining = 2000 - 600 = 1400 split among lunch/dinner/pre_sleep
-        unfilled_total = remaining["lunch"]["calories"] + remaining["dinner"]["calories"] + remaining["pre_sleep"]["calories"]
-        assert unfilled_total == 1400
-        # Lunch should still get the largest share of unfilled (dinner is biggest share)
+    def test_after_eating_breakfast_absorbs_remainder(self):
+        """After logging 600 kcal breakfast, the other three slots absorb 1400 kcal."""
+        remaining = redistribute_remaining(2000, {"breakfast": 600})
+        unfilled_total = (
+            remaining["lunch"]["calories"]
+            + remaining["dinner"]["calories"]
+            + remaining["pre_sleep"]["calories"]
+        )
+        assert abs(unfilled_total - 1400) <= 2  # rounding tolerance
         assert remaining["dinner"]["calories"] > remaining["lunch"]["calories"]
         assert remaining["lunch"]["calories"] > remaining["pre_sleep"]["calories"]
 
-    def test_after_eating_less(self):
-        """Eating less at breakfast -> more budget for later slots."""
-        daily = {"calories": 2000, "protein": 176, "carbs": 250, "fat": 64, "fiber": 35}
-        eaten_less = {"breakfast": {"calories": 300, "protein": 30, "carbs": 30, "fat": 10, "fiber": 5}}
-        eaten_more = {"breakfast": {"calories": 600, "protein": 50, "carbs": 60, "fat": 20, "fiber": 8}}
-        remaining_less = redistribute_remaining(daily, eaten_less)
-        remaining_more = redistribute_remaining(daily, eaten_more)
-        assert remaining_less["lunch"]["calories"] > remaining_more["lunch"]["calories"]
+    def test_eating_less_leaves_more_for_later(self):
+        less = redistribute_remaining(2000, {"breakfast": 300})
+        more = redistribute_remaining(2000, {"breakfast": 600})
+        assert less["lunch"]["calories"] > more["lunch"]["calories"]
 
-    def test_no_meals_eaten_returns_default(self):
-        daily = {"calories": 2000, "protein": 176, "carbs": 250, "fat": 64, "fiber": 35}
-        remaining = redistribute_remaining(daily, {})
-        assert remaining["breakfast"]["calories"] == 500  # default 25%
+    def test_no_meals_eaten_returns_default_distribution(self):
+        remaining = redistribute_remaining(2000, {})
+        assert remaining["breakfast"]["calories"] == 560  # 28%
+        assert remaining["pre_sleep"]["calories"] == 200  # 10%
 
     def test_all_meals_eaten_preserves_eaten_values(self):
-        daily = {"calories": 2000, "protein": 176, "carbs": 250, "fat": 64, "fiber": 35}
-        eaten = {
-            "breakfast": {"calories": 500, "protein": 44, "carbs": 62, "fat": 16, "fiber": 7},
-            "lunch": {"calories": 600, "protein": 44, "carbs": 75, "fat": 19, "fiber": 11},
-            "dinner": {"calories": 700, "protein": 56, "carbs": 88, "fat": 22, "fiber": 12},
-            "pre_sleep": {"calories": 200, "protein": 32, "carbs": 25, "fat": 7, "fiber": 5},
-        }
-        remaining = redistribute_remaining(daily, eaten)
-        for slot in eaten:
-            assert remaining[slot]["calories"] == eaten[slot]["calories"]
+        eaten = {"breakfast": 500, "lunch": 600, "dinner": 700, "pre_sleep": 200}
+        remaining = redistribute_remaining(2000, eaten)
+        for slot, kcal in eaten.items():
+            assert remaining[slot]["calories"] == kcal
 
     def test_overeating_clamps_remaining_to_zero(self):
-        """If total eaten exceeds daily target, remaining should be 0 not negative."""
-        daily = {"calories": 2000, "protein": 176, "carbs": 250, "fat": 64, "fiber": 35}
-        eaten = {"breakfast": {"calories": 1200, "protein": 100, "carbs": 150, "fat": 40, "fiber": 20},
-                 "lunch": {"calories": 1000, "protein": 90, "carbs": 120, "fat": 30, "fiber": 18}}
-        remaining = redistribute_remaining(daily, eaten)
+        eaten = {"breakfast": 1200, "lunch": 1000}
+        remaining = redistribute_remaining(2000, eaten)
         for slot in ["dinner", "pre_sleep"]:
-            assert remaining[slot]["calories"] >= 0
-            assert remaining[slot]["protein"] >= 0
+            assert remaining[slot]["calories"] == 0
 
-    def test_protein_redistributes_by_remaining_slot_weights(self):
-        """Protein should be split proportionally among unfilled slots."""
-        daily = {"calories": 2000, "protein": 176, "carbs": 250, "fat": 64, "fiber": 35}
-        eaten = {"breakfast": {"calories": 500, "protein": 44, "carbs": 62, "fat": 16, "fiber": 7}}
-        remaining = redistribute_remaining(daily, eaten)
-        # Remaining protein = 176 - 44 = 132
-        total_remaining_protein = remaining["lunch"]["protein"] + remaining["dinner"]["protein"] + remaining["pre_sleep"]["protein"]
-        # Allow rounding error of ±len(unfilled_slots) since each slot rounds independently
-        assert abs(total_remaining_protein - 132) <= 3
+    def test_result_has_only_calories_key(self):
+        """The shape invariant: no protein/carbs/fat/fiber keys in the output."""
+        remaining = redistribute_remaining(2000, {"breakfast": 500})
+        for slot, macros in remaining.items():
+            assert set(macros.keys()) == {"calories"}, (
+                f"{slot} has non-kcal keys — per-slot P/C/F/Fi is the bug #81 fixed"
+            )

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { computeMacroTargetsFromContext } from "@/lib/macro-targets";
 import type { Mode } from "@/lib/mode-engine";
+import type { SlotBudgets } from "@/lib/nutrition-types";
 
 export const runtime = "edge";
 
@@ -9,70 +10,59 @@ const VALID_MODES: readonly Mode[] = [
   "standard", "aggressive", "reverse", "maintenance", "bulk", "injured",
 ];
 
-/* ── Per-slot distribution fractions ── */
-const SLOT_DISTRIBUTION: Record<string, Record<string, number>> = {
-  breakfast: { calories: 0.28, protein: 0.25, carbs: 0.28, fat: 0.28, fiber: 0.2 },
-  lunch: { calories: 0.25, protein: 0.25, carbs: 0.25, fat: 0.25, fiber: 0.3 },
-  dinner: { calories: 0.37, protein: 0.32, carbs: 0.37, fat: 0.37, fiber: 0.35 },
-  pre_sleep: { calories: 0.1, protein: 0.18, carbs: 0.1, fat: 0.1, fiber: 0.15 },
+/**
+ * Per-slot calorie distribution fractions.
+ *
+ * Only kcal. Protein/carbs/fat/fiber have no scientific basis for per-slot
+ * allocation (Schoenfeld & Aragon 2018; Trommelen 2023). See
+ * `web/lib/nutrition-types.ts` for the full invariant.
+ */
+const SLOT_KCAL_DISTRIBUTION: Record<string, number> = {
+  breakfast: 0.28,
+  lunch: 0.25,
+  dinner: 0.37,
+  pre_sleep: 0.1,
 };
 
 const ALL_SLOTS = ["breakfast", "lunch", "dinner", "pre_sleep"] as const;
-const MACROS = ["calories", "protein", "carbs", "fat", "fiber"] as const;
 
 /**
- * Redistribute remaining daily macros across unfilled meal slots,
- * weighted by each slot's default distribution fraction.
+ * Redistribute remaining daily kcal across unfilled meal slots, weighted by
+ * each slot's default kcal fraction. Non-kcal macros are not allocated.
  */
 function redistributeRemaining(
-  dayTargets: Record<string, number>,
-  eatenBySlot: Record<string, Record<string, number>>,
+  dayKcalTarget: number,
+  eatenKcalBySlot: Record<string, number>,
   skippedSlots: string[] = [],
-): Record<string, Record<string, number>> {
-  const totalEaten: Record<string, number> = {};
-  for (const m of MACROS) totalEaten[m] = 0;
-
+): SlotBudgets {
+  let totalEaten = 0;
   const filledSlots = new Set<string>();
-  for (const [slot, vals] of Object.entries(eatenBySlot)) {
+  for (const [slot, kcal] of Object.entries(eatenKcalBySlot)) {
     filledSlots.add(slot);
-    for (const m of MACROS) totalEaten[m] += vals[m] ?? 0;
+    totalEaten += kcal;
   }
+  for (const s of skippedSlots) filledSlots.add(s);
 
-  // Treat skipped slots as filled (zero macros) so their budget redistributes
-  for (const s of skippedSlots) {
-    if (!filledSlots.has(s)) {
-      filledSlots.add(s);
-    }
-  }
-
-  const remaining: Record<string, number> = {};
-  for (const m of MACROS) remaining[m] = Math.max(0, dayTargets[m] - totalEaten[m]);
-
+  const remaining = Math.max(0, dayKcalTarget - totalEaten);
   const unfilled = ALL_SLOTS.filter((s) => !filledSlots.has(s));
+
   if (unfilled.length === 0) {
-    // All slots filled — return actual eaten values (or zeros)
     return Object.fromEntries(
-      ALL_SLOTS.map((s) => [
-        s,
-        eatenBySlot[s] ?? Object.fromEntries(MACROS.map((m) => [m, 0])),
-      ]),
+      ALL_SLOTS.map((s) => [s, { calories: eatenKcalBySlot[s] ?? 0 }]),
     );
   }
 
-  // Distribute remaining across unfilled slots proportional to kcal weight
   const slotWeights: Record<string, number> = {};
-  for (const s of unfilled) slotWeights[s] = SLOT_DISTRIBUTION[s].calories;
+  for (const s of unfilled) slotWeights[s] = SLOT_KCAL_DISTRIBUTION[s];
   const totalWeight = Object.values(slotWeights).reduce((a, b) => a + b, 0) || 1;
 
-  const result: Record<string, Record<string, number>> = {};
+  const result: SlotBudgets = {};
   for (const slot of ALL_SLOTS) {
     if (filledSlots.has(slot)) {
-      result[slot] = eatenBySlot[slot];
+      result[slot] = { calories: Math.round(eatenKcalBySlot[slot] ?? 0) };
     } else {
       const frac = slotWeights[slot] / totalWeight;
-      result[slot] = Object.fromEntries(
-        MACROS.map((m) => [m, Math.round(remaining[m] * frac)]),
-      );
+      result[slot] = { calories: Math.round(remaining * frac) };
     }
   }
   return result;
@@ -127,7 +117,7 @@ export async function GET(req: NextRequest) {
 
   // Compute day targets, remaining, and per-slot budgets
   let remaining: Record<string, number> | null = null;
-  let slotBudgets: Record<string, Record<string, number>> | null = null;
+  let slotBudgets: SlotBudgets | null = null;
   let breakdown: Record<string, unknown> | null = null;
 
   if (plan) {
@@ -400,22 +390,15 @@ export async function GET(req: NextRequest) {
       fiber: Math.round(dayTargets.fiber - consumed.fiber),
     };
 
-    // Aggregate eaten macros by meal_slot
-    const eatenBySlot: Record<string, Record<string, number>> = {};
+    // Aggregate eaten kcal by meal_slot — only kcal is budgeted per slot.
+    const eatenKcalBySlot: Record<string, number> = {};
     for (const m of mealRows) {
       const slot = m.meal_slot as string;
       if (!slot) continue;
-      if (!eatenBySlot[slot]) {
-        eatenBySlot[slot] = { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 };
-      }
-      eatenBySlot[slot].calories += Number(m.calories) || 0;
-      eatenBySlot[slot].protein += Number(m.protein) || 0;
-      eatenBySlot[slot].carbs += Number(m.carbs) || 0;
-      eatenBySlot[slot].fat += Number(m.fat) || 0;
-      eatenBySlot[slot].fiber += Number(m.fiber) || 0;
+      eatenKcalBySlot[slot] = (eatenKcalBySlot[slot] ?? 0) + (Number(m.calories) || 0);
     }
 
-    slotBudgets = redistributeRemaining(dayTargets, eatenBySlot, skippedSlots);
+    slotBudgets = redistributeRemaining(dayTargets.calories, eatenKcalBySlot, skippedSlots);
 
     // ── Build observability breakdown ──
     breakdown = {

--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -4,6 +4,7 @@ import React, { useState, useMemo, useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { NumberInput } from "@/components/number-input";
+import { ProteinQualityPill } from "@/lib/per-meal-protein";
 import {
   type Ingredient,
   type PortionResult,
@@ -231,36 +232,52 @@ export function ComposeMealView({
         </div>
       )}
 
-      {/* Macro progress bars */}
+      {/* Per-meal read-out — kcal is a soft pacing bar; P/C/F/Fi are plain
+          numbers. Per-meal P/C/F/Fi do NOT have scientific caps (Schoenfeld &
+          Aragon 2018; Trommelen 2023), so we don't draw goal markers or flip
+          to an "over" state for them. Protein gets an MPS-quality pill. */}
       <div className="space-y-1.5 border-t pt-2">
-        {[
-          { label: "kcal", current: totals.calories, max: budget?.calories || 0, color: "bg-primary" },
-          { label: "P", current: totals.protein, max: budget?.protein || 0, color: "bg-blue-500", suffix: "g" },
-          { label: "C", current: totals.carbs, max: budget?.carbs || 0, color: "bg-amber-500", suffix: "g" },
-          { label: "F", current: totals.fat, max: budget?.fat || 0, color: "bg-rose-500", suffix: "g" },
-          { label: "Fi", current: totals.fiber, max: budget?.fiber || 0, color: "bg-green-500", suffix: "g" },
-        ].map(({ label, current, max, color, suffix }) => {
-          const barMax = Math.max(max * 1.3, current * 1.05, max + 1);
-          const fillPct = barMax > 0 ? Math.min(100, (current / barMax) * 100) : 0;
-          const goalPct = barMax > 0 ? Math.min(100, (max / barMax) * 100) : 0;
-          const over = max > 0 && current > max;
+        {(() => {
+          const kcalBudget = budget?.calories || 0;
+          const barMax = Math.max(kcalBudget * 1.3, totals.calories * 1.05, kcalBudget + 1);
+          const fillPct = barMax > 0 ? Math.min(100, (totals.calories / barMax) * 100) : 0;
+          const goalPct = barMax > 0 && kcalBudget > 0 ? Math.min(100, (kcalBudget / barMax) * 100) : 0;
           return (
-            <div key={label} className="flex items-center gap-2 text-xs">
-              <span className="w-8 text-muted-foreground text-right">{label}</span>
-              <div className="relative flex-1 h-2 bg-muted rounded-full overflow-hidden">
-                <div className="absolute right-0 top-0 h-full bg-muted-foreground/10" style={{ width: `${100 - goalPct}%` }} />
+            <div className="flex items-center gap-2 text-xs">
+              <span className="w-8 text-muted-foreground text-right">kcal</span>
+              <div
+                className="relative flex-1 h-2 bg-muted rounded-full overflow-hidden"
+                title="Per-meal kcal is a soft pacing hint — splits the daily target across slots. Going over here is fine as long as the day total lands right."
+              >
+                {kcalBudget > 0 && (
+                  <div className="absolute right-0 top-0 h-full bg-muted-foreground/10" style={{ width: `${100 - goalPct}%` }} />
+                )}
                 <div
-                  className={`absolute left-0 top-0 h-full rounded-full transition-all ${over ? "bg-amber-500" : color}`}
+                  className="absolute left-0 top-0 h-full rounded-full transition-all bg-primary"
                   style={{ width: `${fillPct}%` }}
                 />
-                {max > 0 && <div className="absolute top-0 h-full w-[2px] bg-foreground/50" style={{ left: `${goalPct}%` }} />}
+                {kcalBudget > 0 && (
+                  <div className="absolute top-0 h-full w-[2px] bg-foreground/40" style={{ left: `${goalPct}%` }} />
+                )}
               </div>
-              <span className={`w-20 text-right tabular-nums ${over ? "text-amber-500" : ""}`}>
-                {Math.round(current)}{suffix || ""} / {Math.round(max)}{suffix || ""}
+              <span className="w-24 text-right tabular-nums text-muted-foreground">
+                {Math.round(totals.calories)}
+                {kcalBudget > 0 && <span className="text-muted-foreground/60"> / {Math.round(kcalBudget)} budget</span>}
               </span>
             </div>
           );
-        })}
+        })()}
+
+        <div className="flex items-center gap-3 text-xs text-muted-foreground pt-0.5">
+          <span className="flex items-center tabular-nums">
+            <span className="text-blue-400 font-medium">{Math.round(totals.protein)}g</span>
+            <span className="ml-1 text-muted-foreground/70">P</span>
+            <ProteinQualityPill grams={totals.protein} />
+          </span>
+          <span className="tabular-nums"><span className="text-amber-400 font-medium">{Math.round(totals.carbs)}g</span> <span className="text-muted-foreground/70">C</span></span>
+          <span className="tabular-nums"><span className="text-rose-400 font-medium">{Math.round(totals.fat)}g</span> <span className="text-muted-foreground/70">F</span></span>
+          <span className="tabular-nums"><span className="text-green-400 font-medium">{Math.round(totals.fiber)}g</span> <span className="text-muted-foreground/70">Fi</span></span>
+        </div>
       </div>
 
       {/* Volume score */}

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -9,8 +9,7 @@ import { IngredientPicker } from "@/components/ingredient-picker";
 import { ComposeMealView } from "@/components/compose-meal-view";
 import { MealDetailModal } from "@/components/meal-detail-modal";
 import { type Ingredient, type PortionResult, solvePortions, computeItemMacros } from "@/lib/portion-solver";
-
-// ── Helpers ───────────────────────────────────────────────────
+import { ProteinQualityPill } from "@/lib/per-meal-protein";
 
 /** Generate a readable name from meal items, e.g. "Salmon, Broccoli & Yogurt" */
 function autoMealName(items: any[]): string {
@@ -200,9 +199,6 @@ export function MealCard({
   const slotLabel = SLOT_LABELS[slot] || slot;
   const slotIcon = SLOT_ICONS[slot] || "";
   const totalCal = meals.reduce((s, m) => s + Number(m.calories || 0), 0);
-  const totalProtein = meals.reduce((s, m) => s + Number(m.protein || 0), 0);
-  const totalCarbs = meals.reduce((s, m) => s + Number(m.carbs || 0), 0);
-  const totalFat = meals.reduce((s, m) => s + Number(m.fat || 0), 0);
 
   // Filter presets for this slot
   const slotTags = SLOT_TAG_MAP[slot] || [];
@@ -503,8 +499,11 @@ export function MealCard({
             </span>
           )}
           {slotBudget && totalCal > 0 && (
-            <span className="text-[10px] text-muted-foreground tabular-nums">
-              / {Math.round(slotBudget.calories)}
+            <span
+              className="text-[10px] text-muted-foreground/70 tabular-nums"
+              title="Soft pacing hint — splits the daily calorie target across slots. Not a hard cap."
+            >
+              budget {Math.round(slotBudget.calories)}
             </span>
           )}
           {expanded ? (
@@ -514,14 +513,6 @@ export function MealCard({
           )}
         </div>
       </button>
-
-      {expanded && meals.length > 0 && slotBudget && (
-        <div className="px-4 pb-2 text-[10px] text-muted-foreground tabular-nums">
-          {Math.round(totalProtein)}P / {Math.round(slotBudget.protein || 0)}
-          {" · "}{Math.round(totalCarbs)}C / {Math.round(slotBudget.carbs || 0)}
-          {" · "}{Math.round(totalFat)}F / {Math.round(slotBudget.fat || 0)}
-        </div>
-      )}
 
       {expanded && (
         <CardContent className="pt-0 space-y-2">
@@ -550,7 +541,9 @@ export function MealCard({
                     </div>
                     <div className="text-xs text-muted-foreground">
                       {Math.round(meal.calories)} kcal &middot;{" "}
-                      {Math.round(meal.protein)}P &middot;{" "}
+                      {Math.round(meal.protein)}P
+                      <ProteinQualityPill grams={meal.protein} />
+                      {" · "}
                       {Math.round(meal.carbs)}C &middot; {Math.round(meal.fat)}F
                       {!disabled && itemsList.some(i => { const ig = ingLookup.get(i.ingredient_id ?? ""); return ig?.is_raw && ig?.raw_to_cooked_ratio && ig.raw_to_cooked_ratio > 1; }) && <span className="text-[9px] ml-1.5 text-muted-foreground/60">20+ min</span>}
                     </div>

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -10,6 +10,7 @@ import { ComposeMealView } from "@/components/compose-meal-view";
 import { MealDetailModal } from "@/components/meal-detail-modal";
 import { type Ingredient, type PortionResult, solvePortions, computeItemMacros } from "@/lib/portion-solver";
 import { ProteinQualityPill } from "@/lib/per-meal-protein";
+import type { SlotBudget } from "@/lib/nutrition-types";
 
 /** Generate a readable name from meal items, e.g. "Salmon, Broccoli & Yogurt" */
 function autoMealName(items: any[]): string {
@@ -106,7 +107,7 @@ interface MealCardProps {
   date: string;
   disabled: boolean;
   skipped?: boolean;
-  slotBudget?: Record<string, number> | null;
+  slotBudget?: SlotBudget | null;
   ingredients?: any[];
   onMealLogged: (changedSlot?: string) => void;
   onSlotSkipped?: () => void;
@@ -328,15 +329,12 @@ export function MealCard({
     const selected = (ingredients as Ingredient[]).filter((i) =>
       selectedIngredients.has(i.id),
     );
-    const budget = slotBudget
-      ? {
-          calories: Number(slotBudget.calories) || 500,
-          protein: Number(slotBudget.protein) || 40,
-          carbs: Number(slotBudget.carbs) || 50,
-          fat: Number(slotBudget.fat) || 20,
-          fiber: Number(slotBudget.fiber) || 10,
-        }
-      : { calories: 500, protein: 40, carbs: 50, fat: 20, fiber: 10 };
+    // Per-meal solver target: only kcal is slot-aware. Non-kcal macros use
+    // neutral defaults (solver's wide contract is retired in #83). These are
+    // NOT science-grounded per-slot caps — they're just seed values for the
+    // auto-portioner until the solver gets the {kcal + MPS floor} contract.
+    const kcal = slotBudget ? Number(slotBudget.calories) || 500 : 500;
+    const budget = { calories: kcal, protein: 40, carbs: 50, fat: 20, fiber: 10 };
     const portions = solvePortions(selected, budget);
     setComposedPortions(portions);
   };
@@ -866,21 +864,20 @@ export function MealCard({
 
           {/* Compose meal view (compose step 2) */}
           {!disabled && composedPortions && (() => {
-            // When editing, budget = slot total - other meals in this slot (gives room for this meal)
-            // When composing new, budget = slot total as-is
+            // Per-meal compose budget: only kcal is slot-derived. Subtract kcal
+            // already consumed by other meals in this slot so the composer
+            // pacing bar reflects remaining headroom. Non-kcal fields are
+            // neutral defaults — the solver rewrite in #83 will drop them.
             const otherMeals = editingMealId ? meals.filter(m => m.id !== editingMealId) : [];
             const otherCal = otherMeals.reduce((s, m) => s + Number(m.calories || 0), 0);
-            const otherP = otherMeals.reduce((s, m) => s + Number(m.protein || 0), 0);
-            const otherC = otherMeals.reduce((s, m) => s + Number(m.carbs || 0), 0);
-            const otherF = otherMeals.reduce((s, m) => s + Number(m.fat || 0), 0);
-            const otherFi = otherMeals.reduce((s, m) => s + Number(m.fiber || 0), 0);
+            const slotKcal = slotBudget ? Number(slotBudget.calories) || 0 : 0;
             const composeBudget = slotBudget ? {
-              calories: Math.max(0, Number(slotBudget.calories) - otherCal),
-              protein: Math.max(0, Number(slotBudget.protein) - otherP),
-              carbs: Math.max(0, Number(slotBudget.carbs) - otherC),
-              fat: Math.max(0, Number(slotBudget.fat) - otherF),
-              fiber: Math.max(0, Number(slotBudget.fiber || 0) - otherFi),
-            } : slotBudget;
+              calories: Math.max(0, slotKcal - otherCal),
+              protein: 40,
+              carbs: 50,
+              fat: 20,
+              fiber: 10,
+            } : null;
             return (
             <ComposeMealView
               portions={composedPortions}

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -10,6 +10,7 @@ import { MealCard } from "@/components/meal-card";
 import { DrinkLogger } from "@/components/drink-logger";
 import { ActivitySelector } from "@/components/activity-selector";
 import { PrepSummary } from "@/components/prep-summary";
+import type { SlotBudgets } from "@/lib/nutrition-types";
 
 // ── Types ─────────────────────────────────────────────────────
 
@@ -241,7 +242,7 @@ export function NutritionDashboard({
   const [selectedWorkouts, setSelectedWorkouts] = useState<string[]>(initialPlan?.selected_workouts ?? []);
   const [gymCalories, setGymCalories] = useState<number>(0);
   const [skippedSlots, setSkippedSlots] = useState<string[]>(initialPlan?.skipped_slots ?? []);
-  const [slotBudgets, setSlotBudgets] = useState<Record<string, Record<string, number>> | null>(null);
+  const [slotBudgets, setSlotBudgets] = useState<SlotBudgets | null>(null);
   const [budgetExpanded, setBudgetExpanded] = useState(false);
   const [breakdown, setBreakdown] = useState<any>(null);
   const [trend7d, setTrend7d] = useState<any>(null);
@@ -639,30 +640,24 @@ export function NutritionDashboard({
                       </div>
                     </div>
 
-                    {/* Per-slot budget */}
+                    {/* Per-slot kcal pacing. P/C/F/Fi are intentionally not
+                        split across slots — no scientific basis for per-slot
+                        non-kcal allocation. See lib/nutrition-types.ts. */}
                     {slotBudgets && (
                       <div className="space-y-1">
-                        <div className="text-[10px] lg:text-xs font-medium text-muted-foreground uppercase tracking-wider">Per-Meal Budget</div>
+                        <div className="text-[10px] lg:text-xs font-medium text-muted-foreground uppercase tracking-wider">Per-Meal kcal Pacing</div>
                         {skippedSlots.length >= 4 ? (
                           <div className="text-xs text-muted-foreground text-center py-2">Fasting day — all meals skipped</div>
                         ) : (
-                          <div className="grid grid-cols-[1fr_auto_auto_auto_auto_auto] gap-x-3 gap-y-0.5 text-xs">
+                          <div className="grid grid-cols-[1fr_auto] gap-x-3 gap-y-0.5 text-xs">
                             <span className="text-muted-foreground text-[10px]">Slot</span>
                             <span className="text-muted-foreground text-[10px] text-right">kcal</span>
-                            <span className="text-muted-foreground text-[10px] text-right">P</span>
-                            <span className="text-muted-foreground text-[10px] text-right">C</span>
-                            <span className="text-muted-foreground text-[10px] text-right">F</span>
-                            <span className="text-muted-foreground text-[10px] text-right">Fi</span>
-                            {Object.entries(slotBudgets).map(([slot, macros]: [string, any]) => (
+                            {Object.entries(slotBudgets).map(([slot, macros]) => (
                               <React.Fragment key={slot}>
                                 <span className={skippedSlots.includes(slot) ? "text-muted-foreground/50 line-through" : ""}>
                                   {slot.replace("_", "-")}
                                 </span>
                                 <span className="tabular-nums text-right">{Math.round(macros.calories)}</span>
-                                <span className="tabular-nums text-right text-blue-500">{Math.round(macros.protein)}</span>
-                                <span className="tabular-nums text-right text-amber-500">{Math.round(macros.carbs)}</span>
-                                <span className="tabular-nums text-right text-rose-500">{Math.round(macros.fat)}</span>
-                                <span className="tabular-nums text-right text-green-500">{Math.round(macros.fiber || 0)}</span>
                               </React.Fragment>
                             ))}
                           </div>

--- a/web/lib/nutrition-types.ts
+++ b/web/lib/nutrition-types.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared nutrition types.
+ *
+ * Scientific invariant — referenced everywhere per-slot budgets appear:
+ *
+ *   Daily: kcal (soft ceiling when cutting), protein (floor, no ceiling),
+ *   fiber (25g floor + 60g ceiling), carbs/fat (emergent).
+ *
+ *   Per-meal: ONLY kcal is softly paced across slots. Protein has an MPS
+ *   quality signal based on absolute grams per eating event (≥30g optimal),
+ *   never proportional to daily. Carbs/fat/fiber have no per-meal caps.
+ *
+ *   Refs: Schoenfeld & Aragon 2018; Trommelen 2023; V9.1.
+ *
+ * Encoding this invariant in the type means any code that tries to read
+ * `slotBudget.protein` is a compile error. Keep it that way.
+ */
+
+export interface SlotBudget {
+  calories: number;
+}
+
+export type SlotBudgets = Record<string, SlotBudget>;
+
+/** MPS floor per eating event. Not proportional to daily target. */
+export const PROTEIN_MPS_FLOOR_G = 30;

--- a/web/lib/per-meal-protein.tsx
+++ b/web/lib/per-meal-protein.tsx
@@ -1,0 +1,41 @@
+/**
+ * Per-meal protein quality (V9.1 / Schoenfeld & Aragon 2018; Trommelen 2023).
+ * Classifies a single eating event for MPS signaling — NOT a day total.
+ * No upper cap: >55g just isn't incrementally better, not harmful.
+ */
+import React from "react";
+
+export type PerMealProteinLevel = "red" | "amber" | "yellow" | "green" | "plenty";
+
+export function perMealProteinLevel(g: number): PerMealProteinLevel {
+  if (g < 15) return "red";
+  if (g < 25) return "amber";
+  if (g < 30) return "yellow";
+  if (g <= 55) return "green";
+  return "plenty";
+}
+
+export function ProteinQualityPill({ grams }: { grams: number }) {
+  const level = perMealProteinLevel(grams);
+  if (level === "green" || level === "plenty") return null;
+  const cls =
+    level === "red"
+      ? "bg-rose-500/15 text-rose-400 border-rose-500/30"
+      : level === "amber"
+        ? "bg-amber-500/15 text-amber-400 border-amber-500/30"
+        : "bg-yellow-500/15 text-yellow-400 border-yellow-500/30";
+  const label =
+    level === "red"
+      ? "low protein"
+      : level === "amber"
+        ? "below MPS"
+        : "near MPS";
+  return (
+    <span
+      className={`text-[9px] ml-1.5 px-1 py-[1px] rounded border ${cls} tabular-nums`}
+      title={`Per-meal protein: ${Math.round(grams)}g. MPS optimum is ≥30g per eating event (Schoenfeld & Aragon 2018; Trommelen 2023).`}
+    >
+      {label}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Per-meal P/C/F/Fi budgets had no scientific basis — they were proportional splits of the daily target (e.g. breakfast = 25% of daily protein) invented by this codebase. Every consumer either displayed them as fake caps or fed them to the portion solver as fake targets.

The scientific invariant (Schoenfeld & Aragon 2018; Trommelen 2023): only kcal is softly paced across meal slots. Protein has a per-meal MPS quality signal based on absolute grams (≥30g per eating event), never proportional to daily. Carbs/fat/fiber have no per-meal caps.

## Changes

- **New** `web/lib/nutrition-types.ts` — `SlotBudget = { calories: number }` with a JSDoc naming the invariant so future code can't reintroduce the bug at the type level
- **Data (TS)** `web/app/api/nutrition/plan/route.ts` — `SLOT_DISTRIBUTION` collapsed to scalar kcal fractions; `redistributeRemaining(dayKcalTarget, eatenKcalBySlot)` returns `{ slot: { calories } }`
- **Data (Python)** `sync/src/nutrition_engine/daily_plan.py` — same collapse; `compute_slot_targets` / `redistribute_remaining` accept + return kcal only
- **Tests** `sync/tests/test_slot_distribution.py` — rewritten; 11 tests enforce the narrowed shape
- **Dashboard** `web/components/nutrition-dashboard.tsx` — "Per-Meal Budget" table → "Per-Meal kcal Pacing", only Slot/kcal columns
- **Meal card** `web/components/meal-card.tsx` — `slotBudget` prop narrowed to `SlotBudget`; solver target constructed from kcal + neutral defaults (solver contract itself is refactored in #83)
- **Display defense** — meal-card slot header "budget N", compose-view macro bars replaced with plain read-outs + MPS pill; cherry-picked forward from the earlier #80 branch so they sit on top of the narrowed data layer

## Behavior change worth calling out

When editing a meal, the compose budget used to subtract other meals' P/C/F/Fi from per-macro slot shares. Now it only subtracts kcal. Correct per the invariant (other meals' protein doesn't constrain this meal's targets) and aligns with the #83 solver refactor.

## Audit finding

`/api/nutrition/rebalance` was already kcal-only; no per-slot non-kcal logic there. One fewer surface for #85 to sweep.

## Remaining scope (NOT in this PR)

- **#83** — refactor `portion-solver.ts` to target `{calories, proteinMpsFloor: 30}` instead of the full macro target
- **#85** — audit LLM prompts, log-meal flags, weekly review, share images, any Python callers

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `pytest tests/test_slot_distribution.py` — 11/11 pass (unrelated sleep-deficit tests in `test_daily_plan.py` fail identically on `main` — pre-existing)
- [x] Playwright on localhost:3456 against prod data: Per-Meal kcal Pacing table renders with 2 columns only; compose view has one kcal pacing bar + plain P/C/F/Fi read-outs; no max bars, no over-state
- [ ] Playwright on Vercel preview URL after CI green
- [ ] Playwright on `soma.gkos.dev` authenticated via GitHub after merge + prod deploy

Closes #80
Closes #81
Closes #82
Closes #84