### PR TITLE
fix(sync): activity-type-aware push notification titles (#178)

### DIFF
--- a/sync/src/pipeline.py
+++ b/sync/src/pipeline.py
@@ -967,8 +967,9 @@ def _run_pipeline_inner(dates_to_sync: list, log_id: int = None):
                     cur.execute("""
                         SELECT DISTINCT ON (g.activity_id)
                                g.activity_id,
-                               COALESCE(g.raw_json->>'activityName', g.raw_json->>'name', 'Run') as name,
-                               g.raw_json->>'startTimeGMT' as start_time
+                               COALESCE(g.raw_json->>'activityName', g.raw_json->>'name', 'Activity') as name,
+                               g.raw_json->>'startTimeGMT' as start_time,
+                               g.raw_json->'activityType'->>'typeKey' as type_key
                         FROM garmin_activity_raw g
                         WHERE EXISTS (
                             SELECT 1 FROM activity_sync_log img
@@ -988,13 +989,15 @@ def _run_pipeline_inner(dates_to_sync: list, log_id: int = None):
                     """)
                     run_rows = cur.fetchall()
 
-            for activity_id, name, start_time in run_rows:
-                run_date = str(start_time or "")[:10]
+            from telegram_notify import activity_label
+            for activity_id, name, start_time, type_key in run_rows:
+                activity_date = str(start_time or "")[:10]
+                label = activity_label(type_key)
                 ok = send_push(
-                    title="Run Synced",
-                    body=f"{name} - {run_date}",
-                    url="/running",
-                    event_type="sync_run",
+                    title=f"{label} Synced",
+                    body=f"{name} - {activity_date}",
+                    url="/running" if label == "Run" else "/activities",
+                    event_type="sync_run",  # the single activity-sync preference
                 )
                 if ok > 0:
                     with get_connection() as conn:

--- a/sync/src/router.py
+++ b/sync/src/router.py
@@ -185,13 +185,15 @@ def execute_routes(
                     logger.warning("Push not configured, skipping rule %s", rule_id)
                     continue
                 if source_platform == "garmin":
-                    activity_name = workout.get("name", workout.get("activityName", "Run"))
-                    run_date = str(workout.get("date", workout.get("startTimeLocal", "")[:10]))
+                    from telegram_notify import activity_label
+                    activity_name = workout.get("name") or workout.get("activityName") or "Activity"
+                    activity_date = str(workout.get("date", workout.get("startTimeLocal", "")[:10]))
+                    label = activity_label(activity_type)
                     ok = send_push(
-                        title="Run Synced",
-                        body=f"{activity_name} - {run_date}",
-                        url="/running",
-                        event_type="sync_run",
+                        title=f"{label} Synced",
+                        body=f"{activity_name} - {activity_date}",
+                        url="/running" if label == "Run" else "/activities",
+                        event_type="sync_run",  # the single activity-sync preference
                     )
                 else:
                     ok = send_push(

--- a/sync/src/telegram_notify.py
+++ b/sync/src/telegram_notify.py
@@ -151,6 +151,38 @@ def activity_emoji(activity_type: str | None) -> str:
     return "🏅"
 
 
+# Human label per Garmin activity type, for notification titles ("Kiteboarding
+# Synced"). Substring match; specific keys before generic ones.
+_ACTIVITY_LABEL: list[tuple[str, str]] = [
+    ("kite", "Kiteboarding"),
+    ("wind_surf", "Windsurf"),
+    ("surf", "Surf"),
+    ("trail", "Trail Run"),
+    ("run", "Run"),
+    ("cycl", "Ride"),
+    ("bik", "Ride"),
+    ("bmx", "Ride"),
+    ("walk", "Walk"),
+    ("hik", "Hike"),
+    ("swim", "Swim"),
+    ("ski", "Ski"),
+    ("snowboard", "Snowboard"),
+    ("row", "Row"),
+    ("strength", "Strength"),
+    ("yoga", "Yoga"),
+]
+
+
+def activity_label(activity_type: str | None) -> str:
+    """Human label for a Garmin activity typeKey (e.g. 'Kiteboarding'). Falls back
+    to a generic 'Activity'."""
+    key = (activity_type or "").lower()
+    for needle, label in _ACTIVITY_LABEL:
+        if needle in key:
+            return label
+    return "Activity"
+
+
 def send_activity_image(
     garmin_activity_id: str | int,
     title: str,

--- a/sync/tests/test_telegram_notify.py
+++ b/sync/tests/test_telegram_notify.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from telegram_notify import activity_emoji  # noqa: E402
+from telegram_notify import activity_emoji, activity_label  # noqa: E402
 
 
 class TestActivityEmoji:
@@ -35,3 +35,23 @@ class TestActivityEmoji:
         assert activity_emoji("some_new_sport") == "🏅"
         assert activity_emoji("") == "🏅"
         assert activity_emoji(None) == "🏅"
+
+
+class TestActivityLabel:
+    """Guards the push-notification title ('Run Synced' was hardcoded for all types)."""
+
+    def test_kite_label(self) -> None:
+        assert activity_label("kiteboarding_v2") == "Kiteboarding"
+        assert activity_label("kiteboarding_v2") != "Run"
+
+    def test_common_labels(self) -> None:
+        assert activity_label("running") == "Run"
+        assert activity_label("treadmill_running") == "Run"
+        assert activity_label("cycling") == "Ride"
+        assert activity_label("walking") == "Walk"
+        assert activity_label("hiking") == "Hike"
+        assert activity_label("lap_swimming") == "Swim"
+
+    def test_unknown_falls_back_to_activity(self) -> None:
+        assert activity_label("some_new_sport") == "Activity"
+        assert activity_label(None) == "Activity"


### PR DESCRIPTION
Closes #178, closes #179, closes #180.

Web push hardcoded `title='Run Synced'` for every Garmin activity in two places (router live push + pipeline backfill push) — the sibling of the Telegram 'Run' bug on the push channel (the 'says Run synced' report).

- `activity_label(typeKey)` → 'Kiteboarding' / 'Run' / 'Ride' / 'Walk' / … ; push title is `f'{label} Synced'`; link `/running` for runs else `/activities`.
- Backfill push query now fetches the typeKey. `event_type` stays `sync_run` so the single activity-sync push preference still gates it (an unknown event_type would have bypassed the preference).

Tests: +3 label cases; full sync suite 1026 passed.