### PR TITLE
feat(ui): day-progress macro bars with multi-goalposts (#93)

### DIFF
--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -432,6 +432,7 @@ export async function GET(req: NextRequest) {
         fat: dayTargets.fat,
         fiber: dayTargets.fiber,
       },
+      weightKg,
     };
 
     // ── Write-back: sync computed values to DB so stored matches dynamic ──

--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -24,17 +24,24 @@ interface DayMacros {
   carbs: number;
   fat: number;
   fiber: number;
+  calories: number;
 }
 
 interface ComposeMealViewProps {
   portions: PortionResult[];
   ingredients: Ingredient[];
   budget: SlotBudget | null;
-  /** Daily P/C/F/Fi targets. When provided, C/F/Fi render as daily-progress bars
-   *  (consumed-today + this-meal vs daily target). */
+  /** Daily P/C/F/Fi/kcal targets (the scalar daily target, not slot-pacing). */
   dayTargets?: DayMacros | null;
-  /** Daily consumed P/C/F/Fi BEFORE this meal (excludes the meal being edited). */
+  /** Daily P/C/F/Fi/kcal consumed BEFORE this meal (excludes the meal being edited).
+   *  Renders as the *darker* segment of each bar so the user can see how this meal
+   *  stacks on top of what they've already logged today. */
   dayConsumed?: DayMacros | null;
+  /** User's body weight (kg). Used to compute protein g/kg and fat g/kg goalposts. */
+  weightKg?: number | null;
+  /** Today's total burn (BMR + steps + workouts). Used as the "maintenance" goalpost
+   *  on the kcal bar — the gap from daily kcal target to total burn = today's deficit. */
+  totalBurn?: number | null;
   onLog: (
     items: { ingredient_id: string; grams: number; calories: number; protein: number; carbs: number; fat: number; fiber: number }[],
     totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number },
@@ -45,8 +52,24 @@ interface ComposeMealViewProps {
   onTotalsChange?: (totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number }) => void;
 }
 
