### PR TITLE
feat(strava): session-based web connector to auto-attach kite photos

### DIFF
--- a/.github/workflows/strava-photos.yml
+++ b/.github/workflows/strava-photos.yml
@@ -1,0 +1,42 @@
+name: Attach kite share images to Strava
+
+# Strava has no photo-upload API, so this drives the web UI with Playwright.
+# Headless is blocked by Strava's reCAPTCHA, so it runs HEADED under xvfb.
+# A stored session (strava_web_session) is reused, so it rarely logs in.
+
+on:
+  schedule:
+    - cron: '30 6,18 * * *'   # twice daily; uploads only when new kite sessions exist
+  workflow_dispatch: {}
+
+concurrency:
+  group: strava-photos
+  cancel-in-progress: false
+
+jobs:
+  attach-photos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps (with the strava-web extra)
+        working-directory: sync
+        run: pip install -e ".[strava-web]"
+
+      - name: Install Playwright Chromium + system deps
+        working-directory: sync
+        run: python -m playwright install --with-deps chromium
+
+      - name: Attach pending kite photos (headed under xvfb)
+        working-directory: sync
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          STRAVA_WEB_EMAIL: ${{ secrets.STRAVA_WEB_EMAIL }}
+          STRAVA_WEB_PASSWORD: ${{ secrets.STRAVA_WEB_PASSWORD }}
+          SOMA_BASE_URL: ${{ secrets.SOMA_WEB_URL }}
+        run: xvfb-run -a python -m src.upload_kite_photos

--- a/sync/pyproject.toml
+++ b/sync/pyproject.toml
@@ -24,6 +24,11 @@ dev = [
     "pytest>=8.0",
     "pytest-mock>=3.12",
 ]
