### PR TITLE
chore: post-migration hardening (calibration_state migration, web CI, doc refresh)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,35 @@ GITHUB_PAT=your_github_pat
 
 # Web app public URL used by the sync engine to generate share images (add as GH Actions secret)
 SOMA_WEB_URL=https://your-app.vercel.app
+
+# ── Web app auth (NextAuth + GitHub OAuth) ──
+AUTH_SECRET=generate_with_openssl_rand_base64_32
+GITHUB_CLIENT_ID=your_github_oauth_app_client_id
+GITHUB_CLIENT_SECRET=your_github_oauth_app_client_secret
+GITHUB_OWNER_USERNAME=your_github_username   # only this account gets access
+# DEMO_MODE=true                              # bypass auth (public demo deploy only)
+# NEXT_PUBLIC_IS_DEMO=true
+
+# ── Cron auth (Vercel cron functions + Actions) ──
+CRON_SECRET=random_secret_shared_with_vercel_crons
+
+# ── Web push notifications (VAPID) ──
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=your_vapid_public_key
+VAPID_PRIVATE_KEY=your_vapid_private_key
+VAPID_SUBJECT=mailto:you@example.com
+
+# ── Telegram notifications (optional) ──
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+TELEGRAM_CHAT_ID=your_telegram_chat_id
+
+# ── Spotify DJ + Last.fm (optional, run-dj / playlist builder) ──
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_REDIRECT_URI=http://localhost:3456/api/spotify/callback
+LASTFM_API_KEY=your_lastfm_api_key
+
+# ── In-app Claude chat tunnel (optional) ──
+SOMA_CHAT_TUNNEL_URL=https://your-tunnel-url
+SOMA_CHAT_TOKEN=shared_secret_for_the_chat_tunnel
+
+# ── Hevy webhook (optional) ──
+HEVY_WEBHOOK_SECRET=your_hevy_webhook_secret

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,31 @@
+name: web-ci
+
+on:
+  pull_request:
+    paths:
+      - "web/**"
+      - ".github/workflows/web-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+
+jobs:
+  test:
+    name: Typecheck + Unit Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - name: Typecheck
+        run: npx tsc --noEmit
+      - name: Unit tests
+        run: npx vitest run

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ web/.agents/
 web/.claude
 prompt.md
 multiple_messages
+# Vercel CLI-generated OIDC token (never commit)
+.env.vercel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,29 @@ Soma is a continuously-deployed self-hosted training stack. This changelog
 documents notable changes to the codebase organized by theme. The format is
 loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## Modularization (ongoing)
+## TypeScript consolidation ([#159](https://github.com/drkostas/soma/issues/159))
 