-/** Per-meal protein anabolic floor (Schoenfeld & Aragon 2018; ≈0.4 g/kg). */
-const MPS_FLOOR_G = 30;
+/** Health floor for daily carbs (mirrors CARB_HEALTH_FLOOR_G in macro-targets.ts). */
+const CARB_HEALTH_FLOOR_G = 100;
+/** Fiber daily target (deficit-bumped) and ceiling. */
+const FIBER_TARGET_G = 30;
+const FIBER_CEILING_G = 60;
+/** Protein g/kg research anchors (Schoenfeld 2018, Helms et al). */
+const PROTEIN_G_PER_KG_TIERS = [1.6, 1.8, 2.0, 2.2] as const;
+/** Fat g/kg tiers (FAT_HARD_FLOOR / FAT_SOFT_FLOOR / FAT_MAINTENANCE_TARGET). */
+const FAT_G_PER_KG_TIERS = [0.6, 0.8, 1.0] as const;
+
+interface Goalpost {
+  value: number;
+  label: string;
+  /** 'achievement' (default): just a tier mark, no overlay past it.
+   *  'softCeiling': render orange overlay past this value (warning, not stop).
+   *  'hardCeiling': render red overlay past this value (real ceiling — stop). */
+  kind?: "achievement" | "softCeiling" | "hardCeiling";
+}
 
 export function ComposeMealView({
   portions: initialPortions,
@@ -54,6 +77,8 @@ export function ComposeMealView({
   budget,
   dayTargets,
   dayConsumed,
+  weightKg,
+  totalBurn,
   onLog,
   onCancel,
   onEditIngredients,
@@ -250,159 +275,162 @@ export function ComposeMealView({
         </div>
       )}
 
-      {/* Per-meal read-out.
-          kcal: per-slot soft pacing bar (kcal is the only macro with scientific
-            per-slot pacing — Schoenfeld & Aragon 2018).
-          Protein: per-meal bar with MPS floor at 30g. Below 30 → missed MPS
-            (blue dim); at/above 30 → blue solid + ProteinQualityPill. No upper cap.
-          C / F / Fi: daily-progress bars. Grey = consumed today excluding this
-            meal; colored = this meal would add; goal line at daily target;
-            over-portion past daily target renders amber so the user can see
-            whether logging this meal pushes the DAY past goal. */}
-      <div className="space-y-1.5 border-t pt-2">
-        {/* kcal pacing bar — slot-level (unchanged) */}
-        {(() => {
-          const kcalBudget = budget?.calories || 0;
-          const barMax = Math.max(kcalBudget * 1.3, totals.calories * 1.05, kcalBudget + 1);
-          const fillPct = barMax > 0 ? Math.min(100, (totals.calories / barMax) * 100) : 0;
-          const goalPct = barMax > 0 && kcalBudget > 0 ? Math.min(100, (kcalBudget / barMax) * 100) : 0;
-          return (
-            <div className="flex items-center gap-2 text-xs">
-              <span className="w-8 text-muted-foreground text-right">kcal</span>
-              <div
-                className="relative flex-1 h-2 bg-muted rounded-full overflow-hidden"
-                title="Per-meal kcal is a soft pacing hint — splits the daily target across slots. Going over here is fine as long as the day total lands right."
-              >
-                {kcalBudget > 0 && (
-                  <div className="absolute right-0 top-0 h-full bg-muted-foreground/10" style={{ width: `${100 - goalPct}%` }} />
-                )}
-                <div
-                  className="absolute left-0 top-0 h-full rounded-full transition-all bg-primary"
-                  style={{ width: `${fillPct}%` }}
-                />
-                {kcalBudget > 0 && (
-                  <div className="absolute top-0 h-full w-[2px] bg-foreground/40" style={{ left: `${goalPct}%` }} />
-                )}
-              </div>
-              <span className="w-24 text-right tabular-nums text-muted-foreground">
-                {Math.round(totals.calories)}
-                {kcalBudget > 0 && <span className="text-muted-foreground/60"> / {Math.round(kcalBudget)} budget</span>}
-              </span>
-            </div>
-          );
-        })()}
+      {/* Per-meal read-out — day-progress shape with multi-goalpost references.
+          Each bar shows:
+          - DARKER segment: macros eaten today before this meal (excludes the
+            meal being edited so we don't double-count).
+          - LIGHTER segment: this meal's preview, stacked on top.
+          - RED segment: portion that pushes the day total past the HIGHEST
+            goalpost (e.g. 2.2 g/kg for protein, fiber ceiling 60g, total burn
+            for kcal — eating past these is "meaningfully over").
+          - Multi-goalpost markers: thin vertical ticks at research-anchored
+            values (4 for protein at 1.6/1.8/2.0/2.2 g/kg, 3 for fat at
+            0.6/0.8/1.0 g/kg, 2 for carbs at 100g floor + today's target,
+            2 for fiber at 30g target / 60g ceiling, 2 for kcal at target +
+            total burn). Crossed (eaten + this meal ≥ marker) → dim. Ahead
+            → bright. NEVER hidden by fill. */}
+      {(() => {
+        const w = weightKg && weightKg > 0 ? weightKg : 0;
+        const dayKcalTarget = dayTargets?.calories ?? 0;
+        const burn = totalBurn && totalBurn > 0 ? totalBurn : 0;
 
-        {/* Protein bar — per-meal MPS floor at 30g (no upper cap) */}
-        {(() => {
-          const thisP = totals.protein;
-          const barMax = Math.max(MPS_FLOOR_G * 1.5, thisP * 1.1, MPS_FLOOR_G + 1);
-          const fillPct = Math.min(100, (thisP / barMax) * 100);
-          const floorPct = Math.min(100, (MPS_FLOOR_G / barMax) * 100);
-          const hitMps = thisP >= MPS_FLOOR_G;
-          const dayP = (dayConsumed?.protein ?? 0) + thisP;
-          const dayTargetP = dayTargets?.protein ?? 0;
-          return (
-            <div className="flex items-center gap-2 text-xs">
-              <span className="w-8 text-muted-foreground text-right">P</span>
-              <div
-                className="relative flex-1 h-2 bg-muted rounded-full overflow-hidden"
-                title={`MPS floor: ${MPS_FLOOR_G}g per meal (Schoenfeld & Aragon 2018). Above the floor is good — there is no upper cap.`}
-              >
-                <div
-                  className={`absolute left-0 top-0 h-full rounded-full transition-all ${hitMps ? "bg-blue-500" : "bg-blue-500/40"}`}
-                  style={{ width: `${fillPct}%` }}
-                />
-                <div className="absolute top-0 h-full w-[2px] bg-foreground/50" style={{ left: `${floorPct}%` }} />
-              </div>
-              <span className="w-24 text-right tabular-nums text-muted-foreground">
-                <span className={hitMps ? "text-blue-400 font-medium" : "text-blue-400/60 font-medium"}>{Math.round(thisP)}g</span>
-                <ProteinQualityPill grams={thisP} />
-                {dayTargetP > 0 && (
-                  <span className="block text-[10px] text-muted-foreground/60">
-                    {Math.round(dayP)} / {Math.round(dayTargetP)} day
-                  </span>
-                )}
-              </span>
-            </div>
-          );
-        })()}
+        // Goalpost taxonomy:
+        //  - kcal: target is a SOFT ceiling (orange — over goal but in deficit
+        //    is fine), burn is the HARD ceiling (red — surplus = stop).
+        //  - Protein/Carbs/Fat: only achievement tiers. No real upper ceiling
+        //    on any of these — eating past them is just "above the highest
+        //    research anchor", not wrong. No orange/red overlay.
+        //  - Fiber: 60g is the HARD ceiling (real GI distress threshold).
+        const goalposts: Record<"kcal" | "P" | "C" | "F" | "Fi", Goalpost[]> = {
+          kcal: [
+            ...(dayKcalTarget > 0 ? [{ value: dayKcalTarget, label: "goal", kind: "softCeiling" as const }] : []),
+            ...(burn > 0 ? [{ value: burn, label: "burn", kind: "hardCeiling" as const }] : []),
+          ],
+          P: w > 0
+            ? PROTEIN_G_PER_KG_TIERS.map((g) => ({ value: w * g, label: g.toFixed(1) }))
+            : (dayTargets?.protein ? [{ value: dayTargets.protein, label: "target" }] : []),
+          C: dayTargets?.carbs
+            ? [
+                { value: CARB_HEALTH_FLOOR_G, label: "min" },
+                { value: dayTargets.carbs, label: "target" },
+              ].sort((a, b) => a.value - b.value)
+            : [{ value: CARB_HEALTH_FLOOR_G, label: "min" }],
+          F: w > 0
+            ? FAT_G_PER_KG_TIERS.map((g) => ({ value: w * g, label: g.toFixed(1) }))
+            : (dayTargets?.fat ? [{ value: dayTargets.fat, label: "target" }] : []),
+          Fi: [
+            { value: FIBER_TARGET_G, label: "target" },
+            { value: FIBER_CEILING_G, label: "ceil", kind: "hardCeiling" },
+          ],
+        };
 
-        {/* Carbs / Fat / Fiber — daily-progress bars */}
-        {(["carbs", "fat", "fiber"] as const).map((key) => {
-          const labelMap = { carbs: "C", fat: "F", fiber: "Fi" } as const;
-          const colorMap = {
-            carbs: "bg-amber-500",
-            fat: "bg-rose-500",
-            fiber: "bg-green-500",
-          } as const;
-          const textColorMap = {
-            carbs: "text-amber-400",
-            fat: "text-rose-400",
-            fiber: "text-green-400",
-          } as const;
-          const eaten = dayConsumed?.[key] ?? 0;
-          const thisMeal = totals[key];
-          const target = dayTargets?.[key] ?? 0;
-          // Fall back to plain read-out if no daily target available (e.g. plan didn't load)
-          if (target <= 0) {
-            return (
-              <div key={key} className="flex items-center gap-2 text-xs">
-                <span className="w-8 text-muted-foreground text-right">{labelMap[key]}</span>
-                <div className="flex-1" />
-                <span className="w-24 text-right tabular-nums">
-                  <span className={`${textColorMap[key]} font-medium`}>{Math.round(thisMeal)}g</span>
-                </span>
-              </div>
-            );
-          }
+        type Key = "kcal" | "P" | "C" | "F" | "Fi";
+        const colorMap: Record<Key, { eaten: string; thisMeal: string; text: string }> = {
+          kcal: { eaten: "bg-primary/60", thisMeal: "bg-primary",     text: "text-foreground" },
+          P:    { eaten: "bg-blue-700",   thisMeal: "bg-blue-500",    text: "text-blue-400" },
+          C:    { eaten: "bg-amber-700",  thisMeal: "bg-amber-500",   text: "text-amber-400" },
+          F:    { eaten: "bg-rose-700",   thisMeal: "bg-rose-500",    text: "text-rose-400" },
+          Fi:   { eaten: "bg-green-700",  thisMeal: "bg-green-500",   text: "text-green-400" },
+        };
+
+        const data: Record<Key, { eaten: number; thisMeal: number; suffix: string; extra?: React.ReactNode }> = {
+          kcal: { eaten: dayConsumed?.calories ?? 0, thisMeal: totals.calories, suffix: "" },
+          P:    { eaten: dayConsumed?.protein ?? 0,  thisMeal: totals.protein,  suffix: "g", extra: <ProteinQualityPill grams={totals.protein} /> },
+          C:    { eaten: dayConsumed?.carbs ?? 0,    thisMeal: totals.carbs,    suffix: "g" },
+          F:    { eaten: dayConsumed?.fat ?? 0,      thisMeal: totals.fat,      suffix: "g" },
+          Fi:   { eaten: dayConsumed?.fiber ?? 0,    thisMeal: totals.fiber,    suffix: "g" },
+        };
+
+        const renderBar = (key: Key) => {
+          const { eaten, thisMeal, suffix, extra } = data[key];
+          const { eaten: eatenColor, thisMeal: liveColor, text: textColor } = colorMap[key];
+          const posts = goalposts[key];
           const total = eaten + thisMeal;
-          const barMax = Math.max(target * 1.3, total * 1.05, target + 1);
+          const highestPost = posts.length > 0 ? Math.max(...posts.map((g) => g.value)) : 0;
+          const softCeiling = posts.find((p) => p.kind === "softCeiling");
+          const hardCeiling = posts.find((p) => p.kind === "hardCeiling");
+
+          // Display denominator: prefer soft ceiling if exists (kcal goal),
+          // else hard ceiling (fiber 60g), else the highest achievement tier.
+          const displayRef = softCeiling?.value ?? hardCeiling?.value ?? highestPost;
+
+          // barMax: enough headroom for highest goalpost + ~5% past total when over.
+          const barMax = Math.max(highestPost * 1.15, total * 1.05, 1);
+
           const eatenPct = Math.min(100, (eaten / barMax) * 100);
-          const targetPct = Math.min(100, (target / barMax) * 100);
-          // Amber over-portion: only the part of `thisMeal` that exceeds the daily target.
-          const underTarget = Math.max(0, Math.min(target, total) - eaten);
-          const overTarget = Math.max(0, total - Math.max(target, eaten));
-          const underPct = Math.min(100, (underTarget / barMax) * 100);
-          const overPct = Math.min(100, (overTarget / barMax) * 100);
-          const overshootStart = Math.max(eatenPct, targetPct);
-          const dayOverGoal = total > target;
+          const totalPct = Math.min(100, (total / barMax) * 100);
+
+          const pastSoft = !!softCeiling && total > softCeiling.value;
+          const pastHard = !!hardCeiling && total > hardCeiling.value;
+          // Orange runs from softCeiling to min(total, hardCeiling).
+          // Red runs from hardCeiling to total.
+          const softStartPct = softCeiling ? Math.min(100, (softCeiling.value / barMax) * 100) : 0;
+          const orangeEndValue = hardCeiling ? Math.min(total, hardCeiling.value) : total;
+          const orangeEndPct = Math.min(100, (orangeEndValue / barMax) * 100);
+          const hardStartPct = hardCeiling ? Math.min(100, (hardCeiling.value / barMax) * 100) : 100;
+
           return (
             <div key={key} className="flex items-center gap-2 text-xs">
-              <span className="w-8 text-muted-foreground text-right">{labelMap[key]}</span>
-              <div
-                className="relative flex-1 h-2 bg-muted rounded-full overflow-hidden"
-                title={`Day so far ${Math.round(eaten)}g + this meal ${Math.round(thisMeal)}g = ${Math.round(total)}g vs ${Math.round(target)}g daily target. Daily totals matter, not per-meal.`}
-              >
-                {/* Already-eaten today (grey) */}
-                <div
-                  className="absolute left-0 top-0 h-full bg-muted-foreground/40"
-                  style={{ width: `${eatenPct}%` }}
-                />
-                {/* This meal — under-target portion (color) */}
-                <div
-                  className={`absolute top-0 h-full ${colorMap[key]}`}
-                  style={{ left: `${eatenPct}%`, width: `${underPct}%` }}
-                />
-                {/* This meal — over-target portion (amber) */}
-                {overPct > 0 && (
-                  <div
-                    className="absolute top-0 h-full bg-amber-500"
-                    style={{ left: `${overshootStart}%`, width: `${overPct}%` }}
-                  />
+              <span className="w-8 text-muted-foreground text-right">{key}</span>
+              <div className="relative flex-1 h-2 bg-muted rounded-full overflow-hidden">
+                {/* Section 1: eaten today before this meal — DARKER shade. */}
+                {eatenPct > 0 && (
+                  <div className={`absolute left-0 top-0 h-full ${eatenColor}`}
+                    style={{ width: `${eatenPct}%` }} />
                 )}
-                {/* Goal marker */}
-                <div className="absolute top-0 h-full w-[2px] bg-foreground/50" style={{ left: `${targetPct}%` }} />
+                {/* Section 2: this meal — NORMAL/lighter shade, stacked on top. */}
+                {totalPct > eatenPct && (
+                  <div className={`absolute top-0 h-full ${liveColor}`}
+                    style={{ left: `${eatenPct}%`, width: `${totalPct - eatenPct}%` }} />
+                )}
+                {/* Soft-ceiling overlay (orange) — only when this macro has a
+                    soft ceiling and total has crossed it. Stops at the hard
+                    ceiling (or total if no hard ceiling). */}
+                {pastSoft && orangeEndPct > softStartPct && (
+                  <div className="absolute top-0 h-full bg-amber-500"
+                    style={{ left: `${softStartPct}%`, width: `${orangeEndPct - softStartPct}%` }} />
+                )}
+                {/* Hard-ceiling overlay (red) — only when this macro has a
+                    hard ceiling and total has crossed it. */}
+                {pastHard && (
+                  <div className="absolute top-0 h-full bg-red-500"
+                    style={{ left: `${hardStartPct}%`, width: `${totalPct - hardStartPct}%` }} />
+                )}
+                {/* Goalpost markers. Always opaque so fill can't hide them.
+                    Crossed = dim (foreground/40), ahead = bright (foreground). */}
+                {posts.map((g, i) => {
+                  const pct = Math.min(100, (g.value / barMax) * 100);
+                  const crossed = total >= g.value;
+                  return (
+                    <div
+                      key={i}
+                      className={`absolute top-0 h-full w-[2px] ${crossed ? "bg-foreground/40" : "bg-foreground"}`}
+                      style={{ left: `${pct}%` }}
+                      title={`${g.label}: ${Math.round(g.value)}${suffix}`}
+                    />
+                  );
+                })}
               </div>
               <span className="w-24 text-right tabular-nums text-muted-foreground">
-                <span className={`${textColorMap[key]} font-medium`}>{Math.round(thisMeal)}g</span>
+                <span className={`${textColor} font-medium`}>{Math.round(thisMeal)}{suffix}</span>
+                {extra}
                 <span className="block text-[10px] text-muted-foreground/60">
-                  <span className={dayOverGoal ? "text-amber-500" : ""}>{Math.round(total)}</span> / {Math.round(target)} day
+                  <span className={pastHard ? "text-red-500" : pastSoft ? "text-amber-500" : ""}>
+                    {Math.round(total)}
+                  </span>
+                  {displayRef > 0 && <> / {Math.round(displayRef)}</>} day
                 </span>
               </span>
             </div>
           );
-        })}
-      </div>
+        };
+
+        return (
+          <div className="space-y-1.5 border-t pt-2">
+            {(["kcal", "P", "C", "F", "Fi"] as const).map(renderBar)}
+          </div>
+        );
+      })()}
 
       {/* Volume score */}
       {totals.calories > 0 && (

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -109,10 +109,14 @@ interface MealCardProps {
   skipped?: boolean;
   slotBudget?: SlotBudget | null;
   ingredients?: any[];
-  /** Daily P/C/F/Fi targets — passed through to ComposeMealView for daily-progress bars. */
-  dayTargets?: { protein: number; carbs: number; fat: number; fiber: number } | null;
-  /** Daily P/C/F/Fi consumed today across all slots, raw (no live preview). */
-  dayConsumed?: { protein: number; carbs: number; fat: number; fiber: number } | null;
+  /** Daily P/C/F/Fi/kcal targets — drives goalposts in compose view. */
+  dayTargets?: { protein: number; carbs: number; fat: number; fiber: number; calories: number } | null;
+  /** Daily P/C/F/Fi/kcal consumed today across all slots, raw (no live preview). */
+  dayConsumed?: { protein: number; carbs: number; fat: number; fiber: number; calories: number } | null;
+  /** User body weight (kg) — used to compute g/kg goalposts on protein/fat bars. */
+  weightKg?: number | null;
+  /** Today's total burn (BMR + steps + workouts) — kcal "burn" goalpost. */
+  totalBurn?: number | null;
   onMealLogged: (changedSlot?: string) => void;
   onSlotSkipped?: () => void;
   onTotalsPreview?: (slot: string, totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number } | null) => void;
@@ -154,6 +158,8 @@ export function MealCard({
   ingredients,
   dayTargets,
   dayConsumed,
+  weightKg,
+  totalBurn,
   onMealLogged,
   onSlotSkipped,
   onTotalsPreview,
@@ -884,6 +890,7 @@ export function MealCard({
                   carbs: Math.max(0, dayConsumed.carbs - editingMealMacros.carbs),
                   fat: Math.max(0, dayConsumed.fat - editingMealMacros.fat),
                   fiber: Math.max(0, dayConsumed.fiber - editingMealMacros.fiber),
+                  calories: Math.max(0, dayConsumed.calories - editingMealMacros.calories),
                 }
               : dayConsumed;
             return (
@@ -893,6 +900,8 @@ export function MealCard({
               budget={composeBudget ?? null}
               dayTargets={dayTargets ?? null}
               dayConsumed={dayConsumedExcl ?? null}
+              weightKg={weightKg ?? null}
+              totalBurn={totalBurn ?? null}
               onLog={handleComposeLog}
               onCancel={handleComposeCancel}
               onEditIngredients={handleEditIngredients}

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -136,6 +136,15 @@ const MEAL_SLOTS = ["breakfast", "lunch", "dinner", "pre_sleep"] as const;
  *   - Carbs: floor = target, ceiling = null (kcal-implicit upper).
  *   - Fiber: floor = target, ceiling = 60g (phytate cap, V2 §2.4).
  */
+interface MacroMarker {
+  value: number;
+  label: string;
+  /** 'achievement' (default): just a tier mark, no overlay past it.
+   *  'softCeiling': orange overlay past this value (warning).
+   *  'hardCeiling': red overlay past this value (real ceiling). */
+  kind?: "achievement" | "softCeiling" | "hardCeiling";
+}
+
 function MacroBar({
   label,
   current,
@@ -143,6 +152,8 @@ function MacroBar({
   color,
   floor,
   ceiling,
+  markers,
+  unit = "g",
 }: {
   label: string;
   current: number;
@@ -150,33 +161,59 @@ function MacroBar({
   color: string;
   floor?: number | null;
   ceiling?: number | null;
+  /** Multi-goalposts. When provided, replaces floor/ceiling rendering with a
+   *  research-anchored set of ticks. Crossed markers render dim, ahead markers
+   *  bright. Bar fill stays in the macro's color until past the HIGHEST marker;
+   *  past the highest, an extra red overlay signals "meaningfully over". */
+  markers?: MacroMarker[];
+  unit?: string;
 }) {
-  // Axis scale: leave room past the highest anchor so both markers show.
-  const axisAnchors = [
-    target * 1.15,
-    floor != null ? floor * 1.15 : 0,
-    ceiling != null ? ceiling * 1.05 : 0,
-    current * 1.05,
-    target + 1,
-  ];
+  const useMulti = !!markers && markers.length > 0;
+  const highest = useMulti ? Math.max(...markers!.map((m) => m.value)) : 0;
+  const softCeiling = useMulti ? markers!.find((m) => m.kind === "softCeiling") : undefined;
+  const hardCeiling = useMulti ? markers!.find((m) => m.kind === "hardCeiling") : undefined;
+
+  // Axis scale: leave room past the highest anchor so all markers show.
+  const axisAnchors = useMulti
+    ? [highest * 1.15, current * 1.05, highest + 1]
+    : [
+        target * 1.15,
+        floor != null ? floor * 1.15 : 0,
+        ceiling != null ? ceiling * 1.05 : 0,
+        current * 1.05,
+        target + 1,
+      ];
   const maxVal = Math.max(...axisAnchors);
   const fillPct = maxVal > 0 ? Math.min(100, (current / maxVal) * 100) : 0;
-  const floorPct = floor != null && maxVal > 0
-    ? Math.min(100, (floor / maxVal) * 100)
-    : null;
-  const ceilingPct = ceiling != null && maxVal > 0
-    ? Math.min(100, (ceiling / maxVal) * 100)
-    : null;
 
-  const overCeiling = ceiling != null && current > ceiling;
-  const underFloor = floor != null && current < floor;
+  const pastSoft = !!softCeiling && current > softCeiling.value;
+  const pastHard = !!hardCeiling && current > hardCeiling.value;
+  const softStartPct = softCeiling && maxVal > 0
+    ? Math.min(100, (softCeiling.value / maxVal) * 100) : 0;
+  const orangeEndValue = hardCeiling ? Math.min(current, hardCeiling.value) : current;
+  const orangeEndPct = useMulti && maxVal > 0
+    ? Math.min(100, (orangeEndValue / maxVal) * 100) : 0;
+  const hardStartPct = hardCeiling && maxVal > 0
+    ? Math.min(100, (hardCeiling.value / maxVal) * 100) : 100;
+
+  // Display denominator: prefer soft ceiling if exists, else hard ceiling,
+  // else highest achievement tier.
+  const displayRef = useMulti ? (softCeiling?.value ?? hardCeiling?.value ?? highest) : target;
+
+  // Legacy floor/ceiling support (used when markers prop not provided).
+  const floorPct = !useMulti && floor != null && maxVal > 0
+    ? Math.min(100, (floor / maxVal) * 100) : null;
+  const ceilingPct = !useMulti && ceiling != null && maxVal > 0
+    ? Math.min(100, (ceiling / maxVal) * 100) : null;
+  const overCeiling = !useMulti && ceiling != null && current > ceiling;
+  const underFloor = !useMulti && floor != null && current < floor;
 
   return (
     <div className="space-y-0.5">
       <div className="flex justify-between text-xs lg:text-sm text-muted-foreground">
         <span>{label}</span>
-        <span className={overCeiling ? "text-amber-500 font-medium" : ""}>
-          {Math.round(current)}/{Math.round(target)}g
+        <span className={pastHard || overCeiling ? "text-red-500 font-medium" : pastSoft ? "text-amber-500 font-medium" : ""}>
+          {Math.round(current)}/{Math.round(displayRef)}{unit}
           {underFloor && (
             <span className="ml-1 text-[10px] text-muted-foreground/70">
               (−{Math.round(floor! - current)} to floor)
@@ -185,8 +222,8 @@ function MacroBar({
         </span>
       </div>
       <div className="relative h-2 rounded-full overflow-hidden bg-muted">
-        {/* Ceiling danger zone — muted warm tint past the ceiling */}
-        {ceilingPct !== null && (
+        {/* Legacy ceiling danger zone (only when not using multi-markers) */}
+        {!useMulti && ceilingPct !== null && (
           <div
             className="absolute right-0 top-0 h-full bg-amber-500/10"
             style={{ width: `${100 - ceilingPct}%` }}
@@ -194,23 +231,54 @@ function MacroBar({
         )}
         {/* Fill */}
         <div
-          className={`absolute left-0 top-0 h-full rounded-full transition-all ${overCeiling ? "bg-amber-500" : color}`}
+          className={`absolute left-0 top-0 h-full rounded-full transition-all ${
+            overCeiling && !useMulti ? "bg-amber-500" : color
+          }`}
           style={{ width: `${fillPct}%` }}
         />
-        {/* Floor marker (teal) — "eat at least here" */}
+        {/* Soft-ceiling overlay (orange) — only when macro has a soft ceiling
+            and current has crossed it. Stops at the hard ceiling (or current). */}
+        {useMulti && pastSoft && orangeEndPct > softStartPct && (
+          <div
+            className="absolute top-0 h-full bg-amber-500"
+            style={{ left: `${softStartPct}%`, width: `${orangeEndPct - softStartPct}%` }}
+          />
+        )}
+        {/* Hard-ceiling overlay (red) — only when macro has a hard ceiling
+            and current has crossed it. */}
+        {useMulti && pastHard && (
+          <div
+            className="absolute top-0 h-full bg-red-500"
+            style={{ left: `${hardStartPct}%`, width: `${fillPct - hardStartPct}%` }}
+          />
+        )}
+        {/* Multi-markers — opaque, dim if crossed, bright if ahead. Always visible. */}
+        {useMulti && markers!.map((m, i) => {
+          const pct = Math.min(100, (m.value / maxVal) * 100);
+          const crossed = current >= m.value;
+          return (
+            <div
+              key={i}
+              className={`absolute top-0 h-full w-[2px] ${crossed ? "bg-foreground/40" : "bg-foreground"}`}
+              style={{ left: `calc(${Math.min(pct, 99.5)}% - 1px)` }}
+              title={`${m.label}: ${Math.round(m.value)}${unit}`}
+            />
+          );
+        })}
+        {/* Legacy floor marker */}
         {floorPct !== null && floor! > 0 && (
           <div
             className="absolute top-0 h-full w-[2px] bg-teal-500/70"
             style={{ left: `calc(${Math.min(floorPct, 99.5)}% - 1px)` }}
-            title={`Floor: ${Math.round(floor!)}g — aim to reach this`}
+            title={`Floor: ${Math.round(floor!)}${unit} — aim to reach this`}
           />
         )}
-        {/* Ceiling marker (warm) — "don't cross this" */}
+        {/* Legacy ceiling marker */}
         {ceilingPct !== null && ceiling! > 0 && (
           <div
             className="absolute top-0 h-full w-[2px] bg-amber-500"
             style={{ left: `calc(${Math.min(ceilingPct, 99.5)}% - 1px)` }}
-            title={`Ceiling: ${Math.round(ceiling!)}g — do not exceed`}
+            title={`Ceiling: ${Math.round(ceiling!)}${unit} — do not exceed`}
           />
         )}
       </div>
@@ -726,21 +794,41 @@ export function NutritionDashboard({
                 )}
               </div>
 
-              {/* Macro bars (always visible) */}
-              {dataReady ? (
-                <div className="grid gap-2 pt-1">
-                  <MacroBar label="Protein" current={consumedProtein} target={targetProtein}
-                    color="bg-blue-500" floor={targetProtein} ceiling={null} />
-                  <MacroBar label="Carbs" current={consumedCarbs} target={targetCarbs}
-                    color="bg-amber-500" floor={targetCarbs} ceiling={null} />
-                  <MacroBar label="Fat" current={consumedFat} target={targetFat}
-                    color="bg-rose-500" floor={targetFat} ceiling={null} />
-                  {targetFiber > 0 && (
-                    <MacroBar label="Fiber" current={consumedFiber} target={targetFiber}
-                      color="bg-green-500" floor={targetFiber} ceiling={60} />
-                  )}
-                </div>
-              ) : (
+              {/* Macro bars (always visible) — multi-goalpost mode.
+                  Each macro gets its natural research-anchored markers, not a
+                  forced "4 goalposts everywhere". Crossed markers dim, ahead
+                  bright. Past the highest marker = red overlay. */}
+              {dataReady ? (() => {
+                const w = (breakdown as any)?.weightKg ?? 0;
+                const proteinMarkers = w > 0
+                  ? [1.6, 1.8, 2.0, 2.2].map((g) => ({ value: w * g, label: g.toFixed(1) }))
+                  : [{ value: targetProtein, label: "target" }];
+                const fatMarkers = w > 0
+                  ? [0.6, 0.8, 1.0].map((g) => ({ value: w * g, label: g.toFixed(1) }))
+                  : [{ value: targetFat, label: "target" }];
+                const carbMarkers = [
+                  { value: 100, label: "min" },
+                  { value: targetCarbs, label: "target" },
+                ].sort((a, b) => a.value - b.value);
+                const fiberMarkers: MacroMarker[] = [
+                  { value: targetFiber || 30, label: "target" },
+                  { value: 60, label: "ceil", kind: "hardCeiling" },
+                ];
+                return (
+                  <div className="grid gap-2 pt-1">
+                    <MacroBar label="Protein" current={consumedProtein} target={targetProtein}
+                      color="bg-blue-500" markers={proteinMarkers} />
+                    <MacroBar label="Carbs" current={consumedCarbs} target={targetCarbs}
+                      color="bg-amber-500" markers={carbMarkers} />
+                    <MacroBar label="Fat" current={consumedFat} target={targetFat}
+                      color="bg-rose-500" markers={fatMarkers} />
+                    {targetFiber > 0 && (
+                      <MacroBar label="Fiber" current={consumedFiber} target={targetFiber}
+                        color="bg-green-500" markers={fiberMarkers} />
+                    )}
+                  </div>
+                );
+              })() : (
                 <div className="h-24" />
               )}
             </CardContent>
@@ -866,7 +954,7 @@ export function NutritionDashboard({
         {/* Meal cards */}
         {slots.map((slot) => {
           // Day-level macros (raw, no live preview) so each compose view can render
-          // daily-progress bars: "if I log this meal, where does my day end up?"
+          // day-progress bars + multi-goalposts.
           const dayConsumedRaw = {
             protein: meals.reduce((s, m) => s + Number(m.protein || 0), 0),
             carbs:
@@ -874,7 +962,12 @@ export function NutritionDashboard({
               drinks.reduce((s, d) => s + Number(d.carbs || 0), 0),
             fat: meals.reduce((s, m) => s + Number(m.fat || 0), 0),
             fiber: meals.reduce((s, m) => s + Number(m.fiber || 0), 0),
+            calories:
+              meals.reduce((s, m) => s + Number(m.calories || 0), 0) +
+              drinks.reduce((s, d) => s + Number(d.calories || 0), 0),
           };
+          const userWeightKg = (breakdown as any)?.weightKg ?? null;
+          const todayTotalBurn = (breakdown as any)?.totalBurn ?? null;
           return (
             <MealCard
               key={slot}
@@ -883,8 +976,10 @@ export function NutritionDashboard({
               presets={presets}
               ingredients={ingredients}
               slotBudget={slotBudgets?.[slot] ?? null}
-              dayTargets={{ protein: targetProtein, carbs: targetCarbs, fat: targetFat, fiber: targetFiber }}
+              dayTargets={{ protein: targetProtein, carbs: targetCarbs, fat: targetFat, fiber: targetFiber, calories: targetCal }}
               dayConsumed={dayConsumedRaw}
+              weightKg={userWeightKg}
+              totalBurn={todayTotalBurn}
               skipped={skippedSlots.includes(slot)}
               date={date}
               disabled={isClosed}


### PR DESCRIPTION
## Summary

Replaces the per-slot pacing iteration from #88 / PR #92. The compose view and the dashboard daily MacroBars now share the same shape: **darker eaten + lighter this-meal** segments, **multi-goalpost** markers always opaque, **orange/red overlays** only past real ceilings.

## Bar shape (uniform across compose + dashboard)

- **Darker shade** = macros eaten today *before this meal* (excludes the meal being edited).
- **Lighter shade** = this meal's preview, stacked on top.
- **Goalpost markers** always opaque. Crossed → dim (`foreground/40`). Ahead → bright (`foreground`). Never hidden by fill.
- **Orange overlay** only past a `softCeiling` marker (warning, not stop).
- **Red overlay** only past a `hardCeiling` marker (real ceiling — stop).

## Per-macro goalposts

Only as many as naturally fit each macro (research-anchored, not forced "4 everywhere"):

| Macro | Markers | Soft ceiling | Hard ceiling |
|---|---|---|---|
| kcal | target + total burn | target (orange past goal) | total burn (red past surplus) |
| Protein | 1.6 / 1.8 / 2.0 / 2.2 g/kg | — | — (no real ceiling) |
| Carbs | 100g floor + matrix target | — | — (no real ceiling) |
| Fat | 0.6 / 0.8 / 1.0 g/kg | — | — (no real ceiling) |
| Fiber | 30g target + 60g ceiling | — | 60g (real GI distress threshold) |

## Type-level guarantees

- `SlotBudget = { calories: number }` from #81 unchanged.
- New `MacroMarker { value, label, kind?: 'achievement' | 'softCeiling' | 'hardCeiling' }` API on `MacroBar` is additive. Legacy `floor` / `ceiling` props still work for any callsite that hasn't migrated.
- Per-meal P/C/F/Fi values stay client-side display state (computed from `dayTargets`, `dayConsumed`, `weightKg`, `totalBurn`) — never enter the data layer or the portion solver.

## Files

- `web/app/api/nutrition/plan/route.ts` — expose `weightKg` in breakdown so dashboard can compute g/kg tiers without an extra query.
- `web/components/compose-meal-view.tsx` — reworked bar section (~150 LoC).
- `web/components/meal-card.tsx` — thread `weightKg` + `totalBurn` through.
- `web/components/nutrition-dashboard.tsx` — `MacroBar` gains multi-marker API; per-macro marker arrays at call sites.

## Verification

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 11/11 vitest green (existing portion-solver suite untouched)
- [x] Playwright on `localhost:3456` against live Apr 26 data:
  - Composed lunch with chicken thigh + olive oil + white rice cranked to ~1900 kcal → day total 2817, past kcal target 1743 AND past burn 2543. **Orange band** rendered between 1743 and 2543, **small red** rendered past 2543. Subtitle `2817` in red text.
  - Same meal pushed protein to 166g, carbs to 270g, fat to 119g — past every tier on each macro. **No overlay** on any of them (no real ceiling). All tier markers dimmed (crossed). Subtitle numbers stay neutral (no red).
  - Fiber stayed at 12g (under 60 ceiling) → no overlay, both markers bright.
  - Dashboard MacroBars and compose bars produced identical shape and overlay logic.
- [ ] Playwright on Vercel preview after CI green
- [ ] Playwright on `soma.gkos.dev` after merge + prod deploy

## Closes

Closes #93
Closes #94
Closes #95
Closes #96