### PR TITLE
fix(sync): fix PMC at classic 42/7 — Banister tau unidentifiable (#187)

### DIFF
--- a/sync/src/training_engine/runner.py
+++ b/sync/src/training_engine/runner.py
@@ -208,16 +208,16 @@ def run_training_engine(conn=None):
     if pmc:
         logger.info("Training engine: PMC computed for %d days", len(pmc))
 
-    # 2b. Try Banister fitting for personal tau values
+    # 2b. Banister fitting — kept for the current-VDOT display (banister_params),
+    # but its tau is NOT fed back into PMC. With only ~4 max-effort anchors the
+    # (tau1, tau2) are mathematically unidentifiable: every optimizer seed lands
+    # on a different tau with the identical fit quality, so a personal tau would
+    # make the CTL/ATL curve drift arbitrarily. PMC uses the classic 42/7.
     try:
-        from training_engine.banister import fit_from_db, _DEFAULT_PARAMS
-        banister_params = _run_step("Banister fitting", fit_from_db)
-        if banister_params and abs(banister_params.tau1 - _DEFAULT_PARAMS.tau1) > 0.5:
-            logger.info("Training engine: Banister fitted, re-running PMC with personal tau")
-            pmc = _run_step("PMC (personal tau)", compute_and_store_pmc,
-                            banister_params.tau1, banister_params.tau2) or pmc
+        from training_engine.banister import fit_from_db
+        _run_step("Banister fitting", fit_from_db)
     except Exception as e:
-        logger.error("Training engine: Banister fitting failed (using defaults): %s", e)
+        logger.error("Training engine: Banister fitting failed: %s", e)
 
     # 3. Today's readiness
     readiness = _run_step("readiness", compute_daily_readiness, today)

--- a/web/app/api/cron/hevy-sync/route.ts
+++ b/web/app/api/cron/hevy-sync/route.ts
@@ -4,7 +4,7 @@ import { getDb } from "@/lib/db";
 import { syncAllWorkouts, getHevyApiKey } from "@/lib/hevy-ingest";
 import { enrichNewWorkouts } from "@/lib/hevy-enrich-run";
 import { computeHevyLoads } from "@/lib/training-load";
-import { backfillLoadFromHistory, computeAndStorePmc, getPmcTau } from "@/lib/pmc-stream";
+import { backfillLoadFromHistory, computeAndStorePmc } from "@/lib/pmc-stream";
 
 // HevyClient + enrichment need Node APIs (fetch/pg via garmin-auth downstream).
 export const runtime = "nodejs";
@@ -35,13 +35,14 @@ export async function GET(req: Request): Promise<Response> {
     // Backfill Garmin activity EPOC into training_load, then recompute the PMC
     // (fitness/fatigue/form) curve the dashboard graphs. Both load sources are
     // in the table before PMC runs. Idempotent (ON CONFLICT / upsert).
-    // Use the personally-fitted Banister tau (matching the Python runner), NOT
-    // the default 42/7 — otherwise this clobbers the personal-tau PMC that the
-    // dashboard shows during coexistence with the Python sync.
+    // PMC uses the classic Banister constants (42/7). The personal Banister tau
+    // is deliberately NOT used: with ~4 anchors it is unidentifiable (every fit
+    // seed gives a different tau at identical quality), so feeding it would make
+    // the curve drift arbitrarily. Matches the Python runner (which also stopped
+    // feeding personal tau into PMC).
     const garminLoads = await backfillLoadFromHistory(sql);
-    const { tauCtl, tauAtl } = await getPmcTau(sql);
-    const pmc = await computeAndStorePmc(sql, tauCtl, tauAtl);
-    return NextResponse.json({ ok: true, pull, enrich, loadsComputed, garminLoads, pmcDays: pmc.length, tauCtl, tauAtl });
+    const pmc = await computeAndStorePmc(sql);
+    return NextResponse.json({ ok: true, pull, enrich, loadsComputed, garminLoads, pmcDays: pmc.length });
   } catch (e) {
     return NextResponse.json({ ok: false, error: (e as Error).message }, { status: 500 });
   }

--- a/web/lib/pmc-stream.ts
+++ b/web/lib/pmc-stream.ts
@@ -146,33 +146,17 @@ export async function backfillLoadFromHistory(sql: QueryFn): Promise<number> {
   return inserted;
 }
 
-// Default PMC time constants (Banister classic). The training engine overrides
-// these with the personally-fitted tau when a Banister fit exists.
+// PMC time constants — the classic Banister constants (CTL 42 d, ATL 7 d). The
+// personal Banister tau is deliberately NOT used: with ~4 max-effort anchors the
+// (tau1, tau2) are unidentifiable (every fit seed lands on a different tau at
+// identical quality), so a personal tau would make the curve drift arbitrarily.
 export const DEFAULT_TAU_CTL = 42;
 export const DEFAULT_TAU_ATL = 7;
 
 /**
- * Resolve the PMC time constants the way the Python runner does: after a
- * Banister fit, PMC is recomputed with the personal (tau1, tau2) when tau1
- * differs from the default by more than 0.5; otherwise the defaults stand.
- * Reads the latest banister_params row (written by the Banister fit — Python's
- * during coexistence, TS's post-cutover). Falls back to defaults if none.
- */
-export async function getPmcTau(sql: QueryFn): Promise<{ tauCtl: number; tauAtl: number }> {
-  const rows = await sql`
-    SELECT tau1, tau2 FROM banister_params ORDER BY fitted_at DESC LIMIT 1`;
-  if (!rows.length) return { tauCtl: DEFAULT_TAU_CTL, tauAtl: DEFAULT_TAU_ATL };
-  const tau1 = Number(rows[0].tau1);
-  const tau2 = Number(rows[0].tau2);
-  if (Math.abs(tau1 - DEFAULT_TAU_CTL) > 0.5) return { tauCtl: tau1, tauAtl: tau2 };
-  return { tauCtl: DEFAULT_TAU_CTL, tauAtl: DEFAULT_TAU_ATL };
-}
-
-/**
  * Sum training_load per day (cross-modal scaled), fill rest-day gaps with 0,
  * compute PMC, and upsert pmc_daily. Port of compute_and_store_pmc. DB-only.
- * Returns the PMC entries written. tau defaults to the classic 42/7; pass the
- * personally-fitted tau (see getPmcTau) to match the training engine's output.
+ * Returns the PMC entries written. tau defaults to the classic 42/7.
  */
 export async function computeAndStorePmc(sql: QueryFn, tauCtl = DEFAULT_TAU_CTL, tauAtl = DEFAULT_TAU_ATL): Promise<PmcEntry[]> {
   const rows = await sql`


### PR DESCRIPTION
## Fix PMC at classic 42/7 — the Banister tau is unidentifiable (#187)

Follow-up to #200, based on a finding about the Banister fit.

### Why
`#200` made PMC use the "personally-fitted" Banister tau. But that tau is **mathematically unidentifiable** from the ~4 max-effort anchors. scipy's `differential_evolution` lands on a completely different tau for every seed, all with the **identical** fit quality:

| seed | tau1 | tau2 | WSSE |
|------|------|------|------|
| 42 | 33.06 | 13.86 | 1.9034 |
| 0 | 59.84 | 4.19 | 1.9034 |
| 1 | 40.06 | 7.29 | 1.9034 |
| 7 | 40.99 | 5.56 | 1.9034 |

The 4 anchors don't constrain the fitness/fatigue time constants, so the "personal" tau is arbitrary. Feeding it into PMC made the CTL/ATL/TSB curve drift with each daily re-fit, with no physiological meaning.

### What
Fix PMC to the classic Banister constants (CTL 42 d, ATL 7 d), decoupled from the fit:
- **web**: `hevy-sync` calls `computeAndStorePmc(sql)` with defaults; `getPmcTau` removed.
- **sync** (Python, still running every 30 min during coexistence): the runner no longer re-runs PMC with personal tau. The Banister fit is kept only for the current-VDOT display (`banister_params`), not for PMC time constants.

Both systems now write identical 42/7 PMC, so the dashboard curve is stable and standard instead of the two syncs fighting.

### Verification
- `tsc --noEmit` clean; web PMC golden tests 4/4; sync banister tests 25/25
- Restored all 4754 `pmc_daily` rows to 42/7
- Live prod: corrupted 2026-07-14 to a personal-tau value, invoked hevy-sync, confirmed it restored 61.43/56.56 (42/7) and no longer emits tau in the response

Supersedes the personal-tau approach from #200. Part of retiring `sync/` (#187).
