### PR TITLE
feat(ui): consume full app theme from soma-style/base.css (#220)

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,127 +1,16 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-/* soma-style design tokens. Direct relative path — Tailwind v4's CSS @import
-   doesn't resolve the package's `exports` subpath, but the file path is reliable. */
+/* soma-style design tokens. Direct relative paths — Tailwind v4's CSS @import
+   doesn't resolve the package's `exports` subpath, but file paths are reliable.
+   base.css = the core theme (surface + brand + charts, dark/light);
+   theme.css = macro + status colors. */
+@import "../node_modules/soma-style/css/base.css";
 @import "../node_modules/soma-style/css/theme.css";
 /* Scan soma-style so the macro utility classes it names (bg-warm, text-indigo,
    text-success, …) are generated even though they only appear in node_modules. */
 @source "../node_modules/soma-style/dist";
 
-@custom-variant dark (&:is(.dark *));
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-inter);
-  --font-mono: var(--font-geist-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --radius-2xl: calc(var(--radius) + 8px);
-  --radius-3xl: calc(var(--radius) + 12px);
-  --radius-4xl: calc(var(--radius) + 16px);
-}
-
-:root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
-  color-scheme: dark;
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.75 0.15 180);
-  --primary-foreground: oklch(0.15 0.04 180);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.35 0.05 180);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.65 0.13 180);
-  --chart-1: oklch(0.75 0.15 180);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.75 0.15 180);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.65 0.13 180);
-}
 
 @layer base {
   * {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -35,7 +35,7 @@
         "react-markdown": "^9.1.0",
         "recharts": "^3.7.0",
         "remark-gfm": "^4.0.1",
-        "soma-style": "^0.1.0",
+        "soma-style": "^0.2.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "web-push": "^3.6.7"
@@ -14471,9 +14471,9 @@
       "license": "MIT"
     },
     "node_modules/soma-style": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-0.1.0.tgz",
-      "integrity": "sha512-SXOAD3WOKgSCotJewZ3J6pZlwAOi8GzbSB/0IlfSc2o/efoHcr3+uiuf4SE21PNlqwwtXBdH5/eMZXXNsd0cYQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-0.2.0.tgz",
+      "integrity": "sha512-lfgxDioJb6Z4fR97FcK/1jyX/FQJQ7wh/rs+mxST643CnfcTBsAZaX3z7K01SrVPo1mBSaOdOvROE7vTeyCBxA==",
       "license": "MIT"
     },
     "node_modules/sonner": {

--- a/web/package.json
+++ b/web/package.json
@@ -38,7 +38,7 @@
     "react-markdown": "^9.1.0",
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
-    "soma-style": "^0.1.0",
+    "soma-style": "^0.2.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "web-push": "^3.6.7"


### PR DESCRIPTION
Follows the macro-palette adoption (#216): move soma's **entire** color scheme — the shadcn/ui base theme (teal primary, card/border/muted/sidebar surfaces, chart-1..5, dark/light) — into `soma-style` so the color scheme is one source of truth for the whole ecosystem, not just nutrition macros.

## What
- `soma-style@0.2.0` adds `base.css` (the full theme extracted from globals.css).
- soma's `globals.css` imports `soma-style/base.css` + `theme.css` and drops its ~110 duplicated theme lines (`@theme inline` + `:root` + `.dark`).

## Verified
- Playwright: dashboard renders identically (teal primary, dark cards, teal/green/orange charts, amber readiness) — zero regression. Tokens resolve to the same values (`--primary` teal, macro `bg-warm` #B17850).

## Next
The standalone macro-engine / hevy2garmin / garmin-auth UIs can now import the same `base.css` for an identical look.