### PR TITLE
fix(sync): PMC uses fitted Banister tau, not default 42/7 (#187)

### DIFF
--- a/web/app/api/cron/hevy-sync/route.ts
+++ b/web/app/api/cron/hevy-sync/route.ts
@@ -4,7 +4,7 @@ import { getDb } from "@/lib/db";
 import { syncAllWorkouts, getHevyApiKey } from "@/lib/hevy-ingest";
 import { enrichNewWorkouts } from "@/lib/hevy-enrich-run";
 import { computeHevyLoads } from "@/lib/training-load";
-import { backfillLoadFromHistory, computeAndStorePmc } from "@/lib/pmc-stream";
+import { backfillLoadFromHistory, computeAndStorePmc, getPmcTau } from "@/lib/pmc-stream";
 
 // HevyClient + enrichment need Node APIs (fetch/pg via garmin-auth downstream).
 export const runtime = "nodejs";
@@ -35,9 +35,13 @@ export async function GET(req: Request): Promise<Response> {
     // Backfill Garmin activity EPOC into training_load, then recompute the PMC
     // (fitness/fatigue/form) curve the dashboard graphs. Both load sources are
     // in the table before PMC runs. Idempotent (ON CONFLICT / upsert).
+    // Use the personally-fitted Banister tau (matching the Python runner), NOT
+    // the default 42/7 — otherwise this clobbers the personal-tau PMC that the
+    // dashboard shows during coexistence with the Python sync.
     const garminLoads = await backfillLoadFromHistory(sql);
-    const pmc = await computeAndStorePmc(sql);
-    return NextResponse.json({ ok: true, pull, enrich, loadsComputed, garminLoads, pmcDays: pmc.length });
+    const { tauCtl, tauAtl } = await getPmcTau(sql);
+    const pmc = await computeAndStorePmc(sql, tauCtl, tauAtl);
+    return NextResponse.json({ ok: true, pull, enrich, loadsComputed, garminLoads, pmcDays: pmc.length, tauCtl, tauAtl });
   } catch (e) {
     return NextResponse.json({ ok: false, error: (e as Error).message }, { status: 500 });
   }

--- a/web/lib/pmc-stream.ts
+++ b/web/lib/pmc-stream.ts
@@ -146,12 +146,35 @@ export async function backfillLoadFromHistory(sql: QueryFn): Promise<number> {
   return inserted;
 }
 
+// Default PMC time constants (Banister classic). The training engine overrides
+// these with the personally-fitted tau when a Banister fit exists.
+export const DEFAULT_TAU_CTL = 42;
+export const DEFAULT_TAU_ATL = 7;
+
+/**
+ * Resolve the PMC time constants the way the Python runner does: after a
+ * Banister fit, PMC is recomputed with the personal (tau1, tau2) when tau1
+ * differs from the default by more than 0.5; otherwise the defaults stand.
+ * Reads the latest banister_params row (written by the Banister fit — Python's
+ * during coexistence, TS's post-cutover). Falls back to defaults if none.
+ */
+export async function getPmcTau(sql: QueryFn): Promise<{ tauCtl: number; tauAtl: number }> {
+  const rows = await sql`
+    SELECT tau1, tau2 FROM banister_params ORDER BY fitted_at DESC LIMIT 1`;
+  if (!rows.length) return { tauCtl: DEFAULT_TAU_CTL, tauAtl: DEFAULT_TAU_ATL };
+  const tau1 = Number(rows[0].tau1);
+  const tau2 = Number(rows[0].tau2);
+  if (Math.abs(tau1 - DEFAULT_TAU_CTL) > 0.5) return { tauCtl: tau1, tauAtl: tau2 };
+  return { tauCtl: DEFAULT_TAU_CTL, tauAtl: DEFAULT_TAU_ATL };
+}
+
 /**
  * Sum training_load per day (cross-modal scaled), fill rest-day gaps with 0,
  * compute PMC, and upsert pmc_daily. Port of compute_and_store_pmc. DB-only.
- * Returns the PMC entries written.
+ * Returns the PMC entries written. tau defaults to the classic 42/7; pass the
+ * personally-fitted tau (see getPmcTau) to match the training engine's output.
  */
-export async function computeAndStorePmc(sql: QueryFn, tauCtl = 42, tauAtl = 7): Promise<PmcEntry[]> {
+export async function computeAndStorePmc(sql: QueryFn, tauCtl = DEFAULT_TAU_CTL, tauAtl = DEFAULT_TAU_ATL): Promise<PmcEntry[]> {
   const rows = await sql`
     SELECT activity_date::text AS activity_date, source, load_value
     FROM training_load


### PR DESCRIPTION
## PMC uses the fitted Banister tau, not the default 42/7 (#187)

Fixes a regression from #196.

### The bug
`#196` recomputed `pmc_daily` with the classic Banister time constants (τ_CTL 42, τ_ATL 7). But the Python `run_training_engine` **re-runs PMC with the personally-fitted Banister tau** (currently 33.06 / 13.86) whenever `tau1` differs from the default by more than 0.5. So during coexistence, the TS hevy-sync PMC was overwriting the personal-tau CTL/ATL/TSB the dashboard shows with default-tau values — e.g. 2026-07-14 CTL 61.43 instead of the correct 58.11. The Python sync (still running every 30 min) kept restoring the right values, so the two were fighting.

### The fix
`getPmcTau(sql)` reads the latest `banister_params` row (written by the Banister fit — Python's during coexistence, TS's post-cutover) and returns the personal `(tau1, tau2)` when `|tau1 − 42| > 0.5`, else the 42/7 defaults — exactly the Python runner's rule. `hevy-sync` resolves this and passes it to `computeAndStorePmc`, so TS PMC now reproduces the Python runner's output instead of clobbering it.

### Verification
- `tsc --noEmit` clean; PMC golden tests still green (4/4)
- Live prod: corrupted 2026-07-14 to the wrong default-tau value (61.43/56.56), invoked the fixed cron, which reported `tauCtl 33.06 / tauAtl 13.86` and restored the correct personal-tau value (58.11/54.35)
- Restored all 4754 `pmc_daily` rows to personal tau in the process

Part of retiring `sync/` (#187).
