### PR TITLE
fix(nutrition): close_yesterday recomputes target_calories from actuals (#116)

### DIFF
--- a/sync/src/nutrition_engine/close_yesterday.py
+++ b/sync/src/nutrition_engine/close_yesterday.py
@@ -6,6 +6,8 @@ Replaces predicted values with actuals:
 - Gym calories -> actual from workout_enrichment
 - Unfinished predicted activities -> 0
 - Steps -> actual from daily_health_summary
+- target_calories -> recomputed from actual burn so un-done predicted
+  workouts/runs don't inflate historical deficit math
 """
 
 import logging
@@ -16,6 +18,30 @@ from config import today_nyc
 
 logger = logging.getLogger(__name__)
 
+# Same step-kcal formula as the TS plan API (route.ts:247)
+KCAL_PER_STEP_PER_KG = 0.000423
+
+
+def compute_actual_target(
+    bmr: float,
+    actual_steps: int,
+    weight_kg: float,
+    actual_run_cal: int,
+    actual_gym_cal: int,
+    deficit_used: int,
+) -> tuple[int, int]:
+    """Recompute target_calories and tdee_used from actuals at close time.
+
+    Strips any predicted run/gym kcal that was baked into the in-day target
+    when those activities were never completed.
+
+    Returns (target_calories, tdee_used).
+    """
+    actual_step_cal = round(actual_steps * KCAL_PER_STEP_PER_KG * weight_kg)
+    actual_total_burn = round(bmr + actual_step_cal + actual_run_cal + actual_gym_cal)
+    new_target = round(actual_total_burn - deficit_used)
+    return new_target, actual_total_burn
+
 
 def close_yesterday(conn) -> None:
     """Close all unclosed past nutrition days with reconciled actuals."""
@@ -24,7 +50,8 @@ def close_yesterday(conn) -> None:
     with conn.cursor() as cur:
         # Find ALL unclosed past days (not just yesterday)
         cur.execute(
-            "SELECT date, selected_workouts, run_enabled, plan "
+            "SELECT date, selected_workouts, run_enabled, plan, "
+            "       deficit_used, target_calories, target_protein, target_fat "
             "FROM nutrition_day WHERE date < %s AND status = 'active' "
             "ORDER BY date",
             (today,),
@@ -33,7 +60,8 @@ def close_yesterday(conn) -> None:
         if not unclosed_days:
             return
 
-    for yesterday, selected_workouts, run_enabled, plan_json in unclosed_days:
+    for (yesterday, selected_workouts, run_enabled, plan_json,
+         old_deficit, old_target, old_protein, old_fat) in unclosed_days:
       with conn.cursor() as cur:
         selected = selected_workouts or []
 
@@ -96,7 +124,46 @@ def close_yesterday(conn) -> None:
             "fiber": round(float(m[4])),
         }
 
-        # 5. Build reconciled data
+        # 5. Recompute target_calories from actuals.
+        #
+        # The in-day plan API write-back may have included PREDICTED run/gym
+        # calories — kcal of activities the user selected but never actually
+        # did. If we leave target_calories alone, the 7-day trend table
+        # silently over-credits historical burn (since it derives burn as
+        # target + deficit_used).
+        #
+        # Strip predictions: target = actual_total_burn - deficit_used.
+        # Protein/fat targets are weight-based so unaffected. Carbs =
+        # leftover kcal, recompute to keep macro sum consistent.
+        cur.execute(
+            "SELECT bmr_kilocalories FROM daily_health_summary "
+            "WHERE date <= %s AND bmr_kilocalories > 1500 "
+            "ORDER BY date DESC LIMIT 1",
+            (yesterday,),
+        )
+        bmr_row = cur.fetchone()
+        bmr = round(float(bmr_row[0])) if bmr_row and bmr_row[0] else 0
+
+        cur.execute("SELECT weight_kg FROM nutrition_profile WHERE id = 1")
+        prof_row = cur.fetchone()
+        weight_kg = float(prof_row[0]) if prof_row and prof_row[0] else 74.0
+
+        deficit_used = int(old_deficit) if old_deficit is not None else 800
+
+        new_target, new_tdee = compute_actual_target(
+            bmr=bmr,
+            actual_steps=actual_steps,
+            weight_kg=weight_kg,
+            actual_run_cal=actual_run_cal,
+            actual_gym_cal=actual_gym_cal,
+            deficit_used=deficit_used,
+        )
+
+        protein_g = int(old_protein) if old_protein is not None else 0
+        fat_g = int(old_fat) if old_fat is not None else 0
+        new_carbs = max(0, round((new_target - protein_g * 4 - fat_g * 9) / 4))
+
+        # 6. Build reconciled data
         existing_plan = plan_json if isinstance(plan_json, dict) else (
             json.loads(plan_json) if plan_json else {}
         )
@@ -106,28 +173,36 @@ def close_yesterday(conn) -> None:
             "actual_gym_calories": actual_gym_cal,
             "actual_gym_details": gym_details,
             "unmatched_workouts": [w for w in selected if w not in gym_details],
+            "actual_total_burn": new_tdee,
+            "old_target_calories": int(old_target) if old_target is not None else None,
+            "new_target_calories": new_target,
             "reconciled_at": today.isoformat(),
         }
         existing_plan["reconciled"] = reconciled
 
-        # 6. Update and close
+        # 7. Update and close
         cur.execute(
             """
             UPDATE nutrition_day SET
                 actual_calories = %s, actual_protein = %s,
                 actual_carbs = %s, actual_fat = %s, actual_fiber = %s,
+                target_calories = %s, target_carbs = %s, tdee_used = %s,
                 plan = %s, status = 'closed'
             WHERE date = %s
             """,
             (
                 actual["calories"], actual["protein"],
                 actual["carbs"], actual["fat"], actual["fiber"],
+                new_target, new_carbs, new_tdee,
                 json.dumps(existing_plan), yesterday,
             ),
         )
 
+        target_delta = new_target - (int(old_target) if old_target else new_target)
         logger.info(
-            "Auto-closed %s: intake=%d cal, steps=%d, run=%d cal, gym=%d cal, unmatched=%s",
+            "Auto-closed %s: intake=%d cal, steps=%d, run=%d cal, gym=%d cal, "
+            "target %d → %d (Δ%+d), unmatched=%s",
             yesterday, actual["calories"], actual_steps, actual_run_cal, actual_gym_cal,
+            int(old_target) if old_target else 0, new_target, target_delta,
             reconciled["unmatched_workouts"],
         )

--- a/sync/tests/test_close_yesterday.py
+++ b/sync/tests/test_close_yesterday.py
@@ -1,0 +1,92 @@
+"""Tests for nutrition_engine.close_yesterday — target recompute from actuals."""
+import pytest
+
+from nutrition_engine.close_yesterday import compute_actual_target
+
+
+class TestComputeActualTarget:
+    def test_no_predicted_no_actual_workouts_target_matches_bmr_plus_steps(self):
+        """Rest day, no run, no gym — target = BMR + step kcal − deficit."""
+        target, tdee = compute_actual_target(
+            bmr=2070, actual_steps=10000, weight_kg=74.0,
+            actual_run_cal=0, actual_gym_cal=0, deficit_used=800,
+        )
+        # step_cal = 10000 × 0.000423 × 74 = 313 kcal
+        # tdee = 2070 + 313 = 2383
+        # target = 2383 − 800 = 1583
+        assert tdee == 2383
+        assert target == 1583
+
+    def test_actual_run_credits_target(self):
+        """6 km run @ 421 kcal lifts both tdee and target."""
+        target, tdee = compute_actual_target(
+            bmr=2070, actual_steps=10000, weight_kg=74.0,
+            actual_run_cal=421, actual_gym_cal=0, deficit_used=800,
+        )
+        assert tdee == 2383 + 421  # 2804
+        assert target == tdee - 800  # 2004
+
+    def test_actual_gym_credits_target(self):
+        """Gym 272 kcal lifts both tdee and target."""
+        target, tdee = compute_actual_target(
+            bmr=2070, actual_steps=10000, weight_kg=74.0,
+            actual_run_cal=0, actual_gym_cal=272, deficit_used=800,
+        )
+        assert tdee == 2383 + 272  # 2655
+        assert target == tdee - 800  # 1855
+
+    def test_undone_workout_does_not_inflate_target(self):
+        """Whether or not a predicted workout existed in the in-day plan,
+        close-time target only reflects actual burn. The function takes
+        actual_gym_cal directly — caller passes 0 when nothing matched."""
+        with_predicted = compute_actual_target(
+            bmr=2070, actual_steps=10000, weight_kg=74.0,
+            actual_run_cal=0, actual_gym_cal=0, deficit_used=800,
+        )
+        without_predicted = compute_actual_target(
+            bmr=2070, actual_steps=10000, weight_kg=74.0,
+            actual_run_cal=0, actual_gym_cal=0, deficit_used=800,
+        )
+        # Same inputs → same output. The bug was in close_yesterday NOT
+        # calling this function and leaving the in-day inflated target.
+        assert with_predicted == without_predicted
+
+    def test_zero_steps_zero_workouts(self):
+        """Sedentary day — target collapses to BMR − deficit."""
+        target, tdee = compute_actual_target(
+            bmr=2070, actual_steps=0, weight_kg=74.0,
+            actual_run_cal=0, actual_gym_cal=0, deficit_used=800,
+        )
+        assert tdee == 2070
+        assert target == 1270
+
+    def test_high_volume_day(self):
+        """Long-run day: 25k steps + 9km run @ 670 kcal + heavy gym 380."""
+        target, tdee = compute_actual_target(
+            bmr=2070, actual_steps=25000, weight_kg=74.0,
+            actual_run_cal=670, actual_gym_cal=380, deficit_used=800,
+        )
+        # step_cal = 25000 × 0.000423 × 74 = 783
+        # tdee = 2070 + 783 + 670 + 380 = 3903
+        # target = 3903 − 800 = 3103
+        assert tdee == 3903
+        assert target == 3103
+
+    def test_zero_deficit_target_equals_tdee(self):
+        """Maintenance day (deficit = 0) — target equals tdee."""
+        target, tdee = compute_actual_target(
+            bmr=2070, actual_steps=10000, weight_kg=74.0,
+            actual_run_cal=0, actual_gym_cal=0, deficit_used=0,
+        )
+        assert target == tdee
+
+    def test_step_kcal_formula_matches_ts_plan_api(self):
+        """Step kcal must use the same formula as web/app/api/nutrition/plan/route.ts:247
+        (KCAL_PER_STEP_PER_KG = 0.000423) — drift here would silently
+        misalign Python close path from TS in-day path."""
+        # 10000 steps × 0.000423 × 80 kg = 338.4 → 338
+        _, tdee = compute_actual_target(
+            bmr=2000, actual_steps=10000, weight_kg=80.0,
+            actual_run_cal=0, actual_gym_cal=0, deficit_used=0,
+        )
+        assert tdee == 2338  # 2000 + 338


### PR DESCRIPTION
## Bug

\`nutrition_day.target_calories\` keeps stale predicted-workout/run kcal after the day closes. The 7-day trend's historical burn is over-credited proportionally.

## Fix

At close, recompute \`target_calories\` from actuals only:

\`\`\`python
target = BMR + actual_step_cal + actual_run_cal + actual_gym_cal − deficit_used
\`\`\`

Same step formula (\`0.000423 kcal/step/kg\`) the TS plan API uses, kept as a constant in the Python module. Recompute extracted to pure function \`compute_actual_target(...)\` so it's unit-testable without DB.

Also updates \`target_carbs\` (leftover kcal / 4) and \`tdee_used\`. \`target_protein\` and \`target_fat\` unchanged (weight-based formulas, unaffected by workouts).

## Files

- \`sync/src/nutrition_engine/close_yesterday.py\` — adds compute_actual_target, fetches BMR/weight/deficit, recomputes targets, expanded UPDATE + log line + reconciled JSON.
- \`sync/tests/test_close_yesterday.py\` — new file, 8 unit tests.

## Verification

- [x] \`pytest tests/test_close_yesterday.py tests/test_daily_plan.py\` — **48/48 green**
- [x] Python smoke import clean
- [x] \`npx tsc --noEmit\` clean (no TS changes but verified)
- [x] \`npm test\` 11/11 green
- [ ] Verify on first prod cron run after merge: log line should show \`target old → new (Δ)\`

## Out of scope

No backfill of already-closed days. User explicitly said historical drift is small.

## Closes

Closes #116
Closes #117
Closes #118