### PR TITLE
fix(sync): cloud kite-jump extraction + activity-type-aware notifications (#167)

### DIFF
--- a/sync/pyproject.toml
+++ b/sync/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "python-dotenv>=1.0",
     "requests>=2.31",
     "fit-tool>=0.9.15",
+    "fitparse>=1.2",
     "Pillow>=10.0",
     "pywebpush>=2.0",
     "scipy>=1.10",

--- a/sync/src/pipeline.py
+++ b/sync/src/pipeline.py
@@ -731,6 +731,7 @@ def _route_garmin_activities(strava_client=None, garmin_client=None) -> int:
         workout = {
             "activity_id": str(activity_id),
             "source_id": str(activity_id),
+            "name": activity_name,
         }
 
         with get_connection() as conn:

--- a/sync/src/router.py
+++ b/sync/src/router.py
@@ -127,15 +127,16 @@ def execute_routes(
                     "error": push_result.get("error"),
                 })
             elif destination == "telegram":
-                from telegram_notify import send_workout_image, send_run_image, is_configured
+                from telegram_notify import send_workout_image, send_activity_image, is_configured
                 if not is_configured():
                     logger.warning("Telegram not configured, skipping rule %s", rule_id)
                     continue
                 if source_platform == "garmin":
-                    ok = send_run_image(
+                    ok = send_activity_image(
                         garmin_activity_id=source_id,
-                        title=workout.get("name", workout.get("activityName", "Run")),
-                        run_date=str(workout.get("date", workout.get("startTimeLocal", "")[:10])),
+                        title=workout.get("name") or workout.get("activityName") or "Activity",
+                        activity_date=str(workout.get("date", workout.get("startTimeLocal", "")[:10])),
+                        activity_type=activity_type,
                     )
                 else:
                     ok = send_workout_image(

--- a/sync/src/telegram_notify.py
+++ b/sync/src/telegram_notify.py
@@ -119,8 +119,46 @@ def send_workout_image(hevy_id: str, title: str, workout_date: str) -> bool:
     return send_image(image_bytes, caption=caption, filename=f"{hevy_id}.png")
 
 
-def send_run_image(garmin_activity_id: str | int, title: str, run_date: str) -> bool:
-    """Fetch a run summary image from the local Next.js server and send it via Telegram."""
+# Emoji + short label per Garmin activity type (typeKey). Matched by substring so
+# variants like "kiteboarding_v2" or "treadmill_running" resolve correctly. The
+# first matching entry wins, so order specific keys before generic ones.
+_ACTIVITY_EMOJI: list[tuple[str, str]] = [
+    ("kite", "🪁"),
+    ("wind_surf", "🏄"),
+    ("surf", "🏄"),
+    ("run", "🏃"),
+    ("trail", "🏃"),
+    ("cycl", "🚴"),
+    ("bik", "🚴"),
+    ("bmx", "🚴"),
+    ("walk", "🚶"),
+    ("hik", "🥾"),
+    ("swim", "🏊"),
+    ("ski", "⛷️"),
+    ("snowboard", "🏂"),
+    ("row", "🚣"),
+    ("strength", "🏋️"),
+    ("yoga", "🧘"),
+]
+
+
+def activity_emoji(activity_type: str | None) -> str:
+    """Emoji for a Garmin activity typeKey. Falls back to a generic medal."""
+    key = (activity_type or "").lower()
+    for needle, emoji in _ACTIVITY_EMOJI:
+        if needle in key:
+            return emoji
+    return "🏅"
+
+
+def send_activity_image(
+    garmin_activity_id: str | int,
+    title: str,
+    activity_date: str,
+    activity_type: str | None = None,
+) -> bool:
+    """Fetch an activity summary image from the Next.js server and send it via
+    Telegram, captioned with the emoji for its activity type (kite/run/bike/…)."""
     if not is_configured():
         return False
 
@@ -129,14 +167,14 @@ def send_run_image(garmin_activity_id: str | int, title: str, run_date: str) -> 
         req = urllib.request.Request(url, method="GET")
         with urllib.request.urlopen(req, timeout=30) as resp:
             if resp.status != 200:
-                print(f"    Telegram: run image fetch failed (HTTP {resp.status})")
+                print(f"    Telegram: activity image fetch failed (HTTP {resp.status})")
                 return False
             image_bytes = resp.read()
     except Exception as e:
-        print(f"    Telegram: run image fetch failed ({e})")
+        print(f"    Telegram: activity image fetch failed ({e})")
         return False
 
-    caption = f"🏃 {title} — {run_date}"
-    return send_image(image_bytes, caption=caption, filename=f"run_{garmin_activity_id}.png")
+    caption = f"{activity_emoji(activity_type)} {title} — {activity_date}"
+    return send_image(image_bytes, caption=caption, filename=f"activity_{garmin_activity_id}.png")
 
 

--- a/sync/tests/test_telegram_notify.py
+++ b/sync/tests/test_telegram_notify.py
@@ -1,0 +1,37 @@
+"""Tests for activity-type-aware Telegram notifications (issue #167/#169).
+
+Regression guard: notifications used to hardcode a 🏃 "run" caption for every
+Garmin activity, so kite/bike/walk sessions were all announced as "Run".
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from telegram_notify import activity_emoji  # noqa: E402
+
+
+class TestActivityEmoji:
+    def test_kite_variants_resolve_to_kite(self) -> None:
+        # The live Garmin typeKey is "kiteboarding_v2"; substring match must catch it.
+        assert activity_emoji("kiteboarding_v2") == "🪁"
+        assert activity_emoji("kitesurfing") == "🪁"
+
+    def test_common_types(self) -> None:
+        assert activity_emoji("running") == "🏃"
+        assert activity_emoji("treadmill_running") == "🏃"
+        assert activity_emoji("cycling") == "🚴"
+        assert activity_emoji("mountain_biking") == "🚴"
+        assert activity_emoji("walking") == "🚶"
+        assert activity_emoji("hiking") == "🥾"
+        assert activity_emoji("lap_swimming") == "🏊"
+        assert activity_emoji("strength_training") == "🏋️"
+
+    def test_kite_is_not_labelled_as_run(self) -> None:
+        # The original bug: kite sessions came through as the run emoji.
+        assert activity_emoji("kiteboarding_v2") != "🏃"
+
+    def test_unknown_falls_back_to_medal(self) -> None:
+        assert activity_emoji("some_new_sport") == "🏅"
+        assert activity_emoji("") == "🏅"
+        assert activity_emoji(None) == "🏅"


### PR DESCRIPTION
Closes #167, closes #168, closes #169.

Two verified root causes behind kite sessions arriving as "Run" with "0 jumps":

### 1. Cloud jump extraction silently broken (missing `fitparse`)
`kite_jumps.py` parses the FIT with `fitparse`, but `sync/pyproject.toml` only declared `fit-tool` (a different library). A clean `pip install -e .` (what the cloud runs) has no `fitparse`, so `_maybe_extract_kite_jumps` raised `ModuleNotFoundError` on every cloud run and was swallowed by its guard. Verified: `fitparse` has an empty `Required-by:` and a clean env throws `ModuleNotFoundError`. All existing jump data came from a one-time local backfill on 2026-07-03. Fix: add `fitparse>=1.2` to deps.

### 2. Notifications not activity-type aware
`_route_garmin_activities` built the `workout` dict without the activity name, so `router.py` fell through to the literal `"Run"` title, and `send_run_image` hardcoded a 🏃 emoji + `run_<id>.png` for every type. Now the real name + `typeKey` flow through, and the emoji is chosen per type (kite 🪁, run 🏃, bike 🚴, walk 🚶, swim 🏊, hike 🥾, …). `send_run_image` → `send_activity_image`.

Strava titles/descriptions were already jump-aware in code; they were just missing data (downstream of #1) and resolve on reprocess.

### Tests
`sync/tests/test_telegram_notify.py` pins the emoji mapping (incl. `kiteboarding_v2` → 🪁, never 🏃). Full sync suite: **1019 passed**.

Follow-up (#170, operational): after this deploys, trigger the cloud pipeline to re-extract jumps via the fixed code, re-send Telegram for the sessions that got wrong info, and refresh the Strava image/description.
