### PR TITLE
test(api): cover the 5 new endpoints

### DIFF
--- a/web/app/api/hevy/status/route.test.ts
+++ b/web/app/api/hevy/status/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSql } = vi.hoisted(() => ({ mockSql: vi.fn() }));
+vi.mock("@/lib/db", () => ({ getDb: () => mockSql }));
+
+import { GET } from "./route";
+
+beforeEach(() => mockSql.mockReset());
+
+describe("GET /api/hevy/status", () => {
+  it("maps workout_enrichment rows + counts into the response shape", async () => {
+    mockSql
+      .mockResolvedValueOnce([
+        { hevy_title: "Push", workout_date: "2026-07-13", calories: 282, exercise_count: 3, total_sets: 11, garmin_activity_id: "23590414049", status: "uploaded" },
+        { hevy_title: "Lower", workout_date: "2026-07-09", calories: 139, exercise_count: 3, total_sets: 11, garmin_activity_id: null, status: "enriched" },
+      ])
+      .mockResolvedValueOnce([{ total: 330, synced: 329, week: 2 }]);
+
+    const body = await (await GET()).json();
+    expect(body.hevyConnected).toBe(true);
+    expect(body.garminConnected).toBe(true);
+    expect(body.totalSynced).toBe(329);
+    expect(body.syncedThisWeek).toBe(2);
+    expect(body.recent).toHaveLength(2);
+    expect(body.recent[0]).toMatchObject({ title: "Push", kcal: 282, exercises: 3, sets: 11, synced: true, status: "uploaded" });
+    expect(body.recent[1].synced).toBe(false); // null garmin_activity_id → not synced
+  });
+
+  it("reports empty/disconnected when there are no workouts", async () => {
+    mockSql.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0, synced: 0, week: 0 }]);
+    const body = await (await GET()).json();
+    expect(body.hevyConnected).toBe(false);
+    expect(body.garminConnected).toBe(false);
+    expect(body.recent).toEqual([]);
+  });
+});

--- a/web/app/api/nutrition/close-day/route.test.ts
+++ b/web/app/api/nutrition/close-day/route.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockSql } = vi.hoisted(() => ({ mockSql: vi.fn() }));
+vi.mock("@/lib/db", () => ({ getDb: () => mockSql }));
+
+import { POST } from "./route";
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/nutrition/close-day", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => mockSql.mockReset());
+
+describe("POST /api/nutrition/close-day", () => {
+  it("400s when date is missing", async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns already_closed when the day is already closed", async () => {
+    mockSql.mockResolvedValueOnce([{ status: "closed" }]); // the status pre-check
+    const body = await (await POST(req({ date: "2026-07-16" }))).json();
+    expect(body.status).toBe("already_closed");
+  });
+});

