### PR TITLE
feat(nutrition): retarget portion-solver to kcal + MPS floor (#83)

### DIFF
--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { NumberInput } from "@/components/number-input";
 import { ProteinQualityPill } from "@/lib/per-meal-protein";
+import type { SlotBudget } from "@/lib/nutrition-types";
 import {
   type Ingredient,
   type PortionResult,
@@ -21,7 +22,7 @@ import {
 interface ComposeMealViewProps {
   portions: PortionResult[];
   ingredients: Ingredient[];
-  budget: Record<string, number> | null;
+  budget: SlotBudget | null;
   onLog: (
     items: { ingredient_id: string; grams: number; calories: number; protein: number; carbs: number; fat: number; fiber: number }[],
     totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number },

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -329,13 +329,10 @@ export function MealCard({
     const selected = (ingredients as Ingredient[]).filter((i) =>
       selectedIngredients.has(i.id),
     );
-    // Per-meal solver target: only kcal is slot-aware. Non-kcal macros use
-    // neutral defaults (solver's wide contract is retired in #83). These are
-    // NOT science-grounded per-slot caps — they're just seed values for the
-    // auto-portioner until the solver gets the {kcal + MPS floor} contract.
+    // Per-meal solver target: kcal from slot budget + MPS floor (30g default).
+    // Carbs / fat / fiber emerge from ingredient selection.
     const kcal = slotBudget ? Number(slotBudget.calories) || 500 : 500;
-    const budget = { calories: kcal, protein: 40, carbs: 50, fat: 20, fiber: 10 };
-    const portions = solvePortions(selected, budget);
+    const portions = solvePortions(selected, { calories: kcal });
     setComposedPortions(portions);
   };
 
@@ -866,18 +863,13 @@ export function MealCard({
           {!disabled && composedPortions && (() => {
             // Per-meal compose budget: only kcal is slot-derived. Subtract kcal
             // already consumed by other meals in this slot so the composer
-            // pacing bar reflects remaining headroom. Non-kcal fields are
-            // neutral defaults — the solver rewrite in #83 will drop them.
+            // pacing bar reflects remaining headroom.
             const otherMeals = editingMealId ? meals.filter(m => m.id !== editingMealId) : [];
             const otherCal = otherMeals.reduce((s, m) => s + Number(m.calories || 0), 0);
             const slotKcal = slotBudget ? Number(slotBudget.calories) || 0 : 0;
-            const composeBudget = slotBudget ? {
-              calories: Math.max(0, slotKcal - otherCal),
-              protein: 40,
-              carbs: 50,
-              fat: 20,
-              fiber: 10,
-            } : null;
+            const composeBudget: SlotBudget | null = slotBudget
+              ? { calories: Math.max(0, slotKcal - otherCal) }
+              : null;
             return (
             <ComposeMealView
               portions={composedPortions}

--- a/web/lib/portion-solver.test.ts
+++ b/web/lib/portion-solver.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the portion solver after #83 — target is {calories, proteinMpsFloor}
+ * only. Non-kcal macros (C/F/Fi) emerge from ingredient selection, not from a
+ * proportional slot allocation.
+ */
+import { describe, it, expect } from "vitest";
+import { solvePortions, sumPortionMacros, type Ingredient } from "./portion-solver";
+
+// ── Test fixtures ────────────────────────────────────────────
+
+const chicken: Ingredient = {
+  id: "chicken_raw",
+  name: "Chicken Breast (raw)",
+  calories_per_100g: 120,
+  protein_per_100g: 23,
+  carbs_per_100g: 0,
+  fat_per_100g: 2.5,
+  fiber_per_100g: 0,
+  category: "protein",
+};
+
+const rice: Ingredient = {
+  id: "white_rice",
+  name: "White Rice (raw)",
+  calories_per_100g: 360,
+  protein_per_100g: 7,
+  carbs_per_100g: 80,
+  fat_per_100g: 0.6,
+  fiber_per_100g: 1.3,
+  category: "carbs",
+};
+
+const oliveOil: Ingredient = {
+  id: "olive_oil",
+  name: "Olive Oil",
+  calories_per_100g: 884,
+  protein_per_100g: 0,
+  carbs_per_100g: 0,
+  fat_per_100g: 100,
+  fiber_per_100g: 0,
+  category: "fat",
+};
+
+const broccoli: Ingredient = {
+  id: "broccoli_raw",
+  name: "Broccoli",
+  calories_per_100g: 34,
+  protein_per_100g: 2.8,
+  carbs_per_100g: 7,
+  fat_per_100g: 0.4,
+  fiber_per_100g: 2.6,
+  category: "vegetable",
+};
+
+// ── Tests ────────────────────────────────────────────
+
+describe("solvePortions (kcal + MPS contract)", () => {
+  it("returns an empty array for empty ingredient list", () => {
+    const result = solvePortions([], { calories: 500 });
+    expect(result).toEqual([]);
+  });
+
+  it("hits the kcal target within ±10% for a balanced meal", () => {
+    const result = solvePortions([chicken, rice, broccoli], { calories: 700 });
+    const totals = sumPortionMacros(result);
+    expect(totals.calories).toBeGreaterThanOrEqual(630);
+    expect(totals.calories).toBeLessThanOrEqual(770);
+  });
+
+  it("ensures protein hits the MPS floor (≥30g) when ingredients allow it", () => {
+    const result = solvePortions([chicken, rice, broccoli], { calories: 700 });
+    const totals = sumPortionMacros(result);
+    expect(totals.protein).toBeGreaterThanOrEqual(30);
+  });
+
+  it("boosts a weak protein source to reach MPS floor when kcal is generous", () => {
+    // Tofu-like mix: only rice (7g P per 100g) + broccoli. Naturally a kcal-
+    // hitting mix gets maybe ~20g protein. The solver must lean on the highest-
+    // protein-density scalable ingredient (rice here, since broccoli is fixed)
+    // to reach the 30g floor.
+    const tofu: Ingredient = {
+      id: "tofu",
+      name: "Tofu",
+      calories_per_100g: 76,
+      protein_per_100g: 8,
+      carbs_per_100g: 1.9,
+      fat_per_100g: 4.8,
+      fiber_per_100g: 0.3,
+      category: "protein",
+    };
+    const result = solvePortions([tofu, rice, broccoli], { calories: 700 });
+    const totals = sumPortionMacros(result);
+    // With tofu as the protein source at ~8g P/100g, reaching 30g means ~375g
+    // of tofu, which fits within kcal budget. The solver must handle this.
+    expect(totals.protein).toBeGreaterThanOrEqual(30);
+    expect(totals.calories).toBeLessThanOrEqual(770); // still respects kcal
+  });
+
+  it("does NOT force carbs/fat/fiber toward a proportional slot share", () => {
+    // With only protein + fat ingredients (no carb source), carbs should be
+    // near-zero — not forced to a 25%-of-daily value.
+    const result = solvePortions([chicken, oliveOil], { calories: 600 });
+    const totals = sumPortionMacros(result);
+    // Chicken has 0 carbs, olive oil has 0 carbs → totals.carbs must be 0
+    expect(totals.carbs).toBe(0);
+  });
+
+  it("does NOT inflate fat above what ingredients naturally provide", () => {
+    // All-chicken meal — fat is whatever 23%-protein chicken provides, not a
+    // proportional slot fat target.
+    const result = solvePortions([chicken], { calories: 400 });
+    const totals = sumPortionMacros(result);
+    // Chicken at ~400 kcal is ~333g, fat ~8.3g. Should emerge, not be fabricated.
+    expect(totals.fat).toBeLessThan(15);
+  });
+
+  it("respects veggie/fixed-category grams (vegetables stay around their base)", () => {
+    const result = solvePortions([chicken, rice, broccoli], { calories: 700 });
+    const broc = result.find((r) => r.ingredient_id === "broccoli_raw")!;
+    // Broccoli is in the vegetable category — kept in [80, 160] by the solver
+    expect(broc.grams).toBeGreaterThanOrEqual(80);
+    expect(broc.grams).toBeLessThanOrEqual(160);
+  });
+
+  it("low-kcal meal with limited protein sources still prioritizes kcal over MPS", () => {
+    // kcal budget 200 with only broccoli — no way to reach 30g protein. Solver
+    // must not bust the kcal budget to hit MPS; the meal just has low protein.
+    const result = solvePortions([broccoli], { calories: 200 });
+    const totals = sumPortionMacros(result);
+    expect(totals.calories).toBeLessThan(220); // kcal is still respected
+    // Protein may be well under 30g — that's fine, the UI shows the MPS pill.
+    expect(totals.protein).toBeLessThan(30);
+  });
+
+  it("accepts default MPS floor of 30g when proteinMpsFloor is omitted", () => {
+    const a = solvePortions([chicken, rice], { calories: 700 });
+    const b = solvePortions([chicken, rice], { calories: 700, proteinMpsFloor: 30 });
+    expect(sumPortionMacros(a).protein).toEqual(sumPortionMacros(b).protein);
+  });
+
+  it("can raise the MPS floor for elite-athlete / bulk cases", () => {
+    // With a 40g floor, the solver should push protein ≥ 40g when possible.
+    const result = solvePortions([chicken, rice, broccoli], {
+      calories: 800,
+      proteinMpsFloor: 40,
+    });
+    const totals = sumPortionMacros(result);
+    expect(totals.protein).toBeGreaterThanOrEqual(40);
+  });
+
+  it("returns one PortionResult per ingredient, each with non-negative grams", () => {
+    const result = solvePortions([chicken, rice, broccoli, oliveOil], {
+      calories: 700,
+    });
+    expect(result.length).toBe(4);
+    for (const p of result) {
+      expect(p.grams).toBeGreaterThanOrEqual(0);
+      expect(p.calories).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/web/lib/portion-solver.ts
+++ b/web/lib/portion-solver.ts
@@ -1,6 +1,14 @@
 /**
  * Client-side portion solver for compose meals.
- * Priority: protein first → carbs → fat → vegetables fill volume.
+ *
+ * Contract (post-#81 / #83): target = { calories, proteinMpsFloor? }.
+ *
+ *   1. Hit the kcal budget with the provided ingredient mix.
+ *   2. Ensure total protein ≥ MPS floor (default 30g) when the mix allows it.
+ *      If not reachable without busting kcal, kcal wins — the meal just has
+ *      low protein and the UI flags it via the MPS quality pill.
+ *   3. Carbs / fat / fiber emerge from the ingredient selection. No proportional
+ *      per-slot targets — those have no scientific basis (see nutrition-types.ts).
  */
 
 export interface Ingredient {
@@ -14,34 +22,27 @@ export interface Ingredient {
   category: string;
   is_raw?: boolean;
   raw_to_cooked_ratio?: number | null;
-  unit?: string; // 'g' (default), 'egg', 'gel', etc.
-  grams_per_unit?: number | null; // grams per 1 unit (e.g., 50 for eggs)
-  unit_step?: number | null; // step increment for count-based (default 0.25, 1 for whole-only)
+  unit?: string;
+  grams_per_unit?: number | null;
+  unit_step?: number | null;
 }
 
-/** Check if an ingredient uses count-based units instead of grams */
 export function isCountBased(ing: Ingredient): boolean {
   return !!ing.unit && ing.unit !== "g" && !!ing.grams_per_unit;
 }
-
-/** Convert count to grams */
 export function countToGrams(ing: Ingredient, count: number): number {
   return count * (ing.grams_per_unit || 100);
 }
-
-/** Convert grams to count (snapped to unit_step increments) */
 export function gramsToCount(ing: Ingredient, grams: number): number {
   const raw = grams / (ing.grams_per_unit || 100);
   const step = ing.unit_step ?? 0.25;
   return Math.round(raw / step) * step;
 }
 
-export interface MacroTarget {
+export interface PerMealSolverTarget {
   calories: number;
-  protein: number;
-  carbs: number;
-  fat: number;
-  fiber?: number;
+  /** MPS floor in grams. Default 30g per Schoenfeld & Aragon 2018. */
+  proteinMpsFloor?: number;
 }
 
 export interface PortionResult {
@@ -57,32 +58,22 @@ export interface PortionResult {
 
 /** Per-category gram adjustment increments (for +/- buttons). */
 const INCREMENTS: Record<string, number> = {
-  protein: 25,
-  carbs: 10,
-  vegetable: 25,
-  fat: 5,
-  dairy: 25,
-  sauce: 10,
-  fruit: 25,
-  supplement: 5,
+  protein: 25, carbs: 10, vegetable: 25, fat: 5,
+  dairy: 25, sauce: 10, fruit: 25, supplement: 5,
 };
 
 /** Per-category gram bounds [min, max]. */
 const BOUNDS: Record<string, [number, number]> = {
-  protein: [50, 300],
-  carbs: [30, 200],
-  vegetable: [50, 250],
-  fat: [5, 100],
-  dairy: [25, 300],
-  sauce: [20, 80],
-  fruit: [50, 200],
-  supplement: [10, 60],
+  protein: [50, 300], carbs: [30, 200], vegetable: [50, 250],
+  fat: [5, 100], dairy: [25, 300], sauce: [20, 80],
+  fruit: [50, 200], supplement: [10, 60],
 };
+
+const FIXED_CATEGORIES = new Set(["vegetable", "sauce", "supplement"]);
 
 function clamp(v: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, v));
 }
-
 function macrosAt(ing: Ingredient, grams: number) {
   const f = grams / 100;
   return {
@@ -93,200 +84,140 @@ function macrosAt(ing: Ingredient, grams: number) {
     fiber: f * ing.fiber_per_100g,
   };
 }
+function fixedSeedGrams(ing: Ingredient): number {
+  if (ing.category === "vegetable") return 120;
+  if (ing.category === "sauce") return 50;
+  if (ing.category === "supplement") {
+    return ing.id === "protein_powder_whey" ? 30 : 35;
+  }
+  return 50;
+}
 
 export function solvePortions(
   ingredients: Ingredient[],
-  target: MacroTarget,
+  target: PerMealSolverTarget,
 ): PortionResult[] {
-  /**
-   * Simultaneous constraint solver:
-   * 1. Assign initial portions based on each ingredient's primary role
-   * 2. Compute total macros
-   * 3. If any macro exceeds budget, scale ALL portions down proportionally
-   * 4. Then iteratively shift grams from over-budget macros to under-budget ones
-   */
+  if (ingredients.length === 0) return [];
 
-  const vegs = ingredients.filter((i) => i.category === "vegetable");
-  const sauces = ingredients.filter((i) => i.category === "sauce");
-  const supplements = ingredients.filter((i) => i.category === "supplement");
-  const scalable = ingredients.filter((i) =>
-    !["vegetable", "sauce", "supplement"].includes(i.category)
-  );
-
+  const mpsFloor = target.proteinMpsFloor ?? 30;
   const portions: Record<string, number> = {};
 
-  // Fixed portions: veggies, sauces, supplements (not optimized)
-  for (const ing of vegs) { portions[ing.id] = 120; }
-  for (const ing of sauces) { portions[ing.id] = 50; }
-  for (const ing of supplements) {
-    portions[ing.id] = ing.id === "protein_powder_whey" ? 30 : 35;
-  }
+  const fixed = ingredients.filter((i) => FIXED_CATEGORIES.has(i.category));
+  const scalable = ingredients.filter((i) => !FIXED_CATEGORIES.has(i.category));
 
-  // Compute calories used by fixed ingredients
-  let fixedCal = 0, fixedP = 0, fixedC = 0, fixedF = 0, fixedFi = 0;
-  for (const ing of [...vegs, ...sauces, ...supplements]) {
-    const m = macrosAt(ing, portions[ing.id]);
-    fixedCal += m.calories;
-    fixedP += m.protein;
-    fixedC += m.carbs;
-    fixedF += m.fat;
-    fixedFi += m.fiber;
-  }
+  for (const ing of fixed) portions[ing.id] = fixedSeedGrams(ing);
 
-  // Remaining budget for scalable ingredients
+  // Cap whole eggs at 1 unit up front (one yolk/day).
+  const clampWholeEggs = () => {
+    const wholeEgg = ingredients.find((i) => i.id === "eggs_whole");
+    if (wholeEgg?.grams_per_unit && portions[wholeEgg.id] > wholeEgg.grams_per_unit) {
+      portions[wholeEgg.id] = wholeEgg.grams_per_unit;
+    }
+  };
+
+  // Kcal already consumed by fixed seeds.
+  let fixedCal = 0;
+  for (const ing of fixed) fixedCal += macrosAt(ing, portions[ing.id]).calories;
+
   const remCal = Math.max(0, target.calories - fixedCal);
-  const remP = Math.max(0, target.protein - fixedP);
-  const remC = Math.max(0, target.carbs - fixedC);
-  const remF = Math.max(0, target.fat - fixedF);
-  const remFi = Math.max(0, (target.fiber || 40) - fixedFi);
 
-  if (scalable.length === 0 || remCal <= 0) {
-    // Nothing to optimize — just use fixed
-    return ingredients.map((ing) => {
-      const grams = portions[ing.id] ?? 50;
-      const m = macrosAt(ing, grams);
-      return {
-        ingredient_id: ing.id, grams,
-        increment: INCREMENTS[ing.category] ?? 10,
-        calories: Math.round(m.calories),
-        protein: Math.round(m.protein * 10) / 10,
-        carbs: Math.round(m.carbs * 10) / 10,
-        fat: Math.round(m.fat * 10) / 10,
-        fiber: Math.round(m.fiber * 10) / 10,
-      };
-    });
+  // Seed scalable ingredients. Give each a share of remCal proportional to its
+  // role weight — protein-dense ingredients get more, so the initial guess is
+  // already close to MPS without overshooting.
+  if (scalable.length > 0 && remCal > 0) {
+    const roleWeight = (ing: Ingredient) =>
+      ing.protein_per_100g > 5 ? 2 : 1;
+    const totalWeight = scalable.reduce((s, ing) => s + roleWeight(ing), 0) || 1;
+    for (const ing of scalable) {
+      const calShare = remCal * (roleWeight(ing) / totalWeight);
+      const grams = ing.calories_per_100g > 0
+        ? (calShare / ing.calories_per_100g) * 100
+        : 50;
+      const [lo, hi] = BOUNDS[ing.category] ?? [10, 300];
+      portions[ing.id] = Math.round(clamp(grams, lo, hi));
+    }
+    clampWholeEggs();
+  } else {
+    for (const ing of scalable) portions[ing.id] = fixedSeedGrams(ing);
   }
 
-  // Step 1: Assign initial portions — each ingredient gets a calorie share
-  // proportional to its "role weight" (protein sources get more if protein target is high)
-  const roleWeight = (ing: Ingredient): number => {
-    const pShare = ing.protein_per_100g > 0 ? (remP * 4) : 0; // cal from protein this ing can help with
-    const cShare = ing.carbs_per_100g > 0 ? (remC * 4) : 0;
-    const fShare = ing.fat_per_100g > 0 ? (remF * 9) : 0;
-    return pShare + cShare + fShare || ing.calories_per_100g;
+  // Step 1: uniform kcal scaling. Scale all scalable ingredients by the same
+  // factor so total kcal lands near target, respecting per-category bounds.
+  const scaleScalable = (factor: number) => {
+    for (const ing of scalable) {
+      const [lo, hi] = BOUNDS[ing.category] ?? [10, 300];
+      portions[ing.id] = Math.round(clamp(portions[ing.id] * factor, lo, hi));
+    }
+    clampWholeEggs();
   };
-
-  const totalRoleWeight = scalable.reduce((s, ing) => s + roleWeight(ing), 0) || 1;
-
-  for (const ing of scalable) {
-    const calShare = remCal * (roleWeight(ing) / totalRoleWeight);
-    const gramsForCal = ing.calories_per_100g > 0 ? (calShare / ing.calories_per_100g) * 100 : 50;
-    const [lo, hi] = BOUNDS[ing.category] ?? [10, 300];
-    portions[ing.id] = Math.round(clamp(gramsForCal, lo, hi));
-  }
-
-  // Step 2: Check ALL macro constraints, scale down to fit the tightest one
-  const totalMacros = () => {
-    let cal = 0, p = 0, c = 0, f = 0, fi = 0;
-    for (const ing of scalable) {
-      const m = macrosAt(ing, portions[ing.id]);
-      cal += m.calories; p += m.protein; c += m.carbs; f += m.fat; fi += m.fiber;
-    }
-    return { cal, p, c, f, fi };
+  const totalKcal = () => {
+    let k = 0;
+    for (const ing of ingredients) k += macrosAt(ing, portions[ing.id]).calories;
+    return k;
   };
-
-  let t = totalMacros();
-
-  // Find the tightest constraint — the macro that overflows the most
-  const constraintScales: number[] = [];
-  if (t.cal > 0 && t.cal > remCal) constraintScales.push(remCal / t.cal);
-  if (t.p > 0 && t.p > remP) constraintScales.push(remP / t.p);
-  if (t.f > 0 && t.f > remF) constraintScales.push(remF / t.f);
-  if (t.fi > 0 && t.fi > remFi) constraintScales.push(remFi / t.fi);
-  // Don't constrain carbs — they're the "fill" macro
-
-  if (constraintScales.length > 0) {
-    const scale = Math.min(...constraintScales); // tightest constraint
-    for (const ing of scalable) {
-      const [lo] = BOUNDS[ing.category] ?? [10, 300];
-      portions[ing.id] = Math.max(lo, Math.round(portions[ing.id] * scale));
+  if (scalable.length > 0) {
+    for (let i = 0; i < 3; i++) {
+      const cur = totalKcal();
+      if (cur === 0) break;
+      const factor = target.calories / cur;
+      if (Math.abs(1 - factor) < 0.02) break;
+      scaleScalable(factor);
     }
-    t = totalMacros();
   }
 
-  // Per-macro targeted scaling: if protein or fat still over, reduce the top contributors
-  for (let iter = 0; iter < 3; iter++) {
-    t = totalMacros();
-    // Check protein
-    if (t.p > remP * 1.05) {
-      const proteinIngs = scalable.filter(i => i.protein_per_100g > 5).sort((a, b) => b.protein_per_100g - a.protein_per_100g);
-      for (const ing of proteinIngs) {
-        const m = macrosAt(ing, portions[ing.id]);
-        const excess = t.p - remP;
-        const reduceGrams = Math.round((excess / ing.protein_per_100g) * 100 / proteinIngs.length);
-        const [lo] = BOUNDS[ing.category] ?? [10, 300];
-        portions[ing.id] = Math.max(lo, portions[ing.id] - reduceGrams);
+  // Step 2: MPS floor enforcement. If total protein < floor, boost the most
+  // protein-dense scalable ingredient and trim the rest to stay within kcal.
+  const totalProtein = () => {
+    let p = 0;
+    for (const ing of ingredients) p += macrosAt(ing, portions[ing.id]).protein;
+    return p;
+  };
+  const proteinDense = scalable
+    .filter((i) => i.protein_per_100g >= 5)
+    .sort((a, b) => b.protein_per_100g - a.protein_per_100g);
+
+  if (proteinDense.length > 0) {
+    for (let iter = 0; iter < 8 && totalProtein() < mpsFloor - 0.5; iter++) {
+      const gap = mpsFloor - totalProtein();
+      const target0 = proteinDense[0];
+      const [tLo, tHi] = BOUNDS[target0.category] ?? [10, 300];
+      const addG = Math.ceil((gap / target0.protein_per_100g) * 100);
+      const newG = Math.min(tHi, portions[target0.id] + addG);
+      const actuallyAdded = newG - portions[target0.id];
+      if (actuallyAdded <= 0) break;
+
+      portions[target0.id] = newG;
+      // Compensate by trimming non-protein-dense scalables uniformly.
+      const others = scalable.filter((i) => i !== target0);
+      if (others.length > 0) {
+        const addedKcal = macrosAt(target0, actuallyAdded).calories;
+        let toRemove = addedKcal;
+        for (const o of others) {
+          const [oLo] = BOUNDS[o.category] ?? [10, 300];
+          const maxShrinkG = Math.max(0, portions[o.id] - oLo);
+          if (maxShrinkG <= 0) continue;
+          const oKcalPerG = o.calories_per_100g / 100;
+          const shrinkByKcal = Math.min(
+            toRemove / others.length,
+            maxShrinkG * oKcalPerG,
+          );
+          if (oKcalPerG > 0) {
+            const shrinkG = Math.round(shrinkByKcal / oKcalPerG);
+            portions[o.id] = Math.max(oLo, portions[o.id] - shrinkG);
+            toRemove -= shrinkG * oKcalPerG;
+          }
+        }
       }
-    }
-    // Check fat
-    t = totalMacros();
-    if (t.f > remF * 1.05) {
-      const fatIngs = scalable.filter(i => i.fat_per_100g > 3).sort((a, b) => b.fat_per_100g - a.fat_per_100g);
-      for (const ing of fatIngs) {
-        const excess = t.f - remF;
-        const reduceGrams = Math.round((excess / ing.fat_per_100g) * 100 / fatIngs.length);
-        const [lo] = BOUNDS[ing.category] ?? [10, 300];
-        portions[ing.id] = Math.max(lo, portions[ing.id] - reduceGrams);
-      }
+      clampWholeEggs();
     }
   }
 
-  // Step 3: Fine-tune — try to shift grams to better hit protein target
-  // If protein is underfilled, increase protein sources slightly at expense of carb/fat sources
-  for (let iter = 0; iter < 5; iter++) {
-    t = totalMacros();
-    const proteinGap = remP - t.p;
-    if (proteinGap <= 1) break; // close enough
-
-    // Find a protein source to increase
-    const proteinIngs = scalable.filter(i => i.category === "protein" && i.protein_per_100g > 5);
-    const carbFatIngs = scalable.filter(i => ["carbs", "fruit", "fat", "dairy"].includes(i.category));
-
-    if (proteinIngs.length === 0 || carbFatIngs.length === 0) break;
-
-    // Increase protein source by 10g, decrease a carb/fat source by equivalent calories
-    for (const pIng of proteinIngs) {
-      const addGrams = 10;
-      const addCal = macrosAt(pIng, addGrams).calories;
-      const [, pHi] = BOUNDS[pIng.category] ?? [10, 300];
-      if (portions[pIng.id] + addGrams > pHi) continue;
-
-      // Find a carb/fat source to shrink
-      for (const cfIng of carbFatIngs) {
-        const shrinkGrams = cfIng.calories_per_100g > 0
-          ? Math.round((addCal / cfIng.calories_per_100g) * 100)
-          : 0;
-        const [cfLo] = BOUNDS[cfIng.category] ?? [10, 300];
-        if (portions[cfIng.id] - shrinkGrams < cfLo) continue;
-
-        portions[pIng.id] += addGrams;
-        portions[cfIng.id] -= shrinkGrams;
-        break;
-      }
-      break; // one shift per iteration
-    }
+  // Step 3: final kcal fit — if over by >2%, scale down once more.
+  const final = totalKcal();
+  if (final > target.calories * 1.02 && final > 0) {
+    scaleScalable(target.calories / final);
   }
 
-  // Constraint: max 1 whole egg (with yolk) per day — clamp to 1 unit
-  const wholeEgg = scalable.find(i => i.id === "eggs_whole");
-  if (wholeEgg && wholeEgg.grams_per_unit) {
-    const maxGrams = wholeEgg.grams_per_unit; // 1 egg = 50g
-    if (portions[wholeEgg.id] > maxGrams) {
-      portions[wholeEgg.id] = maxGrams;
-    }
-  }
-
-  // Final calorie check — scale down again if over
-  t = totalMacros();
-  if (t.cal > remCal * 1.02 && t.cal > 0) {
-    const scale = remCal / t.cal;
-    for (const ing of scalable) {
-      const [lo] = BOUNDS[ing.category] ?? [10, 300];
-      portions[ing.id] = Math.max(lo, Math.round(portions[ing.id] * scale));
-    }
-  }
-
-  // Build results
   return ingredients.map((ing) => {
     const grams = portions[ing.id] ?? 50;
     const m = macrosAt(ing, grams);
@@ -303,7 +234,6 @@ export function solvePortions(
   });
 }
 
-/** Recompute macros for a single ingredient at a given gram amount. */
 export function computeItemMacros(ing: Ingredient, grams: number) {
   const m = macrosAt(ing, grams);
   return {
@@ -315,7 +245,6 @@ export function computeItemMacros(ing: Ingredient, grams: number) {
   };
 }
 
-/** Convert between raw and cooked grams using the ingredient's ratio. */
 export function rawToCooked(ing: Ingredient, rawGrams: number): number {
   const ratio = ing.raw_to_cooked_ratio;
   if (!ing.is_raw || !ratio || ratio <= 0) return rawGrams;
@@ -328,12 +257,10 @@ export function cookedToRaw(ing: Ingredient, cookedGrams: number): number {
   return Math.round(cookedGrams / ratio);
 }
 
-/** Check if an ingredient supports cooked weight toggle. */
 export function hasRawCookedToggle(ing: Ingredient): boolean {
   return !!ing.is_raw && !!ing.raw_to_cooked_ratio && ing.raw_to_cooked_ratio > 0 && ing.raw_to_cooked_ratio !== 1;
 }
 
-/** Sum macros across a list of portion results. */
 export function sumPortionMacros(portions: PortionResult[]) {
   return {
     calories: Math.round(portions.reduce((s, p) => s + p.calories, 0)),

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -35,13 +35,15 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/spotify-web-playback-sdk": "^0.1.19",
+        "@vitest/ui": "^4.1.5",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "serwist": "^9.5.6",
         "shadcn": "^3.8.5",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -754,21 +756,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -776,9 +778,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2198,6 +2200,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -2216,6 +2228,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3760,6 +3779,307 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4331,6 +4651,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -4392,6 +4723,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -5127,6 +5465,148 @@
       "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+      "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.5"
+      }
+    },
+    "node_modules/@vitest/ui/node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5468,6 +5948,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -5785,6 +6275,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -6802,6 +7302,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7334,6 +7841,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7408,6 +7925,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -7689,9 +8216,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7800,6 +8327,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -9927,6 +10469,16 @@
       "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10423,6 +10975,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -10741,6 +11304,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pbf": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
@@ -10824,9 +11394,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -11589,6 +12159,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -12153,6 +12757,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -12163,6 +12774,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/sisteransi": {
@@ -12280,6 +12906,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -12289,6 +12922,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -12715,6 +13355,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -12726,14 +13373,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12761,9 +13408,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12778,6 +13425,16 @@
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tldts": {
       "version": "7.0.23",
@@ -12820,6 +13477,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -13354,6 +14021,473 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -13483,6 +14617,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev -p 3456",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",
@@ -36,12 +38,14 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/spotify-web-playback-sdk": "^0.1.19",
+    "@vitest/ui": "^4.1.5",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "serwist": "^9.5.6",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   }
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    include: ["lib/**/*.test.ts", "tests/**/*.test.ts"],
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Completes the scope of parent #81. The portion solver previously took a full MacroTarget `{calories, protein, carbs, fat, fiber}` and tried to hit all five. When the per-slot macro budget was a proportional split of the daily target (the bug fixed in #81), the solver was optimizing ingredient quantities toward fake constraints.

## New contract

```ts
interface PerMealSolverTarget {
  calories: number;
  proteinMpsFloor?: number;  // default 30g — Schoenfeld & Aragon 2018
}
```

Three-phase algorithm, dropped from 329 lines to 143:

1. **Seed** scalable ingredients proportionally to remaining kcal, with 2× role weight for protein-dense sources (protein_per_100g ≥ 5).
2. **Uniform kcal scaling** — scale all scalable ingredients by the same factor until total kcal lands within 2% of target.
3. **MPS boost** — if total protein < `mpsFloor` (30g), increase the highest-protein-density scalable ingredient and trim non-protein sources uniformly to stay within kcal.

Carbs / fat / fiber emerge from ingredient selection rather than being optimized toward proportional slot shares (the scientific invariant from #81).

## Test infrastructure

First vitest setup in the web package. Added:
- `web/vitest.config.ts`
- `test` / `test:watch` scripts in `package.json`
- `lib/portion-solver.test.ts` (11 cases)

## Tests

- empty input → empty array
- kcal hit within ±10%
- protein ≥ 30g MPS floor when ingredients allow
- **weak-protein mix (tofu + rice + broccoli) still hits 30g** — this was the red→green test that drove the rewrite
- no forced C/F/Fi targets (all-chicken meal: fat stays low, not inflated to hit a slot share)
- low-kcal meals prioritize kcal over MPS (can't bust kcal to reach 30g)
- custom MPS floor (40g) works for elite/bulk cases
- default floor is 30g

## Callers updated

- `meal-card.tsx`: `solvePortions(selected, { calories: kcal })` — no more hardcoded `{protein: 40, carbs: 50, ...}` fallback
- `compose-meal-view.tsx`: `budget` prop tightened from `Record<string, number> | null` to `SlotBudget | null`

## Verification

- [x] `npm test` — 11/11 vitest green (same suite enforces the invariant)
- [x] `npx tsc --noEmit` — 0 errors
- [x] Playwright on `localhost:3456` against prod data: compose view renders with single kcal pacing bar, solver hits kcal 821/831, protein 79g (well above MPS floor), plain P/C/F/Fi read-outs, no regression on daily MacroBars
- [ ] Playwright on Vercel preview after CI green
- [ ] Playwright on `soma.gkos.dev` after merge + prod deploy

Closes #83