### PR TITLE
fix(ui): per-meal MPS floor scales by user weight (#125)

### DIFF
--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -387,7 +387,7 @@ export function ComposeMealView({
 
         const data: Record<Key, { eaten: number; thisMeal: number; suffix: string; extra?: React.ReactNode }> = {
           kcal: { eaten: dayConsumed?.calories ?? 0, thisMeal: totals.calories, suffix: "" },
-          P:    { eaten: dayConsumed?.protein ?? 0,  thisMeal: totals.protein,  suffix: "g", extra: <ProteinQualityPill grams={totals.protein} /> },
+          P:    { eaten: dayConsumed?.protein ?? 0,  thisMeal: totals.protein,  suffix: "g", extra: <ProteinQualityPill grams={totals.protein} weightKg={weightKg} /> },
           C:    { eaten: dayConsumed?.carbs ?? 0,    thisMeal: totals.carbs,    suffix: "g" },
           F:    { eaten: dayConsumed?.fat ?? 0,      thisMeal: totals.fat,      suffix: "g" },
           Fi:   { eaten: dayConsumed?.fiber ?? 0,    thisMeal: totals.fiber,    suffix: "g" },

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -549,7 +549,7 @@ export function MealCard({
                     <div className="text-xs text-muted-foreground">
                       {Math.round(meal.calories)} kcal &middot;{" "}
                       {Math.round(meal.protein)}P
-                      <ProteinQualityPill grams={meal.protein} />
+                      <ProteinQualityPill grams={meal.protein} weightKg={weightKg} />
                       {" · "}
                       {Math.round(meal.carbs)}C &middot; {Math.round(meal.fat)}F
                       {!disabled && itemsList.some(i => { const ig = ingLookup.get(i.ingredient_id ?? ""); return ig?.is_raw && ig?.raw_to_cooked_ratio && ig.raw_to_cooked_ratio > 1; }) && <span className="text-[9px] ml-1.5 text-muted-foreground/60">20+ min</span>}

--- a/web/lib/per-meal-protein.tsx
+++ b/web/lib/per-meal-protein.tsx
@@ -1,22 +1,55 @@
 /**
  * Per-meal protein quality (V9.1 / Schoenfeld & Aragon 2018; Trommelen 2023).
  * Classifies a single eating event for MPS signaling — NOT a day total.
- * No upper cap: >55g just isn't incrementally better, not harmful.
+ *
+ * MPS-floor formula: 0.4 × weight_kg per eating event. For a 75 kg user that's
+ * exactly 30g (the value commonly cited as a single threshold), but the actual
+ * literature scales by body mass — a 60 kg user's MPS floor is ~24g, a 90 kg
+ * user's is ~36g. Pass `weightKg` to use the personalised floor; omit it for
+ * the legacy 30g default.
+ *
+ * No upper cap: >~0.55 g/kg per meal isn't incrementally better, not harmful.
  */
 import React from "react";
 
 export type PerMealProteinLevel = "red" | "amber" | "yellow" | "green" | "plenty";
 
-export function perMealProteinLevel(g: number): PerMealProteinLevel {
-  if (g < 15) return "red";
-  if (g < 25) return "amber";
-  if (g < 30) return "yellow";
-  if (g <= 55) return "green";
+const MPS_G_PER_KG = 0.4;
+const PLENTY_G_PER_KG = 0.55;
+const FALLBACK_MPS_G = 30;
+
+interface Thresholds {
+  red: number;       // below this = "low protein"
+  amber: number;     // below this = "below MPS"
+  yellow: number;    // below this = "near MPS"
+  plenty: number;    // above this = "plenty" (hidden)
+}
+
+function thresholds(weightKg: number | null | undefined): Thresholds {
+  if (!weightKg || weightKg <= 0) {
+    return { red: 15, amber: 25, yellow: 30, plenty: 55 };
+  }
+  const mps = Math.max(20, Math.round(weightKg * MPS_G_PER_KG));
+  const plenty = Math.max(40, Math.round(weightKg * PLENTY_G_PER_KG));
+  return {
+    red: Math.max(10, Math.round(mps * 0.5)),
+    amber: Math.max(15, Math.round(mps * 0.83)),
+    yellow: mps,
+    plenty,
+  };
+}
+
+export function perMealProteinLevel(g: number, weightKg?: number | null): PerMealProteinLevel {
+  const t = thresholds(weightKg);
+  if (g < t.red) return "red";
+  if (g < t.amber) return "amber";
+  if (g < t.yellow) return "yellow";
+  if (g <= t.plenty) return "green";
   return "plenty";
 }
 
-export function ProteinQualityPill({ grams }: { grams: number }) {
-  const level = perMealProteinLevel(grams);
+export function ProteinQualityPill({ grams, weightKg }: { grams: number; weightKg?: number | null }) {
+  const level = perMealProteinLevel(grams, weightKg);
   if (level === "green" || level === "plenty") return null;
   const cls =
     level === "red"
@@ -30,10 +63,13 @@ export function ProteinQualityPill({ grams }: { grams: number }) {
       : level === "amber"
         ? "below MPS"
         : "near MPS";
+  const mpsFloor = weightKg && weightKg > 0
+    ? Math.max(20, Math.round(weightKg * MPS_G_PER_KG))
+    : FALLBACK_MPS_G;
   return (
     <span
       className={`text-[9px] ml-1.5 px-1 py-[1px] rounded border ${cls} tabular-nums`}
-      title={`Per-meal protein: ${Math.round(grams)}g. MPS optimum is ≥30g per eating event (Schoenfeld & Aragon 2018; Trommelen 2023).`}
+      title={`Per-meal protein: ${Math.round(grams)}g. MPS optimum is ≥${mpsFloor}g per eating event (0.4 × weight_kg, Schoenfeld & Aragon 2018; Trommelen 2023).`}
     >
       {label}
     </span>


### PR DESCRIPTION
## Summary

\`ProteinQualityPill\` and \`perMealProteinLevel\` used hardcoded thresholds (15/25/30/55g). The actual Schoenfeld & Aragon 2018 formula is \`0.4 × weight_kg\` per eating event — only equals 30g for a 75 kg user. Now derives thresholds from \`weightKg\` (optional prop). For 74.4 kg → still ~30g, no user-visible change.

## Threshold derivation

\`\`\`
yellow (MPS floor) = max(20, round(weightKg × 0.4))
green (plenty)     = max(40, round(weightKg × 0.55))
amber (below MPS)  = round(MPS × 0.83)
red (low protein)  = max(10, round(MPS × 0.5))
\`\`\`

Falls back to legacy fixed thresholds when \`weightKg\` is missing/zero so older callsites still render.

## Files

- \`web/lib/per-meal-protein.tsx\` — derive thresholds from weight, optional prop
- \`web/components/compose-meal-view.tsx\` — pass \`weightKg\` to ProteinQualityPill
- \`web/components/meal-card.tsx\` — pass \`weightKg\` to ProteinQualityPill

## Verification

- [x] \`tsc --noEmit\` clean
- [x] \`npm test\` 11/11 green
- [x] No user-visible change for 74.4 kg user (floor stays ~30g)

## Closes

Closes #125