### PR TITLE
feat(ui): color-coded macro goalpost markers + hover descriptions (#102)

### DIFF
--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -67,8 +67,14 @@ interface Goalpost {
   label: string;
   /** 'achievement' (default): just a tier mark, no overlay past it.
    *  'softCeiling': render orange overlay past this value (warning, not stop).
-   *  'hardCeiling': render red overlay past this value (real ceiling — stop). */
+   *  'hardCeiling': render red overlay past this value + RED marker (real ceiling — stop). */
   kind?: "achievement" | "softCeiling" | "hardCeiling";
+  /** Optimal hit-this target for this macro. Renders the marker line in GREEN.
+   *  Independent from `kind` — kcal target is BOTH softCeiling (orange overlay
+   *  past) AND optimal (green marker line). */
+  optimal?: boolean;
+  /** Hover tooltip text. Falls back to "{label}: {value}" if not provided. */
+  description?: string;
 }
 
 export function ComposeMealView({
@@ -295,32 +301,78 @@ export function ComposeMealView({
         const burn = totalBurn && totalBurn > 0 ? totalBurn : 0;
 
         // Goalpost taxonomy:
-        //  - kcal: target is a SOFT ceiling (orange — over goal but in deficit
-        //    is fine), burn is the HARD ceiling (red — surplus = stop).
-        //  - Protein/Carbs/Fat: only achievement tiers. No real upper ceiling
-        //    on any of these — eating past them is just "above the highest
-        //    research anchor", not wrong. No orange/red overlay.
-        //  - Fiber: 60g is the HARD ceiling (real GI distress threshold).
+        //  Markers are COLOR-CODED by meaning:
+        //    - red    = hardCeiling (don't cross): kcal burn, fiber 60g.
+        //    - green  = optimal hit-this target: kcal goal, protein 2.2 g/kg
+        //               (user pref), carbs today's matrix target, fat 0.8 g/kg
+        //               (research-consensus cutting target), fiber 30g.
+        //    - white  = other achievement tiers.
+        //  Each marker has a description for hover.
+        const proteinDescs: Record<string, string> = {
+          "1.6": "Hypertrophy minimum (Schoenfeld 2018 meta)",
+          "1.8": "Common cutting target",
+          "2.0": "Conservative high — diminishing returns past this",
+          "2.2": "Aggressive cut sweet spot — best muscle preservation in deficit",
+        };
+        const fatDescs: Record<string, string> = {
+          "0.6": "Hormone-risk floor — going below for long deficits suppresses test/T3",
+          "0.8": "Sufficient for hormones, leaves carbs for training (cutting consensus)",
+          "1.0": "Maintenance/bulk target — no extra hormonal benefit in deficit",
+        };
         const goalposts: Record<"kcal" | "P" | "C" | "F" | "Fi", Goalpost[]> = {
           kcal: [
-            ...(dayKcalTarget > 0 ? [{ value: dayKcalTarget, label: "goal", kind: "softCeiling" as const }] : []),
-            ...(burn > 0 ? [{ value: burn, label: "burn", kind: "hardCeiling" as const }] : []),
+            ...(dayKcalTarget > 0 ? [{
+              value: dayKcalTarget, label: "goal",
+              kind: "softCeiling" as const,
+              optimal: true,
+              description: "Daily deficit target — hit this to land your goal",
+            }] : []),
+            ...(burn > 0 ? [{
+              value: burn, label: "burn",
+              kind: "hardCeiling" as const,
+              description: "Total burn (BMR + steps + workouts). Past this is surplus.",
+            }] : []),
           ],
           P: w > 0
-            ? PROTEIN_G_PER_KG_TIERS.map((g) => ({ value: w * g, label: g.toFixed(1) }))
-            : (dayTargets?.protein ? [{ value: dayTargets.protein, label: "target" }] : []),
+            ? PROTEIN_G_PER_KG_TIERS.map((g) => ({
+                value: w * g,
+                label: g.toFixed(1),
+                optimal: g === 2.2,
+                description: proteinDescs[g.toFixed(1)],
+              }))
+            : (dayTargets?.protein ? [{ value: dayTargets.protein, label: "target", optimal: true }] : []),
           C: dayTargets?.carbs
             ? [
-                { value: CARB_HEALTH_FLOOR_G, label: "min" },
-                { value: dayTargets.carbs, label: "target" },
+                {
+                  value: CARB_HEALTH_FLOOR_G, label: "min",
+                  description: "Health floor — keto-ish below this",
+                },
+                {
+                  value: dayTargets.carbs, label: "target",
+                  optimal: true,
+                  description: "Today's matrix-computed carb target",
+                },
               ].sort((a, b) => a.value - b.value)
             : [{ value: CARB_HEALTH_FLOOR_G, label: "min" }],
           F: w > 0
-            ? FAT_G_PER_KG_TIERS.map((g) => ({ value: w * g, label: g.toFixed(1) }))
-            : (dayTargets?.fat ? [{ value: dayTargets.fat, label: "target" }] : []),
+            ? FAT_G_PER_KG_TIERS.map((g) => ({
+                value: w * g,
+                label: g.toFixed(1),
+                optimal: g === 0.8,
+                description: fatDescs[g.toFixed(1)],
+              }))
+            : (dayTargets?.fat ? [{ value: dayTargets.fat, label: "target", optimal: true }] : []),
           Fi: [
-            { value: FIBER_TARGET_G, label: "target" },
-            { value: FIBER_CEILING_G, label: "ceil", kind: "hardCeiling" },
+            {
+              value: FIBER_TARGET_G, label: "target",
+              optimal: true,
+              description: "Daily fiber target — gut health + satiety",
+            },
+            {
+              value: FIBER_CEILING_G, label: "ceil",
+              kind: "hardCeiling",
+              description: "GI distress threshold — past this risks bloating/cramps",
+            },
           ],
         };
 
@@ -396,17 +448,31 @@ export function ComposeMealView({
                   <div className="absolute top-0 h-full bg-red-500"
                     style={{ left: `${hardStartPct}%`, width: `${totalPct - hardStartPct}%` }} />
                 )}
-                {/* Goalpost markers. Always opaque so fill can't hide them.
-                    Crossed = dim (foreground/40), ahead = bright (foreground). */}
+                {/* Goalpost markers. Always visible regardless of fill overlap.
+                    Color = meaning:
+                      red    = don't cross (hardCeiling)
+                      green  = optimal hit-this target
+                      white  = other achievement tier
+                    Crossed markers render at /40 opacity (dimmer but still visible). */}
                 {posts.map((g, i) => {
                   const pct = Math.min(100, (g.value / barMax) * 100);
                   const crossed = total >= g.value;
+                  const colorClass =
+                    g.kind === "hardCeiling"
+                      ? (crossed ? "bg-red-500/40" : "bg-red-500")
+                      : g.optimal
+                        ? (crossed ? "bg-green-500/40" : "bg-green-500")
+                        : (crossed ? "bg-foreground/40" : "bg-foreground");
                   return (
                     <div
                       key={i}
-                      className={`absolute top-0 h-full w-[2px] ${crossed ? "bg-foreground/40" : "bg-foreground"}`}
+                      className={`absolute top-0 h-full w-[2px] ${colorClass}`}
                       style={{ left: `${pct}%` }}
-                      title={`${g.label}: ${Math.round(g.value)}${suffix}`}
+                      title={
+                        g.description
+                          ? `${g.description} (${Math.round(g.value)}${suffix})`
+                          : `${g.label}: ${Math.round(g.value)}${suffix}`
+                      }
                     />
                   );
                 })}

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -141,8 +141,13 @@ interface MacroMarker {
   label: string;
   /** 'achievement' (default): just a tier mark, no overlay past it.
    *  'softCeiling': orange overlay past this value (warning).
-   *  'hardCeiling': red overlay past this value (real ceiling). */
+   *  'hardCeiling': red overlay + RED marker past this value (real ceiling). */
   kind?: "achievement" | "softCeiling" | "hardCeiling";
+  /** Optimal hit-this target — renders the marker line in GREEN. Independent
+   *  from `kind` (e.g. kcal target is BOTH softCeiling and optimal). */
+  optimal?: boolean;
+  /** Hover tooltip text. Falls back to "{label}: {value}" if not provided. */
+  description?: string;
 }
 
 function MacroBar({
@@ -252,16 +257,28 @@ function MacroBar({
             style={{ left: `${hardStartPct}%`, width: `${fillPct - hardStartPct}%` }}
           />
         )}
-        {/* Multi-markers — opaque, dim if crossed, bright if ahead. Always visible. */}
+        {/* Multi-markers — color-coded by meaning, always visible.
+            Red = hardCeiling (don't cross). Green = optimal hit-this target.
+            White = other achievement tier. Crossed renders at /40 opacity. */}
         {useMulti && markers!.map((m, i) => {
           const pct = Math.min(100, (m.value / maxVal) * 100);
           const crossed = current >= m.value;
+          const colorClass =
+            m.kind === "hardCeiling"
+              ? (crossed ? "bg-red-500/40" : "bg-red-500")
+              : m.optimal
+                ? (crossed ? "bg-green-500/40" : "bg-green-500")
+                : (crossed ? "bg-foreground/40" : "bg-foreground");
           return (
             <div
               key={i}
-              className={`absolute top-0 h-full w-[2px] ${crossed ? "bg-foreground/40" : "bg-foreground"}`}
+              className={`absolute top-0 h-full w-[2px] ${colorClass}`}
               style={{ left: `calc(${Math.min(pct, 99.5)}% - 1px)` }}
-              title={`${m.label}: ${Math.round(m.value)}${unit}`}
+              title={
+                m.description
+                  ? `${m.description} (${Math.round(m.value)}${unit})`
+                  : `${m.label}: ${Math.round(m.value)}${unit}`
+              }
             />
           );
         })}
@@ -800,19 +817,55 @@ export function NutritionDashboard({
                   bright. Past the highest marker = red overlay. */}
               {dataReady ? (() => {
                 const w = (breakdown as any)?.weightKg ?? 0;
-                const proteinMarkers = w > 0
-                  ? [1.6, 1.8, 2.0, 2.2].map((g) => ({ value: w * g, label: g.toFixed(1) }))
-                  : [{ value: targetProtein, label: "target" }];
-                const fatMarkers = w > 0
-                  ? [0.6, 0.8, 1.0].map((g) => ({ value: w * g, label: g.toFixed(1) }))
-                  : [{ value: targetFat, label: "target" }];
-                const carbMarkers = [
-                  { value: 100, label: "min" },
-                  { value: targetCarbs, label: "target" },
+                const proteinDescs: Record<string, string> = {
+                  "1.6": "Hypertrophy minimum (Schoenfeld 2018 meta)",
+                  "1.8": "Common cutting target",
+                  "2.0": "Conservative high — diminishing returns past this",
+                  "2.2": "Aggressive cut sweet spot — best muscle preservation in deficit",
+                };
+                const fatDescs: Record<string, string> = {
+                  "0.6": "Hormone-risk floor — going below for long deficits suppresses test/T3",
+                  "0.8": "Sufficient for hormones, leaves carbs for training (cutting consensus)",
+                  "1.0": "Maintenance/bulk target — no extra hormonal benefit in deficit",
+                };
+                const proteinMarkers: MacroMarker[] = w > 0
+                  ? [1.6, 1.8, 2.0, 2.2].map((g) => ({
+                      value: w * g,
+                      label: g.toFixed(1),
+                      optimal: g === 2.2,
+                      description: proteinDescs[g.toFixed(1)],
+                    }))
+                  : [{ value: targetProtein, label: "target", optimal: true }];
+                const fatMarkers: MacroMarker[] = w > 0
+                  ? [0.6, 0.8, 1.0].map((g) => ({
+                      value: w * g,
+                      label: g.toFixed(1),
+                      optimal: g === 0.8,
+                      description: fatDescs[g.toFixed(1)],
+                    }))
+                  : [{ value: targetFat, label: "target", optimal: true }];
+                const carbMarkers: MacroMarker[] = [
+                  {
+                    value: 100, label: "min",
+                    description: "Health floor — keto-ish below this",
+                  },
+                  {
+                    value: targetCarbs, label: "target",
+                    optimal: true,
+                    description: "Today's matrix-computed carb target",
+                  },
                 ].sort((a, b) => a.value - b.value);
                 const fiberMarkers: MacroMarker[] = [
-                  { value: targetFiber || 30, label: "target" },
-                  { value: 60, label: "ceil", kind: "hardCeiling" },
+                  {
+                    value: targetFiber || 30, label: "target",
+                    optimal: true,
+                    description: "Daily fiber target — gut health + satiety",
+                  },
+                  {
+                    value: 60, label: "ceil",
+                    kind: "hardCeiling",
+                    description: "GI distress threshold — past this risks bloating/cramps",
+                  },
                 ];
                 return (
                   <div className="grid gap-2 pt-1">


### PR DESCRIPTION
## Summary

Markers were uniformly white before — no visual distinction between *hit this*, *you can cross this*, and *stop*. Now color-coded by meaning, plus each marker carries a descriptive hover tooltip.

## Color taxonomy

| Color | Meaning | Markers |
|---|---|---|
| 🔴 Red | hardCeiling — don't cross | kcal burn (2543), fiber 60g |
| 🟢 Green | optimal hit-this target | kcal goal (1672), **protein 2.2 g/kg**, carbs today's target, **fat 0.8 g/kg**, fiber 30g |
| ⚪ White | other achievement tier | protein 1.6 / 1.8 / 2.0, fat 0.6 / 1.0, carbs 100g floor |

Crossed markers render at `/40` opacity — dimmer but always visible.

## Hover tooltips

Each marker now carries a description used in the `title` attribute, e.g.:
- `1.6 g/kg` → "Hypertrophy minimum (Schoenfeld 2018 meta) — 119g"
- `2.2 g/kg` → "Aggressive cut sweet spot — best muscle preservation in deficit (164g)"
- `0.8 g/kg` → "Sufficient for hormones, leaves carbs for training (cutting consensus) — 60g"
- `60g fiber` → "GI distress threshold — past this risks bloating/cramps (60g)"

Same descriptions on both compose view and dashboard MacroBar.

## Why fat optimal at 0.8 g/kg in deficit (not 1.0)

User asked: *"if we're under deficit, then highest fat is best for hormones, optimal should be high?"*

Honest answer: hormones plateau at 0.6–0.8 g/kg. Past that:
- No further endocrine benefit (Volek 1997, Hämäläinen 1984 — effect captured by ~0.8).
- Stolen kcal from carbs hurt training intensity, glycogen, mood, sleep.
- Helms / Trexler / Smith-Ryan reviews converge on ~20–30% kcal from fat in cuts → for 1672 kcal that's 0.5–0.75 g/kg. 0.8 is the conservative middle, slightly above literature consensus.

User confirmed 0.8 as optimal pick.

## Type changes (additive only)

`Goalpost` and `MacroMarker` gain two optional fields:

```ts
optimal?: boolean;       // green marker
description?: string;    // hover tooltip
```

Existing `kind: 'achievement' | 'softCeiling' | 'hardCeiling'` discriminator unchanged. `optimal` is independent — kcal target is BOTH `softCeiling` (orange overlay past) AND `optimal` (green marker line).

## Verification

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 11/11 vitest green
- [x] Playwright on dev: dashboard shows green tick at fiber 30 + red tick at fiber 60. Carbs shows white tick at 100 + green at 129. Fat shows white-white-white-green-white pattern reflecting current 71g vs 45/60/75 (0.8 g/kg green dimmed because crossed). Hover tooltip renders the description text.
- [ ] Playwright on Vercel preview after CI green
- [ ] Playwright on `soma.gkos.dev` after merge + prod deploy

## Closes

Closes #102
Closes #103
Closes #104