+# Session-based Strava web connector (photo upload). Heavy (bundled Chromium),
+# so it's only installed in the dedicated strava-photos workflow, not the main sync.
+strava-web = [
+    "playwright>=1.40",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/sync/src/strava_web.py
+++ b/sync/src/strava_web.py
@@ -1,0 +1,186 @@
+"""Session-based Strava web connector (no public API).
+
+Strava's public API cannot attach photos to an activity (and the API app is
+subscription-locked), so this connector drives Strava's web UI with Playwright to
+log in and upload the generated kite share image. Modeled on the vessel_fort AXS
+pattern: let the browser do the login, then act as the logged-in user.
+
+Validated 2026-07-06: headless login is blocked by Strava's reCAPTCHA ("unexpected
+error"); a HEADED browser logs in cleanly. In CI (Linux) run headed under xvfb.
+The activity edit page exposes a file input; Playwright set_input_files lands the
+photo in the Media section and Save persists it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+LOGIN_URL = "https://www.strava.com/login"
+
+
+def _creds() -> tuple[str | None, str | None]:
+    return os.environ.get("STRAVA_WEB_EMAIL"), os.environ.get("STRAVA_WEB_PASSWORD")
+
+
+def is_configured() -> bool:
+    email, password = _creds()
+    return bool(email and password)
+
+
+_SESSION_COOKIES = ("_strava4_session", "_currentH", "_strava_cpra", "_strava_cpra_uid")
+
+
+def _ensure_session_table(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS strava_web_session ("
+            "id INT PRIMARY KEY DEFAULT 1, cookies JSONB NOT NULL, "
+            "updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW())"
+        )
+
+
+def _load_session(conn) -> list[dict] | None:
+    """Load stored Playwright cookies for reuse (avoids logging in every run,
+    which Strava rate-limits). Returns None if no session stored."""
+    if conn is None:
+        return None
+    _ensure_session_table(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT cookies FROM strava_web_session WHERE id = 1")
+        row = cur.fetchone()
+    return row[0] if row and row[0] else None
+
+
+def _save_session(conn, cookies: list[dict]) -> None:
+    import json
+    keep = [
+        {k: c.get(k) for k in ("name", "value", "domain", "path", "httpOnly", "secure", "sameSite", "expires")}
+        for c in cookies if any(n in (c.get("name") or "") for n in _SESSION_COOKIES) or "strava" in (c.get("domain") or "")
+    ]
+    if conn is None or not keep:
+        return
+    _ensure_session_table(conn)
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO strava_web_session (id, cookies, updated_at) VALUES (1, %s, NOW()) "
+            "ON CONFLICT (id) DO UPDATE SET cookies = EXCLUDED.cookies, updated_at = NOW()",
+            (json.dumps(keep),),
+        )
+
+
+def _session_valid(page) -> bool:
+    """A stored session is only trustworthy if a real authed page loads."""
+    page.goto("https://www.strava.com/dashboard", wait_until="domcontentloaded", timeout=45000)
+    page.wait_for_timeout(2000)
+    return "/login" not in page.url
+
+
+def _login(page, email: str, password: str) -> None:
+    """The proven 3-step flow: email → 'Use password instead' → password → dashboard.
+    Raises if the session does not leave /login (bad creds or a bot challenge)."""
+    page.goto(LOGIN_URL, wait_until="domcontentloaded", timeout=45000)
+    page.wait_for_timeout(2000)
+    for label in ("Accept All", "Reject Non-Essential"):
+        btn = page.get_by_role("button", name=label)
+        if btn.count():
+            btn.first.click()
+            break
+    page.wait_for_timeout(700)
+    page.locator('input[type="email"]:visible').first.fill(email)
+    page.locator('button[type="submit"]:visible').first.click()
+    page.wait_for_timeout(3500)
+    # Strava now promotes one-time codes; click through to the password field.
+    use_pw = page.get_by_role("button", name="Use password instead")
+    if use_pw.count():
+        try:
+            use_pw.first.click(force=True)
+        except Exception:  # noqa: BLE001
+            pass
+        page.wait_for_timeout(2000)
+    page.locator('input[type="password"]:visible').first.fill(password)
+    page.locator('button[type="submit"]:visible').first.click()
+    page.wait_for_timeout(7000)
+    if "/login" in page.url:
+        raise RuntimeError("Strava login failed (still on /login — bad creds or bot challenge)")
+
+
+def _upload_one(page, activity_id: int, image_path: str) -> None:
+    """Attach `image_path` to the activity via the edit page's Media file input."""
+    page.goto(
+        f"https://www.strava.com/activities/{activity_id}/edit",
+        wait_until="domcontentloaded", timeout=45000,
+    )
+    page.wait_for_timeout(3500)
+    before = page.locator("img").count()
+    page.locator("input[type=file]").first.set_input_files(image_path)
+    # wait for the new media thumbnail to appear (presigned upload completes)
+    for _ in range(25):
+        page.wait_for_timeout(1000)
+        if page.locator("img").count() > before:
+            break
+    else:
+        raise RuntimeError(f"photo did not attach for activity {activity_id}")
+    page.get_by_role("button", name="Save").first.click()
+    page.wait_for_timeout(5000)
+
+
+def upload_photos(items: list[tuple[int, str]], conn=None, channel: str | None = None) -> list[tuple[int, bool]]:
+    """Upload photos to Strava activities in one logged-in session.
+
+    items: list of (strava_activity_id, image_path).
+    conn:  optional DB connection for session reuse (stores the login cookies so we
+           don't log in every run — Strava rate-limits repeated logins).
+    channel: browser channel ("chrome" locally; None uses Playwright's Chromium,
+             which is what CI uses under xvfb).
+    Returns [(activity_id, ok)]. Never raises — per-activity failures are isolated
+    (axs skip-on-failure). Always headed; headless is blocked by Strava's reCAPTCHA.
+    """
+    from playwright.sync_api import sync_playwright
+
+    email, password = _creds()
+    if not (email and password):
+        logger.warning("Strava web connector not configured (no STRAVA_WEB_EMAIL/PASSWORD)")
+        return [(a, False) for a, _ in items]
+    if not items:
+        return []
+
+    channel = channel or os.environ.get("STRAVA_WEB_CHANNEL") or None
+    results: list[tuple[int, bool]] = []
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=False, channel=channel)  # headed (xvfb in CI)
+        ctx = browser.new_context(viewport={"width": 1366, "height": 1000})
+        page = ctx.new_page()
+        # Reuse a stored session; only log in when it's missing or expired.
+        stored = _load_session(conn)
+        authed = False
+        if stored:
+            try:
+                ctx.add_cookies(stored)
+                authed = _session_valid(page)
+            except Exception:  # noqa: BLE001
+                authed = False
+        if not authed:
+            try:
+                _login(page, email, password)
+                authed = True
+                try:
+                    _save_session(conn, ctx.cookies())
+                except Exception:  # noqa: BLE001
+                    pass
+            except Exception as exc:  # noqa: BLE001
+                logger.error("Strava web login failed: %s", exc)
+                browser.close()
+                return [(a, False) for a, _ in items]
+        for activity_id, image_path in items:
+            try:
+                _upload_one(page, activity_id, image_path)
+                logger.info("Attached photo to Strava activity %s", activity_id)
+                results.append((activity_id, True))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Photo upload failed for %s: %s", activity_id, exc)
+                results.append((activity_id, False))
+        browser.close()
+    return results

