### PR TITLE
feat(ui): per-meal protein MPS floor + daily-progress C/F/Fi bars (#88)

### DIFF
--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -19,10 +19,22 @@ import {
   gramsToCount,
 } from "@/lib/portion-solver";
 
+interface DayMacros {
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number;
+}
+
 interface ComposeMealViewProps {
   portions: PortionResult[];
   ingredients: Ingredient[];
   budget: SlotBudget | null;
+  /** Daily P/C/F/Fi targets. When provided, C/F/Fi render as daily-progress bars
+   *  (consumed-today + this-meal vs daily target). */
+  dayTargets?: DayMacros | null;
+  /** Daily consumed P/C/F/Fi BEFORE this meal (excludes the meal being edited). */
+  dayConsumed?: DayMacros | null;
   onLog: (
     items: { ingredient_id: string; grams: number; calories: number; protein: number; carbs: number; fat: number; fiber: number }[],
     totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number },
@@ -33,10 +45,15 @@ interface ComposeMealViewProps {
   onTotalsChange?: (totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number }) => void;
 }
 
+/** Per-meal protein anabolic floor (Schoenfeld & Aragon 2018; ≈0.4 g/kg). */
+const MPS_FLOOR_G = 30;
+
 export function ComposeMealView({
   portions: initialPortions,
   ingredients,
   budget,
+  dayTargets,
+  dayConsumed,
   onLog,
   onCancel,
   onEditIngredients,
@@ -233,11 +250,17 @@ export function ComposeMealView({
         </div>
       )}
 
-      {/* Per-meal read-out — kcal is a soft pacing bar; P/C/F/Fi are plain
-          numbers. Per-meal P/C/F/Fi do NOT have scientific caps (Schoenfeld &
-          Aragon 2018; Trommelen 2023), so we don't draw goal markers or flip
-          to an "over" state for them. Protein gets an MPS-quality pill. */}
+      {/* Per-meal read-out.
+          kcal: per-slot soft pacing bar (kcal is the only macro with scientific
+            per-slot pacing — Schoenfeld & Aragon 2018).
+          Protein: per-meal bar with MPS floor at 30g. Below 30 → missed MPS
+            (blue dim); at/above 30 → blue solid + ProteinQualityPill. No upper cap.
+          C / F / Fi: daily-progress bars. Grey = consumed today excluding this
+            meal; colored = this meal would add; goal line at daily target;
+            over-portion past daily target renders amber so the user can see
+            whether logging this meal pushes the DAY past goal. */}
       <div className="space-y-1.5 border-t pt-2">
+        {/* kcal pacing bar — slot-level (unchanged) */}
         {(() => {
           const kcalBudget = budget?.calories || 0;
           const barMax = Math.max(kcalBudget * 1.3, totals.calories * 1.05, kcalBudget + 1);
@@ -269,16 +292,116 @@ export function ComposeMealView({
           );
         })()}
 
-        <div className="flex items-center gap-3 text-xs text-muted-foreground pt-0.5">
-          <span className="flex items-center tabular-nums">
-            <span className="text-blue-400 font-medium">{Math.round(totals.protein)}g</span>
-            <span className="ml-1 text-muted-foreground/70">P</span>
-            <ProteinQualityPill grams={totals.protein} />
-          </span>
-          <span className="tabular-nums"><span className="text-amber-400 font-medium">{Math.round(totals.carbs)}g</span> <span className="text-muted-foreground/70">C</span></span>
-          <span className="tabular-nums"><span className="text-rose-400 font-medium">{Math.round(totals.fat)}g</span> <span className="text-muted-foreground/70">F</span></span>
-          <span className="tabular-nums"><span className="text-green-400 font-medium">{Math.round(totals.fiber)}g</span> <span className="text-muted-foreground/70">Fi</span></span>
-        </div>
+        {/* Protein bar — per-meal MPS floor at 30g (no upper cap) */}
+        {(() => {
+          const thisP = totals.protein;
+          const barMax = Math.max(MPS_FLOOR_G * 1.5, thisP * 1.1, MPS_FLOOR_G + 1);
+          const fillPct = Math.min(100, (thisP / barMax) * 100);
+          const floorPct = Math.min(100, (MPS_FLOOR_G / barMax) * 100);
+          const hitMps = thisP >= MPS_FLOOR_G;
+          const dayP = (dayConsumed?.protein ?? 0) + thisP;
+          const dayTargetP = dayTargets?.protein ?? 0;
+          return (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="w-8 text-muted-foreground text-right">P</span>
+              <div
+                className="relative flex-1 h-2 bg-muted rounded-full overflow-hidden"
+                title={`MPS floor: ${MPS_FLOOR_G}g per meal (Schoenfeld & Aragon 2018). Above the floor is good — there is no upper cap.`}
+              >
+                <div
+                  className={`absolute left-0 top-0 h-full rounded-full transition-all ${hitMps ? "bg-blue-500" : "bg-blue-500/40"}`}
+                  style={{ width: `${fillPct}%` }}
+                />
+                <div className="absolute top-0 h-full w-[2px] bg-foreground/50" style={{ left: `${floorPct}%` }} />
+              </div>
+              <span className="w-24 text-right tabular-nums text-muted-foreground">
+                <span className={hitMps ? "text-blue-400 font-medium" : "text-blue-400/60 font-medium"}>{Math.round(thisP)}g</span>
+                <ProteinQualityPill grams={thisP} />
+                {dayTargetP > 0 && (
+                  <span className="block text-[10px] text-muted-foreground/60">
+                    {Math.round(dayP)} / {Math.round(dayTargetP)} day
+                  </span>
+                )}
+              </span>
+            </div>
+          );
+        })()}
+
+        {/* Carbs / Fat / Fiber — daily-progress bars */}
+        {(["carbs", "fat", "fiber"] as const).map((key) => {
+          const labelMap = { carbs: "C", fat: "F", fiber: "Fi" } as const;
+          const colorMap = {
+            carbs: "bg-amber-500",
+            fat: "bg-rose-500",
+            fiber: "bg-green-500",
+          } as const;
+          const textColorMap = {
+            carbs: "text-amber-400",
+            fat: "text-rose-400",
+            fiber: "text-green-400",
+          } as const;
+          const eaten = dayConsumed?.[key] ?? 0;
+          const thisMeal = totals[key];
+          const target = dayTargets?.[key] ?? 0;
+          // Fall back to plain read-out if no daily target available (e.g. plan didn't load)
+          if (target <= 0) {
+            return (
+              <div key={key} className="flex items-center gap-2 text-xs">
+                <span className="w-8 text-muted-foreground text-right">{labelMap[key]}</span>
+                <div className="flex-1" />
+                <span className="w-24 text-right tabular-nums">
+                  <span className={`${textColorMap[key]} font-medium`}>{Math.round(thisMeal)}g</span>
+                </span>
+              </div>
+            );
+          }
+          const total = eaten + thisMeal;
+          const barMax = Math.max(target * 1.3, total * 1.05, target + 1);
+          const eatenPct = Math.min(100, (eaten / barMax) * 100);
+          const targetPct = Math.min(100, (target / barMax) * 100);
+          // Amber over-portion: only the part of `thisMeal` that exceeds the daily target.
+          const underTarget = Math.max(0, Math.min(target, total) - eaten);
+          const overTarget = Math.max(0, total - Math.max(target, eaten));
+          const underPct = Math.min(100, (underTarget / barMax) * 100);
+          const overPct = Math.min(100, (overTarget / barMax) * 100);
+          const overshootStart = Math.max(eatenPct, targetPct);
+          const dayOverGoal = total > target;
+          return (
+            <div key={key} className="flex items-center gap-2 text-xs">
+              <span className="w-8 text-muted-foreground text-right">{labelMap[key]}</span>
+              <div
+                className="relative flex-1 h-2 bg-muted rounded-full overflow-hidden"
+                title={`Day so far ${Math.round(eaten)}g + this meal ${Math.round(thisMeal)}g = ${Math.round(total)}g vs ${Math.round(target)}g daily target. Daily totals matter, not per-meal.`}
+              >
+                {/* Already-eaten today (grey) */}
+                <div
+                  className="absolute left-0 top-0 h-full bg-muted-foreground/40"
+                  style={{ width: `${eatenPct}%` }}
+                />
+                {/* This meal — under-target portion (color) */}
+                <div
+                  className={`absolute top-0 h-full ${colorMap[key]}`}
+                  style={{ left: `${eatenPct}%`, width: `${underPct}%` }}
+                />
+                {/* This meal — over-target portion (amber) */}
+                {overPct > 0 && (
+                  <div
+                    className="absolute top-0 h-full bg-amber-500"
+                    style={{ left: `${overshootStart}%`, width: `${overPct}%` }}
+                  />
+                )}
+                {/* Goal marker */}
+                <div className="absolute top-0 h-full w-[2px] bg-foreground/50" style={{ left: `${targetPct}%` }} />
+              </div>
+              <span className="w-24 text-right tabular-nums text-muted-foreground">
+                <span className={`${textColorMap[key]} font-medium`}>{Math.round(thisMeal)}g</span>
+                <span className="block text-[10px] text-muted-foreground/60">
+                  <span className={dayOverGoal ? "text-amber-500" : ""}>{Math.round(total)}</span> / {Math.round(target)} day
+                </span>
+              </span>
+            </div>
+          );
+        })}
       </div>
 
       {/* Volume score */}

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -109,6 +109,10 @@ interface MealCardProps {
   skipped?: boolean;
   slotBudget?: SlotBudget | null;
   ingredients?: any[];
+  /** Daily P/C/F/Fi targets — passed through to ComposeMealView for daily-progress bars. */
+  dayTargets?: { protein: number; carbs: number; fat: number; fiber: number } | null;
+  /** Daily P/C/F/Fi consumed today across all slots, raw (no live preview). */
+  dayConsumed?: { protein: number; carbs: number; fat: number; fiber: number } | null;
   onMealLogged: (changedSlot?: string) => void;
   onSlotSkipped?: () => void;
   onTotalsPreview?: (slot: string, totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number } | null) => void;
@@ -148,6 +152,8 @@ export function MealCard({
   skipped,
   slotBudget,
   ingredients,
+  dayTargets,
+  dayConsumed,
   onMealLogged,
   onSlotSkipped,
   onTotalsPreview,
@@ -870,11 +876,23 @@ export function MealCard({
             const composeBudget: SlotBudget | null = slotBudget
               ? { calories: Math.max(0, slotKcal - otherCal) }
               : null;
+            // dayConsumed includes ALL day's logged meals; when editing, subtract the
+            // meal being edited so the daily-progress bar isn't double-counting it.
+            const dayConsumedExcl = dayConsumed && editingMealMacros
+              ? {
+                  protein: Math.max(0, dayConsumed.protein - editingMealMacros.protein),
+                  carbs: Math.max(0, dayConsumed.carbs - editingMealMacros.carbs),
+                  fat: Math.max(0, dayConsumed.fat - editingMealMacros.fat),
+                  fiber: Math.max(0, dayConsumed.fiber - editingMealMacros.fiber),
+                }
+              : dayConsumed;
             return (
             <ComposeMealView
               portions={composedPortions}
               ingredients={(ingredients ?? []) as Ingredient[]}
               budget={composeBudget ?? null}
+              dayTargets={dayTargets ?? null}
+              dayConsumed={dayConsumedExcl ?? null}
               onLog={handleComposeLog}
               onCancel={handleComposeCancel}
               onEditIngredients={handleEditIngredients}

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -864,24 +864,38 @@ export function NutritionDashboard({
         )}
 
         {/* Meal cards */}
-        {slots.map((slot) => (
-          <MealCard
-            key={slot}
-            slot={slot}
-            meals={meals.filter((m) => m.meal_slot === slot)}
-            presets={presets}
-            ingredients={ingredients}
-            slotBudget={slotBudgets?.[slot] ?? null}
-            skipped={skippedSlots.includes(slot)}
-            date={date}
-            disabled={isClosed}
-            onMealLogged={(slot?: string) => handleMealChanged(slot)}
-            onSlotSkipped={refreshData}
-            onTotalsPreview={handleTotalsPreview}
-            locked={lockedSlots.has(slot)}
-            onLockToggle={handleLockToggle}
-          />
-        ))}
+        {slots.map((slot) => {
+          // Day-level macros (raw, no live preview) so each compose view can render
+          // daily-progress bars: "if I log this meal, where does my day end up?"
+          const dayConsumedRaw = {
+            protein: meals.reduce((s, m) => s + Number(m.protein || 0), 0),
+            carbs:
+              meals.reduce((s, m) => s + Number(m.carbs || 0), 0) +
+              drinks.reduce((s, d) => s + Number(d.carbs || 0), 0),
+            fat: meals.reduce((s, m) => s + Number(m.fat || 0), 0),
+            fiber: meals.reduce((s, m) => s + Number(m.fiber || 0), 0),
+          };
+          return (
+            <MealCard
+              key={slot}
+              slot={slot}
+              meals={meals.filter((m) => m.meal_slot === slot)}
+              presets={presets}
+              ingredients={ingredients}
+              slotBudget={slotBudgets?.[slot] ?? null}
+              dayTargets={{ protein: targetProtein, carbs: targetCarbs, fat: targetFat, fiber: targetFiber }}
+              dayConsumed={dayConsumedRaw}
+              skipped={skippedSlots.includes(slot)}
+              date={date}
+              disabled={isClosed}
+              onMealLogged={(slot?: string) => handleMealChanged(slot)}
+              onSlotSkipped={refreshData}
+              onTotalsPreview={handleTotalsPreview}
+              locked={lockedSlots.has(slot)}
+              onLockToggle={handleLockToggle}
+            />
+          );
+        })}
 
         {/* Drink logger */}
         <DrinkLogger


### PR DESCRIPTION
## Summary

Re-introduces visual macro feedback in the compose view that was lost in #81 (which correctly removed fake per-slot P/C/F/Fi caps). The previous "5 progress bars" preview was useful at-a-glance but built on an unscientific premise (proportional splits of the daily target as fake slot caps). This PR restores the visual richness using only scientifically defensible anchors.

## Anchors

- **Protein** — per-meal bar with MPS floor at **30g** (Schoenfeld & Aragon 2018, Trommelen 2023, ~0.4 g/kg). Below 30g → blue dim + "below MPS" pill. At/above 30g → blue solid + `ProteinQualityPill`. **No upper amber state** — going above 30g is never wrong.
- **Carbs / Fat / Fiber** — daily-progress bars. Grey = consumed today excluding this meal; colored = this meal would add; goal line at daily target. If `consumed + thisMeal > dailyTarget`, the over-portion of the meal renders amber so the user can see whether logging pushes the **day** past goal. **No per-slot caps**.
- **kcal** — existing per-slot soft pacing bar untouched.

## Type-level guarantee

`SlotBudget = { calories: number }` from #81 stays unchanged. The new `dayTargets` and `dayConsumed` props on `ComposeMealView` are separate, optional, and read from the daily plan response (never from per-slot data). The PR cannot reintroduce per-slot P/C/F/Fi caps without changing `SlotBudget` itself, which would require deleting the JSDoc invariant from #81.

## Edit-aware

When editing an existing meal, `MealCard` subtracts the editing meal's macros from `dayConsumed` before passing to `ComposeMealView`, so the daily-progress bars aren't double-counting the meal being edited.

## Files

- `web/components/compose-meal-view.tsx` — new bars (kcal unchanged, P with floor, C/F/Fi as daily-progress with day-overshoot signal)
- `web/components/meal-card.tsx` — pass-through props + editing-meal subtraction
- `web/components/nutrition-dashboard.tsx` — computes `dayConsumedRaw` (no preview) and `dayTargets`, threads them to each `MealCard`

## Verification

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 11/11 vitest green (existing portion-solver suite from #87 untouched)
- [x] Playwright on `localhost:3456` against live Apr 26 data (470 kcal / 49C eaten via breakfast, daily carb target 112g): composed a lunch with thigh + honey + oats + rice cakes + white rice (~93C this meal, ~23P, 553 kcal). **C bar** showed clear three-segment shape with amber over-portion past the goal line, right-side "142 / 112 day" in amber. **P bar** showed blue dim + "below MPS" pill (~23g, under 30g floor). **kcal bar** unchanged.
- [ ] Playwright on Vercel preview after CI green
- [ ] Playwright on `soma.gkos.dev` after merge + prod deploy

## Closes

Closes #88
Closes #89
Closes #90
Closes #91