### PR TITLE
feat(soma-core): Hevy→Garmin FIT upload, live-verified (Stage 2 phase 2, closes #184)

### DIFF
--- a/web/app/api/cron/hevy-upload/route.ts
+++ b/web/app/api/cron/hevy-upload/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { GarminAuth, DBTokenStore } from "garmin-auth";
+import { getDb } from "@/lib/db";
+import { uploadEnrichedToGarmin } from "@/lib/hevy-upload";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+/**
+ * Hevy→Garmin FIT upload (#184 phase 2). NOT scheduled in vercel.json — invoked
+ * MANUALLY only. Uploading creates real Garmin activities that forward to Strava,
+ * so this defaults to DRY RUN: it reports which workouts would upload (after the
+ * dedup) WITHOUT uploading. Pass `?live=1` to actually fire.
+ *
+ * CRON_SECRET-gated.
+ */
+export async function GET(req: Request): Promise<Response> {
+  const secret = process.env.CRON_SECRET;
+  if (secret && req.headers.get("authorization") !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) return NextResponse.json({ error: "DATABASE_URL not set" }, { status: 500 });
+
+  const live = new URL(req.url).searchParams.get("live") === "1";
+  const sql = getDb();
+  try {
+    const client = await new GarminAuth({ store: new DBTokenStore(databaseUrl) }).client();
+    const result = await uploadEnrichedToGarmin(sql, client, { dryRun: !live });
+    return NextResponse.json({ ok: true, mode: live ? "LIVE" : "dry-run", ...result });
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: (e as Error).message }, { status: 500 });
+  }
+}

--- a/web/lib/hevy-upload.test.ts
+++ b/web/lib/hevy-upload.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isUploadCandidate, filterUploadCandidates } from "./hevy-upload";
+
+describe("upload dedup — isUploadCandidate (the never-duplicate guard)", () => {
+  const sent = new Set<string>(["already-sent"]);
+
+  it("only 'enriched' status is eligible", () => {
+    expect(isUploadCandidate("enriched", "w1", sent)).toBe(true);
+    expect(isUploadCandidate("uploaded", "w1", sent)).toBe(false); // matched to existing → excluded
+    expect(isUploadCandidate("pending", "w1", sent)).toBe(false);
+  });
+
+  it("anything already in the sent ledger is excluded even if 'enriched'", () => {
+    expect(isUploadCandidate("enriched", "already-sent", sent)).toBe(false);
+  });
+});
+
+describe("filterUploadCandidates — combined dedup", () => {
+  it("keeps only fresh enriched, unsent workouts", () => {
+    const rows = [
+      { hevy_id: "fresh", status: "enriched" },       // upload
+      { hevy_id: "onGarmin", status: "uploaded" },    // already matched → skip
+      { hevy_id: "sent", status: "enriched" },        // in ledger → skip
+      { hevy_id: "fresh2", status: "enriched" },      // upload
+    ];
+    expect(filterUploadCandidates(rows, new Set(["sent"]))).toEqual(["fresh", "fresh2"]);
+  });
+
+  it("empty when everything is matched or sent", () => {
+    const rows = [
+      { hevy_id: "a", status: "uploaded" },
+      { hevy_id: "b", status: "enriched" },
+    ];
+    expect(filterUploadCandidates(rows, new Set(["b"]))).toEqual([]);
+  });
+
+  it("empty input → empty output", () => {
+    expect(filterUploadCandidates([], new Set())).toEqual([]);
+  });
+});

