### PR TITLE
feat(nutrition): alcohol parity + weekly adherence band (#69)

### DIFF
--- a/web/app/api/nutrition/log-drink/route.ts
+++ b/web/app/api/nutrition/log-drink/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { ETHANOL_DENSITY, fatOxidationPauseHours } from "macro-engine-core";
 
-export const runtime = "edge";
+// nodejs (not edge): imports the CJS macro-engine-core package for the alcohol
+// helpers, matching the other nutrition routes.
+export const runtime = "nodejs";
 
 // ---------------------------------------------------------------------------
 // Drink database — mirrors Python seed_data.DRINK_DATABASE (9 types)
@@ -82,24 +85,8 @@ const DRINK_DB: Record<
   },
 };
 
-// Ethanol density: 0.789 g/ml
-const ETHANOL_DENSITY = 0.789;
-
-/**
- * Estimate how long fat oxidation is suppressed by alcohol intake.
- *   0g        -> 0h
- *   1-14g     -> 0-4h (linear)
- *   14-28g    -> 4-6h (linear)
- *   28-56g    -> 6-12h (linear)
- *   56g+      -> 12-24h (linear, capped)
- */
-function fatOxidationPause(alcoholGrams: number): number {
-  if (alcoholGrams <= 0) return 0;
-  if (alcoholGrams <= 14) return (alcoholGrams / 14) * 4;
-  if (alcoholGrams <= 28) return 4 + ((alcoholGrams - 14) / 14) * 2;
-  if (alcoholGrams <= 56) return 6 + ((alcoholGrams - 28) / 28) * 6;
-  return Math.min(24, 12 + ((alcoholGrams - 56) / 56) * 12);
-}
+// ETHANOL_DENSITY (0.789 g/ml) and the fat-oxidation-pause curve now come from
+// macro-engine-core so soma and the package can't drift apart.
 
 export async function GET() {
   return NextResponse.json({ drinks: DRINK_DB });
@@ -133,7 +120,7 @@ export async function POST(req: NextRequest) {
   const carbs = Math.round(((drink.carbs_per_100ml * totalMl) / 100) * 10) / 10;
   const alcoholGrams =
     Math.round(totalMl * (drink.alcohol_pct / 100) * ETHANOL_DENSITY * 10) / 10;
-  const pauseHours = Math.round(fatOxidationPause(alcoholGrams) * 10) / 10;
+  const pauseHours = Math.round(fatOxidationPauseHours(alcoholGrams) * 10) / 10;
 
   // Ensure nutrition_day row exists for this date
   await sql`

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -4,6 +4,8 @@ import { computeMacroTargetsFromContext } from "@/lib/macro-targets";
 import type { Mode } from "@/lib/mode-engine";
 import type { SlotBudgets } from "@/lib/nutrition-types";
 import { computeAdaptiveContext } from "@/lib/adaptive-tdee";
+import { computeWeeklyAdherence } from "@/lib/adherence";
+import { computeAlcoholDisplacement } from "macro-engine-core";
 
 export const runtime = "edge";
 
@@ -385,16 +387,13 @@ export async function GET(req: NextRequest) {
     }
 
     // ── Alcohol offset: reduce food macro targets by drink calories ──
+    // Parity with macro-engine-core: alcohol kcal displace fat first (65%) then
+    // carbs, capped at the day's budget, never protein.
     if (drinkCalories > 0) {
       dayTargets.calories = Math.max(0, dayTargets.calories - drinkCalories);
-      // Reduce carbs first (alcohol inhibits carb oxidation), then fat
-      const carbGramsToRemove = Math.min(Math.round(drinkCalories / 4), dayTargets.carbs);
-      dayTargets.carbs -= carbGramsToRemove;
-      const remainingDrinkCal = drinkCalories - carbGramsToRemove * 4;
-      if (remainingDrinkCal > 0) {
-        const fatGramsToRemove = Math.min(Math.round(remainingDrinkCal / 9), dayTargets.fat);
-        dayTargets.fat -= fatGramsToRemove;
-      }
+      const disp = computeAlcoholDisplacement(drinkCalories, dayTargets.fat, dayTargets.carbs);
+      dayTargets.fat = Math.max(0, dayTargets.fat - disp.fat_reduction_g);
+      dayTargets.carbs = Math.max(0, dayTargets.carbs - disp.carbs_reduction_g);
     }
 
     remaining = {
@@ -532,6 +531,17 @@ export async function GET(req: NextRequest) {
     goalExpectedDeficit: trendRows
       .filter((r: Record<string, unknown>) => r.status === "closed")
       .length * goalDeficit,
+    // Weekly adherence (±10% band). Achieved deficit = burn − ate, summed over
+    // closed days (positive = in deficit); goal = closed days × goal/day.
+    adherence: (() => {
+      const closed = trendRows.filter((r: Record<string, unknown>) => r.status === "closed");
+      const weeklyActual = closed.reduce((s: number, r: Record<string, unknown>) => {
+        const ate = Number(r.actual_calories) || 0;
+        const burn = Math.round(computeBurn(r, false));
+        return s + (burn - ate);
+      }, 0);
+      return computeWeeklyAdherence(weeklyActual, closed.length * goalDeficit);
+    })(),
   };
 
   // Adaptive TDEE + deficit-duration (display-only — never changes targets).

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -808,6 +808,17 @@ export function NutritionDashboard({
                             );
                           })()}
                         </div>
+                        {trend7d.adherence && (() => {
+                          const a = trend7d.adherence;
+                          const label = a.status === "on_track" ? "on track" : a.status === "under" ? "under goal" : "over goal";
+                          const color = a.status === "on_track" ? "text-green-500" : "text-amber-400";
+                          return (
+                            <div className="flex justify-between items-baseline text-[10px] mt-1 pt-1 border-t border-white/10">
+                              <span className="text-muted-foreground">Weekly adherence</span>
+                              <span className={`${color} tabular-nums`}>{label} · {Math.round(a.ratio * 100)}%</span>
+                            </div>
+                          );
+                        })()}
                         {trend7d.days.some((d: any) => d.manual) && (
                           <div className="text-[9px] text-muted-foreground/60">* offset target in parentheses · +/− vs {trend7d.goalDeficit}/day goal</div>
                         )}

--- a/web/lib/adherence.test.ts
+++ b/web/lib/adherence.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { computeWeeklyAdherence } from "./adherence";
+
+describe("computeWeeklyAdherence", () => {
+  it("is on_track within ±10% of goal", () => {
+    expect(computeWeeklyAdherence(5600, 5600)?.status).toBe("on_track"); // exact
+    expect(computeWeeklyAdherence(5100, 5600)?.status).toBe("on_track"); // ~0.91
+    expect(computeWeeklyAdherence(6100, 5600)?.status).toBe("on_track"); // ~1.09
+  });
+
+  it("is under below 90% of goal", () => {
+    expect(computeWeeklyAdherence(4000, 5600)?.status).toBe("under"); // ~0.71
+  });
+
+  it("is over above 110% of goal", () => {
+    expect(computeWeeklyAdherence(7000, 5600)?.status).toBe("over"); // 1.25
+  });
+
+  it("returns null when there is no goal", () => {
+    expect(computeWeeklyAdherence(500, 0)).toBeNull();
+  });
+
+  it("rounds the reported kcal figures", () => {
+    const a = computeWeeklyAdherence(5601.7, 5600.4);
+    expect(a?.weeklyActual).toBe(5602);
+    expect(a?.weeklyGoal).toBe(5600);
+  });
+});

--- a/web/lib/adherence.ts
+++ b/web/lib/adherence.ts
@@ -1,0 +1,36 @@
+/**
+ * Weekly deficit adherence — how the achieved deficit over the recent closed
+ * days compares to the goal, with a ±10% tolerance band. Display-only: it labels
+ * the week, it doesn't change targets.
+ */
+export type AdherenceStatus = "under" | "on_track" | "over";
+
+export interface Adherence {
+  ratio: number;
+  status: AdherenceStatus;
+  weeklyActual: number;
+  weeklyGoal: number;
+}
+
+/** ±10% tolerance around the goal deficit. */
+export const ADHERENCE_TOLERANCE = 0.1;
+
+/**
+ * @param weeklyActualDeficit summed achieved deficit (kcal, positive = deficit) over closed days
+ * @param weeklyGoalDeficit   goal deficit for the same number of closed days (kcal, positive)
+ */
+export function computeWeeklyAdherence(
+  weeklyActualDeficit: number,
+  weeklyGoalDeficit: number,
+): Adherence | null {
+  if (weeklyGoalDeficit <= 0) return null;
+  const ratio = weeklyActualDeficit / weeklyGoalDeficit;
+  const status: AdherenceStatus =
+    ratio < 1 - ADHERENCE_TOLERANCE ? "under" : ratio > 1 + ADHERENCE_TOLERANCE ? "over" : "on_track";
+  return {
+    ratio,
+    status,
+    weeklyActual: Math.round(weeklyActualDeficit),
+    weeklyGoal: Math.round(weeklyGoalDeficit),
+  };
+}


### PR DESCRIPTION
Completes the nutrition-science port (final item).

## Alcohol parity
- Plan route now uses macro-engine-core's `computeAlcoholDisplacement` (fat first at 65%, then carbs, never protein, capped at budget) instead of the old inline carbs-first offset.
- `log-drink` drops its duplicated `ETHANOL_DENSITY` + fat-oxidation-pause curve (byte-identical to the package) and imports them, so soma and the package can't drift. Route switched `edge`→`nodejs` for the CJS import (matches the other nutrition routes).

## Adherence tolerance
- New `web/lib/adherence.ts`: a ±10% weekly-deficit band — achieved deficit vs goal over closed days → `under` / `on_track` / `over`.
- Surfaced in the `/api/nutrition/plan` response and as a **Weekly adherence** line under the 7-day trend.

## Verified
- Live: adherence "over goal · 317%" (deficit far exceeds the 800/day goal); `log-drink` GET 200 with 9 drink types on nodejs. Playwright-confirmed both the adherence line and the (existing) adaptive card render.
- 5 adherence vitest cases; full suite **165/165**, tsc clean.

## Note
Adopting the 65%-fat displacement changes the old carbs-first behavior — this is the researched macro-engine default and the point of "parity".

Closes #69