### PR TITLE
fix(ui): goalpost marker invisible on matching bar fill (fiber 30g) (#114)

### DIFF
--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -453,7 +453,10 @@ export function ComposeMealView({
                       red    = don't cross (hardCeiling)
                       green  = optimal hit-this target
                       white  = other achievement tier
-                    Crossed markers render at /40 opacity (dimmer but still visible). */}
+                    Crossed markers render at /40 opacity.
+                    Dark 1px shadow ring ensures the marker stays visible even
+                    when its color matches the underlying bar fill (e.g. green
+                    optimal marker on a green fiber bar — would otherwise blend). */}
                 {posts.map((g, i) => {
                   const pct = Math.min(100, (g.value / barMax) * 100);
                   const crossed = total >= g.value;
@@ -466,7 +469,7 @@ export function ComposeMealView({
                   return (
                     <div
                       key={i}
-                      className={`absolute top-0 h-full w-[2px] ${colorClass}`}
+                      className={`absolute top-0 h-full w-[2px] shadow-[0_0_0_1px_rgba(0,0,0,0.7)] ${colorClass}`}
                       style={{ left: `${pct}%` }}
                       title={
                         g.description

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -259,7 +259,10 @@ function MacroBar({
         )}
         {/* Multi-markers — color-coded by meaning, always visible.
             Red = hardCeiling (don't cross). Green = optimal hit-this target.
-            White = other achievement tier. Crossed renders at /40 opacity. */}
+            White = other achievement tier. Crossed renders at /40 opacity.
+            Dark 1px shadow ring ensures the marker stays visible even
+            when its color matches the underlying bar fill (e.g. green
+            optimal marker on a green fiber bar — would otherwise blend). */}
         {useMulti && markers!.map((m, i) => {
           const pct = Math.min(100, (m.value / maxVal) * 100);
           const crossed = current >= m.value;
@@ -272,7 +275,7 @@ function MacroBar({
           return (
             <div
               key={i}
-              className={`absolute top-0 h-full w-[2px] ${colorClass}`}
+              className={`absolute top-0 h-full w-[2px] shadow-[0_0_0_1px_rgba(0,0,0,0.7)] ${colorClass}`}
               style={{ left: `calc(${Math.min(pct, 99.5)}% - 1px)` }}
               title={
                 m.description


### PR DESCRIPTION
## Bug

The fiber bar's 30g target marker is colored \`bg-green-500\` (per the optimal-marker rule from PR #102/#105). The fiber bar's fill is also \`bg-green-500\`. Once fiber consumed crosses 30g, the marker sits inside the green fill area and disappears.

## Fix

1px dark shadow ring on every marker via \`shadow-[0_0_0_1px_rgba(0,0,0,0.7)]\`. Universal — works against any fill color underneath (green / amber / rose / blue / teal / red) and against the muted unfilled background. No layout change (no width expansion, no clipping).

Applied in both \`compose-meal-view.tsx\` (compose flow) and \`nutrition-dashboard.tsx\` (daily MacroBar) so the rule is consistent.

## Files

- \`web/components/compose-meal-view.tsx\` — +1 class on marker div + comment
- \`web/components/nutrition-dashboard.tsx\` — +1 class on marker div + comment

## Verification

- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npm test\` — 11/11 vitest green
- [x] Playwright on dev (\`localhost:3456/nutrition?date=2026-04-30\`): fiber at 39/60g, the green 30g target tick is clearly visible inside the green fill area. Other macros (protein/carbs/fat) markers unchanged. Screenshot saved as \`.playwright-mcp/19-fiber-marker-visible.png\`.
- [ ] Verify on prod after merge

## Closes

Closes #114