### PR TITLE
feat(sync): autonomous cloud Garmin→Strava bridge

### DIFF
--- a/.github/workflows/strava-bridge.yml
+++ b/.github/workflows/strava-bridge.yml
@@ -1,0 +1,46 @@
+name: Bridge activities to Strava
+
+# soma can't use Strava's paid upload API, so finalized Garmin activities reach
+# Strava through the facterino bridge account (Garmin forwards an uploaded FIT to
+# Strava for free) and are finished (title/description/image) by driving Strava's
+# web edit page. Headless is blocked by Strava's reCAPTCHA, so this runs HEADED
+# under xvfb, reusing the stored session — same mechanism as strava-photos.yml.
+
+on:
+  schedule:
+    - cron: '0 11,15,19 * * *'   # a few times/day; pushes only new activities
+  workflow_dispatch: {}
+
+concurrency:
+  group: strava-bridge
+  cancel-in-progress: false
+
+jobs:
+  bridge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps (with the strava-web extra)
+        working-directory: sync
+        run: pip install -e ".[strava-web]"
+
+      - name: Install Playwright Chromium + system deps
+        working-directory: sync
+        run: python -m playwright install --with-deps chromium
+
+      - name: Push pending activities to Strava (headed under xvfb)
+        working-directory: sync
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          GARMIN_EMAIL: ${{ secrets.GARMIN_EMAIL }}
+          GARMIN_PASSWORD: ${{ secrets.GARMIN_PASSWORD }}
+          STRAVA_WEB_EMAIL: ${{ secrets.STRAVA_WEB_EMAIL }}
+          STRAVA_WEB_PASSWORD: ${{ secrets.STRAVA_WEB_PASSWORD }}
+          SOMA_WEB_URL: ${{ secrets.SOMA_WEB_URL }}
+        run: xvfb-run -a python -m src.strava_bridge_push

