### PR TITLE
feat(nutrition): wire adaptive TDEE + deficit-duration (display-only) (#68)

### DIFF
--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -3,6 +3,7 @@ import { getDb } from "@/lib/db";
 import { computeMacroTargetsFromContext } from "@/lib/macro-targets";
 import type { Mode } from "@/lib/mode-engine";
 import type { SlotBudgets } from "@/lib/nutrition-types";
+import { computeAdaptiveContext } from "@/lib/adaptive-tdee";
 
 export const runtime = "edge";
 
@@ -533,6 +534,9 @@ export async function GET(req: NextRequest) {
       .length * goalDeficit,
   };
 
+  // Adaptive TDEE + deficit-duration (display-only — never changes targets).
+  const adaptive = await computeAdaptiveContext(sql).catch(() => null);
+
   return NextResponse.json({
     plan,
     meals: mealRows,
@@ -546,5 +550,6 @@ export async function GET(req: NextRequest) {
     gymCalories,
     breakdown,
     trend7d,
+    adaptive,
   });
 }

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -335,6 +335,7 @@ export function NutritionDashboard({
   const [budgetExpanded, setBudgetExpanded] = useState(false);
   const [breakdown, setBreakdown] = useState<any>(null);
   const [trend7d, setTrend7d] = useState<any>(null);
+  const [adaptive, setAdaptive] = useState<any>(null);
   const [dataReady, setDataReady] = useState(false);
   const [rebalanceToast, setRebalanceToast] = useState<string | null>(null);
 
@@ -358,6 +359,7 @@ export function NutritionDashboard({
         if (data.slotBudgets) setSlotBudgets(data.slotBudgets);
         if (data.breakdown) setBreakdown(data.breakdown);
         if (data.trend7d) setTrend7d(data.trend7d);
+        setAdaptive(data.adaptive ?? null);
       }
       if (presetsRes.ok) {
         const presetsData = await presetsRes.json();
@@ -811,6 +813,35 @@ export function NutritionDashboard({
                         )}
                       </div>
                     )}
+                    {adaptive && (adaptive.driftFlag || adaptive.dietBreakLevel !== "none") && (() => {
+                      const level = adaptive.dietBreakLevel as string;
+                      const levelColor = level === "mandatory" ? "text-red-500"
+                        : level === "strong" ? "text-orange-400"
+                        : level === "suggested" ? "text-amber-400" : "text-muted-foreground";
+                      const levelLabel = level === "mandatory" ? "Diet break due"
+                        : level === "strong" ? "Diet break strongly advised"
+                        : level === "suggested" ? "Diet break suggested" : null;
+                      return (
+                        <div className="mt-3 pt-3 border-t border-white/10 space-y-1">
+                          <div className="text-[10px] lg:text-xs font-medium text-muted-foreground uppercase tracking-wider">Adaptive</div>
+                          {levelLabel && (
+                            <div className="flex justify-between items-baseline text-xs">
+                              <span className={`font-medium ${levelColor}`}>{levelLabel}</span>
+                              <span className="text-muted-foreground tabular-nums">{adaptive.deficitDurationDays}d in deficit</span>
+                            </div>
+                          )}
+                          {adaptive.driftFlag && (
+                            <div className="flex justify-between items-baseline text-xs">
+                              <span className="text-amber-400">TDEE drift</span>
+                              <span className="text-muted-foreground tabular-nums">
+                                ~{Math.round(adaptive.effectiveTdee)} vs {Math.round(adaptive.reportedTdee)} kcal
+                              </span>
+                            </div>
+                          )}
+                          <div className="text-[9px] text-muted-foreground/60">Informational — your targets are unchanged.</div>
+                        </div>
+                      );
+                    })()}
                   </div>
                 )}
               </div>

--- a/web/lib/adaptive-tdee.test.ts
+++ b/web/lib/adaptive-tdee.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { countDeficitDuration, buildDayPoints } from "./adaptive-tdee";
+
+type Row = Parameters<typeof countDeficitDuration>[0][number];
+
+function day(date: string, o: Partial<Row> = {}): Row {
+  return {
+    date,
+    actual_calories: 2000,
+    tdee_used: 2800,
+    target_calories: 2000,
+    deficit_used: 800,
+    is_diet_break: false,
+    is_refeed: false,
+    status: "closed",
+    ...o,
+  } as Row;
+}
+
+describe("countDeficitDuration", () => {
+  it("counts consecutive closed deficit days from the end", () => {
+    const rows = [day("2026-07-10"), day("2026-07-11"), day("2026-07-12")];
+    expect(countDeficitDuration(rows)).toBe(3);
+  });
+
+  it("stops at a diet break", () => {
+    const rows = [day("2026-07-10"), day("2026-07-11", { is_diet_break: true }), day("2026-07-12")];
+    expect(countDeficitDuration(rows)).toBe(1); // only the last day
+  });
+
+  it("stops at a refeed", () => {
+    const rows = [day("2026-07-10"), day("2026-07-11", { is_refeed: true }), day("2026-07-12")];
+    expect(countDeficitDuration(rows)).toBe(1);
+  });
+
+  it("stops at a surplus (no deficit)", () => {
+    const rows = [day("2026-07-11", { deficit_used: 0 }), day("2026-07-12")];
+    expect(countDeficitDuration(rows)).toBe(1);
+  });
+
+  it("skips not-yet-closed days without breaking the streak", () => {
+    const rows = [day("2026-07-10"), day("2026-07-11", { status: "open" }), day("2026-07-12")];
+    expect(countDeficitDuration(rows)).toBe(2);
+  });
+});
+
+describe("buildDayPoints", () => {
+  it("forward-fills weight and skips days before the first weigh-in", () => {
+    const rows = [day("2026-07-10"), day("2026-07-11"), day("2026-07-12")];
+    const weights = [{ date: "2026-07-11", weightKg: 80 }];
+    const pts = buildDayPoints(rows, weights);
+    // 2026-07-10 skipped (no weigh-in yet), 11 and 12 carry 80
+    expect(pts.map((p) => p.weightKg)).toEqual([80, 80]);
+    expect(pts.map((p) => p.intakeKcal)).toEqual([2000, 2000]);
+  });
+
+  it("carries a weigh-in that predates the day rows (date-misaligned)", () => {
+    const rows = [day("2026-07-10"), day("2026-07-12")];
+    const pts = buildDayPoints(rows, [{ date: "2026-07-08", weightKg: 81 }]);
+    expect(pts.map((p) => p.weightKg)).toEqual([81, 81]);
+  });
+
+  it("skips non-closed and zero-intake days", () => {
+    const rows = [
+      day("2026-07-10", { status: "open" }),
+      day("2026-07-11", { actual_calories: 0 }),
+      day("2026-07-12"),
+    ];
+    const pts = buildDayPoints(rows, [{ date: "2026-07-09", weightKg: 80 }]);
+    expect(pts).toHaveLength(1);
+    expect(pts[0].intakeKcal).toBe(2000);
+  });
+
+  it("reconstructs tdee from target + deficit when tdee_used is null", () => {
+    const rows = [day("2026-07-12", { tdee_used: null, target_calories: 1900, deficit_used: 700 })];
+    const pts = buildDayPoints(rows, [{ date: "2026-07-12", weightKg: 79 }]);
+    expect(pts[0].tdeeKcal).toBe(2600);
+  });
+});

--- a/web/lib/adaptive-tdee.ts
+++ b/web/lib/adaptive-tdee.ts
@@ -1,0 +1,120 @@
+/**
+ * Adaptive TDEE + deficit-duration — wires macro-engine-core's adaptive engine
+ * into soma. Display-only: it surfaces how the body's effective TDEE has drifted
+ * from the reported figure and whether a diet break is due. It never changes the
+ * day's targets (the user decides).
+ *
+ * No schema change: DayPoints come from `nutrition_day` (intake, tdee) joined to
+ * `weight_log` (weight), and the deficit-phase duration is counted from
+ * consecutive recent deficit days that aren't diet breaks / refeeds.
+ */
+import { computeAdaptiveTdee, recommendDietBreak, type DietBreakLevel } from "macro-engine-core";
+import type { QueryFn } from "@/lib/db";
+
+export interface AdaptiveContext {
+  effectiveTdee: number;
+  reportedTdee: number;
+  discrepancyPct: number;
+  driftFlag: boolean;
+  deficitDurationDays: number;
+  dietBreakLevel: DietBreakLevel;
+}
+
+interface DayRow {
+  date: string;
+  actual_calories: number | null;
+  tdee_used: number | null;
+  target_calories: number | null;
+  deficit_used: number | null;
+  is_diet_break: boolean | null;
+  is_refeed: boolean | null;
+  status: string | null;
+}
+
+// How far back to look. 130 days covers the diet-break ceiling (112) for the
+// duration count; the adaptive-TDEE window itself is only the last 14.
+const LOOKBACK_DAYS = 130;
+
+/**
+ * Count consecutive closed deficit days ending at the most recent day, stopping
+ * at the first diet break, refeed, or non-deficit day. This is the length of the
+ * current deficit phase.
+ */
+export function countDeficitDuration(rows: DayRow[]): number {
+  let n = 0;
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const r = rows[i];
+    if (r.status !== "closed") continue; // ignore not-yet-closed days without breaking the streak
+    if (r.is_diet_break || r.is_refeed) break;
+    if ((Number(r.deficit_used) || 0) <= 0) break;
+    n++;
+  }
+  return n;
+}
+
+export interface WeighIn {
+  date: string;
+  weightKg: number;
+}
+
+/**
+ * Build the DayPoints the adaptive engine needs: last-N closed days with a real
+ * intake, each carrying a forward-filled body weight. Weigh-ins rarely land on
+ * the same dates as nutrition days, so we merge-walk the sorted weigh-ins and
+ * carry the most recent weight at or before each day.
+ */
+export function buildDayPoints(
+  rows: DayRow[],
+  weights: WeighIn[],
+): { day: number; intakeKcal: number; tdeeKcal: number; weightKg: number }[] {
+  const points: { day: number; intakeKcal: number; tdeeKcal: number; weightKg: number }[] = [];
+  let lastWeight = 0;
+  let wi = 0;
+  let idx = 0;
+  for (const r of rows) {
+    while (wi < weights.length && weights[wi].date <= r.date) {
+      if (weights[wi].weightKg > 0) lastWeight = weights[wi].weightKg;
+      wi++;
+    }
+    if (r.status !== "closed") continue;
+    const intake = Number(r.actual_calories) || 0;
+    if (intake <= 0) continue;
+    if (lastWeight <= 0) continue; // no weigh-in yet — skip until we have one
+    // tdee: prefer the stored figure, else reconstruct target + deficit
+    const tdee = Number(r.tdee_used) || (Number(r.target_calories) || 0) + (Number(r.deficit_used) || 0);
+    if (tdee <= 0) continue;
+    points.push({ day: idx++, intakeKcal: intake, tdeeKcal: tdee, weightKg: lastWeight });
+  }
+  return points;
+}
+
+export async function computeAdaptiveContext(sql: QueryFn): Promise<AdaptiveContext | null> {
+  const rows = (await sql`
+    SELECT date::text AS date, actual_calories, tdee_used, target_calories,
+           deficit_used, is_diet_break, is_refeed, status
+    FROM nutrition_day
+    WHERE date >= CURRENT_DATE - ${`${LOOKBACK_DAYS} days`}::interval
+    ORDER BY date
+  `) as unknown as DayRow[];
+  if (!rows.length) return null;
+
+  const weightRows = (await sql`
+    SELECT date::text AS date, weight_grams / 1000.0 AS weight_kg
+    FROM weight_log
+    WHERE weight_grams IS NOT NULL
+      AND date >= CURRENT_DATE - ${`${LOOKBACK_DAYS} days`}::interval
+    ORDER BY date
+  `) as unknown as { date: string; weight_kg: number }[];
+  const weights: WeighIn[] = weightRows.map((w) => ({ date: w.date, weightKg: Number(w.weight_kg) }));
+
+  const days = buildDayPoints(rows, weights);
+  const adaptive = computeAdaptiveTdee(days);
+  if (!adaptive) return null;
+
+  const deficitDurationDays = countDeficitDuration(rows);
+  return {
+    ...adaptive,
+    deficitDurationDays,
+    dietBreakLevel: recommendDietBreak(deficitDurationDays),
+  };
+}