--- a/sync/src/upload_kite_photos.py
+++ b/sync/src/upload_kite_photos.py
@@ -1,0 +1,123 @@
+"""Attach soma kite share images to their Strava activities via the web connector.
+
+Strava has no photo-upload API, so this fetches each kite session's generated share
+image from the deployed image endpoint and uploads it through strava_web (Playwright,
+headed under xvfb in CI). A small strava_photo_uploads table records what's done so
+images are never re-attached.
+
+Run:  cd sync && .venv/bin/python -m src.upload_kite_photos [--only GARMIN_ID] [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+
+import psycopg2
+import requests
+
+from strava_web import is_configured, upload_photos
+
+DB_URL = os.environ.get("DATABASE_URL") or ""
+BASE_URL = os.environ.get("SOMA_BASE_URL", "https://soma.gkos.dev")
+
+
+def _ensure_table(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS strava_photo_uploads (
+                garmin_activity_id BIGINT PRIMARY KEY,
+                strava_activity_id BIGINT NOT NULL,
+                uploaded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+
+
+def _pending(conn, only: int | None, limit: int) -> list[tuple[int, int]]:
+    """(garmin_activity_id, strava_activity_id) for kite sessions with jumps that
+    have a matched Strava activity and no photo uploaded yet.
+
+    Match is exact: Strava's external_id is '<garmin_id>_ACTIVITY.fit'."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT k.activity_id, (s.raw_json->>'id')::bigint
+            FROM garmin_activity_raw k
+            JOIN strava_raw_data s
+              ON jsonb_typeof(s.raw_json) = 'object'
+             AND s.raw_json->>'external_id' LIKE k.activity_id || '_%%'
+            WHERE k.endpoint_name = 'kite_jumps'
+              AND (k.raw_json->'summary'->>'jump_count')::int > 0
+              AND NOT EXISTS (
+                  SELECT 1 FROM strava_photo_uploads u WHERE u.garmin_activity_id = k.activity_id
+              )
+              AND (%(only)s IS NULL OR k.activity_id = %(only)s)
+            ORDER BY k.activity_id DESC
+            LIMIT %(limit)s
+            """,
+            {"only": only, "limit": limit},
+        )
+        return [(int(g), int(s)) for g, s in cur.fetchall()]
+
+
+def _mark_done(conn, garmin_id: int, strava_id: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO strava_photo_uploads (garmin_activity_id, strava_activity_id) "
+            "VALUES (%s, %s) ON CONFLICT (garmin_activity_id) DO NOTHING",
+            (garmin_id, strava_id),
+        )
+
+
+def _fetch_image(garmin_id: int) -> str | None:
+    """Fetch the share image from the deployed endpoint; return a temp file path."""
+    resp = requests.get(f"{BASE_URL}/api/activity/{garmin_id}/image", timeout=90)
+    if resp.status_code != 200 or not resp.content:
+        print(f"  {garmin_id}: image fetch failed ({resp.status_code})")
+        return None
+    fd, path = tempfile.mkstemp(prefix=f"kite_{garmin_id}_", suffix=".png")
+    with os.fdopen(fd, "wb") as f:
+        f.write(resp.content)
+    return path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--only", type=int, help="single Garmin activity id")
+    ap.add_argument("--limit", type=int, default=10)
+    args = ap.parse_args()
+
+    if not is_configured():
+        print("Strava web connector not configured (STRAVA_WEB_EMAIL/PASSWORD) — skipping.")
+        return
+
+    conn = psycopg2.connect(DB_URL)
+    conn.autocommit = True
+    _ensure_table(conn)
+    pending = _pending(conn, args.only, args.limit)
+    if not pending:
+        print("No kite activities pending a Strava photo.")
+        return
+    print(f"{len(pending)} kite activities pending a Strava photo.")
+
+    items, meta = [], []
+    for garmin_id, strava_id in pending:
+        path = _fetch_image(garmin_id)
+        if path:
+            items.append((strava_id, path))
+            meta.append((garmin_id, strava_id))
+
+    results = upload_photos(items, conn=conn)
+    ok_count = 0
+    for (strava_id, ok), (garmin_id, _) in zip(results, meta):
+        if ok:
+            _mark_done(conn, garmin_id, strava_id)
+            ok_count += 1
+    print(f"Done: {ok_count}/{len(meta)} photos attached.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sync/tests/test_strava_web.py
+++ b/sync/tests/test_strava_web.py
@@ -1,0 +1,49 @@
+"""Tests for the Strava web connector's pure helpers (browser paths are covered
+by the manual spike documented in the connector docstring)."""
+
+import strava_web
+
+
+def test_is_configured_reflects_env(monkeypatch):
+    monkeypatch.delenv("STRAVA_WEB_EMAIL", raising=False)
+    monkeypatch.delenv("STRAVA_WEB_PASSWORD", raising=False)
+    assert strava_web.is_configured() is False
+    monkeypatch.setenv("STRAVA_WEB_EMAIL", "a@b.com")
+    monkeypatch.setenv("STRAVA_WEB_PASSWORD", "secret")
+    assert strava_web.is_configured() is True
+
+
+def test_save_session_keeps_only_strava_cookies():
+    captured = {}
+
+    class _Cur:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def execute(self, sql, params=None):
+            if params:
+                captured["cookies"] = params[0]
+
+    class _Conn:
+        def cursor(self): return _Cur()
+
+    cookies = [
+        {"name": "_strava4_session", "value": "abc", "domain": ".strava.com", "path": "/", "httpOnly": True, "secure": True, "sameSite": "Lax", "expires": -1},
+        {"name": "_ga", "value": "junk", "domain": ".google.com", "path": "/"},          # dropped
+    ]
+    strava_web._save_session(_Conn(), cookies)
+    import json
+    kept = json.loads(captured["cookies"])
+    names = {c["name"] for c in kept}
+    assert "_strava4_session" in names
+    assert "_ga" not in names
+
+
+def test_save_session_noop_without_conn():
+    strava_web._save_session(None, [{"name": "_strava4_session", "domain": ".strava.com"}])  # must not raise
+
+
+def test_upload_photos_unconfigured_returns_failures(monkeypatch):
+    monkeypatch.delenv("STRAVA_WEB_EMAIL", raising=False)
+    monkeypatch.delenv("STRAVA_WEB_PASSWORD", raising=False)
+    out = strava_web.upload_photos([(123, "/tmp/x.png")])
+    assert out == [(123, False)]


### PR DESCRIPTION
Auto-attaches the generated kite share image to its Strava activity by driving the web UI with Playwright (Strava has no photo API). Modeled on the vessel_fort AXS connector.

**Proven end-to-end** (spike in #139): headless login is blocked by Strava reCAPTCHA; headed works. The edit-page file input + `set_input_files` + Save attaches the photo (uploaded to Rafina live as the test). Session reuse (`strava_web_session`) so it rarely logs in; runs headed under xvfb in a dedicated workflow.

Note: the first cloud runs reuse a seeded session (no login). The CI headed-under-xvfb *login* path only triggers when the session expires; that's the one bit still to validate on real Actions IPs.

Closes #139
