### PR TITLE
feat(kite): custom share image with 3D jump flight

### DIFF
--- a/sync/src/backfill_kite_jumps.py
+++ b/sync/src/backfill_kite_jumps.py
@@ -1,0 +1,131 @@
+"""Backfill per-jump kite data into garmin_activity_raw (endpoint 'kite_jumps').
+
+For every kiteboarding activity: download its FIT, extract per-jump
+height+position+time from the Surfr Connect IQ `heights` stream, match Surfr's
+auto-exported Strava description by start time to enrich the top jumps with
+airtime/distance, and store the payload so the share-image route can read it.
+
+Run:  cd sync && .venv/bin/python -m src.backfill_kite_jumps [--only ACTIVITY_ID]
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+
+import psycopg2
+
+from garmin_client import init_garmin
+from garmin_push import _download_fit_file
+from kite_jumps import build_kite_jumps
+
+DB_URL = os.environ.get("DATABASE_URL") or ""
+
+
+def _kite_activities(conn):
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT activity_id, raw_json->>'startTimeGMT'
+            FROM garmin_activity_raw
+            WHERE endpoint_name = 'summary'
+              AND raw_json->'activityType'->>'typeKey' ILIKE '%kite%'
+            ORDER BY raw_json->>'startTimeGMT' DESC
+            """
+        )
+        return cur.fetchall()
+
+
+def _surfr_description(conn, start_time_gmt: str | None) -> str | None:
+    """Find the Surfr-exported Strava activity whose UTC start is within 15 min
+    of this Garmin activity, and return its corrected description."""
+    if not start_time_gmt:
+        return None
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT raw_json->>'description'
+            FROM strava_raw_data
+            WHERE jsonb_typeof(raw_json) = 'object'
+              AND raw_json->>'name' ILIKE '%%surfr%%'
+              AND raw_json->>'description' ILIKE '%%Top%%Jump%%'
+              AND abs(EXTRACT(EPOCH FROM (
+                    (raw_json->>'start_date')::timestamptz
+                    - (%s || ' UTC')::timestamptz))) < 900
+            ORDER BY abs(EXTRACT(EPOCH FROM (
+                    (raw_json->>'start_date')::timestamptz
+                    - (%s || ' UTC')::timestamptz)))
+            LIMIT 1
+            """,
+            (start_time_gmt, start_time_gmt),
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def _store(conn, activity_id, payload):
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO garmin_activity_raw (activity_id, endpoint_name, raw_json, synced_at)
+            VALUES (%s, 'kite_jumps', %s, NOW())
+            ON CONFLICT (activity_id, endpoint_name)
+            DO UPDATE SET raw_json = EXCLUDED.raw_json, synced_at = NOW()
+            """,
+            (activity_id, json.dumps(payload)),
+        )
+
+
+def store_kite_jumps_for_activity(conn, garmin, activity_id, start_gmt: str | None) -> dict:
+    """Download the FIT, extract per-jump data (heights, 3D flight paths, native
+    airtime/distance), match Surfr's description for enrichment, and store the
+    payload under endpoint 'kite_jumps'. Reused by the backfill and the live sync
+    hook. Cleans up the downloaded FIT afterwards. Returns the payload."""
+    fit_dir = None
+    try:
+        fit_path = _download_fit_file(garmin, activity_id)
+        fit_dir = os.path.dirname(fit_path)
+        desc = _surfr_description(conn, start_gmt)
+        payload = build_kite_jumps(fit_path, desc)
+        _store(conn, activity_id, payload)
+        return payload
+    finally:
+        if fit_dir and os.path.isdir(fit_dir):
+            shutil.rmtree(fit_dir, ignore_errors=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--only", type=int, help="Backfill a single activity id")
+    args = ap.parse_args()
+
+    conn = psycopg2.connect(DB_URL)
+    conn.autocommit = True
+    garmin = init_garmin()
+
+    activities = _kite_activities(conn)
+    if args.only:
+        activities = [a for a in activities if int(a[0]) == args.only]
+
+    print(f"Backfilling {len(activities)} kite activities")
+    done = jumps_total = 0
+    for activity_id, start_gmt in activities:
+        try:
+            payload = store_kite_jumps_for_activity(conn, garmin, activity_id, start_gmt)
+            n = payload["summary"]["jump_count"]
+            jumps_total += n
+            done += 1
+            print(
+                f"  {activity_id} {start_gmt}: {n} jumps, "
+                f"max {payload['summary']['max_height_m']}m"
+                f"{' (surfr-enriched)' if payload['summary']['surfr_matched'] else ''}"
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {activity_id} {start_gmt}: ERROR {exc}", file=sys.stderr)
+
+    print(f"Done: {done}/{len(activities)} activities, {jumps_total} jumps stored")
+
+
+if __name__ == "__main__":
+    main()

--- a/sync/src/garmin_push.py
+++ b/sync/src/garmin_push.py
@@ -145,6 +145,79 @@ def generate_run_strava_description(summary: dict, hr_zones: list | None = None)
     return "\n".join(lines)
 
 
+def _get_kite_jumps(conn, activity_id: int) -> dict | None:
+    """Fetch the stored kite_jumps payload for an activity, if any."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT raw_json FROM garmin_activity_raw "
+            "WHERE activity_id = %s AND endpoint_name = 'kite_jumps'",
+            (activity_id,),
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def kite_activity_name(summary: dict, payload: dict) -> str:
+    """Custom kite naming: 'Schinias · Max Jump: 5.2m · 29 jumps'."""
+    s = payload.get("summary", {})
+    spot = s.get("spot") or summary.get("activityName") or "Kiteboarding"
+    n, mh = s.get("jump_count") or 0, s.get("max_height_m")
+    if mh and n:
+        return f"{spot} · Max Jump: {mh}m · {n} jumps"
+    return f"{spot} Kiteboarding" if s.get("spot") else (summary.get("activityName") or "Kiteboarding")
+
+
+def generate_kite_strava_description(summary: dict, payload: dict) -> str:
+    """Rich Strava description for a kiteboarding session (jumps in metres,
+    speed in knots), built from the extracted per-jump data."""
+    s = payload.get("summary", {})
+    jumps = payload.get("jumps", [])
+    lines: list[str] = []
+
+    headline = []
+    if s.get("max_height_m"):
+        headline.append(f"🪁 Max Jump: {s['max_height_m']} m")
+    if s.get("max_airtime_s"):
+        headline.append(f"⏱️ Airtime: {round(float(s['max_airtime_s']), 1)} s")
+    if s.get("jump_count"):
+        headline.append(f"🔢 {s['jump_count']} jumps")
+    if headline:
+        lines.append("  ·  ".join(headline))
+
+    stats = []
+    dist = summary.get("distance", 0)
+    if dist > 0:
+        stats.append(f"📏 {dist / 1000:.1f} km")
+    max_speed = summary.get("maxSpeed", 0)
+    if max_speed and max_speed > 0:
+        stats.append(f"💨 {max_speed * 1.94384:.1f} kn")
+    dur = summary.get("movingDuration") or summary.get("duration") or 0
+    if dur > 0:
+        stats.append(f"🕒 {int(dur // 3600)}h {int((dur % 3600) // 60):02d}m")
+    avg_hr = summary.get("averageHR", 0)
+    if avg_hr and avg_hr > 0:
+        stats.append(f"❤️ {round(avg_hr)} bpm")
+    if stats:
+        lines.append("  ·  ".join(stats))
+
+    top = [j for j in jumps if j.get("rank")][:5]
+    if top:
+        lines.append("")
+        lines.append("Top jumps:")
+        for j in top:
+            seg = f"  {j['rank']}. {j['height_m']} m"
+            if j.get("airtime_s"):
+                seg += f", {round(float(j['airtime_s']), 1)} s air"
+            if j.get("distance_m"):
+                seg += f", {j['distance_m']} m"
+            lines.append(seg)
+
+    if lines:
+        lines.append("")
+        lines.append("Tracked by github.com/drkostas/soma")
+    return "\n".join(lines)
+
+
 def _download_fit_file(garmin_client, activity_id: int) -> str:
     """Download the original FIT file from Garmin Connect.
 
@@ -213,6 +286,14 @@ def push_garmin_activity_to_strava(
         garmin_type = summary.get("activityType", {}).get("typeKey", "")
         sport_type = GARMIN_TO_STRAVA_SPORT.get(garmin_type, "Workout")
 
+        # Kite sessions get a custom name + description from the extracted jump data.
+        kite_payload = None
+        if "kite" in garmin_type.lower():
+            with get_connection() as db_conn:
+                kite_payload = _get_kite_jumps(db_conn, activity_id)
+            if kite_payload and kite_payload.get("summary", {}).get("jump_count"):
+                name = kite_activity_name(summary, kite_payload)
+
         # 2. Init Garmin client if not provided
         if garmin_client is None:
             garmin_client = init_garmin()
@@ -255,9 +336,12 @@ def push_garmin_activity_to_strava(
         # 6. Update Strava activity with rich description
         if strava_activity_id:
             try:
-                with get_connection() as db_conn:
-                    hr_zones = _get_activity_hr_zones(db_conn, activity_id)
-                desc = generate_run_strava_description(summary, hr_zones)
+                if kite_payload:
+                    desc = generate_kite_strava_description(summary, kite_payload)
+                else:
+                    with get_connection() as db_conn:
+                        hr_zones = _get_activity_hr_zones(db_conn, activity_id)
+                    desc = generate_run_strava_description(summary, hr_zones)
                 if desc:
                     strava_client.update_activity(strava_activity_id, description=desc)
                     logger.info("Description updated for Strava activity %s", strava_activity_id)

--- a/sync/src/garmin_sync.py
+++ b/sync/src/garmin_sync.py
@@ -126,6 +126,25 @@ def sync_activities_for_date(client, sync_date: date) -> list[int]:
         return []
 
 
+def _maybe_extract_kite_jumps(conn, client, activity_id: int) -> None:
+    """If this activity is a kiteboarding session, extract and store its per-jump
+    data (heights + 3D flight paths) so the share image can render it. Guarded so a
+    failure never breaks the main activity sync."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT raw_json->'activityType'->>'typeKey', raw_json->>'startTimeGMT' "
+            "FROM garmin_activity_raw WHERE activity_id = %s AND endpoint_name = 'summary'",
+            (activity_id,),
+        )
+        row = cur.fetchone()
+    if not row or not row[0] or "kite" not in row[0].lower():
+        return
+    from backfill_kite_jumps import store_kite_jumps_for_activity
+
+    payload = store_kite_jumps_for_activity(conn, client, activity_id, row[1])
+    print(f"    Kite: {payload['summary']['jump_count']} jumps extracted for {activity_id}")
+
+
 def sync_activity_details(client, activity_id: int) -> int:
     """Fetch all detail endpoints for a single activity. Returns count saved."""
     from db import upsert_activity_raw
@@ -139,6 +158,10 @@ def sync_activity_details(client, activity_id: int) -> int:
                     count += 1
             except Exception as e:
                 print(f"    Warning: activity {activity_id}/{endpoint_name} failed: {e}")
+        try:
+            _maybe_extract_kite_jumps(conn, client, activity_id)
+        except Exception as e:
+            print(f"    Warning: kite extraction for {activity_id} failed: {e}")
     return count
 
 

--- a/sync/src/kite_jumps.py
+++ b/sync/src/kite_jumps.py
@@ -1,0 +1,246 @@
+"""Extract kiteboarding jump data from Garmin/Surfr FIT files.
+
+The watch runs Surfr's Connect IQ data field, which writes per-jump height into
+the FIT `record` stream (developer field `heights`) together with GPS position
+and timestamp. We validated that this per-record height matches Surfr's
+cloud-corrected value exactly (e.g. 5.20/4.74/4.23/3.78/3.69 m on Schinias
+2025-11-18). The session-level summary `maxheight` field is unreliable (it can
+glitch to e.g. 13.51 m) and is intentionally ignored.
+
+Surfr's auto-exported Strava activity (stored in `strava_raw_data`) carries the
+corrected Top-5 description with per-jump airtime / distance / approach-speed.
+We join that in by rank to enrich the biggest jumps.
+
+Heights stay in meters (the kiteboarding convention for jump height). Speeds are
+exposed in knots per the project preference.
+"""
+
+import re
+
+import fitparse
+
+KMH_TO_KNOTS = 1 / 1.852
+MS_TO_KNOTS = 3.6 / 1.852
+
+# A record's `heights` field is non-zero only during a jump; the same height
+# repeats across the airtime samples. Runs separated by more than this many
+# seconds are treated as separate jumps.
+_JUMP_GAP_S = 4
+_MIN_JUMP_M = 0.3
+# Surfr only corrects heights it agrees with within this tolerance; used to
+# guard the rank-based join so a mismatched session can't attach wrong airtimes.
+_SURFR_MATCH_TOL_M = 0.5
+
+_SURFR_JUMP_RE = re.compile(
+    r"Nr\.\s*(\d+)\s*,\s*H:\s*([\d.]+)\s*m\s*,\s*A:\s*([\d.]+)\s*sec\.?\s*,\s*"
+    r"D:\s*(\d+)\s*m\s*,\s*Max\s*Speed:\s*(\d+)\s*Km/h",
+    re.IGNORECASE,
+)
+_SURFR_SPOT_RE = re.compile(r"Spot:\s*'([^']+)'", re.IGNORECASE)
+_SURFR_MAXAIR_RE = re.compile(r"Max\.?\s*Airtime:\s*([\d.]+)\s*sec", re.IGNORECASE)
+
+
+def _semicircles_to_deg(v):
+    return v * (180 / 2**31) if v is not None else None
+
+
+def _read_jump_samples(fit_path: str) -> list[dict]:
+    """Read the per-record jump samples (heights>0) from a FIT file.
+
+    Besides the `heights` value, each record carries three richer developer
+    fields written by Surfr's Connect IQ app (validated against Surfr's
+    cloud-corrected output — exact match):
+      - `jump`:      (height_m, airtime_s, distance_m, approach_speed_ms)
+      - `jumpchart`: uint32[20] — the measured height trajectory in cm
+      - `timestamps`: (detect_ts, takeoff_ts, landing_ts) unix seconds
+    """
+    fit = fitparse.FitFile(fit_path)
+    samples = []
+    for msg in fit.get_messages("record"):
+        d = {x.name: x.value for x in msg}
+        h = d.get("heights")
+        if isinstance(h, (int, float)) and h and h > _MIN_JUMP_M:
+            samples.append(
+                {
+                    "time": d.get("timestamp"),
+                    "height_m": float(h),
+                    "lat": _semicircles_to_deg(d.get("position_lat")),
+                    "lng": _semicircles_to_deg(d.get("position_long")),
+                    "speed_ms": d.get("enhanced_speed"),
+                    "jump_tuple": d.get("jump"),
+                    "jumpchart": d.get("jumpchart"),
+                    "jump_ts": d.get("timestamps"),
+                }
+            )
+    return samples
+
+
+def group_jumps(samples: list[dict]) -> list[dict]:
+    """Group time-ordered jump samples into individual jumps (peak per run),
+    sorted biggest-first. Pure function over sample dicts."""
+    groups: list[list[dict]] = []
+    cur: list[dict] = []
+    for s in samples:
+        if not cur or (s["time"] - cur[-1]["time"]).total_seconds() <= _JUMP_GAP_S:
+            cur.append(s)
+        else:
+            groups.append(cur)
+            cur = [s]
+    if cur:
+        groups.append(cur)
+
+    jumps = []
+    for g in groups:
+        peak = max(g, key=lambda x: x["height_m"])
+        jump = {
+            "height_m": round(peak["height_m"], 2),
+            "lat": round(peak["lat"], 6) if peak["lat"] is not None else None,
+            "lng": round(peak["lng"], 6) if peak["lng"] is not None else None,
+            "time": peak["time"].isoformat() if hasattr(peak["time"], "isoformat") else peak["time"],
+        }
+        # Rich per-jump data from the Surfr CIQ developer fields (exact match with
+        # Surfr's corrected output — validated). Falls back gracefully when absent.
+        tup = peak.get("jump_tuple")
+        if tup and len(tup) >= 4 and tup[0] and tup[0] > 0:
+            jump["airtime_s"] = round(float(tup[1]), 2)
+            jump["distance_m"] = round(float(tup[2]), 1)
+            jump["approach_speed_kn"] = round(float(tup[3]) * MS_TO_KNOTS, 1)
+        elif peak.get("speed_ms"):
+            # NB: never derive airtime from the heights-run span — it lingers past
+            # the real airtime and overestimates badly.
+            jump["approach_speed_kn"] = round(peak["speed_ms"] * MS_TO_KNOTS, 1)
+        chart = peak.get("jumpchart")
+        if chart:
+            vals = [v / 100 for v in chart]
+            last = max((i for i, v in enumerate(vals) if v > 0), default=-1)
+            if last >= 0:
+                # Keep one bounding zero on each side (takeoff/landing on the water).
+                jump["trajectory_m"] = [0.0] + [round(v, 2) for v in vals[1 : last + 1]] + [0.0]
+        ts = peak.get("jump_ts")
+        if ts and len(ts) >= 3 and ts[1] and ts[2]:
+            jump["takeoff_ts"] = int(ts[1])
+            jump["landing_ts"] = int(ts[2])
+        jumps.append(jump)
+    jumps.sort(key=lambda j: j["height_m"], reverse=True)
+    return jumps
+
+
+# Seconds of on-water context captured around each jump's flight path.
+_PATH_LEAD_S = 3
+
+
+def _read_track(fit_path: str) -> list[tuple[int, float, float]]:
+    """(unix_ts, lat, lng) for every 1Hz record with a GPS fix.
+
+    FIT record timestamps are NAIVE UTC datetimes; `.timestamp()` on a naive
+    value assumes local time and shifts by the machine's UTC offset, breaking
+    the match against the dev-field unix timestamps. Force UTC explicitly.
+    """
+    from datetime import timezone
+
+    fit = fitparse.FitFile(fit_path)
+    track = []
+    for msg in fit.get_messages("record"):
+        d = {x.name: x.value for x in msg}
+        lat = _semicircles_to_deg(d.get("position_lat"))
+        lng = _semicircles_to_deg(d.get("position_long"))
+        t = d.get("timestamp")
+        if lat and lng and t is not None:
+            track.append((int(t.replace(tzinfo=timezone.utc).timestamp()), lat, lng))
+    return track
+
+
+def attach_jump_paths(jumps: list[dict], track: list[tuple[int, float, float]], top_n: int = 3) -> None:
+    """Attach the real flight-window GPS path (takeoff-3s .. landing+3s, 1Hz) to
+    the top N jumps: `path` = [[t_rel_s_from_takeoff, lat, lng], ...]."""
+    if not track:
+        return
+    for j in jumps[:top_n]:
+        t0, t1 = j.get("takeoff_ts"), j.get("landing_ts")
+        if not t0 or not t1:
+            continue
+        window = [
+            [ts - t0, round(lat, 6), round(lng, 6)]
+            for ts, lat, lng in track
+            if t0 - _PATH_LEAD_S <= ts <= t1 + _PATH_LEAD_S
+        ]
+        if len(window) >= 3:
+            j["path"] = window
+
+
+def extract_jumps_from_fit(fit_path: str) -> list[dict]:
+    """Per-jump {height_m, lat, lng, time, airtime, trajectory, path} from a FIT,
+    biggest-first.
+
+    Uses only the per-record `heights` developer field, never the glitchy
+    session-level `maxheight`.
+    """
+    jumps = group_jumps(_read_jump_samples(fit_path))
+    attach_jump_paths(jumps, _read_track(fit_path))
+    return jumps
+
+
+def parse_surfr_description(description: str | None) -> list[dict]:
+    """Parse Surfr's 'Top 5 Jumps' block into per-jump corrected detail."""
+    if not description:
+        return []
+    out = []
+    for m in _SURFR_JUMP_RE.finditer(description):
+        rank, h, air, dist, kmh = m.groups()
+        out.append(
+            {
+                "rank": int(rank),
+                "height_m": float(h),
+                "airtime_s": float(air),
+                "distance_m": int(dist),
+                "approach_speed_kn": round(int(kmh) * KMH_TO_KNOTS, 1),
+            }
+        )
+    return out
+
+
+def assemble_jumps(jumps: list[dict], surfr_description: str | None = None) -> dict:
+    """Rank jumps, enrich the top ones with Surfr airtime/distance (matched by
+    rank, height-guarded), and compute the session summary. Pure function."""
+    surfr = parse_surfr_description(surfr_description)
+    for i, j in enumerate(jumps):
+        j["rank"] = i + 1
+        s = next((s for s in surfr if s["rank"] == i + 1), None)
+        if s and abs(s["height_m"] - j["height_m"]) <= _SURFR_MATCH_TOL_M:
+            # Native airtime/distance (from the CIQ `jump` tuple) match Surfr's
+            # corrected values exactly, so Surfr's text is only a fallback for
+            # old sessions plus a cross-check marker.
+            j.setdefault("airtime_s", s["airtime_s"])
+            j.setdefault("distance_m", s["distance_m"])
+            j["surfr_height_m"] = s["height_m"]
+
+    # Spot name + session max-airtime from Surfr's description when available.
+    spot = None
+    surfr_max_air = None
+    if surfr_description:
+        m = _SURFR_SPOT_RE.search(surfr_description)
+        if m:
+            spot = m.group(1)
+        m = _SURFR_MAXAIR_RE.search(surfr_description)
+        if m:
+            surfr_max_air = float(m.group(1))
+    # Native per-jump airtimes are Surfr-accurate; Surfr's text is the fallback.
+    airtimes = [j["airtime_s"] for j in jumps if j.get("airtime_s")]
+    max_airtime = max(airtimes) if airtimes else surfr_max_air
+
+    heights = [j["height_m"] for j in jumps]
+    summary = {
+        "jump_count": len(jumps),
+        "max_height_m": max(heights) if heights else None,
+        "avg_height_m": round(sum(heights) / len(heights), 2) if heights else None,
+        "total_height_m": round(sum(heights), 1) if heights else None,
+        "max_airtime_s": max_airtime,
+        "spot": spot,
+        "surfr_matched": bool(surfr),
+    }
+    return {"jumps": jumps, "summary": summary}
+
+
+def build_kite_jumps(fit_path: str, surfr_description: str | None = None) -> dict:
+    """Assemble the stored jump payload from a FIT path + optional Surfr text."""
+    return assemble_jumps(extract_jumps_from_fit(fit_path), surfr_description)

--- a/sync/tests/test_kite_jumps.py
+++ b/sync/tests/test_kite_jumps.py
@@ -1,0 +1,158 @@
+"""Tests for kiteboarding jump extraction (kite_jumps).
+
+Ground truth: the watch per-record `heights` stream matches Surfr's cloud
+correction exactly (validated on Schinias 2025-11-18: 5.20/4.74/4.23/3.78/3.69).
+"""
+
+from datetime import datetime, timedelta
+
+from kite_jumps import (
+    assemble_jumps,
+    attach_jump_paths,
+    group_jumps,
+    parse_surfr_description,
+)
+
+# Real Surfr description text from the Schinias 2025-11-18 Strava export.
+SURFR_DESC = (
+    "The Surfr. App - Session at Spot: 'Schinias' \r\n Highest Jump: 5.20 m \r\n "
+    "Max. Airtime: 5.43 sec. \r\n Max. Distance: 30 m \r\n Max. Speed: 36 Km/h \r\n\r\n"
+    "Top 5 Jumps:\r\n"
+    " Nr. 1, H: 5.20 m, A: 5.20 sec., D: 17 m, Max Speed: 21 Km/h, \r\n"
+    " Nr. 2, H: 4.74 m, A: 5.43 sec., D: 27 m, Max Speed: 22 Km/h, \r\n"
+    " Nr. 3, H: 4.23 m, A: 4.71 sec., D: 30 m, Max Speed: 28 Km/h, \r\n"
+    " Nr. 4, H: 3.78 m, A: 3.43 sec., D: 25 m, Max Speed: 22 Km/h, \r\n"
+    " Nr. 5, H: 3.69 m, A: 4.22 sec., D: 26 m, Max Speed: 24 Km/h, \r\n"
+)
+
+
+def _sample(t0, secs, h, lat=38.14, lng=24.05, speed=10.0, tup=None, chart=None, ts=None):
+    return {
+        "time": t0 + timedelta(seconds=secs), "height_m": h, "lat": lat, "lng": lng,
+        "speed_ms": speed, "jump_tuple": tup, "jumpchart": chart, "jump_ts": ts,
+    }
+
+
+# --- parse_surfr_description ---
+
+def test_parse_surfr_all_five_jumps():
+    jumps = parse_surfr_description(SURFR_DESC)
+    assert len(jumps) == 5
+    assert [j["height_m"] for j in jumps] == [5.20, 4.74, 4.23, 3.78, 3.69]
+    assert jumps[1]["airtime_s"] == 5.43
+    assert jumps[2]["distance_m"] == 30
+
+
+def test_parse_surfr_converts_speed_to_knots():
+    jumps = parse_surfr_description(SURFR_DESC)
+    # 21 Km/h -> 21 / 1.852 = 11.3 kn
+    assert jumps[0]["approach_speed_kn"] == 11.3
+
+
+def test_parse_surfr_empty():
+    assert parse_surfr_description(None) == []
+    assert parse_surfr_description("just a normal run, no jumps") == []
+
+
+# --- group_jumps ---
+
+def test_group_jumps_peak_and_sort():
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    # jump A spans 3 samples peaking at 5.2, jump B (after a >4s gap) peaks 3.0
+    samples = [
+        _sample(t0, 0, 4.0), _sample(t0, 1, 5.2), _sample(t0, 2, 4.5),
+        _sample(t0, 30, 2.8), _sample(t0, 31, 3.0),
+    ]
+    jumps = group_jumps(samples)
+    assert len(jumps) == 2
+    assert [j["height_m"] for j in jumps] == [5.2, 3.0]  # sorted biggest-first
+
+
+def test_group_jumps_splits_on_gap():
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    # three jumps each separated by a >4s gap
+    samples = [_sample(t0, 0, 3.0), _sample(t0, 10, 3.5), _sample(t0, 20, 4.0)]
+    assert len(group_jumps(samples)) == 3
+
+
+def test_group_jumps_position_from_peak():
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    samples = [_sample(t0, 0, 2.0, lat=1.0, lng=1.0), _sample(t0, 1, 5.0, lat=2.0, lng=2.0)]
+    j = group_jumps(samples)[0]
+    assert j["lat"] == 2.0 and j["lng"] == 2.0  # position at the peak sample
+
+
+def test_group_jumps_native_tuple_and_trajectory():
+    """The CIQ `jump` tuple gives real airtime/distance/approach; `jumpchart`
+    (cm) becomes a metre trajectory trimmed to one bounding zero per side."""
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    chart = (0, 28, 99, 319, 466, 519, 464, 339, 179, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    tup = (5.197, 5.2, 17.1, 5.757)
+    ts = (1763469942, 1763469941, 1763469947)
+    j = group_jumps([_sample(t0, 0, 5.2, tup=tup, chart=chart, ts=ts)])[0]
+    assert j["airtime_s"] == 5.2
+    assert j["distance_m"] == 17.1
+    assert j["approach_speed_kn"] == 11.2  # 5.757 m/s → kn
+    assert j["trajectory_m"][0] == 0.0 and j["trajectory_m"][-1] == 0.0
+    assert max(j["trajectory_m"]) == 5.19  # 519 cm
+    assert len(j["trajectory_m"]) == 11    # 9 in-air points + 2 bounding zeros
+    assert j["takeoff_ts"] == 1763469941 and j["landing_ts"] == 1763469947
+
+
+def test_group_jumps_no_tuple_falls_back():
+    """Without the dev fields (old Surfr-synced FITs) there's no airtime and no
+    trajectory — just height/position, approach from GPS speed."""
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    j = group_jumps([_sample(t0, 0, 3.0, speed=6.0)])[0]
+    assert "airtime_s" not in j and "trajectory_m" not in j
+    assert j["approach_speed_kn"] == round(6.0 * 3.6 / 1.852, 1)
+
+
+# --- assemble_jumps ---
+
+def test_assemble_enriches_top_jumps_by_rank():
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    samples = [_sample(t0, i * 10, h) for i, h in enumerate([5.20, 4.74, 4.23])]
+    payload = assemble_jumps(group_jumps(samples), SURFR_DESC)
+    assert payload["summary"]["jump_count"] == 3
+    assert payload["summary"]["max_height_m"] == 5.20
+    assert payload["jumps"][0]["airtime_s"] == 5.20   # from Surfr rank 1
+    assert payload["jumps"][1]["distance_m"] == 27     # from Surfr rank 2
+
+
+def test_assemble_height_guard_blocks_mismatched_enrichment():
+    """If the watch height disagrees with Surfr's rank-N height by >0.5m, do not
+    attach Surfr's enrichment (protects against a bad session match). A group-span
+    airtime estimate is still present, but Surfr's distance/height markers are not."""
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    samples = [_sample(t0, 0, 9.9)]  # nowhere near Surfr's 5.20
+    payload = assemble_jumps(group_jumps(samples), SURFR_DESC)
+    assert "surfr_height_m" not in payload["jumps"][0]
+    assert "distance_m" not in payload["jumps"][0]
+
+
+def test_attach_jump_paths_slices_flight_window():
+    """Path = 1Hz GPS from takeoff-3s to landing+3s, times relative to takeoff."""
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    take, land = 1763469941, 1763469947
+    j = group_jumps([_sample(t0, 0, 5.2, tup=(5.2, 5.2, 17.1, 5.8),
+                             chart=(0, 100, 519, 100, 0), ts=(take + 1, take, land))])
+    track = [(ts, 38.0 + i * 1e-5, 24.0 + i * 1e-5) for i, ts in enumerate(range(take - 10, land + 10))]
+    attach_jump_paths(j, track)
+    path = j[0]["path"]
+    assert path[0][0] == -3 and path[-1][0] == (land - take) + 3
+    assert len(path) == (land - take) + 7  # 1Hz inclusive
+
+
+def test_attach_jump_paths_skips_without_timestamps():
+    t0 = datetime(2025, 11, 18, 11, 0, 0)
+    j = group_jumps([_sample(t0, 0, 3.0)])  # no dev fields
+    attach_jump_paths(j, [(100, 38.0, 24.0), (101, 38.0, 24.0), (102, 38.0, 24.0)])
+    assert "path" not in j[0]
+
+
+def test_assemble_empty_session():
+    payload = assemble_jumps([], SURFR_DESC)
+    assert payload["summary"]["jump_count"] == 0
+    assert payload["summary"]["max_height_m"] is None
+    assert payload["jumps"] == []

--- a/sync/tests/test_kite_push.py
+++ b/sync/tests/test_kite_push.py
@@ -1,0 +1,48 @@
+"""Tests for kite-aware Strava naming + description (garmin_push)."""
+
+from garmin_push import generate_kite_strava_description, kite_activity_name
+
+SUMMARY = {
+    "activityName": "Kiteboarding",
+    "distance": 25750.0,      # m
+    "maxSpeed": 10.1,         # m/s -> ~19.6 kn
+    "movingDuration": 5760,   # 1h 36m
+    "averageHR": 149,
+}
+PAYLOAD = {
+    "summary": {"spot": "Schinias", "jump_count": 29, "max_height_m": 5.2, "max_airtime_s": 5.43},
+    "jumps": [
+        {"rank": 1, "height_m": 5.2, "airtime_s": 5.2, "distance_m": 17.1},
+        {"rank": 2, "height_m": 4.74, "airtime_s": 5.43, "distance_m": 27.0},
+        {"rank": 3, "height_m": 4.23},
+    ],
+}
+
+
+def test_kite_name_with_jumps():
+    assert kite_activity_name(SUMMARY, PAYLOAD) == "Schinias · Max Jump: 5.2m · 29 jumps"
+
+
+def test_kite_name_no_jumps_falls_back():
+    assert kite_activity_name(SUMMARY, {"summary": {"jump_count": 0}}) == "Kiteboarding"
+
+
+def test_kite_description_headline_and_units():
+    desc = generate_kite_strava_description(SUMMARY, PAYLOAD)
+    assert "Max Jump: 5.2 m" in desc
+    assert "29 jumps" in desc
+    assert "19.6 kn" in desc          # knots, not km/h
+    assert "25.8 km" in desc          # distance
+    assert "1h 36m" in desc           # moving duration
+    assert "github.com/drkostas/soma" in desc
+
+
+def test_kite_description_top_jumps_ranked():
+    desc = generate_kite_strava_description(SUMMARY, PAYLOAD)
+    assert "Top jumps:" in desc
+    assert "1. 5.2 m, 5.2 s air, 17.1 m" in desc
+    assert "3. 4.23 m" in desc        # rank 3 has no airtime/distance -> height only
+
+
+def test_kite_description_empty_session():
+    assert generate_kite_strava_description(SUMMARY, {"summary": {}, "jumps": []}) != ""

--- a/web/app/api/activity/[id]/image/route.tsx
+++ b/web/app/api/activity/[id]/image/route.tsx
@@ -1,7 +1,18 @@
 import { ImageResponse } from "@vercel/og";
+import sharp from "sharp";
 import { getDb } from "@/lib/db";
 
 export const runtime = "nodejs";
+
+// #rrggbb -> [r,g,b]
+function hexToRgb(h: string): [number, number, number] {
+  const n = parseInt(h.replace("#", ""), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+function hexToRgba(h: string, a: number): string {
+  const [r, g, b] = hexToRgb(h);
+  return `rgba(${r},${g},${b},${a})`;
+}
 
 // ── Formatters ────────────────────────────────────────────────────────────────
 
@@ -66,12 +77,101 @@ function selectZoom(minLat: number, maxLat: number, minLng: number, maxLng: numb
   }
   return 12;
 }
-async function fetchTile(z: number, x: number, y: number): Promise<string | null> {
+// Minimum enclosing circle (Ritter's approximation) of points in zoom-0 world px.
+// Used to frame the route consistently regardless of its shape (no aspect-ratio bias).
+function boundingCircle(pts: { x: number; y: number }[]) {
+  const d2 = (a: { x: number; y: number }, b: { x: number; y: number }) => (a.x - b.x) ** 2 + (a.y - b.y) ** 2;
+  let p1 = pts.reduce((a, b) => (d2(pts[0], b) > d2(pts[0], a) ? b : a), pts[0]);
+  let p2 = pts.reduce((a, b) => (d2(p1, b) > d2(p1, a) ? b : a), pts[0]);
+  let cx = (p1.x + p2.x) / 2, cy = (p1.y + p2.y) / 2;
+  let r = Math.sqrt(d2(p1, p2)) / 2;
+  for (const p of pts) {
+    const d = Math.hypot(p.x - cx, p.y - cy);
+    if (d > r) {
+      const k = (d - r) / (2 * d);
+      cx += (p.x - cx) * k; cy += (p.y - cy) * k;
+      r = (r + d) / 2;
+    }
+  }
+  return { cx, cy, r };
+}
+// Basemap tile sources (several have a real blue sea). {z}/{x}/{y} placeholders;
+// Esri uses {z}/{y}/{x} order, handled by the template string itself.
+const BASEMAPS: Record<string, string> = {
+  dark:        "https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+  darknolabels:"https://basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+  voyager:     "https://basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png",
+  positron:    "https://basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png",
+  ocean:       "https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}",
+  satellite:   "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+  darkgray:    "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+  lightgray:   "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+  natgeo:      "https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}",
+  terrain:     "https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}",
+  osm:         "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+};
+
+async function fetchTile(
+  tpl: string, z: number, x: number, y: number,
+  opts?: { duo?: { lo: [number, number, number]; hi: [number, number, number] }; bright?: number; sat?: number; hue?: number; sea?: [number, number, number]; seaDeep?: [number, number, number] },
+): Promise<string | null> {
   try {
-    const res = await fetch(`https://basemaps.cartocdn.com/dark_all/${z}/${x}/${y}.png`, { signal: AbortSignal.timeout(6000) });
-    if (!res.ok) return null;
-    return `data:image/png;base64,${Buffer.from(await res.arrayBuffer()).toString("base64")}`;
+    const url = tpl.replace("{z}", String(z)).replace("{x}", String(x)).replace("{y}", String(y));
+    // Retry once so a transient tile miss doesn't leave a black gap in the map.
+    let res: Response | null = null;
+    for (let attempt = 0; attempt < 2 && !res; attempt++) {
+      try {
+        const r = await fetch(url, { headers: { "User-Agent": "soma-activity-image" }, signal: AbortSignal.timeout(6500) });
+        if (r.ok) res = r;
+      } catch { /* retry */ }
+    }
+    if (!res) return null;
+    const ct = res.headers.get("content-type") || "image/png";
+    let buf = Buffer.from(await res.arrayBuffer());
+    const duo = opts?.duo, bright = opts?.bright, sat = opts?.sat, hue = opts?.hue, sea = opts?.sea;
+    const mod = (bright && bright !== 1) || (sat && sat !== 1) || (hue && hue !== 0);
+    if (duo || mod || sea) {
+      let img = sharp(buf);
+      if (mod) img = img.modulate({ brightness: bright ?? 1, saturation: sat ?? 1, hue: hue ?? 0 });
+      if (duo) {
+        const mult = [0, 1, 2].map((i) => (duo.hi[i] - duo.lo[i]) / 255);
+        img = img.grayscale().toColourspace("srgb").linear(mult, duo.lo);
+      }
+      buf = await img.png().toBuffer();
+      if (sea) buf = await recolorSea(buf, sea, opts?.seaDeep);
+      return `data:image/png;base64,${buf.toString("base64")}`;
+    }
+    // Emit with the real mime (Esri returns JPEG; a wrong png mime renders blank).
+    return `data:${ct};base64,${buf.toString("base64")}`;
   } catch { return null; }
+}
+
+// Repaint the sea (bluish pixels) to a target color, keeping land untouched.
+// Voyager's water is the region where blue is clearly the dominant channel.
+async function recolorSea(
+  buf: Buffer, shallow: [number, number, number], deep?: [number, number, number],
+): Promise<Buffer> {
+  const { data, info } = await sharp(buf).removeAlpha().raw().toBuffer({ resolveWithObject: true });
+  const ch = info.channels;
+  for (let i = 0; i < data.length; i += ch) {
+    const r = data[i], g = data[i + 1], b = data[i + 2];
+    if (b > r + 6 && b >= g - 4) {
+      const lum = (0.35 * r + 0.5 * g + 0.15 * b) / 255;
+      if (deep) {
+        // Tropical gradient: bright shallow (light water) → deep blue (dark water).
+        const t = Math.max(0, Math.min(1, (lum - 0.5) / 0.4));
+        data[i]     = Math.round(deep[0] + (shallow[0] - deep[0]) * t);
+        data[i + 1] = Math.round(deep[1] + (shallow[1] - deep[1]) * t);
+        data[i + 2] = Math.round(deep[2] + (shallow[2] - deep[2]) * t);
+      } else {
+        const f = 0.55 + 0.55 * lum;
+        data[i] = Math.min(255, Math.round(shallow[0] * f));
+        data[i + 1] = Math.min(255, Math.round(shallow[1] * f));
+        data[i + 2] = Math.min(255, Math.round(shallow[2] * f));
+      }
+    }
+  }
+  return sharp(data, { raw: { width: info.width, height: info.height, channels: info.channels } }).png().toBuffer();
 }
 
 // ── Pace color (matches run-map.tsx) ─────────────────────────────────────────
@@ -91,23 +191,214 @@ function speedToColor(speed: number | null): string {
   return "#00e5ff";
 }
 
+// ── Kiteboarding speed color (water/spray: deep ocean → cyan → foam) ─────────
+// speed is m/s; kiteboarding ranges roughly 0–30+ km/h.
+
+function lerpHex(a: string, b: string, t: number): string {
+  const pa = [1, 3, 5].map((i) => parseInt(a.slice(i, i + 2), 16));
+  const pb = [1, 3, 5].map((i) => parseInt(b.slice(i, i + 2), 16));
+  const c = pa.map((v, i) => Math.round(v + (pb[i] - v) * t).toString(16).padStart(2, "0"));
+  return `#${c.join("")}`;
+}
+// Kite route speed palettes (color stops mapped across ~4–32 km/h). On a teal/
+// tropical sea the cool (blue/cyan) end blends in, so warm palettes read better.
+const KITE_PALETTES: Record<string, string[]> = {
+  cool:     ["#2563eb", "#06b6d4", "#f59e0b", "#ff1744"], // original (cyan blends on teal)
+  heat:     ["#fef3c7", "#fb923c", "#ef4444", "#7f1d1d"], // cream → orange → red → dark
+  magenta:  ["#fbcfe8", "#e879f9", "#f43f5e", "#9f1239"], // pink → magenta → rose → crimson
+  coral:    ["#fed7aa", "#fb7185", "#e11d48", "#4c0519"], // peach → coral → rose → dark
+  fire:     ["#fde047", "#f97316", "#dc2626", "#450a0a"], // yellow → orange → red → near-black
+  // Cold→hot with a PURE blue slow end (distinct from the teal sea, no cyan/green):
+  spectral: ["#1d4ed8", "#a855f7", "#f59e0b", "#ef4444"], // blue → purple → amber → red
+  coolwarm: ["#2563eb", "#e2e8f0", "#fb923c", "#dc2626"], // blue → white → orange → red
+  jet:      ["#1d4ed8", "#7c3aed", "#f472b6", "#f59e0b", "#dc2626"], // blue→violet→pink→amber→red
+};
+// t is already normalised 0..1 (a speed rank); map it across the palette stops.
+function kiteRouteColor(t: number, stops: string[]): string {
+  const tt = Math.max(0, Math.min(0.9999, t));
+  const n = stops.length - 1;
+  const seg = Math.floor(tt * n);
+  return lerpHex(stops[seg], stops[seg + 1], tt * n - seg);
+}
+
+// The top jump's REAL flight in 3D, framed from a viewpoint FITTED to the user's
+// own hand-picks (jump-viewer tool). Statistical analysis of 9 framings found the
+// invariant is a specific geometry, not "camera behind takeoff": takeoff (green)
+// nearest the viewer, the approach line showing ~0.69 of its true length, the
+// landing line ~0.51, a low ~16° camera, and a tall arc. We search azimuth ×
+// elevation on the upper hemisphere (camera always above the water) and pick the
+// view best matching those targets — reproducing how the user frames jumps.
+function renderJumpArcSvg(
+  W: number, H: number, traj: number[], airtimeS: number,
+  path: [number, number, number][],
+  windFromDeg?: number | null,
+  azBiasDeg = 0,
+): string {
+  const t0p = path.reduce((a, b) => (Math.abs(b[0]) < Math.abs(a[0]) ? b : a), path[0]);
+  const lat0 = t0p[1], lng0 = t0p[2];
+  const mPerLng = 111320 * Math.cos((lat0 * Math.PI) / 180), mPerLat = 110540;
+  const horiz = path.map(([t, la, lg]) => ({ t, x: (lg - lng0) * mPerLng, y: (la - lat0) * mPerLat }));
+  const Z_EXAG = 1.9;
+  const hAt = (t: number) => {
+    if (t < 0 || t > airtimeS || traj.length < 2) return 0;
+    const f = (t / airtimeS) * (traj.length - 1), i = Math.min(traj.length - 2, Math.floor(f));
+    return traj[i] + (traj[i + 1] - traj[i]) * (f - i);
+  };
+  const xyAt = (t: number) => {
+    if (t <= horiz[0].t) return horiz[0];
+    for (let i = 0; i < horiz.length - 1; i++) {
+      if (t <= horiz[i + 1].t) {
+        const f = (t - horiz[i].t) / Math.max(0.001, horiz[i + 1].t - horiz[i].t);
+        return { x: horiz[i].x + (horiz[i + 1].x - horiz[i].x) * f, y: horiz[i].y + (horiz[i + 1].y - horiz[i].y) * f };
+      }
+    }
+    return horiz[horiz.length - 1];
+  };
+  const tMin = Math.max(horiz[0].t, -1.2), tMax = Math.min(horiz[horiz.length - 1].t, airtimeS + 1.5);
+  const samples: { t: number; x: number; y: number; z: number; w: number[] }[] = [];
+  for (let t = tMin; t <= tMax + 1e-6; t += 0.25) { const p = xyAt(t); samples.push({ t, x: p.x, y: p.y, z: hAt(t) * Z_EXAG, w: [0, 0, 0] }); }
+  const cx = samples.reduce((a, p) => a + p.x, 0) / samples.length;
+  const cy = samples.reduce((a, p) => a + p.y, 0) / samples.length;
+  samples.forEach((p) => { p.w = [p.x - cx, p.y - cy, p.z]; });
+  const peakZ = Math.max(...samples.map((p) => p.z), 0.01);
+  const iT = Math.max(0, samples.findIndex((p) => p.t >= 0));
+  let iL = samples.findIndex((p) => p.t >= airtimeS); if (iL < 0) iL = samples.length - 1;
+  const iP = samples.reduce((a, p, i) => (p.z > samples[a].z ? i : a), 0);
+  const tgt = [0, 0, peakZ / 3];
+
+  const nrm = (v: number[]) => { const n = Math.hypot(v[0], v[1], v[2]) || 1; return [v[0] / n, v[1] / n, v[2] / n]; };
+  const cross = (a: number[], b: number[]) => [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
+  const dot = (a: number[], b: number[]) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+  type Basis = { camDir: number[]; right: number[]; up: number[] };
+  const basis = (A: number, E: number): Basis => {
+    const camDir = [Math.cos(E) * Math.sin(A), Math.cos(E) * Math.cos(A), Math.sin(E)];
+    const f = [-camDir[0], -camDir[1], -camDir[2]];
+    const right = nrm(cross(f, [0, 0, 1]));
+    return { camDir, right, up: cross(right, f) };
+  };
+  const pW = (w: number[], b: Basis) => { const d = [w[0] - tgt[0], w[1] - tgt[1], w[2] - tgt[2]]; return { sx: dot(d, b.right), sy: dot(d, b.up), depth: dot(d, b.camDir) }; };
+  const len2 = (ps: { sx: number; sy: number }[]) => { let s = 0; for (let i = 1; i < ps.length; i++) s += Math.hypot(ps[i].sx - ps[i - 1].sx, ps[i].sy - ps[i - 1].sy); return s; };
+  const len3 = (ws: number[][]) => { let s = 0; for (let i = 1; i < ws.length; i++) s += Math.hypot(ws[i][0] - ws[i - 1][0], ws[i][1] - ws[i - 1][1], ws[i][2] - ws[i - 1][2]); return s; };
+
+  // viewpoint search: match the user's measured framing invariants
+  const appW = samples.slice(0, iT + 1).map((p) => p.w);
+  const runW = samples.slice(iL).map((p) => p.w);
+  const trueA = Math.max(1e-6, len3(appW)), trueR = Math.max(1e-6, len3(runW));
+  let best: { A: number; E: number; score: number } | null = null;
+  for (let Ad = 0; Ad < 360; Ad += 6) {
+    const A = (Ad * Math.PI) / 180;
+    for (let Ed = 10; Ed <= 26; Ed += 2) {
+      const b = basis(A, (Ed * Math.PI) / 180);
+      const gd = pW(samples[iT].w, b).depth, rd = pW(samples[iL].w, b).depth;
+      if (gd <= rd) continue;                                   // green (takeoff) must be nearest
+      const visT = len2(appW.map((w) => pW(w, b))) / trueA;
+      const visL = len2(runW.map((w) => pW(w, b))) / trueR;
+      if (visT < 0.25 || visL < 0.12) continue;                 // avoid end-on degeneracy
+      const pk = pW(samples[iP].w, b), tk = pW(samples[iT].w, b), ld = pW(samples[iL].w, b);
+      const fw = Math.hypot(ld.sx - tk.sx, ld.sy - tk.sy) || 1;
+      const peakRise = (pk.sy - (tk.sy + ld.sy) / 2) / fw;
+      const score = -2.4 * (visT - 0.69) ** 2 - 0.7 * (visL - 0.51) ** 2 - 0.01 * (Ed - 16) ** 2 + 0.08 * Math.min(peakRise, 1.4);
+      if (!best || score > best.score) best = { A, E: (Ed * Math.PI) / 180, score };
+    }
+  }
+  if (!best) best = { A: 0, E: (16 * Math.PI) / 180, score: 0 };
+  const B = basis(best.A + (azBiasDeg * Math.PI) / 180, best.E);
+  const proj = (w: number[]) => { const p = pW(w, B); return { px: p.sx, py: -p.sy }; };
+
+  const flight = samples.map((p) => proj(p.w));
+  const ground = samples.map((p) => proj([p.w[0], p.w[1], 0]));
+  // grid aligned to the flight direction (always projects obliquely, reads as a plane)
+  const fd = nrm([samples[iL].w[0] - samples[iT].w[0], samples[iL].w[1] - samples[iT].w[1], 0]);
+  const pd = [-fd[1], fd[0], 0];
+  const af = samples.map((p) => p.w[0] * fd[0] + p.w[1] * fd[1]);
+  const ap = samples.map((p) => p.w[0] * pd[0] + p.w[1] * pd[1]);
+  const GRID = 5, gp = 4;
+  const f0 = Math.floor((Math.min(...af) - gp) / GRID) * GRID, f1 = Math.ceil((Math.max(...af) + gp) / GRID) * GRID;
+  const p0 = Math.floor((Math.min(...ap) - gp) / GRID) * GRID, p1 = Math.ceil((Math.max(...ap) + gp) / GRID) * GRID;
+  const gw = (a: number, c: number) => [a * fd[0] + c * pd[0], a * fd[1] + c * pd[1], 0];
+  const gridPts: { px: number; py: number }[] = [];
+  for (let a = f0; a <= f1; a += GRID) gridPts.push(proj(gw(a, p0)), proj(gw(a, p1)));
+  for (let c = p0; c <= p1; c += GRID) gridPts.push(proj(gw(f0, c)), proj(gw(f1, c)));
+  const seaCorners = [gw(f0, p0), gw(f1, p0), gw(f1, p1), gw(f0, p1)].map(proj);
+
+  const all = [...flight, ...ground, ...gridPts];
+  const minX = Math.min(...all.map((p) => p.px)), maxX = Math.max(...all.map((p) => p.px));
+  const minY = Math.min(...all.map((p) => p.py)), maxY = Math.max(...all.map((p) => p.py));
+  const pad = { l: 6, r: 6, t: 12, b: 6 };
+  const sc = Math.min((W - pad.l - pad.r) / Math.max(1e-6, maxX - minX), (H - pad.t - pad.b) / Math.max(1e-6, maxY - minY));
+  const fit = (p: { px: number; py: number }) => ({
+    x: pad.l + (p.px - minX) * sc + (W - pad.l - pad.r - (maxX - minX) * sc) / 2,
+    y: pad.t + (p.py - minY) * sc + (H - pad.t - pad.b - (maxY - minY) * sc) / 2,
+  });
+  const F = flight.map(fit), G = ground.map(fit), SC = seaCorners.map(fit);
+  const toPath = (pts: { x: number; y: number }[]) => `M${pts.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(" L")}`;
+  let grid = "";
+  for (let i = 0; i < gridPts.length; i += 2) {
+    const a = fit(gridPts[i]), b = fit(gridPts[i + 1]);
+    grid += `<line x1="${a.x.toFixed(1)}" y1="${a.y.toFixed(1)}" x2="${b.x.toFixed(1)}" y2="${b.y.toFixed(1)}" stroke="#ffffff" stroke-opacity="0.2" stroke-width="0.8"/>`;
+  }
+  let drops = "";
+  samples.forEach((p, i) => {
+    if (p.z > 0.3 && Math.abs((p.t * 4) % 4) < 0.5)
+      drops += `<line x1="${F[i].x.toFixed(1)}" y1="${F[i].y.toFixed(1)}" x2="${G[i].x.toFixed(1)}" y2="${G[i].y.toFixed(1)}" stroke="#ffffff" stroke-opacity="0.25" stroke-width="1" stroke-dasharray="2,2"/>`;
+  });
+  const peakZs = Math.max(...samples.map((p) => p.z), 0.01);
+  const zColor = (z: number) => { const t = Math.max(0, Math.min(1, z / peakZs)); return t < 0.5 ? lerpHex("#38bdf8", "#f59e0b", t * 2) : lerpHex("#f59e0b", "#fff5e6", (t - 0.5) * 2); };
+  let flightSegs = "";
+  for (let i = iT; i < iL; i++)
+    flightSegs += `<line x1="${F[i].x.toFixed(1)}" y1="${F[i].y.toFixed(1)}" x2="${F[i + 1].x.toFixed(1)}" y2="${F[i + 1].y.toFixed(1)}" stroke="${zColor((samples[i].z + samples[i + 1].z) / 2)}" stroke-width="3" stroke-linecap="round"/>`;
+  const gFlight = G.slice(iT, iL + 1);
+  const approach = F.slice(0, iT + 1), runout = F.slice(iL);
+  let wind = "";
+  if (windFromDeg != null && isFinite(windFromDeg)) {
+    const bw = ((windFromDeg + 180) * Math.PI) / 180;
+    const o = proj([0, 0, 0]), wt = proj([Math.sin(bw), Math.cos(bw), 0]);
+    const wl = Math.hypot(wt.px - o.px, wt.py - o.py) || 1;
+    const ux = (wt.px - o.px) / wl, uy = (wt.py - o.py) / wl;
+    const cxw = 18, cyw = H - 12, L = 13, x2 = cxw + ux * L, y2 = cyw + uy * L, hx = -ux, hy = -uy;
+    wind = `<g opacity="0.55"><line x1="${(cxw - ux * L * 0.4).toFixed(1)}" y1="${(cyw - uy * L * 0.4).toFixed(1)}" x2="${x2.toFixed(1)}" y2="${y2.toFixed(1)}" stroke="#e0f2fe" stroke-width="1.6" stroke-linecap="round"/><path d="M${x2.toFixed(1)},${y2.toFixed(1)} L${(x2 + hx * 4 - uy * 2.6).toFixed(1)},${(y2 + hy * 4 + ux * 2.6).toFixed(1)} L${(x2 + hx * 4 + uy * 2.6).toFixed(1)},${(y2 + hy * 4 - ux * 2.6).toFixed(1)} Z" fill="#e0f2fe"/><text x="${(cxw + 10).toFixed(1)}" y="${(cyw + 3.5).toFixed(1)}" font-size="8.5" fill="#bae6fd" font-family="sans-serif">wind</text></g>`;
+  }
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">
+    <defs>
+      <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#334155" stop-opacity="0.35"/><stop offset="70%" stop-color="#334155" stop-opacity="0"/></linearGradient>
+      <linearGradient id="seafill" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#2DD4BF" stop-opacity="0.5"/><stop offset="100%" stop-color="#0E7490" stop-opacity="0.72"/></linearGradient>
+    </defs>
+    <rect x="0" y="0" width="${W}" height="${H}" fill="url(#sky)"/>
+    <path d="${toPath(SC)} Z" fill="url(#seafill)"/>
+    ${grid}
+    ${wind}
+    <path d="${toPath(G)}" fill="none" stroke="#0a0a0a" stroke-opacity="0.35" stroke-width="2" stroke-linecap="round"/>
+    <path d="${toPath(gFlight)}" fill="none" stroke="#0a0a0a" stroke-opacity="0.55" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="3,3"/>
+    ${drops}
+    <path d="${toPath(approach)}" fill="none" stroke="#7dd3fc" stroke-opacity="0.9" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="${toPath(runout)}" fill="none" stroke="#7dd3fc" stroke-opacity="0.9" stroke-width="2.5" stroke-linecap="round"/>
+    ${flightSegs}
+    <circle cx="${F[iT].x.toFixed(1)}" cy="${F[iT].y.toFixed(1)}" r="3.2" fill="#22c55e"/>
+    <circle cx="${F[iL].x.toFixed(1)}" cy="${F[iL].y.toFixed(1)}" r="3.2" fill="#ef4444"/>
+    <circle cx="${F[iP].x.toFixed(1)}" cy="${F[iP].y.toFixed(1)}" r="4" fill="#ffffff"/>
+  </svg>`;
+}
+
 // ── Route SVG ─────────────────────────────────────────────────────────────────
 
 function renderRouteSvg(
   pts: { lat: number; lng: number; speed: number | null }[],
-  zoom: number, originX: number, originY: number, W: number, H: number
+  zoom: number, cx: number, cy: number, scale: number, W: number, H: number,
+  colorFn: (s: number | null) => string = speedToColor,
+  lineOpacity = 0.95,
+  lineWidth = 1.5
 ): string {
   const valid = pts.filter((p) => p.lat !== 0 && p.lng !== 0);
   if (valid.length < 2) return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}"/>`;
   const step = Math.max(1, Math.floor(valid.length / 600));
   const s = valid.filter((_, i) => i % step === 0);
-  const proj = (lat: number, lng: number) => ({ x: worldX(lng, zoom) - originX, y: worldY(lat, zoom) - originY });
+  const proj = (lat: number, lng: number) => ({ x: W / 2 + (worldX(lng, zoom) - cx) * scale, y: H / 2 + (worldY(lat, zoom) - cy) * scale });
   let glow = "", lines = "";
   for (let i = 0; i < s.length - 1; i++) {
     const p1 = proj(s[i].lat, s[i].lng), p2 = proj(s[i + 1].lat, s[i + 1].lng);
-    const c = speedToColor(s[i].speed);
-    glow  += `<line x1="${p1.x.toFixed(1)}" y1="${p1.y.toFixed(1)}" x2="${p2.x.toFixed(1)}" y2="${p2.y.toFixed(1)}" stroke="${c}" stroke-width="5" stroke-linecap="round" opacity="0.15"/>`;
-    lines += `<line x1="${p1.x.toFixed(1)}" y1="${p1.y.toFixed(1)}" x2="${p2.x.toFixed(1)}" y2="${p2.y.toFixed(1)}" stroke="${c}" stroke-width="1.5" stroke-linecap="round" opacity="0.95"/>`;
+    const c = colorFn(s[i].speed);
+    glow  += `<line x1="${p1.x.toFixed(1)}" y1="${p1.y.toFixed(1)}" x2="${p2.x.toFixed(1)}" y2="${p2.y.toFixed(1)}" stroke="${c}" stroke-width="${(lineWidth * 3.3).toFixed(1)}" stroke-linecap="round" opacity="0.15"/>`;
+    lines += `<line x1="${p1.x.toFixed(1)}" y1="${p1.y.toFixed(1)}" x2="${p2.x.toFixed(1)}" y2="${p2.y.toFixed(1)}" stroke="${c}" stroke-width="${lineWidth}" stroke-linecap="round" opacity="${lineOpacity}"/>`;
   }
   const start = proj(s[0].lat, s[0].lng), end = proj(s[s.length - 1].lat, s[s.length - 1].lng);
   const dots = `<circle cx="${start.x.toFixed(1)}" cy="${start.y.toFixed(1)}" r="4" fill="#22c55e" stroke="#09090b" stroke-width="1.5"/><circle cx="${end.x.toFixed(1)}" cy="${end.y.toFixed(1)}" r="4" fill="#ef4444" stroke="#09090b" stroke-width="1.5"/>`;
@@ -175,7 +466,10 @@ const CHART_H = 100;
 
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const showBranding = new URL(req.url).searchParams.get("branding") !== "0";
+  const q = new URL(req.url).searchParams;
+  const showBranding = q.get("branding") !== "0";
+  const duo = (q.get("wcol") && q.get("lcol"))
+    ? { lo: hexToRgb(q.get("wcol")!), hi: hexToRgb(q.get("lcol")!) } : undefined;
   const sql = getDb();
   const rows = await sql`SELECT endpoint_name, raw_json FROM garmin_activity_raw WHERE activity_id = ${id}`;
   if (!rows.length) return new Response("Not found", { status: 404 });
@@ -185,11 +479,69 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
   const summary = data["summary"] ?? {};
   const hrZones: any[] = Array.isArray(data["hr_zones"]) ? data["hr_zones"] : [];
 
-  const title     = summary.activityName || "Run";
+  const typeKey   = (summary.activityType?.typeKey || "").toLowerCase();
+  const isKite    = typeKey.includes("kite");
+  const routePal = q.get("routepal") || "spectral";
+
+  // Visual knobs: query params override; otherwise kite uses its tuned defaults
+  // (voyager vivid map, tight zoom, thin faded route, gold proportional dots).
+  const tpl = BASEMAPS[q.get("basemap") || (isKite ? "voyager" : "dark")] || BASEMAPS.dark;
+  const sat = q.get("sat") ? parseFloat(q.get("sat")!) : (isKite ? 1.3 : undefined);
+  const bright = q.get("bdim") ? parseFloat(q.get("bdim")!) : undefined;
+  const hue = q.get("hue") ? parseFloat(q.get("hue")!) : undefined;
+  const sea = q.get("sea") ? hexToRgb(q.get("sea")!) : (isKite ? hexToRgb("2DD4BF") : undefined);
+  const seaDeep = q.get("sead") ? hexToRgb(q.get("sead")!) : (isKite ? hexToRgb("0E7490") : undefined);
+  const zoomAdj = q.get("zoomadj") != null ? (parseFloat(q.get("zoomadj")!) || 0) : 0;
+  const lineWQ = q.get("linew") ? parseFloat(q.get("linew")!) : (isKite ? 1 : null);
+  const lineOpQ = q.get("lineop") ? parseFloat(q.get("lineop")!) : (isKite ? 0.8 : null);
+  const dotSzQ = q.get("dotsz") ? parseInt(q.get("dotsz")!, 10) : null;
+  const dotColQ = q.get("dotcol") ? `#${q.get("dotcol")!.replace("#", "")}` : null;
+  const dotOpQ = q.get("dotop") ? parseFloat(q.get("dotop")!) : null;
+
+  let title       = summary.activityName || (isKite ? "Kiteboarding" : "Run");
   const startTime = summary.startTimeLocal || "";
   const distKm    = summary.distance > 0 ? (summary.distance / 1000).toFixed(2) : null;
   const duration  = summary.duration > 0 ? formatDuration(summary.duration) : null;
+  const movingDur = summary.movingDuration > 0 ? formatDuration(summary.movingDuration) : null;
   const pace      = summary.averageSpeed > 0 ? formatPace(summary.averageSpeed) : null;
+  const maxSpeedKmh = summary.maxSpeed > 0 ? (summary.maxSpeed * 3.6).toFixed(1) : null;
+  const avgSpeedKmh = summary.averageSpeed > 0 ? (summary.averageSpeed * 3.6).toFixed(1) : null;
+  // Kiteboarding speeds are shown in knots (project preference).
+  const maxSpeedKn = summary.maxSpeed > 0 ? (summary.maxSpeed * 1.94384).toFixed(1) : null;
+  const avgSpeedKn = summary.averageSpeed > 0 ? (summary.averageSpeed * 1.94384).toFixed(1) : null;
+  // Per-jump data (height + GPS position) extracted from the FIT into garmin_activity_raw.
+  const kiteData = data["kite_jumps"] ?? {};
+  const jumps: any[] = Array.isArray(kiteData.jumps) ? kiteData.jumps : [];
+  const jumpSummary = kiteData.summary ?? {};
+  const maxJumpM = jumpSummary.max_height_m != null ? Number(jumpSummary.max_height_m).toFixed(1) : null;
+  const jumpCount = jumpSummary.jump_count ?? jumps.length;
+  const maxAirtime = jumpSummary.max_airtime_s != null ? Number(jumpSummary.max_airtime_s).toFixed(1) : null;
+  const kiteSpot = jumpSummary.spot
+    || (summary.activityName || "")
+        .replace(/session at spot:?/i, "")
+        .replace(/kiteboarding|kitesurfing|kitesurf|kiteboard/gi, "")
+        .replace(/surfr\.?/i, "")
+        .replace(/['".]/g, "")
+        .trim()
+    || summary.locationName || "Kite";
+  if (isKite) {
+    title = maxJumpM
+      ? `${kiteSpot} · Max Jump: ${maxJumpM}m · ${jumpCount} jumps`
+      : `${kiteSpot} Kiteboarding`;
+  }
+  // Jump dots: biggest jump = max size, the rest scaled proportionally by height.
+  const maxJumpNum = jumpSummary.max_height_m
+    ? Number(jumpSummary.max_height_m)
+    : (jumps.length ? Math.max(...jumps.map((j: any) => j.height_m)) : 1);
+  const maxDot = dotSzQ ?? 20;
+  const dotCol = dotColQ ?? "#0a0a0a";                                  // black-transparent bullseye
+  const dotAlpha = dotOpQ != null ? dotOpQ : (isKite ? 0.55 : 1);       // translucent fill
+  const dotOutline = q.get("dotout") ? parseFloat(q.get("dotout")!) : (isKite ? 1 : 0); // ring, EXTRA on top
+  const showArc = q.get("arc") !== "0";
+  const topJump = jumps.length ? jumps[0] : null;
+  // Only render when we have the REAL flight: measured heights + the GPS window.
+  const hasTraj = !!(topJump?.trajectory_m?.length >= 3 && topJump?.airtime_s > 0 && topJump?.path?.length >= 3);
+  const arcSvg = hasTraj ? renderJumpArcSvg(184, 118, topJump.trajectory_m, topJump.airtime_s, topJump.path, Number((data["weather"] ?? {}).windDirection), q.get("arcrot") ? parseFloat(q.get("arcrot")!) : 0) : "";
   const avgHr     = summary.averageHR > 0 ? Math.round(summary.averageHR) : null;
   const maxHr     = summary.maxHR > 0 ? Math.round(summary.maxHR) : null;
   const calories  = summary.calories > 0 ? Math.round(summary.calories) : null;
@@ -219,6 +571,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
   const gpsPoints: { lat: number; lng: number; speed: number | null }[] = [];
   const tsPace: (number | null)[] = [], tsHr: (number | null)[] = [];
   const tsElev: (number | null)[] = [], tsCad: (number | null)[] = [];
+  const tsSpeed: (number | null)[] = []; // km/h, for kiteboarding and watercraft
 
   if (details?.metricDescriptors && details?.activityDetailMetrics) {
     const desc = details.metricDescriptors as Array<{ key: string; metricsIndex: number }>;
@@ -236,6 +589,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
       const lng = lngI != null ? m[lngI] ?? null : null;
       if (lat && lng && lat !== 0 && lng !== 0) gpsPoints.push({ lat, lng, speed: sp });
       tsPace.push(sp && sp > 0.5 ? 1000 / sp / 60 : null);
+      tsSpeed.push(sp && sp > 0 ? sp * 3.6 : null);
       tsHr.push(hrI != null ? m[hrI] ?? null : null);
       tsElev.push(elI != null ? m[elI] ?? null : null);
       const dc = caI != null ? m[caI] ?? null : null;
@@ -243,33 +597,89 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
     }
   }
 
+  // Speed→color scaled to THIS session's speed distribution (kite planes fast, so a
+  // fixed low anchor makes the whole track read as fast). Percentiles give a real spread.
+  const speedsKmh = gpsPoints.map((p) => p.speed).filter((s): s is number => !!s && s > 0).map((s) => s * 3.6).sort((a, b) => a - b);
+  // Rank (percentile) of a speed within the session — histogram equalization so the
+  // clustered planing speeds still spread across the whole palette.
+  const rankOf = (kmh: number) => {
+    if (speedsKmh.length < 2) return 0.5;
+    let lo = 0, hi = speedsKmh.length;
+    while (lo < hi) { const mid = (lo + hi) >> 1; if (speedsKmh[mid] < kmh) lo = mid + 1; else hi = mid; }
+    return lo / (speedsKmh.length - 1);
+  };
+  // Distribution: the bulk of the route splits ~50/50 slow↔medium (blue→amber), and
+  // only the top `redPct` of speeds get pushed into the final red — so just a few
+  // segments read fast, exactly as intended.
+  const redPct = q.get("redpct") ? parseFloat(q.get("redpct")!) : 0.04;
+  const kiteStops = KITE_PALETTES[routePal] || KITE_PALETTES.spectral;
+  const topStart = (kiteStops.length - 2) / (kiteStops.length - 1); // t where the last color starts
+  const rankToT = (rank: number) => (rank <= 1 - redPct
+    ? (rank / (1 - redPct)) * topStart
+    : topStart + ((rank - (1 - redPct)) / redPct) * (1 - topStart));
+  const routeColorFn = isKite
+    ? (s: number | null) => kiteRouteColor(s && s > 0 ? rankToT(rankOf(s * 3.6)) : 0, kiteStops)
+    : speedToColor;
+
   // ── Tiles ──
-  const tilePlacements: { dataUri: string; left: number; top: number }[] = [];
+  const tilePlacements: { dataUri: string; left: number; top: number; size: number }[] = [];
   let routeSvg = "";
+  const jumpMarkers: { x: number; y: number; height_m: number; rank: number; airtime_s?: number }[] = [];
 
   if (gpsPoints.length >= 2) {
-    const lats = gpsPoints.map((p) => p.lat), lngs = gpsPoints.map((p) => p.lng);
-    const [minLat, maxLat, minLng, maxLng] = [Math.min(...lats), Math.max(...lats), Math.min(...lngs), Math.max(...lngs)];
-    const zoom = selectZoom(minLat, maxLat, minLng, maxLng, MAP_W, MAP_H);
-    const cx = worldX((minLng + maxLng) / 2, zoom), cy = worldY((minLat + maxLat) / 2, zoom);
-    const originX = cx - MAP_W / 2, originY = cy - MAP_H / 2;
-    const T = 256;
-    const ftx = Math.floor(originX / T), fty = Math.floor(originY / T);
-    const ltx = Math.ceil((originX + MAP_W) / T), lty = Math.ceil((originY + MAP_H) / T);
+    // Framing: kite uses the route's minimum enclosing CIRCLE (consistent across
+    // route shapes, matches the round vignette); runs keep the bounding-box fit.
+    // Everything is computed in zoom-0 world px then scaled to the tile zoom.
+    let fitZoom: number, cx0: number, cy0: number;
+    if (isKite) {
+      const w0 = gpsPoints.map((p) => ({ x: worldX(p.lng, 0), y: worldY(p.lat, 0) }));
+      const circ = boundingCircle(w0);
+      // When the top-jump card is shown, reserve headroom: the route circle fits
+      // into the area BELOW the card so the overlay never touches the lines.
+      const reserveTop = showArc && hasTraj ? 195 : 0;
+      const TARGET = Math.round((MAP_H - reserveTop) * 0.71); // 440 at full height
+      fitZoom = Math.log2(TARGET / (2 * Math.max(circ.r, 1e-9))) + zoomAdj;
+      cx0 = circ.cx; cy0 = circ.cy;
+      // Shift the view centre up in zoom-0 world px so the route sits centred in
+      // the lower band (screen px → zoom-0 world px via the FRACTIONAL fitZoom).
+      cy0 -= (reserveTop / 2) / Math.pow(2, fitZoom);
+    } else {
+      const lats = gpsPoints.map((p) => p.lat), lngs = gpsPoints.map((p) => p.lng);
+      const [minLat, maxLat, minLng, maxLng] = [Math.min(...lats), Math.max(...lats), Math.min(...lngs), Math.max(...lngs)];
+      fitZoom = selectZoom(minLat, maxLat, minLng, maxLng, MAP_W, MAP_H) + zoomAdj;
+      cx0 = worldX((minLng + maxLng) / 2, 0); cy0 = worldY((minLat + maxLat) / 2, 0);
+    }
+    const zoom = Math.max(10, Math.min(18, Math.round(fitZoom)));
+    const scale = Math.pow(2, fitZoom - zoom); // residual scale (~0.7..1.4), keeps tiles sharp
+    const cx = cx0 * Math.pow(2, zoom), cy = cy0 * Math.pow(2, zoom);
+    const T = 256, tSize = T * scale;
+    const project = (lat: number, lng: number) => ({
+      x: MAP_W / 2 + (worldX(lng, zoom) - cx) * scale,
+      y: MAP_H / 2 + (worldY(lat, zoom) - cy) * scale,
+    });
+    for (const j of jumps) {
+      if (j.lat == null || j.lng == null) continue;
+      const p = project(j.lat, j.lng);
+      if (p.x >= 6 && p.x <= MAP_W - 6 && p.y >= 6 && p.y <= MAP_H - 6)
+        jumpMarkers.push({ x: p.x, y: p.y, height_m: j.height_m, rank: j.rank, airtime_s: j.airtime_s });
+    }
+    const halfW = MAP_W / (2 * scale), halfH = MAP_H / (2 * scale);
+    const ftx = Math.floor((cx - halfW) / T), fty = Math.floor((cy - halfH) / T);
+    const ltx = Math.ceil((cx + halfW) / T), lty = Math.ceil((cy + halfH) / T);
     const coords: { tx: number; ty: number }[] = [];
-    for (let ty = fty; ty <= lty && coords.length < 30; ty++)
-      for (let tx = ftx; tx <= ltx && coords.length < 30; tx++)
+    for (let ty = fty; ty <= lty && coords.length < 42; ty++)
+      for (let tx = ftx; tx <= ltx && coords.length < 42; tx++)
         coords.push({ tx, ty });
 
     const results = await Promise.all(coords.map(async ({ tx, ty }) => {
       const maxT = Math.pow(2, zoom);
-      const uri = await fetchTile(zoom, ((tx % maxT) + maxT) % maxT, ((ty % maxT) + maxT) % maxT);
+      const uri = await fetchTile(tpl, zoom, ((tx % maxT) + maxT) % maxT, ((ty % maxT) + maxT) % maxT, { duo, bright, sat, hue, sea, seaDeep });
       return { tx, ty, uri };
     }));
     for (const { tx, ty, uri } of results)
-      if (uri) tilePlacements.push({ dataUri: uri, left: tx * T - originX, top: ty * T - originY });
+      if (uri) tilePlacements.push({ dataUri: uri, left: MAP_W / 2 + (tx * T - cx) * scale, top: MAP_H / 2 + (ty * T - cy) * scale, size: tSize });
 
-    routeSvg = renderRouteSvg(gpsPoints, zoom, originX, originY, MAP_W, MAP_H);
+    routeSvg = renderRouteSvg(gpsPoints, zoom, cx, cy, scale, MAP_W, MAP_H, routeColorFn, lineOpQ ?? (isKite ? 0.72 : 0.95), lineWQ ?? 1.5);
   }
 
   // ── Vignette SVG overlay ──
@@ -281,6 +691,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
   const hrChart   = renderChartSvg(tsHr,   "#f43f5e", CHART_W, CHART_H, false, (v) => Math.round(v).toString(), distNum);
   const elevChart = renderChartSvg(tsElev, "#4ade80", CHART_W, CHART_H, false, (v) => `${Math.round(v)}m`, distNum);
   const cadChart  = renderChartSvg(tsCad,  "#a78bfa", CHART_W, CHART_H, false, (v) => Math.round(v).toString(), distNum);
+  const speedChart = renderChartSvg(tsSpeed, "#22d3ee", CHART_W, CHART_H, false, (v) => `${Math.round(v)}`, distNum);
 
   // ── Peak values for chart labels ──
   const validPace = tsPace.filter((v): v is number => v != null && isFinite(v) && v > 2 && v < 15);
@@ -289,12 +700,63 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
   const peakElev = validElev.length > 0 ? Math.round(Math.max(...validElev)) : null;
   const validCad = tsCad.filter((v): v is number => v != null && isFinite(v));
   const peakCad = validCad.length > 0 ? Math.round(Math.max(...validCad) * 2) : null; // tsCad is /2 (per-foot), summary is total spm
+  const validSpeed = tsSpeed.filter((v): v is number => v != null && isFinite(v));
+  const peakSpeed = validSpeed.length > 0 ? Math.round(Math.max(...validSpeed)) : null;
 
-  // ── Subtitle parts ──
+  // ── Subtitle parts (drop the run-specific training-effect label for kite) ──
   const subtitleParts: { text: string; color?: string }[] = [];
-  if (startTimeFormatted) subtitleParts.push({ text: startTimeFormatted, color: "#71717a" });
-  if (teLabel)             subtitleParts.push({ text: teLabel, color: teColor });
+  if (startTimeFormatted)  subtitleParts.push({ text: startTimeFormatted, color: "#71717a" });
+  if (teLabel && !isKite)  subtitleParts.push({ text: teLabel, color: teColor });
   if (weatherStr)          subtitleParts.push({ text: weatherStr, color: "#71717a" });
+
+  // ── Sport profile: which metric cards, charts, and map legend to render ──
+  type CardProps = { label: string; val: string; unit: string; color: string };
+  type ChartProps = { svg: string; label: string; avg: string; peak?: string; color: string; totalDistKm?: number; avgPrefix?: string };
+  let metricRows: CardProps[][];
+  let chartRows: ChartProps[][];
+  let legendGrad: string, legendSlow: string, legendFast: string;
+
+  if (isKite) {
+    metricRows = [
+      [
+        ...(distKm ? [{ label: "Distance", val: distKm, unit: "km", color: "#22c55e" }] : []),
+        ...(maxSpeedKmh ? [{ label: "Max Speed", val: maxSpeedKmh, unit: "km/h", color: "#22d3ee" }] : []),
+      ],
+      [
+        ...(avgSpeedKmh ? [{ label: "Avg Speed", val: avgSpeedKmh, unit: "km/h", color: "#38bdf8" }] : []),
+        ...(calories ? [{ label: "Calories", val: String(calories), unit: "kcal", color: "#f97316" }] : []),
+      ],
+    ];
+    chartRows = [[
+      { svg: speedChart, label: "Speed", avg: avgSpeedKmh ?? "—", peak: peakSpeed ? `${peakSpeed}` : undefined, color: "#22d3ee", totalDistKm: distNum, avgPrefix: "avg" },
+      { svg: hrChart, label: "HR", avg: avgHr ? `${avgHr}` : "—", peak: maxHr ? `${maxHr}` : undefined, color: "#f43f5e", totalDistKm: distNum },
+    ]];
+    legendGrad = "linear-gradient(to right, #0c4a6e, #06b6d4, #cffbff)";
+    legendSlow = "#38bdf8"; legendFast = "#cffbff";
+  } else {
+    metricRows = [
+      [
+        ...(distKm ? [{ label: "Distance", val: distKm, unit: "km", color: "#22c55e" }] : []),
+        ...(pace ? [{ label: "Pace", val: pace, unit: "/km", color: "#00e5ff" }] : []),
+      ],
+      [
+        ...(avgHr ? [{ label: "Avg HR", val: String(avgHr), unit: "bpm", color: "#f43f5e" }] : []),
+        ...(calories ? [{ label: "Calories", val: String(calories), unit: "kcal", color: "#f97316" }] : []),
+      ],
+    ];
+    chartRows = [
+      [
+        { svg: paceChart, label: "Pace", avg: pace ?? "—", peak: peakPace ?? undefined, color: "#00e5ff", totalDistKm: distNum },
+        { svg: hrChart, label: "HR", avg: avgHr ? `${avgHr}` : "—", peak: maxHr ? `${maxHr}` : undefined, color: "#f43f5e", totalDistKm: distNum },
+      ],
+      [
+        { svg: elevChart, label: "Elev", avg: elevGain ? `+${elevGain}m` : "—", peak: peakElev ? `${peakElev}m` : undefined, color: "#4ade80", totalDistKm: distNum, avgPrefix: "gain" },
+        { svg: cadChart, label: "Cadence", avg: cadence ? `${cadence}` : "—", peak: peakCad ? `${peakCad}` : undefined, color: "#a78bfa", totalDistKm: distNum },
+      ],
+    ];
+    legendGrad = "linear-gradient(to right, #00e5ff, #ffab00, #ff1744)";
+    legendSlow = "#00e5ff"; legendFast = "#ff1744";
+  }
 
   // ── Layout helpers ──
   function MetricCard({ label, val, unit, color }: { label: string; val: string; unit: string; color: string }) {
@@ -404,7 +866,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
             border: "1px solid #1f1f23",
           }}>
             {tilePlacements.map((t, i) => (
-              <img key={i} src={t.dataUri} width={256} height={256}
+              <img key={i} src={t.dataUri} width={Math.ceil(t.size) + 1} height={Math.ceil(t.size) + 1}
                 style={{ position: "absolute", left: t.left, top: t.top }} />
             ))}
             {routeSvg && (
@@ -415,21 +877,109 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
             <img src={`data:image/svg+xml,${encodeURIComponent(vignetteSvg)}`}
               width={MAP_W} height={MAP_H}
               style={{ position: "absolute", top: 0, left: 0, width: MAP_W, height: MAP_H }} />
-            {/* Pace legend */}
-            <div style={{
-              display: "flex", position: "absolute", bottom: 10, left: 10,
-              alignItems: "center", gap: 6,
-              backgroundColor: "rgba(9,9,11,0.78)", borderRadius: 8, padding: "4px 10px",
-            }}>
-              <span style={{ display: "flex", fontSize: 12, color: "#00e5ff", fontWeight: 600 }}>Slow</span>
-              <div style={{ display: "flex", width: 48, height: 4, borderRadius: 2, background: "linear-gradient(to right, #00e5ff, #ffab00, #ff1744)" }} />
-              <span style={{ display: "flex", fontSize: 12, color: "#ff1744", fontWeight: 600 }}>Fast</span>
-            </div>
+            {/* Kite jump markers: a dot per jump, height label on the top 3 */}
+            {isKite && jumpMarkers.map((jm, i) => {
+              const top3 = jm.rank <= 3;
+              // d = the proportional dot size (the fill). The white ring is drawn EXTRA
+              // on top of d (content-box), so it never changes the calculated dot size.
+              const d = Math.max(6, Math.round(maxDot * (jm.height_m / maxJumpNum)));
+              const outline = top3 ? dotOutline : 0;
+              const total = d + 2 * outline;
+              const fill = hexToRgba(dotCol, top3 ? dotAlpha : dotAlpha * 0.8);
+              return (
+                <div key={`jm${i}`} style={{ display: "flex", boxSizing: "content-box", position: "absolute", zIndex: 50, left: jm.x - total / 2, top: jm.y - total / 2, width: d, height: d, borderRadius: 999, backgroundColor: fill, border: top3 ? `${outline}px solid #ffffff` : "none" }} />
+              );
+            })}
+            {isKite && jumpMarkers.filter((j) => j.rank <= 3).map((jm, i) => (
+              <div key={`jl${i}`} style={{ display: "flex", position: "absolute", zIndex: 60, left: jm.x + 12, top: jm.y - 24, alignItems: "baseline", gap: 2, backgroundColor: "rgba(9,9,11,0.85)", borderRadius: 6, padding: "1px 6px" }}>
+                <span style={{ display: "flex", fontSize: 16, fontWeight: 800, color: "#ecfeff" }}>{jm.height_m.toFixed(1)}</span>
+                <span style={{ display: "flex", fontSize: 10, color: "#67e8f9" }}>m</span>
+              </div>
+            ))}
+            {/* Legend */}
+            {isKite ? (
+              <div style={{ display: "flex", position: "absolute", bottom: 10, left: 10, alignItems: "center", gap: 6, backgroundColor: "rgba(9,9,11,0.78)", borderRadius: 8, padding: "4px 10px" }}>
+                <div style={{ display: "flex", width: 9, height: 9, borderRadius: 9, backgroundColor: "#0a0a0a", border: "1.5px solid #ffffff" }} />
+                <span style={{ display: "flex", fontSize: 12, color: "#a1a1aa" }}>jumps</span>
+                <span style={{ display: "flex", fontSize: 12, color: "#3f3f46" }}>·</span>
+                <span style={{ display: "flex", fontSize: 12, color: kiteStops[0], fontWeight: 600 }}>slow</span>
+                <div style={{ display: "flex", width: 44, height: 4, borderRadius: 2, background: `linear-gradient(to right, ${kiteStops.join(", ")})` }} />
+                <span style={{ display: "flex", fontSize: 12, color: kiteStops[kiteStops.length - 1], fontWeight: 600 }}>fast</span>
+              </div>
+            ) : (
+              <div style={{ display: "flex", position: "absolute", bottom: 10, left: 10, alignItems: "center", gap: 6, backgroundColor: "rgba(9,9,11,0.78)", borderRadius: 8, padding: "4px 10px" }}>
+                <span style={{ display: "flex", fontSize: 12, color: "#00e5ff", fontWeight: 600 }}>Slow</span>
+                <div style={{ display: "flex", width: 48, height: 4, borderRadius: 2, background: "linear-gradient(to right, #00e5ff, #ffab00, #ff1744)" }} />
+                <span style={{ display: "flex", fontSize: 12, color: "#ff1744", fontWeight: 600 }}>Fast</span>
+              </div>
+            )}
+            {/* Top-jump arc overlay */}
+            {isKite && showArc && hasTraj && (
+              <div style={{ display: "flex", flexDirection: "column", position: "absolute", top: 12, right: 12, width: 204, backgroundColor: "rgba(12,14,16,0.9)", borderRadius: 12, padding: "8px 10px 5px", border: "1px solid rgba(255,255,255,0.14)" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                  <span style={{ display: "flex", fontSize: 10, color: "#a1a1aa", letterSpacing: 1, textTransform: "uppercase" as const }}>Top Jump</span>
+                  <div style={{ display: "flex", alignItems: "baseline", gap: 2 }}>
+                    <span style={{ display: "flex", fontSize: 20, fontWeight: 800, color: "#ffffff" }}>{topJump.height_m.toFixed(1)}</span>
+                    <span style={{ display: "flex", fontSize: 11, color: "#71717a" }}>m</span>
+                  </div>
+                </div>
+                <img src={`data:image/svg+xml,${encodeURIComponent(arcSvg)}`} width={184} height={118} style={{ width: 184, height: 118 }} />
+                {(topJump.airtime_s || topJump.distance_m) && (
+                  <div style={{ display: "flex", justifyContent: "center", gap: 12 }}>
+                    {topJump.airtime_s && <span style={{ display: "flex", fontSize: 11, color: "#a1a1aa" }}>{topJump.airtime_s}s air</span>}
+                    {topJump.distance_m && <span style={{ display: "flex", fontSize: 11, color: "#a1a1aa" }}>{topJump.distance_m}m flight</span>}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           {/* RIGHT: Data */}
           <div style={{ display: "flex", flexDirection: "column", flex: 1, justifyContent: "space-around" }}>
 
+            {isKite ? (
+            <div style={{ display: "flex", flexDirection: "column", flex: 1, gap: 8, justifyContent: "space-around" }}>
+            {/* Hero jump + airtime */}
+            <div style={{ display: "flex", gap: 8 }}>
+              {maxJumpM && <MetricCard label="Max Jump" val={maxJumpM} unit="m" color="#22d3ee" />}
+              {maxAirtime
+                ? <MetricCard label="Max Air" val={maxAirtime} unit="s" color="#38bdf8" />
+                : <MetricCard label="Jumps" val={String(jumpCount)} unit="" color="#38bdf8" />}
+            </div>
+            <div style={{ display: "flex", gap: 8 }}>
+              {maxSpeedKn && <MetricCard label="Max Speed" val={maxSpeedKn} unit="kn" color="#22c55e" />}
+              {distKm && <MetricCard label="Distance" val={distKm} unit="km" color="#a78bfa" />}
+            </div>
+            {/* Top jumps ranked bars */}
+            {jumps.length > 0 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 5, backgroundColor: "#111113", borderRadius: 10, padding: "10px 12px" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                  <span style={{ display: "flex", fontSize: 12, fontWeight: 600, color: "#52525b", letterSpacing: 2, textTransform: "uppercase" as const }}>TOP JUMPS</span>
+                  <span style={{ display: "flex", fontSize: 11, color: "#3f3f46" }}>{jumpCount} total</span>
+                </div>
+                {jumps.slice(0, 5).map((j, i) => {
+                  const pct = maxJumpM ? Math.max(6, (j.height_m / Number(maxJumpM)) * 100) : 0;
+                  return (
+                    <div key={i} style={{ display: "flex", alignItems: "center", gap: 7 }}>
+                      <span style={{ display: "flex", fontSize: 12, color: "#52525b", width: 18 }}>#{j.rank}</span>
+                      <div style={{ display: "flex", flex: 1, height: 11, backgroundColor: "#1c1c1e", borderRadius: 5 }}>
+                        <div style={{ display: "flex", width: `${pct.toFixed(0)}%`, height: "100%", backgroundColor: "#22d3ee", borderRadius: 5 }} />
+                      </div>
+                      <span style={{ display: "flex", fontSize: 14, fontWeight: 700, color: "#ecfeff", width: 46 }}>{j.height_m.toFixed(1)}m</span>
+                      {j.airtime_s ? <span style={{ display: "flex", fontSize: 11, color: "#52525b", width: 40 }}>{j.airtime_s}s</span> : <span style={{ display: "flex", width: 40 }} />}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {/* Time on water + HR */}
+            <div style={{ display: "flex", gap: 8 }}>
+              {movingDur && <MetricCard label="Time on Water" val={movingDur} unit="" color="#38bdf8" />}
+              {avgHr && <MetricCard label="Avg HR" val={String(avgHr)} unit="bpm" color="#f43f5e" />}
+            </div>
+            </div>
+            ) : (
+            <div style={{ display: "flex", flexDirection: "column", flex: 1, gap: 8, justifyContent: "space-around" }}>
             {/* 4 metrics in a 2×2 grid */}
             <div style={{ display: "flex", gap: 8 }}>
               {distKm && <MetricCard label="Distance" val={distKm} unit="km" color="#22c55e" />}
@@ -472,6 +1022,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
                 })}
               </div>
             )}
+            </div>
+            )}
 
           </div>
         </div>
@@ -488,6 +1040,12 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
         )}
       </div>
     ),
-    { width: IMG_W, height: IMG_H }
+    {
+      width: IMG_W,
+      height: IMG_H,
+      // A given activity's image is immutable — let the CDN serve repeats instantly
+      // (each cold render is ~4s of tile fetch + sharp recolor).
+      headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800" },
+    }
   );
 }

--- a/web/app/api/activity/[id]/image/route.tsx
+++ b/web/app/api/activity/[id]/image/route.tsx
@@ -127,7 +127,7 @@ async function fetchTile(
     }
     if (!res) return null;
     const ct = res.headers.get("content-type") || "image/png";
-    let buf = Buffer.from(await res.arrayBuffer());
+    let buf: Buffer<ArrayBufferLike> = Buffer.from(await res.arrayBuffer());
     const duo = opts?.duo, bright = opts?.bright, sat = opts?.sat, hue = opts?.hue, sea = opts?.sea;
     const mod = (bright && bright !== 1) || (sat && sat !== 1) || (hue && hue !== 0);
     if (duo || mod || sea) {


### PR DESCRIPTION
Custom kiteboarding share image, replacing the default run template.

## What it does
- Extracts per-jump data from the Surfr Connect IQ FIT fields (heights, native airtime/distance/approach, the jumpchart height trajectory, takeoff/landing timestamps), validated against Surfr's cloud correction. Slices the real 1Hz GPS flight path for the top jumps.
- Renders a kite image: teal water map, spectral speed-colored route, a glassy dot per jump, stats in knots, and a top-jump 3D flight card.
- The 3D card's camera is fitted to hand-picked framings (drag-to-frame tool) reduced to statistical invariants; the selector reproduces them to the decimal.
- Auto-extract on new kite sessions, plus kite-aware Strava naming and description.

## Verification
18 unit tests (extraction + naming/description) pass. 0-jump sessions render cleanly. Renders verified across Schinias, Rafina, Artemida. Output is CDN-cacheable.

Closes #133
Closes #134
Closes #135
Closes #136
Closes #137