--- a/sync/src/strava_bridge_push.py
+++ b/sync/src/strava_bridge_push.py
@@ -1,0 +1,217 @@
+"""Push recent Garmin activities that aren't on Strava yet, autonomously.
+
+soma can't use Strava's paid upload API, so a finalized Garmin activity reaches
+Strava through the facterino bridge account (uploading a FIT to it makes Garmin
+forward the activity to Strava for free). The forward carries only the workout
+data, so the title, description and image are set afterwards on the Strava web
+edit page. Both legs run in CI: Garmin `connectapi` works from GitHub Actions,
+and the Strava edit page is driven headed under xvfb (headless is reCAPTCHA-
+blocked), reusing the stored `strava_web_session`.
+
+Dedup: `strava_bridge_uploads(garmin_activity_id PK -> strava_activity_id)`. The
+row is written the moment the forward is seen, before the finalize, so a failed
+finalize never causes a re-upload (and re-uploading an identical FIT is Garmin-
+dedup-safe anyway). Per-activity failures are isolated. Prints one `RESULT:`
+line for the workflow log / chat summary.
+"""
+from __future__ import annotations
+
+import datetime
+import io
+import logging
+import os
+import re
+import time
+import urllib.request
+import zipfile
+
+import psycopg2
+from garminconnect import Garmin
+
+import strava_bridge
+import strava_web
+from garmin_client import init_garmin
+
+logger = logging.getLogger(__name__)
+
+DATABASE_URL = os.environ["DATABASE_URL"]
+SOMA = os.environ.get("SOMA_WEB_URL") or os.environ.get("SOMA_BASE_URL") or "https://soma.gkos.dev"
+LOOKBACK_DAYS = 3
+FORWARD_POLL_S = 15
+FORWARD_TRIES = 48  # ~12 minutes for Garmin to forward to Strava
+
+
+def _missed(g, conn) -> list[dict]:
+    """Recent Garmin activities not yet on Strava (not bridged, not already synced)."""
+    today = datetime.date.today()
+    start = (today - datetime.timedelta(days=LOOKBACK_DAYS)).isoformat()
+    acts = g.get_activities_by_date(start, today.isoformat())
+    with conn.cursor() as cur:
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS strava_bridge_uploads ("
+            "garmin_activity_id BIGINT PRIMARY KEY, strava_activity_id BIGINT, "
+            "uploaded_at TIMESTAMPTZ DEFAULT NOW())"
+        )
+        cur.execute("SELECT garmin_activity_id FROM strava_bridge_uploads")
+        done = {r[0] for r in cur.fetchall()}
+        cur.execute(
+            "SELECT raw_json->>'external_id' FROM strava_raw_data "
+            "WHERE jsonb_typeof(raw_json)='object' AND raw_json->>'external_id' IS NOT NULL"
+        )
+        ext = " ".join(r[0] for r in cur.fetchall() if r[0])
+    conn.commit()
+    return [a for a in acts if a["activityId"] not in done and str(a["activityId"]) not in ext]
+
+
+def _image_for(gid: int, conn) -> str | None:
+    """Download the share image: the hevy card for strength, else the activity card."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT hevy_id FROM workout_enrichment WHERE garmin_activity_id=%s "
+            "ORDER BY processed_at DESC LIMIT 1",
+            (gid,),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    url = f"{SOMA}/api/workout/{row[0]}/image" if row else f"{SOMA}/api/activity/{gid}/image"
+    path = f"/tmp/bridge_{gid}.png"
+    try:
+        with urllib.request.urlopen(urllib.request.Request(url), timeout=60) as r:
+            with open(path, "wb") as fp:
+                fp.write(r.read())
+        return path
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("image fetch failed for %s: %s", gid, exc)
+        return None
+
+
+def _fit_for(g, gid: int) -> str:
+    """Download the activity's original FIT (the file that gets forwarded)."""
+    data = g.download_activity(gid, dl_fmt=Garmin.ActivityDownloadFormat.ORIGINAL)
+    z = zipfile.ZipFile(io.BytesIO(data))
+    name = next(n for n in z.namelist() if n.lower().endswith(".fit"))
+    path = f"/tmp/bridge_{gid}.fit"
+    with open(path, "wb") as fp:
+        fp.write(z.read(name))
+    return path
+
+
+def _record(conn, gid: int, sid: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO strava_bridge_uploads VALUES (%s,%s,NOW()) "
+            "ON CONFLICT (garmin_activity_id) DO UPDATE SET "
+            "strava_activity_id=EXCLUDED.strava_activity_id, uploaded_at=NOW()",
+            (gid, int(sid)),
+        )
+    conn.commit()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    conn = psycopg2.connect(DATABASE_URL)
+    g = init_garmin()
+
+    missed = _missed(g, conn)
+    if not missed:
+        print("RESULT: nothing to push (all recent activities on Strava)")
+        return
+    logger.info("bridge: %d to push: %s", len(missed), [a["activityId"] for a in missed])
+
+    email, password = strava_web._creds()
+    if not (email and password):
+        print("RESULT: ISSUES: Strava web not configured (no STRAVA_WEB_EMAIL/PASSWORD)")
+        return
+
+    from playwright.sync_api import sync_playwright
+
+    channel = os.environ.get("STRAVA_WEB_CHANNEL") or None
+    pushed: list[str] = []
+    issues: list[str] = []
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=False, channel=channel)  # headed (xvfb in CI)
+        ctx = browser.new_context(viewport={"width": 1366, "height": 1000})
+        page = ctx.new_page()
+
+        # Reuse the stored session; log in only if it's missing or expired.
+        authed = False
+        stored = strava_web._load_session(conn)
+        if stored:
+            try:
+                ctx.add_cookies(stored)
+                authed = strava_web._session_valid(page)
+            except Exception:  # noqa: BLE001
+                authed = False
+        if not authed:
+            try:
+                strava_web._login(page, email, password)
+                authed = True
+                try:
+                    strava_web._save_session(conn, ctx.cookies())
+                    conn.commit()
+                except Exception:  # noqa: BLE001
+                    pass
+            except Exception as exc:  # noqa: BLE001
+                print(f"RESULT: ISSUES: Strava login failed: {str(exc)[:60]}")
+                browser.close()
+                return
+
+        def own() -> set[str]:
+            """The user's OWN Strava activity ids (training log, not the social feed)."""
+            for _ in range(4):
+                try:
+                    page.goto("https://www.strava.com/athlete/training",
+                              wait_until="domcontentloaded", timeout=60000)
+                    page.wait_for_timeout(3500)
+                    ids = set(re.findall(r"/activities/(\d+)", page.content()))
+                    if ids:
+                        return ids
+                except Exception:  # noqa: BLE001
+                    pass
+                page.wait_for_timeout(4000)
+            raise RuntimeError("athlete/training would not load")
+
+        for a in missed:
+            gid = a["activityId"]
+            name = a.get("activityName") or "Workout"
+            try:
+                desc = (g.get_activity(gid) or {}).get("description") or ""
+                img = _image_for(gid, conn)
+                fit = _fit_for(g, gid)
+                before = own()
+                strava_bridge.upload_finalized_activity(fit)  # facterino forwards to Strava
+                newid = None
+                for _ in range(FORWARD_TRIES):
+                    time.sleep(FORWARD_POLL_S)
+                    try:
+                        diff = own() - before
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if diff:
+                        newid = sorted(diff, key=int)[-1]
+                        break
+                if not newid:
+                    issues.append(f"{name}: forward not seen in {FORWARD_TRIES * FORWARD_POLL_S // 60}min")
+                    continue
+                _record(conn, gid, newid)  # record BEFORE finalize -> never a duplicate
+                strava_web.set_activity_details(
+                    page, int(newid), title=name, description=desc,
+                    image_path=img, replace_photo=True,
+                )
+                pushed.append(f"{name}->strava/{newid}")
+                logger.info("pushed %s (%s) -> strava/%s", name, gid, newid)
+            except Exception as exc:  # noqa: BLE001
+                issues.append(f"{name}: {str(exc)[:60]}")
+                logger.warning("bridge push failed for %s: %s", gid, exc)
+        browser.close()
+
+    parts = []
+    if pushed:
+        parts.append("PUSHED: " + " ;; ".join(pushed))
+    if issues:
+        parts.append("ISSUES: " + " ;; ".join(issues))
+    print("RESULT: " + (" | ".join(parts) if parts else "nothing to push"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Makes soma's Garmin→Strava push fully autonomous in the cloud. No laptop, no phone, no paid Strava API.

Since Strava's upload API is paywalled (2026-06-30), finalized activities reach Strava through the facterino bridge Garmin account: uploading a FIT to it makes Garmin forward the activity to Strava for free. The forward carries only workout data, so title, description and image are set afterwards on the Strava web edit page.

Both legs already work in CI, this just wires them together:
- Garmin `connectapi` calls (read activities, download FIT, facterino upload) work from GitHub Actions runners. Only login needs the CF Worker, which `init_garmin()` already handles.
- Strava's web edit page is driven headed under xvfb (headless is reCAPTCHA-blocked), reusing the stored `strava_web_session`. Same mechanism as `strava-photos.yml`.

## Changes

- `sync/src/strava_bridge_push.py` — finds recent Garmin activities not yet on Strava (skips anything in `strava_bridge_uploads` or already synced), and per activity: downloads the FIT, uploads it to facterino, polls the user's own Strava activities for the forwarded id, records the mapping, then sets title/description/image via `strava_web.set_activity_details`. Dedup is written the moment the forward is seen (before the finalize), so a failed finalize never causes a duplicate. Per-activity failures are isolated.
- `.github/workflows/strava-bridge.yml` — runs `xvfb-run python -m src.strava_bridge_push` at 11:00, 15:00, 19:00 UTC (after the morning sync has pulled the workout into Garmin), modeled on `strava-photos.yml`.

## Verified

- Module imports clean and detection is correct: with today's "Upper" and "Legs" already bridged, it reports `nothing to push`.
- End-to-end forward+finalize logic is the same path that put today's "Upper" on Strava with the right title/description/image.
- Sync suite: 1009 passed. The 10 failures are an unrelated nutrition deficit-cap constant/test mismatch, untouched by this change.

Closes #151
Closes #152
Closes #153