--- a/web/app/api/nutrition/log-drink/route.test.ts
+++ b/web/app/api/nutrition/log-drink/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockSql } = vi.hoisted(() => ({ mockSql: vi.fn().mockResolvedValue([]) }));
+vi.mock("@/lib/db", () => ({ getDb: () => mockSql }));
+
+import { GET, POST } from "./route";
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/nutrition/log-drink", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => mockSql.mockClear());
+
+describe("/api/nutrition/log-drink", () => {
+  it("GET returns the drink catalog", async () => {
+    const body = await (await GET()).json();
+    expect(body.drinks).toBeDefined();
+    expect(body.drinks.beer_light).toMatchObject({ name: expect.any(String) });
+  });
+
+  it("POST 400s when date or drink_type is missing", async () => {
+    const res = await POST(req({ date: "2026-07-16" }));
+    expect(res.status).toBe(400);
+    expect(mockSql).not.toHaveBeenCalled();
+  });
+
+  it("POST 400s on an unknown drink_type", async () => {
+    const res = await POST(req({ date: "2026-07-16", drink_type: "not_a_drink" }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/web/app/api/nutrition/log-meal/route.test.ts
+++ b/web/app/api/nutrition/log-meal/route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockSql } = vi.hoisted(() => ({ mockSql: vi.fn() }));
+vi.mock("@/lib/db", () => ({ getDb: () => mockSql }));
+
+import { POST } from "./route";
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/nutrition/log-meal", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// The meal_log INSERT positional values: [0]=strings, [1]=date, [2]=meal_slot,
+// [3]=source, [4]=preset_meal_id, [5]=portion, [6]=itemsJson, [7]=calories, [8]=protein…
+const mealInsert = () => mockSql.mock.calls.find((c) => String(c[0]).includes("meal_log"));
+
+beforeEach(() => {
+  mockSql.mockReset();
+  mockSql.mockResolvedValue([{ id: 42 }]);
+});
+
+describe("POST /api/nutrition/log-meal", () => {
+  it("400s without date or meal_slot", async () => {
+    const res = await POST(req({ items: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("computes totals from preset_macros × portion and returns the id", async () => {
+    const res = await POST(req({
+      date: "2026-07-16", meal_slot: "lunch", preset_meal_id: "p1", portion_multiplier: 2,
+      items: [], preset_macros: { calories: 100, protein: 10, carbs: 5, fat: 2, fiber: 1 },
+    }));
+    expect((await res.json()).id).toBe(42);
+    const ins = mealInsert()!;
+    expect(ins[7]).toBe(200); // calories 100 × 2
+    expect(ins[8]).toBe(20);  // protein 10 × 2
+    expect(ins[6]).toBe("[]"); // items serialized (omitting it bound undefined → 500)
+  });
+
+  it("sums totals from items when no preset_macros", async () => {
+    await POST(req({
+      date: "2026-07-16", meal_slot: "lunch",
+      items: [
+        { name: "x", grams: 100, calories: 50, protein: 5, carbs: 0, fat: 0, fiber: 0 },
+        { name: "y", grams: 100, calories: 30, protein: 3, carbs: 0, fat: 0, fiber: 0 },
+      ],
+    }));
+    expect(mealInsert()![7]).toBe(80); // 50 + 30
+  });
+});

--- a/web/app/api/training/calibration/toggle/route.test.ts
+++ b/web/app/api/training/calibration/toggle/route.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSql } = vi.hoisted(() => ({ mockSql: vi.fn().mockResolvedValue([]) }));
+vi.mock("@/lib/db", () => ({ getDb: () => mockSql }));
+
+import { POST } from "./route";
+
+function req(body: unknown): Request {
+  return new Request("http://localhost/api/training/calibration/toggle", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => mockSql.mockClear());
+
+describe("POST /api/training/calibration/toggle", () => {
+  it("400s when forceEqual is not a boolean (no DB write)", async () => {
+    const res = await POST(req({ forceEqual: "yes" }));
+    expect(res.status).toBe(400);
+    expect(mockSql).not.toHaveBeenCalled();
+  });
+
+  it("updates calibration_state and echoes forceEqual", async () => {
+    const res = await POST(req({ forceEqual: true }));
+    expect(await res.json()).toEqual({ ok: true, forceEqual: true });
+    expect(mockSql).toHaveBeenCalledOnce();
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,14 +1,11 @@
 import { defineConfig } from "vitest/config";
-import path from "node:path";
+import path from "path";
 
+// Minimal config: resolve the `@/` path alias (matches tsconfig) so route
+// handlers that import `@/lib/*` can be unit-tested. Test discovery + all
+// other behaviour stays on the vitest defaults.
 export default defineConfig({
-  test: {
-    include: ["lib/**/*.test.ts", "tests/**/*.test.ts"],
-    environment: "node",
-  },
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "."),
-    },
+    alias: { "@": path.resolve(__dirname, ".") },
   },
 });


### PR DESCRIPTION
Closes #228. 12 handler tests (mocked getDb + @/ alias vitest config): log-meal totals/items guard, close-day + log-drink validation, calibration boolean guard, hevy/status mapping. Web suite 165→177.