### PR TITLE
fix(nutrition): run distance shows 0km + actual run missing from Today's Activity (#110)

### DIFF
--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -179,7 +179,11 @@ export async function GET(req: NextRequest) {
           AND (raw_json->>'startTimeLocal')::date = ${date}::date
       `;
       const runCal2 = Number(runActualRows[0]?.total_cal) || 0;
-      const actualRunDistKm = Math.round((Number(runActualRows[0]?.total_dist) || 0) / 1000 * 10) / 10;
+      // NB: assign to the outer-scope `actualRunDistKm`, not a new const.
+      // Earlier this line was `const actualRunDistKm = ...` which shadowed
+      // the outer variable, so `breakdown.runActualDistKm` always rendered
+      // 0km in the dashboard even when a real run was completed.
+      actualRunDistKm = Math.round((Number(runActualRows[0]?.total_dist) || 0) / 1000 * 10) / 10;
       if (runCal2 > 0) actualRunCalories = Math.round(runCal2);
 
       // Actual gym calories from workout_enrichment for today

--- a/web/components/activity-selector.tsx
+++ b/web/components/activity-selector.tsx
@@ -31,6 +31,12 @@ interface ActivitySelectorProps {
   expectedSteps: number;
   stepGoal: number;
   runStepEstimate: number;
+  /** True when a real Garmin-completed run was found for `date`. */
+  runActual?: boolean;
+  /** Distance of the actual completed run, km. */
+  actualRunKm?: number;
+  /** Calories of the actual completed run. */
+  actualRunCalories?: number;
   onActivityChanged: () => void;
   disabled?: boolean;
   disabledReason?: string;
@@ -45,6 +51,9 @@ export function ActivitySelector({
   expectedSteps: initialExpectedSteps,
   stepGoal,
   runStepEstimate,
+  runActual,
+  actualRunKm,
+  actualRunCalories,
   onActivityChanged,
   disabled,
   disabledReason,
@@ -141,8 +150,31 @@ export function ActivitySelector({
             )}
           </div>
 
-          {/* Run toggle */}
-          {hasRun && (
+          {/* Actual completed run (Garmin) — read-only row.
+              Renders whenever a real run is detected for `date`, even when
+              there's no matching planned run in training_plan. Takes
+              precedence over the planned-run toggle since the actual data
+              is what actually drives the day's burn calculation. */}
+          {runActual && actualRunKm && actualRunKm > 0 ? (
+            <div className="w-full flex items-center justify-between rounded-md px-3 py-2 text-sm bg-primary/10 border border-primary/30">
+              <div className="flex items-center gap-2">
+                <span>🏃</span>
+                <div className="text-left">
+                  <div className="font-medium text-xs">
+                    {training?.run_title || "Run"}
+                  </div>
+                  <div className="text-[10px] text-muted-foreground">
+                    {actualRunKm}km
+                    {actualRunCalories ? ` · ${actualRunCalories}cal` : ""}
+                  </div>
+                </div>
+              </div>
+              <span className="text-[10px] uppercase tracking-wide text-emerald-500 font-medium">
+                actual
+              </span>
+            </div>
+          ) : hasRun ? (
+            /* Planned run toggle — only when no actual run exists yet. */
             <button
               className={`w-full flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors ${
                 runEnabled
@@ -167,7 +199,7 @@ export function ActivitySelector({
                 {runEnabled ? "ON" : "OFF"}
               </span>
             </button>
-          )}
+          ) : null}
 
           {/* Expected steps */}
           <NumberInput

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -946,6 +946,9 @@ export function NutritionDashboard({
           expectedSteps={breakdown?.expectedSteps || Number(plan?.step_goal) || 10000}
           stepGoal={Number(plan?.step_goal) || 10000}
           runStepEstimate={breakdown?.runStepEstimate || 0}
+          runActual={!!breakdown?.runActual}
+          actualRunKm={Number(breakdown?.runActualDistKm) || 0}
+          actualRunCalories={Number(breakdown?.runCalories) || 0}
           onActivityChanged={refreshData}
           disabled={(() => {
             const isPast = date < new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });


### PR DESCRIPTION
## Bugs

After a real Garmin run synced for 2026-04-30 (Knoxville Running, 6.01 km, 421 kcal), two cosmetic display issues surfaced — kcal credit was correct but the UI rendered wrong:

### 1. Calorie breakdown: `Run (0km) actual`

Variable shadowing in `web/app/api/nutrition/plan/route.ts:182`:

```ts
let actualRunDistKm = 0;        // outer (line 168)
try {
  // ...
  const actualRunDistKm = ...;  // shadows outer (line 182)
}
breakdown.runActualDistKm = actualRunDistKm;  // → 0 always
```

The `const` declared a new block-scoped binding instead of assigning to the outer `let`. Drop the `const` so the assignment writes back.

### 2. Today's Activity: actual run not displayed

`ActivitySelector` only rendered the run row when there was a **planned** run (`hasRun = training?.target_distance_km > 0`). Ad-hoc / unplanned runs got their kcal credited via the breakdown but never appeared in the panel.

Fix: added a read-only "actual run" row that renders when `breakdown.runActual` is true, regardless of whether a plan exists. Takes precedence over the planned-run toggle since the actual data is what drives the burn calculation.

## Files

| File | Change |
|---|---|
| `web/app/api/nutrition/plan/route.ts` | Drop `const` → assign to outer scope (1 line behaviorally) |
| `web/components/activity-selector.tsx` | New props `runActual`, `actualRunKm`, `actualRunCalories`. New "actual run" row before planned toggle. |
| `web/components/nutrition-dashboard.tsx` | Thread breakdown fields into ActivitySelector |

## Verification

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 11/11 vitest green
- [x] Playwright on dev (`localhost:3456/nutrition?date=2026-04-30`):
  - Calorie breakdown reads `Run (6km) actual +421` (was `Run (0km)`)
  - Today's Activity shows `🏃 Run · 6km · 421cal · ACTUAL` row with green badge
  - Screenshot saved as `.playwright-mcp/17-run-display-fix.png`
- [ ] Verify on prod after merge

## Closes

Closes #110
Closes #111
Closes #112