-Extracting self-contained subsystems from `sync/src/` into standalone PyPI
-packages so other people can use them without running all of soma. Cross-repo
-progress is tracked in the [Soma Ecosystem project](https://github.com/users/drkostas/projects/9).
+The whole stack moved to **one language, TypeScript**. The Python `sync/` was
+deleted; the ingest/routing/notification pipeline now runs as GitHub Actions
+(`scripts/sync-pipeline.mts`) + Vercel cron functions. Self-contained subsystems
+are published as **npm packages** that soma imports as thin re-export shims.
+Cross-repo progress is tracked in the [Soma Ecosystem project](https://github.com/users/drkostas/projects/9).
 
 ### Shipped
 
-- **hevy2garmin integration** ([#2](https://github.com/drkostas/soma/issues/2), [#1](https://github.com/drkostas/soma/pull/1)) — replaced `hevy_client.py`, `exercise_mapper.py`, `fit_generator.py` with thin re-export wrappers from the published `hevy2garmin` PyPI package. `activity_replacer` uses hevy2garmin for FIT generation, upload, and rename. Added browser-based Garmin auth to the Next.js web app via the hevy2garmin Cloudflare Worker flow. Removed ~1073 lines of duplicate code.
-- **garmin-auth package** ([#3](https://github.com/drkostas/soma/issues/3), [#1](https://github.com/drkostas/soma/pull/1)) — extracted the Garmin SSO + token storage layer into the standalone `garmin-auth` package. `sync/src/garmin_client.py` now imports `GarminAuth`. Removed duplicate Vercel SSO middleware. Bumped to `garmin-auth==0.2.1` for the cloud `expires_at` fix.
+- **macro-engine-core** `0.1.1` ([#160](https://github.com/drkostas/soma/issues/160)) — nutrition math (TDEE, deficit, sleep/alcohol/day-close, macro targets) with 2322 golden-parity cases. Deleted the Python `sync/src/nutrition_engine`.
+- **banister** `0.2.0` ([#161](https://github.com/drkostas/soma/issues/161)) — fitness/fatigue predict + differential-evolution fit, VDOT, calibration.
+- **run-dj** `0.3.0` ([#162](https://github.com/drkostas/soma/issues/162)) — HR→BPM formula, interleaved shuffle, segment playlist scoring. `web/lib/{bpm-formula,dj-shuffle,playlist-algorithm}.ts` re-export from it.
+- **garmin-auth** `0.4.1` ([#164](https://github.com/drkostas/soma/issues/164)) — self-healing Garmin OAuth + token store (TS).
+- **hevy2garmin core** ([#163](https://github.com/drkostas/soma/issues/163)) — Hevy→FIT→Garmin in TS.
+- **soma-core** ([#165](https://github.com/drkostas/soma/issues/165)) — the whole `sync/` pipeline ported to TS crons; Python `sync/` deleted.
+- **hevy2garmin integration** ([#2](https://github.com/drkostas/soma/issues/2)) and **garmin-auth** ([#3](https://github.com/drkostas/soma/issues/3)) — the earlier Python-package extractions (predecessors to the TS move above).
 
-### Planned
+## Universal UI ([#223](https://github.com/drkostas/soma/issues/223))
 
-- **run-dj** ([#4](https://github.com/drkostas/soma/issues/4)) — HR-driven Spotify song selection during runs. Extracted from `sync/src/dj_daemon.py`.
-- **banister** ([#5](https://github.com/drkostas/soma/issues/5)) — Banister fitness/fatigue model, VDOT, readiness scoring, plan generation. Extracted from `sync/src/training_engine/`.
-- **macro-engine** ([#6](https://github.com/drkostas/soma/issues/6)) — TDEE, carb periodization, meal slot distribution. Extracted from `sync/src/nutrition_engine/`.
+- Unified all product UIs (soma, macro-engine, hevy2garmin) onto **one** RN framework — Expo + React Native Web + NativeWind — consuming the shared [`soma-style`](https://github.com/drkostas/soma-style) design system. Each repo gains a cross-platform `universal/` app.
+- soma `universal/`: Overview (live health), Nutrition (+ preset meal-logging, log-a-drink, close-day writes), Training (PMC/readiness/fitness + a readiness-weighting toggle).
+- New read-only endpoint `GET /api/hevy/status` (recent Hevy workouts + Garmin sync counts) powering the hevy2garmin universal dashboard.
 
 ## Sync pipeline
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,19 @@ See exactly what synced, configure push rules (e.g. Hevy strength → Strava), a
 
 ```
 Garmin Connect ──┐
-                 ├──▶  sync/ (Python, hourly)  ──▶  Neon PostgreSQL  ◀──  web/ (Next.js)  ──▶  Vercel
-Hevy API ────────┘                                                                │
-                                                                                  ▼
-                                                                             Strava (push)
+                 ├──▶  TS sync (Actions + Vercel crons)  ──▶  Neon PostgreSQL  ◀──  web/ (Next.js)  ──▶  Vercel
+Hevy API ────────┘                                                                       │
+                                                                                         ▼
+                                                                                    Strava (push)
 ```
 
-`sync/` writes. `web/` reads. That boundary never crosses.
+The stack is **all TypeScript**. The ingest/routing pipeline runs as GitHub Actions
+([`.github/workflows/sync.yml`](.github/workflows/sync.yml) → `scripts/sync-pipeline.mts`)
+plus Vercel cron functions, composing the same lib modules the `web/` app reads.
+Shared logic is published as npm packages — [`macro-engine-core`](https://github.com/drkostas/macro-engine),
+[`banister`](https://github.com/drkostas/banister), [`run-dj`](https://github.com/drkostas/run-dj),
+[`garmin-auth`](https://github.com/drkostas/garmin-auth) — and the UI (`web/` + the cross-platform
+`universal/` Expo app) renders from the shared [`soma-style`](https://github.com/drkostas/soma-style) design system.
 
 ---
 
@@ -93,7 +99,8 @@ Hevy API ────────┘                                            
 ### 1 — Database
 
 ```bash
-psql "$DATABASE_URL" -f sync/schema.sql
+# Apply the schema migrations (in order)
+for f in web/lib/db/migrations/*.sql; do psql "$DATABASE_URL" -f "$f"; done
 ```
 
 ### 2 — Web app
@@ -147,8 +154,9 @@ Runs every 4 hours via [`.github/workflows/sync.yml`](.github/workflows/sync.yml
 ## Development
 
 ```bash
-cd web && npm install && npm run dev    # → http://localhost:3456
-cd sync && python -m src.pipeline      # manual sync run
+cd web && npm install && npm run dev          # → http://localhost:3456
+cd web && npx tsx scripts/sync-pipeline.mts    # manual sync run (TS pipeline)
+cd universal && npm install && npm run web     # cross-platform Expo app (RN Web)
 ```
 
 ### In-app Claude chat

--- a/web/lib/db/migrations/20260717_calibration_state.sql
+++ b/web/lib/db/migrations/20260717_calibration_state.sql
@@ -1,0 +1,22 @@
+-- Migration: 20260717_calibration_state
+-- Description: Readiness calibration state for the training engine. Read by
+--   app/api/training/graph + forward-sim (they degrade to equal weights if the
+--   row is absent) and written by app/api/training/calibration/toggle.
+-- Apply: psql "$DATABASE_URL" -f web/lib/db/migrations/20260717_calibration_state.sql
+
+CREATE TABLE IF NOT EXISTS calibration_state (
+  id          SERIAL PRIMARY KEY,
+  phase       INT DEFAULT 1,
+  data_days   INT DEFAULT 0,
+  weights     JSONB,
+  correlations JSONB,
+  force_equal BOOLEAN DEFAULT FALSE,
+  updated_at  TIMESTAMPTZ DEFAULT NOW(),
+  computed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Seed the singleton row the toggle updates (WHERE id = 1) with equal-weight
+-- defaults, so a fresh DB behaves identically to the graceful fallback.
+INSERT INTO calibration_state (id, phase, data_days, weights, correlations, force_equal)
+VALUES (1, 1, 0, '{"hrv":0.25,"sleep":0.25,"rhr":0.25,"bb":0.25}', '{}', FALSE)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Closes #224. Post-TS-migration audit fixes: commit the `calibration_state` migration (was live-only), add a `web-ci` workflow (tsc + 165 vitest tests — nothing gated soma/web before), refresh README/CHANGELOG/.env.example for the TS pipeline + universal apps + packages, and gitignore `.env.vercel`.
