### PR TITLE
feat(sync): cloud tool to re-send Telegram notifications (#170)

### DIFF
--- a/.github/workflows/resend-telegram.yml
+++ b/.github/workflows/resend-telegram.yml
@@ -1,0 +1,36 @@
+name: Resend Telegram Notification
+
+# One-off corrective tool: re-send the Telegram activity image for specific
+# Garmin activities (e.g. after a wrong "Run" label or a 0-jumps image went out).
+# Runs on the cloud — no local dependency.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ids:
+        description: "Space-separated Garmin activity ids to re-send"
+        required: true
+
+jobs:
+  resend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        working-directory: sync
+        run: pip install -e .
+
+      - name: Re-send notifications
+        working-directory: sync
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          SOMA_WEB_URL: ${{ secrets.SOMA_WEB_URL }}
+        run: python -m src.resend_telegram ${{ github.event.inputs.ids }}

--- a/sync/src/resend_telegram.py
+++ b/sync/src/resend_telegram.py
@@ -1,0 +1,64 @@
+"""Re-send the Telegram activity notification for one or more Garmin activities.
+
+One-off corrective tool: the original notification may have gone out with the
+wrong label ("Run") or before jump data existed. This re-fetches the (now
+correct) share image and re-sends it with the activity-type-aware caption. Runs
+on the cloud via the resend-telegram workflow — no local dependency.
+
+Run:  cd sync && python -m src.resend_telegram 23573197188 23572684262 ...
+"""
+import argparse
+import sys
+
+import psycopg2
+
+from config import DATABASE_URL
+from telegram_notify import is_configured, send_activity_image
+
+
+def _summary(conn, activity_id: int):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT raw_json->'activityType'->>'typeKey', "
+            "raw_json->>'activityName', raw_json->>'startTimeLocal' "
+            "FROM garmin_activity_raw WHERE activity_id = %s AND endpoint_name = 'summary'",
+            (activity_id,),
+        )
+        return cur.fetchone()
+
+
+def resend(activity_ids: list[int]) -> int:
+    if not is_configured():
+        print("Telegram not configured — skipping.")
+        return 0
+    conn = psycopg2.connect(DATABASE_URL)
+    conn.autocommit = True
+    sent = 0
+    for aid in activity_ids:
+        row = _summary(conn, aid)
+        if not row:
+            print(f"  {aid}: no summary row, skipping")
+            continue
+        type_key, name, start_local = row
+        activity_date = (start_local or "")[:10]
+        ok = send_activity_image(
+            garmin_activity_id=aid,
+            title=name or "Activity",
+            activity_date=activity_date,
+            activity_type=type_key,
+        )
+        print(f"  {aid}: {'re-sent' if ok else 'FAILED'} ({type_key})")
+        sent += 1 if ok else 0
+    print(f"Done: {sent}/{len(activity_ids)} notifications re-sent.")
+    return sent
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ids", nargs="+", type=int, help="Garmin activity ids to re-send")
+    args = ap.parse_args()
+    resend(args.ids)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of #170. Adds `resend_telegram.py` + `resend-telegram.yml` (workflow_dispatch) to re-send the activity image for specific Garmin activity ids with the fixed activity-type-aware caption — for the kite sessions whose original Telegram went out as 'Run' with 0 jumps. Cloud-only, no local dependency.