### PR TITLE
feat(ui): adopt soma-style base design tokens for macro colors (#216)

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,6 +1,12 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+/* soma-style design tokens. Direct relative path — Tailwind v4's CSS @import
+   doesn't resolve the package's `exports` subpath, but the file path is reliable. */
+@import "../node_modules/soma-style/css/theme.css";
+/* Scan soma-style so the macro utility classes it names (bg-warm, text-indigo,
+   text-success, …) are generated even though they only appear in node_modules. */
+@source "../node_modules/soma-style/dist";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/web/components/compose-meal-view.tsx
+++ b/web/components/compose-meal-view.tsx
@@ -378,11 +378,14 @@ export function ComposeMealView({
 
         type Key = "kcal" | "P" | "C" | "F" | "Fi";
         const colorMap: Record<Key, { eaten: string; thisMeal: string; text: string }> = {
-          kcal: { eaten: "bg-primary/60", thisMeal: "bg-primary",     text: "text-foreground" },
-          P:    { eaten: "bg-blue-700",   thisMeal: "bg-blue-500",    text: "text-blue-400" },
-          C:    { eaten: "bg-amber-700",  thisMeal: "bg-amber-500",   text: "text-amber-400" },
-          F:    { eaten: "bg-rose-700",   thisMeal: "bg-rose-500",    text: "text-rose-400" },
-          Fi:   { eaten: "bg-green-700",  thisMeal: "bg-green-500",   text: "text-green-400" },
+          // Macro colors from soma-style/theme.css. Single-token palette, so
+          // "eaten" (already consumed) is the muted /50 variant and "thisMeal"
+          // (being added) is the full-strength token.
+          kcal: { eaten: "bg-primary/60",  thisMeal: "bg-primary",   text: "text-foreground" },
+          P:    { eaten: "bg-warm/50",       thisMeal: "bg-warm",       text: "text-warm" },
+          C:    { eaten: "bg-indigo/50",     thisMeal: "bg-indigo",     text: "text-indigo" },
+          F:    { eaten: "bg-lime/50",       thisMeal: "bg-lime",       text: "text-lime" },
+          Fi:   { eaten: "bg-teal-light/50", thisMeal: "bg-teal-light", text: "text-teal-light" },
         };
 
         const data: Record<Key, { eaten: number; thisMeal: number; suffix: string; extra?: React.ReactNode }> = {

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { MACRO_COLORS } from "soma-style";
 import { Trash2, Plus, ChevronDown, ChevronUp, X } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -796,15 +797,15 @@ export function MealCard({
                     <div className="text-muted-foreground">kcal</div>
                   </div>
                   <div>
-                    <div className="font-bold tabular-nums text-blue-500">{previewMacros.protein}g</div>
+                    <div className={`font-bold tabular-nums ${MACRO_COLORS.protein.text}`}>{previewMacros.protein}g</div>
                     <div className="text-muted-foreground">P</div>
                   </div>
                   <div>
-                    <div className="font-bold tabular-nums text-amber-500">{previewMacros.carbs}g</div>
+                    <div className={`font-bold tabular-nums ${MACRO_COLORS.carbs.text}`}>{previewMacros.carbs}g</div>
                     <div className="text-muted-foreground">C</div>
                   </div>
                   <div>
-                    <div className="font-bold tabular-nums text-rose-500">{previewMacros.fat}g</div>
+                    <div className={`font-bold tabular-nums ${MACRO_COLORS.fat.text}`}>{previewMacros.fat}g</div>
                     <div className="text-muted-foreground">F</div>
                   </div>
                 </div>

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useCallback, useEffect } from "react";
+import { MACRO_COLORS } from "soma-style";
 import { AlertTriangle, Lock, Moon, Footprints, Dumbbell, ChevronLeft, ChevronRight, X } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -873,14 +874,14 @@ export function NutritionDashboard({
                 return (
                   <div className="grid gap-2 pt-1">
                     <MacroBar label="Protein" current={consumedProtein} target={targetProtein}
-                      color="bg-blue-500" markers={proteinMarkers} />
+                      color={MACRO_COLORS.protein.bg} markers={proteinMarkers} />
                     <MacroBar label="Carbs" current={consumedCarbs} target={targetCarbs}
-                      color="bg-amber-500" markers={carbMarkers} />
+                      color={MACRO_COLORS.carbs.bg} markers={carbMarkers} />
                     <MacroBar label="Fat" current={consumedFat} target={targetFat}
-                      color="bg-rose-500" markers={fatMarkers} />
+                      color={MACRO_COLORS.fat.bg} markers={fatMarkers} />
                     {targetFiber > 0 && (
                       <MacroBar label="Fiber" current={consumedFiber} target={targetFiber}
-                        color="bg-green-500" markers={fiberMarkers} />
+                        color={MACRO_COLORS.fiber.bg} markers={fiberMarkers} />
                     )}
                   </div>
                 );

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -35,6 +35,7 @@
         "react-markdown": "^9.1.0",
         "recharts": "^3.7.0",
         "remark-gfm": "^4.0.1",
+        "soma-style": "^0.1.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "web-push": "^3.6.7"
@@ -14467,6 +14468,12 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/soma-style": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-0.1.0.tgz",
+      "integrity": "sha512-SXOAD3WOKgSCotJewZ3J6pZlwAOi8GzbSB/0IlfSc2o/efoHcr3+uiuf4SE21PNlqwwtXBdH5/eMZXXNsd0cYQ==",
       "license": "MIT"
     },
     "node_modules/sonner": {

--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,7 @@
     "react-markdown": "^9.1.0",
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
+    "soma-style": "^0.1.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "web-push": "^3.6.7"


### PR DESCRIPTION
Adopts the new [soma-style](https://github.com/drkostas/soma-style) base design-token package (npm `soma-style@0.1.0`) as soma's macro-color source of truth.

## What
- Adds `soma-style` dependency + imports its Tailwind v4 theme.
- Replaces stock-Tailwind macro colors (blue/amber/rose/green) in `nutrition-dashboard.tsx`, `meal-card.tsx`, `compose-meal-view.tsx` with the designed warm/cool palette via `MACRO_COLORS` tokens.

## Palette
protein `#B17850` · carbs `#6366B0` · fat `#CBE896` · calories `#77C8D1` · fiber `#82D0C8`

## Verified
- Live computed styles on the rendered macro bars match the exact design hex (protein rgb(177,120,80)=#B17850, carbs #6366B0, fat #CBE896, fiber #82D0C8).
- `tsc --noEmit` clean.

## Note on the Tailwind wiring
Tailwind v4's CSS `@import` doesn't resolve the package's `exports` subpath, so globals.css imports the theme by direct relative path and `@source`s the package dist so the `bg-warm`/`text-indigo` utilities generate.

Closes #216