### PR TITLE
feat(ui): show fiber on per-ingredient macro readout (#99)

### DIFF
--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -204,7 +204,7 @@ export function ComposeMealView({
                 <span className="truncate flex-1 min-w-0">
                   {ing?.name ?? p.ingredient_id}
                   <span className="block text-[10px] text-muted-foreground">
-                    {p.calories}kcal · {p.protein}P · {p.carbs}C · {p.fat}F
+                    {p.calories}kcal · {p.protein}P · {p.carbs}C · {p.fat}F · {p.fiber}Fi
                   </span>
                 </span>
                 {ing && isCountBased(ing) && !gramMode.has(p.ingredient_id) ? (


### PR DESCRIPTION
## Summary

Each ingredient row in the composed-meal panel previously read `{kcal}kcal · {P}P · {C}C · {F}F`. Fiber was missing — added for parity with the bottom-summary bars (which already include Fi).

## Change

Single-line edit at `web/components/compose-meal-view.tsx:207`:

```diff
-{p.calories}kcal · {p.protein}P · {p.carbs}C · {p.fat}F
+{p.calories}kcal · {p.protein}P · {p.carbs}C · {p.fat}F · {p.fiber}Fi
```

`p.fiber` was already on the `PortionResult` object (used at line 157 when building the log payload), so no plumbing required.

## Verification

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 11/11 vitest green
- [x] grepped — only one occurrence of this readout pattern in the codebase

## Closes

Closes #99
Closes #100