### PR TITLE
feat(sync): cut sync.yml over to the TS pipeline (#187)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -79,16 +79,19 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-node@v4
         with:
-          python-version: '3.12'
+          node-version: '22'
 
-      - name: Install dependencies
-        working-directory: sync
-        run: pip install -e .
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
 
-      - name: Run sync pipeline (smart — auto-detects stale dates)
-        working-directory: sync
+      # Runs the TypeScript sync pipeline (#187 cutover — replaced
+      # `python -m src.pipeline`). Composes the same ported lib functions the
+      # Vercel crons use; no Vercel involvement → no 300s function limit.
+      - name: Run sync pipeline (TS — auto-detects stale dates)
+        working-directory: web
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GARMIN_EMAIL: ${{ secrets.GARMIN_EMAIL }}
@@ -100,8 +103,9 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           TRIGGERED_BY: ${{ github.event_name }}
           SOMA_WEB_URL: ${{ secrets.SOMA_WEB_URL }}
+          NEXT_PUBLIC_BASE_URL: ${{ secrets.SOMA_WEB_URL }}
           VAPID_PUBLIC_KEY: ${{ secrets.VAPID_PUBLIC_KEY }}
           VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
           VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
           MERGE_MODE: ${{ secrets.MERGE_MODE }}
-        run: python -m src.pipeline
+        run: npx tsx scripts/sync-pipeline.mts

--- a/web/lib/kite-jumps.ts
+++ b/web/lib/kite-jumps.ts
@@ -282,6 +282,11 @@ export async function extractKiteJumpsForActivity(
   sql: QueryFn, client: GarminClient, activityId: number, typeKey: string | null, startGmt: string | null,
 ): Promise<KitePayload | null> {
   if (!typeKey || !typeKey.toLowerCase().includes("kite")) return null;
+  // Dedup: a completed activity's jumps never change, so skip the FIT download
+  // if we've already extracted them (mirrors syncActivityDetails' 'details' skip).
+  const seen = await sql`
+    SELECT 1 FROM garmin_activity_raw WHERE activity_id = ${activityId} AND endpoint_name = 'kite_jumps' LIMIT 1`;
+  if (seen.length) return null;
   const fitBytes = await downloadFit(client, activityId);
   const desc = await surfrDescription(sql, startGmt);
   const payload = buildKiteJumps(fitBytes, desc);

--- a/web/lib/pmc-stream.ts
+++ b/web/lib/pmc-stream.ts
@@ -109,39 +109,40 @@ export async function backfillLoadFromHistory(sql: QueryFn): Promise<number> {
     SELECT activity_id, raw_json
     FROM garmin_activity_raw
     WHERE endpoint_name = 'summary'`;
-  let inserted = 0;
+  // Build all candidate rows in JS, then batch-insert (a per-row loop is one
+  // Neon round-trip per activity — hundreds of them). ON CONFLICT DO NOTHING +
+  // RETURNING counts only the genuinely new activities.
+  type Tuple = [string, number, string, string, number, number | null, string];
+  const tuples: Tuple[] = [];
   for (const row of rows) {
     const raw = typeof row.raw_json === "string" ? JSON.parse(row.raw_json) : row.raw_json;
     const activityDateStr: string | undefined = raw.startTimeLocal;
     if (!activityDateStr) continue;
-    const activityDate = activityDateStr.slice(0, 10);
     const activityType = (raw.activityType || {}).typeKey || "unknown";
     const source = `garmin_${activityType}`;
     const load = computeActivityLoad(raw, source);
+    const trimp = computeTrimp(Math.max((raw.duration || 0) / 60, 0), raw.averageHR ?? null, raw.minHR || 50, raw.maxHR || 190);
+    const details = JSON.stringify({ activity_type: activityType, original_epoc: raw.activityTrainingLoad ?? null, trimp: trimp !== null ? r(trimp, 1) : null });
+    tuples.push([activityDateStr.slice(0, 10), row.activity_id, load.source, load.load_metric, load.load_value, load.duration_seconds === null ? null : Math.trunc(load.duration_seconds), details]);
+  }
 
-    const trimp = computeTrimp(
-      Math.max((raw.duration || 0) / 60, 0),
-      raw.averageHR ?? null,
-      raw.minHR || 50,
-      raw.maxHR || 190,
-    );
-
-    const details = JSON.stringify({
-      activity_type: activityType,
-      original_epoc: raw.activityTrainingLoad ?? null,
-      trimp: trimp !== null ? r(trimp, 1) : null,
+  const client = sql as unknown as { query(text: string, params: unknown[]): Promise<unknown[]> };
+  let inserted = 0;
+  const CHUNK = 500; // 7 params/row → 3500 params/chunk, well under the cap
+  for (let i = 0; i < tuples.length; i += CHUNK) {
+    const chunk = tuples.slice(i, i + CHUNK);
+    const params: unknown[] = [];
+    const values = chunk.map((t) => {
+      const b = params.length;
+      params.push(t[0], t[1], t[2], t[3], t[4], t[5], t[6]);
+      return `($${b + 1},$${b + 2},$${b + 3},$${b + 4},$${b + 5},$${b + 6},$${b + 7}::jsonb)`;
     });
-    // RETURNING so the result array is non-empty only on a real insert
-    // (ON CONFLICT DO NOTHING yields [] when the activity is already present).
-    const res = await sql`
-      INSERT INTO training_load
-        (activity_date, activity_id, source, load_metric, load_value, duration_seconds, details)
-      VALUES (${activityDate}, ${row.activity_id}, ${load.source}, ${load.load_metric},
-              ${load.load_value}, ${load.duration_seconds === null ? null : Math.trunc(load.duration_seconds)},
-              ${details}::jsonb)
-      ON CONFLICT DO NOTHING
-      RETURNING activity_id`;
-    if (res.length > 0) inserted += 1;
+    const res = await client.query(
+      `INSERT INTO training_load (activity_date, activity_id, source, load_metric, load_value, duration_seconds, details)
+       VALUES ${values.join(",")} ON CONFLICT DO NOTHING RETURNING activity_id`,
+      params,
+    );
+    inserted += res.length;
   }
   return inserted;
 }
@@ -180,12 +181,23 @@ export async function computeAndStorePmc(sql: QueryFn, tauCtl = DEFAULT_TAU_CTL,
   }
 
   const pmc = computePmc(dailyLoads, tauCtl, tauAtl);
-  for (const e of pmc) {
-    await sql`
-      INSERT INTO pmc_daily (date, ctl, atl, tsb, daily_load)
-      VALUES (${e.date}, ${e.ctl}, ${e.atl}, ${e.tsb}, ${e.daily_load})
-      ON CONFLICT (date) DO UPDATE SET
-        ctl = EXCLUDED.ctl, atl = EXCLUDED.atl, tsb = EXCLUDED.tsb, daily_load = EXCLUDED.daily_load`;
+  // Batch the upsert (matches Python's execute_values): a per-row loop is ~4700
+  // sequential Neon round-trips. Chunk to stay well under Postgres' param cap.
+  const client = sql as unknown as { query(text: string, params: unknown[]): Promise<unknown[]> };
+  const CHUNK = 1000;
+  for (let i = 0; i < pmc.length; i += CHUNK) {
+    const chunk = pmc.slice(i, i + CHUNK);
+    const params: unknown[] = [];
+    const rows = chunk.map((e) => {
+      const b = params.length;
+      params.push(e.date, e.ctl, e.atl, e.tsb, e.daily_load);
+      return `($${b + 1},$${b + 2},$${b + 3},$${b + 4},$${b + 5})`;
+    });
+    await client.query(
+      `INSERT INTO pmc_daily (date, ctl, atl, tsb, daily_load) VALUES ${rows.join(",")}
+       ON CONFLICT (date) DO UPDATE SET ctl=EXCLUDED.ctl, atl=EXCLUDED.atl, tsb=EXCLUDED.tsb, daily_load=EXCLUDED.daily_load`,
+      params,
+    );
   }
   return pmc;
 }

--- a/web/scripts/sync-pipeline.mts
+++ b/web/scripts/sync-pipeline.mts
@@ -1,0 +1,73 @@
+/**
+ * Soma sync pipeline — TS entrypoint that replaces the Python sync/src/pipeline.py
+ * (#187 cutover). Run by the GitHub Actions sync workflow via `npx tsx` on the
+ * 30-min schedule (no Vercel involvement → no 300s limit, no daily-cron cap).
+ * Composes the same ported lib functions the Vercel crons use; each step is
+ * non-fatal so one failure doesn't abort the rest, mirroring pipeline.py.
+ */
+import { neon } from "@neondatabase/serverless";
+import { GarminAuth, DBTokenStore } from "garmin-auth";
+import { HevyClient } from "hevy2garmin";
+import type { QueryFn } from "../lib/db";
+import { runGarminIngest } from "../lib/garmin-ingest";
+import { getHevyApiKey, syncAllWorkouts } from "../lib/hevy-ingest";
+import { enrichNewWorkouts } from "../lib/hevy-enrich-run";
+import { computeHevyLoads } from "../lib/training-load";
+import { backfillLoadFromHistory, computeAndStorePmc } from "../lib/pmc-stream";
+import { pushPlanToGarmin } from "../lib/garmin-workout-builder";
+import { enrichGarminRunActivities } from "../lib/garmin-run-enrich";
+import { notifyPendingWorkouts } from "../lib/notify";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) { console.error("[sync] DATABASE_URL not set"); process.exit(1); }
+const sql = neon(databaseUrl) as unknown as QueryFn;
+const webBaseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.SOMA_WEB_URL || "https://soma.gkos.dev";
+
+async function step(name: string, fn: () => Promise<unknown>): Promise<void> {
+  const t0 = Date.now();
+  try {
+    const r = await fn();
+    console.log(`[sync] ${name} OK (${Date.now() - t0}ms):`, JSON.stringify(r));
+  } catch (e) {
+    console.error(`[sync] ${name} FAILED (${Date.now() - t0}ms):`, (e as Error).message);
+  }
+}
+
+// 1. Garmin daily + activities + parse + training-engine streams + kite.
+await step("garmin-ingest", () => runGarminIngest(databaseUrl!, sql));
+
+// 2. Hevy pull + enrich + training loads + PMC.
+await step("hevy", async () => {
+  const apiKey = await getHevyApiKey(sql);
+  if (!apiKey) throw new Error("Hevy API key not configured");
+  const client = new HevyClient(apiKey);
+  const pull = await syncAllWorkouts(client, sql);
+  const enrich = await enrichNewWorkouts(sql);
+  const loadsComputed = await computeHevyLoads(sql);
+  const garminLoads = await backfillLoadFromHistory(sql);
+  const pmc = await computeAndStorePmc(sql);
+  return { pull, enrich, loadsComputed, garminLoads, pmcDays: pmc.length };
+});
+
+// 3+4. Garmin client for the external-write steps (plan push + run enrichment).
+let garminClient: Awaited<ReturnType<GarminAuth["client"]>> | null = null;
+try {
+  garminClient = await new GarminAuth({ store: new DBTokenStore(databaseUrl) }).client();
+} catch (e) {
+  console.error("[sync] Garmin auth for push/enrich failed:", (e as Error).message);
+}
+
+if (garminClient) {
+  await step("plan-push", async () => {
+    const rows = await sql`SELECT id FROM training_plan WHERE status = 'active' LIMIT 1`;
+    if (!rows.length) return { activePlan: null, pushed: 0 };
+    const planId = Number(rows[0].id);
+    return { activePlan: planId, ...(await pushPlanToGarmin(sql, garminClient!, planId)) };
+  });
+  await step("garmin-enrich", () => enrichGarminRunActivities(sql, garminClient!, webBaseUrl));
+}
+
+// 5. Telegram + push notifications for new activities/workouts.
+await step("notify", () => notifyPendingWorkouts(sql));
+
+console.log("[sync] pipeline complete");


### PR DESCRIPTION
Replaces the Python sync pipeline with a TS entrypoint run by GitHub Actions. **web/scripts/sync-pipeline.mts** composes the ported lib functions the Vercel crons use (ingest+streams+kite → hevy+loads+PMC → plan-push → garmin-enrich → notify). **sync.yml** swaps setup-python + `python -m src.pipeline` for setup-node + `npx tsx scripts/sync-pipeline.mts` (same 30-min schedule + secrets) — runs on Actions, not Vercel, so no 300s limit and no daily-cron cap. **Perf**: batched computeAndStorePmc + backfillLoadFromHistory (matches Python's execute_values; hevy step 5min→11s) and kite extraction now dedups on stored kite_jumps (stops re-downloading FITs). Verified: full pipeline ran end-to-end in 176s, exit 0, every step green; also confirms the kite download+extract works live. tsc clean; suite 131/131. Vercel crons stay as a daily backup; sync/ deletion is the next PR after this runs green on Actions. (#187)