### PR TITLE
feat(nutrition): ad-hoc planned run with calorie pre-allocation (#120)

### DIFF
--- a/sync/src/nutrition_engine/schema.py
+++ b/sync/src/nutrition_engine/schema.py
@@ -147,6 +147,7 @@ ALTER TABLE nutrition_day ADD COLUMN IF NOT EXISTS run_enabled         BOOLEAN D
 ALTER TABLE nutrition_day ADD COLUMN IF NOT EXISTS selected_workouts   TEXT[] DEFAULT '{}';
 ALTER TABLE nutrition_day ADD COLUMN IF NOT EXISTS expected_steps      INTEGER;
 ALTER TABLE nutrition_day ADD COLUMN IF NOT EXISTS manual_override     BOOLEAN DEFAULT FALSE;
+ALTER TABLE nutrition_day ADD COLUMN IF NOT EXISTS planned_run_km      REAL;
 
 -- Migrate closed → status
 UPDATE nutrition_day SET status = 'closed' WHERE closed = TRUE;

--- a/web/app/api/nutrition/activity-select/route.ts
+++ b/web/app/api/nutrition/activity-select/route.ts
@@ -10,9 +10,12 @@ export async function POST(req: NextRequest) {
     run_enabled?: boolean;
     selected_workouts?: string[];
     expected_steps?: number | null;
+    /** Ad-hoc planned run distance in km. NULL clears the override and falls back
+     *  to training_plan_day.target_distance_km in the plan API read path. */
+    planned_run_km?: number | null;
     manual_override?: boolean;
   };
-  const { date, run_enabled, selected_workouts, expected_steps } = body;
+  const { date, run_enabled, selected_workouts, expected_steps, planned_run_km } = body;
 
   if (!date) {
     return NextResponse.json({ error: "date is required" }, { status: 400 });
@@ -44,6 +47,16 @@ export async function POST(req: NextRequest) {
           selected_workouts = ${selected_workouts},
           expected_steps = ${expected_steps ?? null}
       WHERE date = ${date}
+    `;
+  }
+
+  // Handle ad-hoc planned run distance independently — user can set/clear it
+  // without touching the run_enabled/selected_workouts pair. NULL clears the
+  // override, in which case the plan API falls back to training_plan_day.
+  if (planned_run_km !== undefined) {
+    const v = planned_run_km !== null && planned_run_km > 0 ? planned_run_km : null;
+    await sql`
+      UPDATE nutrition_day SET planned_run_km = ${v} WHERE date = ${date}
     `;
   }
 

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -254,14 +254,24 @@ export async function GET(req: NextRequest) {
     let runStepEstimate = 0;
     let runDistanceKm = 0;
 
-    // Fetch run distance for step dedup
-    const runDistanceRows = await sql`
-      SELECT target_distance_km FROM training_plan_day d
-      JOIN training_plan p ON d.plan_id = p.id
-      WHERE p.status = 'active' AND d.day_date = ${date}
-      LIMIT 1
-    `;
-    runDistanceKm = Number(runDistanceRows[0]?.target_distance_km) || 0;
+    // Fetch run distance for step dedup. Resolution order:
+    //   1. Ad-hoc planned run (nutrition_day.planned_run_km) — user-set
+    //      via the Today's Activity panel for unplanned/ad-hoc runs.
+    //   2. Coach plan (training_plan_day.target_distance_km) — fallback
+    //      when no ad-hoc value but an active training plan exists.
+    //   3. 0 — no planned run.
+    const adhocRunKm = Number(plan?.planned_run_km) || 0;
+    if (adhocRunKm > 0) {
+      runDistanceKm = adhocRunKm;
+    } else {
+      const runDistanceRows = await sql`
+        SELECT target_distance_km FROM training_plan_day d
+        JOIN training_plan p ON d.plan_id = p.id
+        WHERE p.status = 'active' AND d.day_date = ${date}
+        LIMIT 1
+      `;
+      runDistanceKm = Number(runDistanceRows[0]?.target_distance_km) || 0;
+    }
 
     if (runEnabled && runDistanceKm > 0) {
       runStepEstimate = Math.round(runDistanceKm * 1300);

--- a/web/components/activity-selector.tsx
+++ b/web/components/activity-selector.tsx
@@ -37,6 +37,12 @@ interface ActivitySelectorProps {
   actualRunKm?: number;
   /** Calories of the actual completed run. */
   actualRunCalories?: number;
+  /** Ad-hoc planned run distance in km. User can set this for unplanned runs
+   *  (between training blocks or ad-hoc) so calories are pre-allocated to the
+   *  day's target. NULL/0 = no ad-hoc plan; falls back to training_plan_day. */
+  plannedRunKm?: number | null;
+  /** User weight (kg) — used to compute the live "X km × Y kg ≈ Z kcal" hint. */
+  weightKg?: number | null;
   onActivityChanged: () => void;
   disabled?: boolean;
   disabledReason?: string;
@@ -54,6 +60,8 @@ export function ActivitySelector({
   runActual,
   actualRunKm,
   actualRunCalories,
+  plannedRunKm: initialPlannedRunKm,
+  weightKg,
   onActivityChanged,
   disabled,
   disabledReason,
@@ -61,14 +69,18 @@ export function ActivitySelector({
   const [runEnabled, setRunEnabled] = useState(initialRunEnabled);
   const [selectedWorkouts, setSelectedWorkouts] = useState<string[]>(initialSelectedWorkouts);
   const [steps, setSteps] = useState(initialExpectedSteps || stepGoal);
+  const [plannedRunKm, setPlannedRunKm] = useState<number>(initialPlannedRunKm ?? 0);
   const [routines, setRoutines] = useState<RoutineCalories[]>([]);
   const [saving, setSaving] = useState(false);
   const minSteps = 1000; // allow setting any reasonable step count
 
-  // Sync steps from parent when expectedSteps prop changes (e.g., after refreshData)
+  // Sync steps + planned-run-km from parent when props change (after refreshData)
   useEffect(() => {
     setSteps(initialExpectedSteps || stepGoal);
   }, [initialExpectedSteps, stepGoal]);
+  useEffect(() => {
+    setPlannedRunKm(initialPlannedRunKm ?? 0);
+  }, [initialPlannedRunKm]);
 
   // Fetch available routines with their average calories
   useEffect(() => {
@@ -79,18 +91,22 @@ export function ActivitySelector({
   }, []);
 
   const saveSelections = useCallback(
-    async (run: boolean, workouts: string[], stepsOverride?: number) => {
+    async (run: boolean, workouts: string[], stepsOverride?: number, plannedRunKmOverride?: number | null) => {
       setSaving(true);
       try {
+        const body: Record<string, unknown> = {
+          date,
+          run_enabled: run,
+          selected_workouts: workouts,
+          expected_steps: stepsOverride ?? steps,
+        };
+        if (plannedRunKmOverride !== undefined) {
+          body.planned_run_km = plannedRunKmOverride && plannedRunKmOverride > 0 ? plannedRunKmOverride : null;
+        }
         const res = await fetch("/api/nutrition/activity-select", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            date,
-            run_enabled: run,
-            selected_workouts: workouts,
-            expected_steps: stepsOverride ?? steps,
-          }),
+          body: JSON.stringify(body),
         });
         if (res.ok) {
           onActivityChanged();
@@ -117,16 +133,17 @@ export function ActivitySelector({
     saveSelections(runEnabled, next, steps);
   };
 
-  // Debounced save for slider-driven changes (steps)
+  // Debounced save for slider-driven changes (steps, planned_run_km)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const debouncedSave = useCallback(
-    (overrides: { expected_steps?: number }) => {
+    (overrides: { expected_steps?: number; planned_run_km?: number | null }) => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => {
         saveSelections(
           runEnabled,
           selectedWorkouts,
           overrides.expected_steps ?? steps,
+          overrides.planned_run_km,
         );
       }, 400);
     },
@@ -200,6 +217,40 @@ export function ActivitySelector({
               </span>
             </button>
           ) : null}
+
+          {/* Ad-hoc planned run distance.
+              Visible only when no actual run is detected and no coach-planned
+              run exists for today (otherwise the planned-run toggle above
+              already covers it). User can override either by entering a
+              non-zero km value here. Predicted kcal ≈ km × weight × 1.0. */}
+          {!runActual && !hasRun && (() => {
+            const w = weightKg && weightKg > 0 ? weightKg : 0;
+            const estKcal = w > 0 && plannedRunKm > 0
+              ? Math.round(plannedRunKm * w)
+              : 0;
+            return (
+              <div>
+                <NumberInput
+                  value={plannedRunKm}
+                  onChange={(v) => {
+                    const next = Math.max(0, v);
+                    setPlannedRunKm(next);
+                    debouncedSave({ planned_run_km: next > 0 ? next : null });
+                  }}
+                  min={0}
+                  max={50}
+                  step={0.5}
+                  suffix="km"
+                  label="Planned run (ad-hoc)"
+                />
+                {plannedRunKm > 0 && estKcal > 0 && (
+                  <div className="text-[10px] text-muted-foreground/70 mt-0.5 ml-0.5">
+                    🏃 ≈ {estKcal} kcal pre-allocated
+                  </div>
+                )}
+              </div>
+            );
+          })()}
 
           {/* Expected steps */}
           <NumberInput

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -952,6 +952,8 @@ export function NutritionDashboard({
           runActual={!!breakdown?.runActual}
           actualRunKm={Number(breakdown?.runActualDistKm) || 0}
           actualRunCalories={Number(breakdown?.runCalories) || 0}
+          plannedRunKm={(plan as any)?.planned_run_km ?? null}
+          weightKg={(breakdown as any)?.weightKg ?? null}
           onActivityChanged={refreshData}
           disabled={(() => {
             const isPast = date < new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });


### PR DESCRIPTION
## Summary

Gym workouts can be pre-planned via routine chips. Runs can only be pre-planned via \`training_plan_day\`. Between training blocks (or for any one-off run), there was no way to say \"I'm planning to run 3 km today\" and get the calories pre-allocated.

This adds an ad-hoc planned-run input in Today's Activity.

## Resolution chain

\`\`\`
runDistanceKm = nutrition_day.planned_run_km
            ?? training_plan_day.target_distance_km
            ?? 0
\`\`\`

Once an actual Garmin run lands, the read-only \"actual run\" row from #110/PR #113 takes over and the ad-hoc input hides automatically. At close, PR #119's recompute strips predicted-but-not-done planned-run kcal — so this feature inherits the correctness fix for free.

## Files

| File | Change |
|---|---|
| \`sync/src/nutrition_engine/schema.py\` | Add \`planned_run_km REAL\` column (NULL = no override) |
| DB migration | Already applied ahead of merge — additive, NULL default |
| \`web/app/api/nutrition/plan/route.ts\` | Fallback chain in run-distance read |
| \`web/app/api/nutrition/activity-select/route.ts\` | Accept \`planned_run_km\` (null/0 clears) |
| \`web/components/activity-selector.tsx\` | NumberInput 0-50 km step 0.5 + live kcal hint, gated on \`!runActual && !hasRun\` |
| \`web/components/nutrition-dashboard.tsx\` | Thread \`plannedRunKm\` + \`weightKg\` |

## Verification

- [x] \`tsc --noEmit\` clean
- [x] \`npm test\` 11/11 green
- [x] Playwright on dev (\`localhost:3456/nutrition?date=2026-05-01\`):
  - Input visible (no actual run, no coach plan today) ✓
  - Set slider to 5 km → breakdown shows \`Run (5km) predicted +370\` ✓
  - Live hint reads \`🏃 ≈ 370 kcal pre-allocated\` ✓
  - Step calories drop by run-step dedup (excl. ~6500 run steps) ✓
  - Total burn 2809 → 2975 (+166 net) ✓
  - Target 2009 → 2175, carbs target jumps from 199 → 240 ✓
  - 7-day trend row updates immediately ✓
  - Reset to 0 → input hides, breakdown restores ✓
  - Screenshots: \`.playwright-mcp/21-planned-run-input.png\` (empty), \`.playwright-mcp/22-planned-run-5km.png\` (set to 5km)
- [ ] Verify on prod after merge

## Closes

Closes #120
Closes #121
Closes #122
Closes #123