### PR TITLE
feat(sync): cloud kite-jump backfill workflow + --missing-only (#170)

### DIFF
--- a/.github/workflows/kite-backfill.yml
+++ b/.github/workflows/kite-backfill.yml
@@ -1,0 +1,52 @@
+name: Kite Jump Backfill
+
+# Extracts per-jump kite data (heights + 3D flight paths) on the cloud, with no
+# dependency on any local machine. Runs the same code the live pipeline uses, so
+# a gap can be re-created here rather than backfilled by hand.
+#
+# --missing-only is cheap and idempotent (it only touches kite sessions that have
+# no kite_jumps row yet), so the daily schedule self-heals any future gap.
+
+on:
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Single Garmin activity id (blank = all missing sessions)"
+        required: false
+        default: ""
+  schedule:
+    - cron: '0 5 * * *' # daily self-heal (05:00 UTC)
+
+concurrency:
+  group: kite-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        working-directory: sync
+        run: pip install -e .
+
+      - name: Backfill kite jumps
+        working-directory: sync
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          GARMIN_EMAIL: ${{ secrets.GARMIN_EMAIL }}
+          GARMIN_PASSWORD: ${{ secrets.GARMIN_PASSWORD }}
+          GARMIN_CF_WORKER_URL: ${{ secrets.GARMIN_CF_WORKER_URL }}
+          GARMIN_CF_WORKER_MFA_URL: ${{ secrets.GARMIN_CF_WORKER_MFA_URL }}
+        run: |
+          if [ -n "${{ github.event.inputs.only }}" ]; then
+            python -m src.backfill_kite_jumps --only "${{ github.event.inputs.only }}"
+          else
+            python -m src.backfill_kite_jumps --missing-only
+          fi

--- a/sync/src/backfill_kite_jumps.py
+++ b/sync/src/backfill_kite_jumps.py
@@ -95,9 +95,24 @@ def store_kite_jumps_for_activity(conn, garmin, activity_id, start_gmt: str | No
             shutil.rmtree(fit_dir, ignore_errors=True)
 
 
+def _activities_with_jumps(conn) -> set[int]:
+    """Activity ids that already have a stored kite_jumps payload."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT activity_id FROM garmin_activity_raw WHERE endpoint_name = 'kite_jumps'"
+        )
+        return {int(r[0]) for r in cur.fetchall()}
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--only", type=int, help="Backfill a single activity id")
+    ap.add_argument(
+        "--missing-only",
+        action="store_true",
+        help="Only process kite sessions that have no kite_jumps row yet (cheap, "
+        "idempotent — safe to run on a schedule to self-heal gaps).",
+    )
     args = ap.parse_args()
 
     conn = psycopg2.connect(DB_URL)
@@ -107,6 +122,9 @@ def main():
     activities = _kite_activities(conn)
     if args.only:
         activities = [a for a in activities if int(a[0]) == args.only]
+    if args.missing_only:
+        have = _activities_with_jumps(conn)
+        activities = [a for a in activities if int(a[0]) not in have]
 
     print(f"Backfilling {len(activities)} kite activities")
     done = jumps_total = 0


### PR DESCRIPTION
Part of #170. Adds a zero-local-dependency way to (re)extract kite jumps on the cloud:

- `backfill_kite_jumps --missing-only`: only processes kite sessions with no `kite_jumps` row yet (cheap, idempotent).
- `.github/workflows/kite-backfill.yml`: `workflow_dispatch` (optional single activity id) + a daily 05:00 UTC schedule that self-heals gaps, running the same extraction code the live pipeline uses.

This is the mechanism to reprocess the sessions affected by the missing-`fitparse` bug (#168) on the cloud rather than by hand.