### PR DESCRIPTION
Wires macro-engine-core's adaptive engine into soma — **display-only** (surfaces insight, never changes targets, per the "goals should not auto-change" principle).

## What
- `web/lib/adaptive-tdee.ts`: builds `DayPoint[]` from `nutrition_day` (intake, tdee) + `weight_log` (weight, forward-filled via merge-walk), counts the current deficit-phase length from consecutive deficit days (excluding diet breaks / refeeds), and calls `computeAdaptiveTdee` + `recommendDietBreak`.
- `/api/nutrition/plan` returns an `adaptive` block (backward-compatible).
- Nutrition dashboard shows an **Adaptive** card: diet-break recommendation + days-in-deficit, plus TDEE drift when flagged, with an explicit "targets are unchanged" note.

## No schema change
The original #68 assumed new `deficit_phase_*` columns. Not needed — `nutrition_day` already has `deficit_used`, `is_diet_break`, `is_refeed`; the phase length is computed from history.

## Verified
- Live: 82 days in deficit → `suggested`; effective 2635 vs reported 2597 kcal (no drift). Playwright-confirmed the card renders.
- 9 new vitest cases (deficit-duration + DayPoint assembly, incl. a date-misaligned weigh-in). Full suite 160/160, tsc clean.

## Caught mid-flight
Fixed a real bug: DayPoint weight only loaded when a weigh-in landed on the exact date of a nutrition day. Weigh-ins aren't date-aligned, so it now merge-walks sorted weigh-ins and carries the most recent weight ≤ each day.

Closes #68