### PR TITLE
feat(strava): Garmin bridge + web finalizer (post-API-paywall push path)

### DIFF
--- a/sync/src/strava_bridge.py
+++ b/sync/src/strava_bridge.py
@@ -1,0 +1,101 @@
+"""Garmin 'facterino' bridge → Strava.
+
+soma pushes finalized activities to Strava WITHOUT Strava's (now paid) API by
+uploading the final FIT to a dedicated Garmin account (facterino) that is
+connected to Strava. Garmin's own outbound sync forwards any uploaded activity
+to the connected Strava within minutes — a Garmin→Strava *direct integration*,
+exempt from both the API paywall and the 2026 intermediary ban. The user's MAIN
+Garmin account stays disconnected from Strava, so there are no duplicates and no
+pre-edit timing problem; only finalized FITs go to facterino.
+
+Auth: Garmin's programmatic login is dead (garth deprecated, "new logins will not
+work"), so facterino's OAuth token bundle is minted ONCE from a real-browser SSO
+ticket and stored in the DB (platform=garmin_facterino_bridge). garth reuses and
+auto-refreshes it (~1yr refresh window); no login ever runs here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import garth
+import psycopg2
+
+from config import DATABASE_URL
+
+logger = logging.getLogger("strava_bridge")
+
+_PLATFORM = "garmin_facterino_bridge"
+_UA = "GCM-iOS-5.7.2.1"
+
+
+def _fetch_dump() -> str | None:
+    conn = psycopg2.connect(DATABASE_URL)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT credentials->>'garth_dump' FROM platform_credentials "
+                "WHERE platform = %s AND status = 'active'",
+                (_PLATFORM,),
+            )
+            row = cur.fetchone()
+    finally:
+        conn.close()
+    return row[0] if row and row[0] else None
+
+
+def _store_dump(dump: str) -> None:
+    conn = psycopg2.connect(DATABASE_URL)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE platform_credentials SET credentials = %s WHERE platform = %s",
+                (json.dumps({"garth_dump": dump}), _PLATFORM),
+            )
+    finally:
+        conn.close()
+
+
+def is_configured() -> bool:
+    return _fetch_dump() is not None
+
+
+def _client() -> garth.Client:
+    """garth client for facterino, from the stored token bundle. Refreshes the
+    short-lived access token and writes the refreshed bundle back to the DB."""
+    dump = _fetch_dump()
+    if not dump:
+        raise RuntimeError(
+            f"Facterino bridge token missing (platform={_PLATFORM}). "
+            "Run the one-time browser-ticket bootstrap to mint it."
+        )
+    c = garth.Client()
+    c.loads(dump)
+    c.sess.headers.update({"User-Agent": _UA})
+    try:
+        c.refresh_oauth2()
+        _store_dump(c.dumps())
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("facterino token refresh failed (using existing): %s", exc)
+    return c
+
+
+def upload_finalized_activity(fit_path: str) -> dict:
+    """Upload a finalized FIT to facterino Garmin. Garmin auto-forwards it to the
+    connected Strava within minutes. Returns garth's upload result (has the new
+    Garmin activityId / uploadId)."""
+    if not os.path.isfile(fit_path):
+        raise FileNotFoundError(fit_path)
+    c = _client()
+    with open(fit_path, "rb") as fp:
+        result = c.upload(fp)
+    logger.info("Uploaded %s to facterino; Garmin will forward to Strava", os.path.basename(fit_path))
+    return result
+
+
+def delete_activity(activity_id: int) -> None:
+    """Remove an activity from facterino Garmin (used to clean up test uploads)."""
+    _client().connectapi(f"/activity-service/activity/{activity_id}", method="DELETE")

--- a/sync/src/strava_web.py
+++ b/sync/src/strava_web.py
@@ -137,12 +137,19 @@ def _delete_existing_photos(page) -> int:
 def _upload_one(page, activity_id: int, image_path: str, replace: bool = False) -> None:
     """Attach `image_path` to the activity via the edit page's Media file input.
     replace=True first deletes any existing photos, so a regenerated image swaps
-    the old one instead of stacking a duplicate."""
+    the old one instead of stacking a duplicate.
+
+    Manual-upload aware: if the activity already has a photo and we're not
+    replacing, this returns without uploading (so a photo the user attached by
+    hand is not duplicated). The caller records it as done, clearing the backlog."""
     page.goto(
         f"https://www.strava.com/activities/{activity_id}/edit",
         wait_until="domcontentloaded", timeout=45000,
     )
     page.wait_for_timeout(3500)
+    if not replace and page.locator(f'img[src*="{_PHOTO_CDN}"]').count() > 0:
+        logger.info("Activity %s already has a photo — skipping (manual upload detected)", activity_id)
+        return
     if replace:
         _delete_existing_photos(page)
         page.wait_for_timeout(500)
@@ -155,6 +162,37 @@ def _upload_one(page, activity_id: int, image_path: str, replace: bool = False) 
             break
     else:
         raise RuntimeError(f"photo did not attach for activity {activity_id}")
+    page.get_by_role("button", name="Save").first.click()
+    page.wait_for_timeout(5000)
+
+
+def set_activity_details(page, activity_id: int, title: str | None = None,
+                         description: str | None = None, image_path: str | None = None,
+                         replace_photo: bool = True) -> None:
+    """On a Strava activity's edit page: set title + description + attach an image,
+    then Save. Finishes an activity that Garmin forwarded — the FIT forward carries
+    the workout data but not the title, description, or photo."""
+    page.goto(f"https://www.strava.com/activities/{activity_id}/edit",
+              wait_until="domcontentloaded", timeout=45000)
+    page.wait_for_timeout(3000)
+    if title:
+        t = page.locator("input#activity_name")
+        if t.count():
+            t.first.fill(title)
+    if description:
+        d = page.locator("textarea:not(#activity_private_note)")
+        if d.count():
+            d.first.fill(description)
+    if image_path and os.path.isfile(image_path):
+        if replace_photo:
+            _delete_existing_photos(page)
+            page.wait_for_timeout(500)
+        before = page.locator("img").count()
+        page.locator("input[type=file]").first.set_input_files(image_path)
+        for _ in range(25):
+            page.wait_for_timeout(1000)
+            if page.locator("img").count() > before:
+                break
     page.get_by_role("button", name="Save").first.click()
     page.wait_for_timeout(5000)
 


### PR DESCRIPTION
Strava's API push has been subscription-gated since 2026-06-30, breaking soma's Garmin→Strava sync. This adds the free replacement path.

- **`strava_bridge.py`** — `upload_finalized_activity(fit)` uploads the FIT to a dedicated Garmin "facterino" account (garth token bundle in DB `platform=garmin_facterino_bridge`, auto-refreshed). Garmin forwards the activity to the connected Strava for free (a direct integration, exempt from the paywall). Garmin's programmatic login is dead (garth deprecated), so the token was minted once from a real-browser SSO ticket. Also `delete_activity` for cleanup.
- **`strava_web.set_activity_details`** — on the Strava activity edit page, sets title + description + attaches an image (the FIT forward carries workout data but not these). Plus a manual-upload-aware photo check.

Verified end-to-end: the July-7 gym workout ("Legs") is on Strava with the correct title, the full rich description, and the workout image.

Still to wire: replace the dead `strava_client` calls in the push pipeline with this path + per-activity dedup (`strava_bridge_uploads` table). Tracked as follow-up.

Closes #149
