### PR TITLE
feat(strava): delete/replace so a regenerated image swaps the old photo

### DIFF
--- a/sync/src/strava_web.py
+++ b/sync/src/strava_web.py
@@ -111,13 +111,41 @@ def _login(page, email: str, password: str) -> None:
         raise RuntimeError("Strava login failed (still on /login — bad creds or bot challenge)")
 
 
-def _upload_one(page, activity_id: int, image_path: str) -> None:
-    """Attach `image_path` to the activity via the edit page's Media file input."""
+_PHOTO_CDN = "dgtzuqphqg23d.cloudfront.net"  # Strava serves activity photos from here
+
+
+def _delete_existing_photos(page) -> int:
+    """Remove all existing photos on the open edit page: click a photo → its
+    'Delete' button → repeat. Caller saves. Returns how many were removed."""
+    deleted = 0
+    for _ in range(12):
+        photos = page.locator(f'img[src*="{_PHOTO_CDN}"]')
+        if photos.count() == 0:
+            break
+        photos.first.scroll_into_view_if_needed()
+        photos.first.click()
+        page.wait_for_timeout(900)
+        btn = page.get_by_role("button", name="Delete")
+        if not btn.count():
+            break
+        btn.first.click()
+        page.wait_for_timeout(900)
+        deleted += 1
+    return deleted
+
+
+def _upload_one(page, activity_id: int, image_path: str, replace: bool = False) -> None:
+    """Attach `image_path` to the activity via the edit page's Media file input.
+    replace=True first deletes any existing photos, so a regenerated image swaps
+    the old one instead of stacking a duplicate."""
     page.goto(
         f"https://www.strava.com/activities/{activity_id}/edit",
         wait_until="domcontentloaded", timeout=45000,
     )
     page.wait_for_timeout(3500)
+    if replace:
+        _delete_existing_photos(page)
+        page.wait_for_timeout(500)
     before = page.locator("img").count()
     page.locator("input[type=file]").first.set_input_files(image_path)
     # wait for the new media thumbnail to appear (presigned upload completes)
@@ -131,7 +159,7 @@ def _upload_one(page, activity_id: int, image_path: str) -> None:
     page.wait_for_timeout(5000)
 
 
-def upload_photos(items: list[tuple[int, str]], conn=None, channel: str | None = None) -> list[tuple[int, bool]]:
+def upload_photos(items: list[tuple[int, str]], conn=None, channel: str | None = None, replace: bool = False) -> list[tuple[int, bool]]:
     """Upload photos to Strava activities in one logged-in session.
 
     items: list of (strava_activity_id, image_path).
@@ -180,7 +208,7 @@ def upload_photos(items: list[tuple[int, str]], conn=None, channel: str | None =
                 return [(a, False) for a, _ in items]
         for activity_id, image_path in items:
             try:
-                _upload_one(page, activity_id, image_path)
+                _upload_one(page, activity_id, image_path, replace=replace)
                 logger.info("Attached photo to Strava activity %s", activity_id)
                 results.append((activity_id, True))
             except Exception as exc:  # noqa: BLE001

--- a/sync/src/upload_kite_photos.py
+++ b/sync/src/upload_kite_photos.py
@@ -36,9 +36,10 @@ def _ensure_table(conn) -> None:
         )
 
 
-def _pending(conn, only: int | None, limit: int) -> list[tuple[int, int]]:
+def _pending(conn, only: int | None, limit: int, replace: bool = False) -> list[tuple[int, int]]:
     """(garmin_activity_id, strava_activity_id) for kite sessions with jumps that
-    have a matched Strava activity and no photo uploaded yet.
+    have a matched Strava activity. Normally excludes ones already uploaded;
+    replace=True includes them (to swap a regenerated image).
 
     Match is exact: Strava's external_id is '<garmin_id>_ACTIVITY.fit'."""
     with conn.cursor() as cur:
@@ -51,14 +52,14 @@ def _pending(conn, only: int | None, limit: int) -> list[tuple[int, int]]:
              AND s.raw_json->>'external_id' LIKE k.activity_id || '_%%'
             WHERE k.endpoint_name = 'kite_jumps'
               AND (k.raw_json->'summary'->>'jump_count')::int > 0
-              AND NOT EXISTS (
+              AND (%(replace)s OR NOT EXISTS (
                   SELECT 1 FROM strava_photo_uploads u WHERE u.garmin_activity_id = k.activity_id
-              )
+              ))
               AND (%(only)s IS NULL OR k.activity_id = %(only)s)
             ORDER BY k.activity_id DESC
             LIMIT %(limit)s
             """,
-            {"only": only, "limit": limit},
+            {"only": only, "limit": limit, "replace": replace},
         )
         return [(int(g), int(s)) for g, s in cur.fetchall()]
 
@@ -66,8 +67,9 @@ def _pending(conn, only: int | None, limit: int) -> list[tuple[int, int]]:
 def _mark_done(conn, garmin_id: int, strava_id: int) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO strava_photo_uploads (garmin_activity_id, strava_activity_id) "
-            "VALUES (%s, %s) ON CONFLICT (garmin_activity_id) DO NOTHING",
+            "INSERT INTO strava_photo_uploads (garmin_activity_id, strava_activity_id, uploaded_at) "
+            "VALUES (%s, %s, NOW()) ON CONFLICT (garmin_activity_id) "
+            "DO UPDATE SET strava_activity_id = EXCLUDED.strava_activity_id, uploaded_at = NOW()",
             (garmin_id, strava_id),
         )
 
@@ -88,6 +90,7 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--only", type=int, help="single Garmin activity id")
     ap.add_argument("--limit", type=int, default=10)
+    ap.add_argument("--replace", action="store_true", help="re-process already-uploaded activities, swapping the photo for a freshly generated one")
     args = ap.parse_args()
 
     if not is_configured():
@@ -97,11 +100,11 @@ def main() -> None:
     conn = psycopg2.connect(DB_URL)
     conn.autocommit = True
     _ensure_table(conn)
-    pending = _pending(conn, args.only, args.limit)
+    pending = _pending(conn, args.only, args.limit, replace=args.replace)
     if not pending:
         print("No kite activities pending a Strava photo.")
         return
-    print(f"{len(pending)} kite activities pending a Strava photo.")
+    print(f"{len(pending)} kite activities to {'replace' if args.replace else 'attach'}.")
 
     items, meta = [], []
     for garmin_id, strava_id in pending:
@@ -110,7 +113,7 @@ def main() -> None:
             items.append((strava_id, path))
             meta.append((garmin_id, strava_id))
 
-    results = upload_photos(items, conn=conn)
+    results = upload_photos(items, conn=conn, replace=args.replace)
     ok_count = 0
     for (strava_id, ok), (garmin_id, _) in zip(results, meta):
         if ok:


### PR DESCRIPTION
Adds delete (click photo → Delete → Save) + replace mode to the web connector, so re-running after a share-image change swaps the photo instead of stacking a duplicate. `upload_kite_photos --replace` re-processes done activities. Verified on Rafina: 1 → delete → 1.

Closes #145