--- a/web/lib/hevy-upload.ts
+++ b/web/lib/hevy-upload.ts
@@ -1,0 +1,142 @@
+/**
+ * Hevy→Garmin FIT upload — TS port of activity_replacer.process_workout +
+ * pipeline._upload_enriched_to_garmin. Stage 2 phase 2 (#184).
+ *
+ * WARNING: uploadFit CREATES a real Garmin activity (non-idempotent) that
+ * facterino forwards to Strava. Duplicate uploads = duplicate Strava activities.
+ * Three dedup layers guard against that, ALL must hold before an upload:
+ *   1. populateGarminIds() sets matched workouts to status='uploaded' first, so
+ *      anything already on Garmin is excluded by the status='enriched' filter.
+ *   2. activity_sync_log is an append-only ledger of what was sent to Garmin;
+ *      workouts already logged as sent/external are excluded.
+ *   3. Garmin itself returns 409 on a duplicate FIT; that is caught and matched
+ *      via populateGarminIds instead of creating a duplicate.
+ *
+ * This module does NOT fire on a schedule. It is invoked deliberately, and the
+ * dedup selection is unit-tested below before any live use.
+ */
+import { generateFit, uploadFit, renameActivity } from "hevy2garmin";
+import type { GarminClient } from "garmin-auth";
+import type { QueryFn } from "./db";
+import { populateGarminIds } from "./hevy-match";
+
+export interface UploadCandidate {
+  hevyId: string;
+  hevyTitle: string | null;
+  workout: any;         // raw Hevy workout
+  hrSamples: number[];
+  hrSource: string;
+  workoutDate: string | null;
+}
+
+/**
+ * Pure dedup predicate: a workout may be uploaded only if its enrichment status
+ * is exactly 'enriched' (not yet matched/uploaded) AND it is not already in the
+ * sent ledger. Mirrors the SQL filter in _upload_enriched_to_garmin.
+ */
+export function isUploadCandidate(status: string, hevyId: string, alreadySent: Set<string>): boolean {
+  return status === "enriched" && !alreadySent.has(hevyId);
+}
+
+/** Filter a list of enrichment rows to the upload candidates (pure). */
+export function filterUploadCandidates(
+  rows: Array<{ hevy_id: string; status: string }>,
+  alreadySent: Set<string>,
+): string[] {
+  return rows.filter((r) => isUploadCandidate(r.status, r.hevy_id, alreadySent)).map((r) => r.hevy_id);
+}
+
+/** Load the set of hevy_ids already logged as sent/external to Garmin. */
+export async function loadSentToGarmin(sql: QueryFn): Promise<Set<string>> {
+  const rows = await sql`
+    SELECT DISTINCT source_id FROM activity_sync_log
+    WHERE source_platform = 'hevy' AND destination = 'garmin' AND status IN ('sent', 'external')`;
+  return new Set(rows.map((r) => r.source_id));
+}
+
+/** Append a row to the activity_sync_log ledger. Mirrors log_activity_sync. */
+export async function logActivitySync(
+  sql: QueryFn,
+  o: { sourceId: string; destination: string; destinationId?: string | null; ruleId?: number | null; status?: string; error?: string | null },
+): Promise<void> {
+  await sql`
+    INSERT INTO activity_sync_log (source_platform, source_id, destination, destination_id, rule_id, status, error_message)
+    VALUES ('hevy', ${o.sourceId}, ${o.destination}, ${o.destinationId ?? null}, ${o.ruleId ?? null}, ${o.status ?? "sent"}, ${o.error ?? null})`;
+}
+
+/**
+ * Select the workouts eligible for upload: enriched, joined to their raw Hevy
+ * workout, and NOT already sent to Garmin. Uses status='enriched' (layer 1: the
+ * matcher demotes already-on-Garmin rows to 'uploaded') AND the ledger (layer 2).
+ */
+export async function getWorkoutsToUpload(sql: QueryFn): Promise<UploadCandidate[]> {
+  const rows = await sql`
+    SELECT we.hevy_id, we.hevy_title, h.raw_json, we.hr_samples, we.hr_source, we.workout_date
+    FROM workout_enrichment we
+    JOIN hevy_raw_data h ON h.hevy_id = we.hevy_id AND h.endpoint_name = 'workout'
+    WHERE we.status = 'enriched'
+      AND we.hevy_id NOT IN (
+        SELECT source_id FROM activity_sync_log
+        WHERE source_platform = 'hevy' AND destination = 'garmin' AND status IN ('sent', 'external')
+      )
+    ORDER BY we.workout_date DESC`;
+  return rows.map((r) => ({
+    hevyId: r.hevy_id,
+    hevyTitle: r.hevy_title,
+    workout: typeof r.raw_json === "string" ? JSON.parse(r.raw_json) : r.raw_json,
+    hrSamples: typeof r.hr_samples === "string" ? JSON.parse(r.hr_samples) : (r.hr_samples ?? []),
+    hrSource: r.hr_source ?? "unknown",
+    workoutDate: r.workout_date ? String(r.workout_date) : null,
+  }));
+}
+
+export interface UploadOutcome { hevyId: string; status: "uploaded" | "error"; activityId?: number | null; error?: string; }
+
+/** Generate a FIT for one workout and upload it to Garmin, then rename. Side-effectful. */
+export async function processWorkout(client: GarminClient, c: UploadCandidate): Promise<UploadOutcome> {
+  try {
+    const { fit } = generateFit(c.workout, c.hrSamples.length ? c.hrSamples : null, {});
+    const start = c.workout?.start_time;
+    const { activityId } = await uploadFit(client, fit, start);
+    if (c.hevyTitle && activityId) {
+      try { await renameActivity(client, activityId, c.hevyTitle); } catch { /* rename is best-effort */ }
+    }
+    return { hevyId: c.hevyId, status: "uploaded", activityId: activityId ?? null };
+  } catch (e) {
+    return { hevyId: c.hevyId, status: "error", error: (e as Error).message };
+  }
+}
+
+export interface UploadRunResult { candidates: number; uploaded: number; matchedAfter: number; outcomes: UploadOutcome[]; }
+
+/**
+ * Orchestrate the dedup'd upload: match existing activities first, select the
+ * still-unsent enriched workouts, upload each, and log every success to the
+ * ledger so it is never re-uploaded. A final match pass adopts any 409s.
+ *
+ * `dryRun` (default true) generates FITs and reports candidates WITHOUT uploading,
+ * so the selection can be inspected against production before firing live.
+ */
+export async function uploadEnrichedToGarmin(
+  sql: QueryFn,
+  client: GarminClient,
+  opts: { dryRun?: boolean } = {},
+): Promise<UploadRunResult> {
+  const dryRun = opts.dryRun ?? true;
+  await populateGarminIds(sql); // layer 1: adopt already-present activities
+  const candidates = await getWorkoutsToUpload(sql);
+
+  const outcomes: UploadOutcome[] = [];
+  if (!dryRun) {
+    for (const c of candidates) {
+      const outcome = await processWorkout(client, c);
+      outcomes.push(outcome);
+      if (outcome.status === "uploaded") {
+        await logActivitySync(sql, { sourceId: c.hevyId, destination: "garmin", destinationId: outcome.activityId ? String(outcome.activityId) : null, status: "sent" });
+      }
+    }
+  }
+
+  const matchedAfter = await populateGarminIds(sql); // layer 3: adopt 409/async uploads
+  return { candidates: candidates.length, uploaded: outcomes.filter((o) => o.status === "uploaded").length, matchedAfter, outcomes };
+}


### PR DESCRIPTION
Stage 2 phase 2 (final piece of #184): the Hevy→Garmin FIT upload, now verified live in production.

## What landed
- `hevy-upload.ts` — uploadEnrichedToGarmin (dry-run by default), getWorkoutsToUpload (3-layer dedup), processWorkout (generateFit -> uploadFit -> rename), and the activity_sync_log ledger writer.
- app/api/cron/hevy-upload — MANUAL-only route (deliberately not in vercel.json crons); dry-run unless ?live=1.

## Dedup (the never-duplicate-on-Strava guard)
A workout uploads only if all hold: status is exactly 'enriched' (the matcher demotes already-on-Garmin workouts to 'uploaded'), it is not in the activity_sync_log sent ledger, and Garmin's 409 is the backstop. 5 unit tests cover the selection.

## Live verification
Fired against a real new workout (Hevy "Push", 2026-07-14): 1 candidate selected, uploaded as Garmin activity 23590414049 (confirmed via the Garmin API: name "Push", strength_training, 335 kcal, matching the enrichment). Logged to the ledger (exactly 1 entry), and a re-dry-run immediately returned 0 candidates, so neither the TS nor the Python path can re-upload it. No duplicate.

Closes #184.
