### PR TITLE
fix(strava): jump-aware kite title/description/image on the bridge path (#174)

### DIFF
--- a/.github/workflows/refinalize-strava.yml
+++ b/.github/workflows/refinalize-strava.yml
@@ -1,0 +1,50 @@
+name: Re-finalize Strava activities
+
+# Re-set title + description + image on already-bridged Strava activities via the
+# Strava web session (no paid API). For kite sessions bridged before their jumps
+# were extracted. Drives the web UI with Playwright, HEADED under xvfb (headless
+# is blocked by Strava's reCAPTCHA); reuses the stored strava_web_session.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ids:
+        description: "Space-separated Garmin activity ids to re-finalize"
+        required: true
+
+concurrency:
+  group: strava-refinalize
+  cancel-in-progress: false
+
+jobs:
+  refinalize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install deps (with the strava-web extra)
+        working-directory: sync
+        run: pip install -e ".[strava-web]"
+
+      - name: Install Playwright Chromium + system deps
+        working-directory: sync
+        run: python -m playwright install --with-deps chromium
+
+      - name: Re-finalize activities (headed under xvfb)
+        working-directory: sync
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          STRAVA_WEB_EMAIL: ${{ secrets.STRAVA_WEB_EMAIL }}
+          STRAVA_WEB_PASSWORD: ${{ secrets.STRAVA_WEB_PASSWORD }}
+          SOMA_WEB_URL: ${{ secrets.SOMA_WEB_URL }}
+          SOMA_BASE_URL: ${{ secrets.SOMA_WEB_URL }}
+          GARMIN_EMAIL: ${{ secrets.GARMIN_EMAIL }}
+          GARMIN_PASSWORD: ${{ secrets.GARMIN_PASSWORD }}
+          GARMIN_CF_WORKER_URL: ${{ secrets.GARMIN_CF_WORKER_URL }}
+          GARMIN_CF_WORKER_MFA_URL: ${{ secrets.GARMIN_CF_WORKER_MFA_URL }}
+        run: xvfb-run -a python -m src.refinalize_strava ${{ github.event.inputs.ids }}

--- a/sync/src/refinalize_strava.py
+++ b/sync/src/refinalize_strava.py
@@ -1,0 +1,121 @@
+"""Re-finalize already-bridged Strava activities: re-set the title, description and
+image via the Strava web session (the same mechanism the bridge uses — no paid API).
+
+For kite sessions that were bridged before their jumps were extracted, so they got a
+0-jump image and a description with no jump data. Looks up the Strava id via
+strava_bridge_uploads, rebuilds the kite title/description from the (now present)
+jump data, regenerates the image, and re-sets all three on the Strava edit page.
+
+Run: cd sync && python -m src.refinalize_strava 23573197188 23572684262 ...
+Runs on the cloud via the refinalize-strava workflow — no local dependency.
+"""
+import argparse
+import json
+import logging
+import os
+
+import psycopg2
+
+import strava_web
+from config import DATABASE_URL
+from garmin_client import init_garmin
+from strava_bridge_push import _image_for, _kite_finalize_fields
+
+logger = logging.getLogger(__name__)
+
+
+def _strava_id(conn, gid: int) -> int | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT strava_activity_id FROM strava_bridge_uploads WHERE garmin_activity_id = %s",
+            (gid,),
+        )
+        row = cur.fetchone()
+    return int(row[0]) if row and row[0] else None
+
+
+def _summary(conn, gid: int) -> dict:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT raw_json FROM garmin_activity_raw "
+            "WHERE activity_id = %s AND endpoint_name = 'summary'",
+            (gid,),
+        )
+        row = cur.fetchone()
+    if not row or row[0] is None:
+        return {}
+    return row[0] if isinstance(row[0], dict) else json.loads(row[0])
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ids", nargs="+", type=int, help="Garmin activity ids to re-finalize")
+    args = ap.parse_args()
+
+    conn = psycopg2.connect(DATABASE_URL)
+    conn.autocommit = True
+    g = init_garmin()
+
+    email, password = strava_web._creds()
+    if not (email and password):
+        print("RESULT: Strava web not configured (no STRAVA_WEB_EMAIL/PASSWORD)")
+        return
+
+    from playwright.sync_api import sync_playwright
+
+    channel = os.environ.get("STRAVA_WEB_CHANNEL") or None
+    done, failed = 0, 0
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=False, channel=channel)  # headed (xvfb in CI)
+        ctx = browser.new_context(viewport={"width": 1366, "height": 1000})
+        page = ctx.new_page()
+
+        authed = False
+        stored = strava_web._load_session(conn)
+        if stored:
+            try:
+                ctx.add_cookies(stored)
+                authed = strava_web._session_valid(page)
+            except Exception:  # noqa: BLE001
+                authed = False
+        if not authed:
+            try:
+                strava_web._login(page, email, password)
+                try:
+                    strava_web._save_session(conn, ctx.cookies())
+                except Exception:  # noqa: BLE001
+                    pass
+            except Exception as exc:  # noqa: BLE001
+                print(f"RESULT: Strava login failed: {str(exc)[:60]}")
+                browser.close()
+                return
+
+        for gid in args.ids:
+            sid = _strava_id(conn, gid)
+            if not sid:
+                print(f"  {gid}: not in strava_bridge_uploads, skipping")
+                continue
+            summary = _summary(conn, gid)
+            title, desc = _kite_finalize_fields(conn, g, gid, summary)
+            if title is None:
+                title = summary.get("activityName") or "Activity"
+                desc = summary.get("description") or ""
+            img = _image_for(gid, conn)
+            try:
+                strava_web.set_activity_details(
+                    page, sid, title=title, description=desc,
+                    image_path=img, replace_photo=True,
+                )
+                print(f"  {gid} -> strava/{sid}: re-finalized ({title})")
+                done += 1
+            except Exception as exc:  # noqa: BLE001
+                print(f"  {gid} -> strava/{sid}: FAILED {str(exc)[:80]}")
+                failed += 1
+        browser.close()
+
+    print(f"RESULT: re-finalized {done}, failed {failed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sync/src/strava_bridge_push.py
+++ b/sync/src/strava_bridge_push.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import io
+import json
 import logging
 import os
 import re
@@ -107,6 +108,41 @@ def _record(conn, gid: int, sid: int) -> None:
     conn.commit()
 
 
+def _load_kite_payload(conn, gid: int) -> dict | None:
+    """Stored kite_jumps payload for a Garmin activity, or None."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT raw_json FROM garmin_activity_raw "
+            "WHERE activity_id = %s AND endpoint_name = 'kite_jumps'",
+            (gid,),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if not row or row[0] is None:
+        return None
+    return row[0] if isinstance(row[0], dict) else json.loads(row[0])
+
+
+def _kite_finalize_fields(conn, g, gid: int, summary: dict) -> tuple[str | None, str | None]:
+    """Title + description for a kite activity, built from its per-jump data
+    (extracting the jumps on demand if they are missing, so the Strava image and
+    description are never stuck at 0 jumps). Returns (None, None) for non-kite
+    activities so the caller keeps the default Garmin name/description."""
+    type_key = ((summary.get("activityType") or {}).get("typeKey") or "").lower()
+    if "kite" not in type_key:
+        return None, None
+    payload = _load_kite_payload(conn, gid)
+    if payload is None:
+        from backfill_kite_jumps import store_kite_jumps_for_activity
+        try:
+            payload = store_kite_jumps_for_activity(conn, g, gid, summary.get("startTimeGMT"))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("kite jump extraction failed for %s during finalize: %s", gid, exc)
+            return None, None
+    from garmin_push import kite_activity_name, generate_kite_strava_description
+    return kite_activity_name(summary, payload), generate_kite_strava_description(summary, payload)
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     conn = psycopg2.connect(DATABASE_URL)
@@ -175,7 +211,12 @@ def main() -> None:
             gid = a["activityId"]
             name = a.get("activityName") or "Workout"
             try:
-                desc = (g.get_activity(gid) or {}).get("description") or ""
+                # Kite sessions get a jump-aware title + description (and jumps are
+                # extracted here if missing, so the image below shows real jumps).
+                kite_title, kite_desc = _kite_finalize_fields(conn, g, gid, a)
+                if kite_title:
+                    name = kite_title
+                desc = kite_desc if kite_desc is not None else ((g.get_activity(gid) or {}).get("description") or "")
                 img = _image_for(gid, conn)
                 fit = _fit_for(g, gid)
                 before = own()


### PR DESCRIPTION
Closes #174, closes #175, closes #176.

The facterino bridge set the Strava description from the raw Garmin description and attached the image before jumps were extracted, so kite sessions landed with no jump text and a 0-jump image. The kite enrichment lived only in the dead direct-push path (403, API paywalled).

- **Bridge finalize** now builds a jump-aware title (`kite_activity_name`) + description (`generate_kite_strava_description`) for kite activities, extracting jumps on demand first so the image also shows them. Uses the existing Strava web session (`set_activity_details`), no paid API.
- **`refinalize_strava.py` + `refinalize-strava.yml`** — cloud workflow_dispatch to re-set title/description/image on already-bridged activities (maps garmin->strava via `strava_bridge_uploads`), to fix the sessions already on Strava.

Verified locally: produces `Aitoloakarnania Kiteboarding · Max Jump: 5.45m · 65 jumps` + full jump description for the affected session.