### PR TITLE
feat(universal): mobile-first bottom-tab navigation

### DIFF
--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/ui": "~57.0.6",
+        "@expo/vector-icons": "^15.0.2",
         "expo": "~57.0.6",
         "expo-constants": "~57.0.5",
         "expo-device": "~57.0.1",
@@ -2047,6 +2048,17 @@
         "react-native-worklets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@expo/xcpretty": {

--- a/universal/package.json
+++ b/universal/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@expo/ui": "~57.0.6",
+    "@expo/vector-icons": "^15.0.2",
     "expo": "~57.0.6",
     "expo-constants": "~57.0.5",
     "expo-device": "~57.0.1",

--- a/universal/src/app/(main)/_layout.tsx
+++ b/universal/src/app/(main)/_layout.tsx
@@ -1,30 +1,78 @@
-import { Slot, usePathname, useRouter } from "expo-router";
-import { View } from "react-native";
-import { NavBar } from "soma-style";
+import { Tabs } from "expo-router";
+import { Pressable, View, type ColorValue } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { ChatProvider, useChat } from "../../components/ChatContext";
 import { ChatSheet } from "../../components/ChatSheet";
 
-const ITEMS = [
-  { key: "overview", label: "Overview" },
-  { key: "training", label: "Training" },
-  { key: "running", label: "Running" },
-  { key: "workouts", label: "Workouts" },
-  { key: "activities", label: "Activities" },
-  { key: "sleep", label: "Sleep" },
-  { key: "nutrition", label: "Nutrition" },
-  { key: "playlist", label: "Playlist" },
-  { key: "connections", label: "Sync" },
-  { key: "system", label: "Status" },
-];
+/* soma-style tokens (mirrored from soma-style/preset.js — the tab bar is native
+   chrome so it reads them directly rather than via NativeWind classes). */
+const TEAL = "#77c8d1";
+const MUTED = "#5a7a8a";
+const SURFACE = "#0e1a26";
+const BORDER = "#1a3040";
+const INK = "#0a1720";
+
+type IconName = React.ComponentProps<typeof Ionicons>["name"];
+const tabIcon =
+  (name: IconName) =>
+  ({ color, size }: { color: ColorValue; size: number }) => (
+    <Ionicons name={name} size={size} color={color as string} />
+  );
+
+/** Center ⊕ — opens the Claude chat as a quick log/ask action (not a route). */
+function CenterLogButton() {
+  const { openChat } = useChat();
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Pressable
+        onPress={openChat}
+        accessibilityLabel="Log or ask Claude"
+        className="h-14 w-14 items-center justify-center rounded-full bg-teal"
+        style={{ marginTop: -18, shadowColor: TEAL, shadowOpacity: 0.4, shadowRadius: 8, elevation: 6 }}
+      >
+        <Ionicons name="add" size={30} color={INK} />
+      </Pressable>
+    </View>
+  );
+}
+
+function TabsNav() {
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: TEAL,
+        tabBarInactiveTintColor: MUTED,
+        tabBarStyle: { backgroundColor: SURFACE, borderTopColor: BORDER, borderTopWidth: 1 },
+        tabBarLabelStyle: { fontSize: 11, fontWeight: "600" },
+        sceneStyle: { backgroundColor: "#0a1720" },
+      }}
+    >
+      <Tabs.Screen name="overview" options={{ title: "Home", tabBarIcon: tabIcon("home-outline") }} />
+      <Tabs.Screen name="training" options={{ title: "Training", tabBarIcon: tabIcon("barbell-outline") }} />
+      <Tabs.Screen name="log" options={{ title: "", tabBarButton: () => <CenterLogButton /> }} />
+      <Tabs.Screen name="nutrition" options={{ title: "Food", tabBarIcon: tabIcon("restaurant-outline") }} />
+      <Tabs.Screen name="more" options={{ title: "More", tabBarIcon: tabIcon("ellipsis-horizontal") }} />
+      {/* Behind "More" — reachable from the More screen, hidden from the tab bar. */}
+      <Tabs.Screen name="running" options={{ href: null }} />
+      <Tabs.Screen name="activities" options={{ href: null }} />
+      <Tabs.Screen name="workouts" options={{ href: null }} />
+      <Tabs.Screen name="sleep" options={{ href: null }} />
+      <Tabs.Screen name="playlist" options={{ href: null }} />
+      <Tabs.Screen name="connections" options={{ href: null }} />
+      <Tabs.Screen name="system" options={{ href: null }} />
+    </Tabs>
+  );
+}
 
 export default function MainLayout() {
-  const router = useRouter();
-  const pathname = usePathname();
-  const active = ITEMS.find((i) => pathname.startsWith(`/${i.key}`))?.key ?? "nutrition";
   return (
-    <View className="flex-1 bg-base">
-      <NavBar brand="soma" items={ITEMS} active={active} onSelect={(k) => router.push(`/${k}` as never)} />
-      <Slot />
+    <ChatProvider>
+      <SafeAreaView edges={["top"]} className="flex-1 bg-base">
+        <TabsNav />
+      </SafeAreaView>
       <ChatSheet />
-    </View>
+    </ChatProvider>
   );
 }

--- a/universal/src/app/(main)/log.tsx
+++ b/universal/src/app/(main)/log.tsx
@@ -1,0 +1,5 @@
+/* Placeholder route for the center ⊕ tab. The tab's custom button opens the chat
+   sheet instead of navigating here, so this screen never actually renders. */
+export default function Log() {
+  return null;
+}

--- a/universal/src/app/(main)/more.tsx
+++ b/universal/src/app/(main)/more.tsx
@@ -1,0 +1,59 @@
+import { useRouter } from "expo-router";
+import { Pressable, ScrollView, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { Text } from "soma-style";
+
+type IconName = React.ComponentProps<typeof Ionicons>["name"];
+
+/* Secondary sections that don't fit the 4 primary tabs. Tapping pushes the route;
+   the bottom tab bar stays visible (these are siblings in the same Tabs group). */
+const SECTIONS: { key: string; label: string; hint: string; icon: IconName }[] = [
+  { key: "running", label: "Running", hint: "Stats, HR zones, PRs, shoes", icon: "walk-outline" },
+  { key: "activities", label: "Activities", hint: "Kiteboarding, snow, cycling & more", icon: "boat-outline" },
+  { key: "workouts", label: "Workouts", hint: "Strength history + Garmin sync", icon: "barbell-outline" },
+  { key: "sleep", label: "Sleep", hint: "Stages, HRV, respiration", icon: "moon-outline" },
+  { key: "playlist", label: "Playlist", hint: "BPM-matched running playlists", icon: "musical-notes-outline" },
+  { key: "connections", label: "Sync", hint: "Integrations & sync rules", icon: "sync-outline" },
+  { key: "system", label: "Status", hint: "Pipeline & platform status", icon: "pulse-outline" },
+];
+
+export default function MoreScreen() {
+  const router = useRouter();
+  return (
+    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+      <View className="w-full max-w-2xl gap-4">
+        <View className="gap-1">
+          <Text variant="headline">More</Text>
+          <Text variant="caption" className="text-text-secondary">
+            Everything beyond the main tabs
+          </Text>
+        </View>
+
+        <View className="overflow-hidden rounded-2xl border border-border-subtle bg-surface">
+          {SECTIONS.map((s, i) => (
+            <Pressable
+              key={s.key}
+              onPress={() => router.push(`/${s.key}` as never)}
+              accessibilityLabel={s.label}
+              className="flex-row items-center gap-3 px-4 py-4 active:bg-surface-hover"
+              style={i > 0 ? { borderTopWidth: 1, borderTopColor: "#142530" } : undefined}
+            >
+              <View className="h-9 w-9 items-center justify-center rounded-full bg-surface-elevated">
+                <Ionicons name={s.icon} size={18} color="#77c8d1" />
+              </View>
+              <View className="flex-1 gap-0.5">
+                <Text variant="body" className="text-text">
+                  {s.label}
+                </Text>
+                <Text variant="micro" className="text-text-muted">
+                  {s.hint}
+                </Text>
+              </View>
+              <Ionicons name="chevron-forward" size={18} color="#5a7a8a" />
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </ScrollView>
+  );
+}

--- a/universal/src/app/_layout.tsx
+++ b/universal/src/app/_layout.tsx
@@ -2,12 +2,15 @@ import "../global.css";
 import { Stack } from "expo-router";
 import { View } from "react-native";
 import { StatusBar } from "expo-status-bar";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 
 export default function RootLayout() {
   return (
-    <View className="flex-1 bg-base">
-      <StatusBar style="light" />
-      <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: "#0a1720" } }} />
-    </View>
+    <SafeAreaProvider>
+      <View className="flex-1 bg-base">
+        <StatusBar style="light" />
+        <Stack screenOptions={{ headerShown: false, contentStyle: { backgroundColor: "#0a1720" } }} />
+      </View>
+    </SafeAreaProvider>
   );
 }

--- a/universal/src/components/ChatContext.tsx
+++ b/universal/src/components/ChatContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+
+/** Lets the bottom tab bar's center ⊕ button open the chat sheet, which lives at
+    the layout root. Keeps the chat's open state out of the tab-button tree. */
+interface ChatCtx {
+  open: boolean;
+  openChat: () => void;
+  closeChat: () => void;
+}
+
+const Ctx = createContext<ChatCtx>({ open: false, openChat: () => {}, closeChat: () => {} });
+
+export function ChatProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const value = useMemo<ChatCtx>(
+    () => ({ open, openChat: () => setOpen(true), closeChat: () => setOpen(false) }),
+    [open],
+  );
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export const useChat = () => useContext(Ctx);

--- a/universal/src/components/ChatSheet.tsx
+++ b/universal/src/components/ChatSheet.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 import { fetch as expoFetch } from "expo/fetch";
 import { Text, Card, Badge, type BadgeTone } from "soma-style";
+import { useChat as useChatSheet } from "./ChatContext";
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
@@ -64,7 +65,7 @@ function summarizeToolInput(name: string, input: Record<string, unknown> | null)
 /* Streaming hook                                                      */
 /* ------------------------------------------------------------------ */
 
-function useChat() {
+function useChatStream() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [busy, setBusy] = useState(false);
   const [transport, setTransport] = useState<"unknown" | "local" | "proxy" | "offline">("unknown");
@@ -353,9 +354,9 @@ function Bubble({ msg }: { msg: Message }) {
 /* ------------------------------------------------------------------ */
 
 export function ChatSheet() {
-  const [open, setOpen] = useState(false);
+  const { open, closeChat } = useChatSheet();
   const [input, setInput] = useState("");
-  const { messages, busy, transport, send, cancel, reset } = useChat();
+  const { messages, busy, transport, send, cancel, reset } = useChatStream();
   const scrollRef = useRef<ScrollView>(null);
 
   useEffect(() => {
@@ -371,19 +372,7 @@ export function ChatSheet() {
 
   return (
     <>
-      {!open ? (
-        <Pressable
-          onPress={() => setOpen(true)}
-          accessibilityLabel="Open chat"
-          className="absolute bottom-6 right-6 h-14 w-14 items-center justify-center rounded-full bg-teal shadow-lg"
-        >
-          <Text variant="title" className="text-ink">
-            ✦
-          </Text>
-        </Pressable>
-      ) : null}
-
-      <Modal visible={open} animationType="slide" transparent onRequestClose={() => setOpen(false)}>
+      <Modal visible={open} animationType="slide" transparent onRequestClose={closeChat}>
         <KeyboardAvoidingView
           behavior={Platform.OS === "ios" ? "padding" : undefined}
           className="flex-1 justify-end"
@@ -403,7 +392,7 @@ export function ChatSheet() {
                     New
                   </Text>
                 </Pressable>
-                <Pressable onPress={() => setOpen(false)} accessibilityLabel="Close chat">
+                <Pressable onPress={closeChat} accessibilityLabel="Close chat">
                   <Text variant="caption" className="text-text-muted">
                     Close
                   </Text>


### PR DESCRIPTION
Closes #239. Refs #238.

Mobile-first bottom-tab navigation, the highest-impact fix from the mobile-UI research (docs/mobile-ui/research-brief.md, assessment.md — both local/gitignored).

## What changed
Replaces the desktop horizontal top NavBar (which overflowed the mobile viewport, leaving nav items cut off / unreachable) with an Expo Router `Tabs` bottom bar:

`[ Home ] [ Training ] [ ⊕ Log ] [ Nutrition ] [ More ]`

- Center **⊕** opens the Claude chat as a quick log/ask action (chat lifted to a `ChatContext`; old floating FAB removed).
- **More** is a full-screen list routing to Running, Activities, Workouts, Sleep, Playlist, Sync, Status; the tab bar stays visible on drill-down.
- `SafeAreaProvider` + top-edge inset so content clears the status bar; the tab bar handles the bottom home-indicator inset.
- Tab bar styled to soma-style tokens (teal active, blue-slate surface).

## Validation
- **Mobile web (390px):** clean bottom bar, ⊕ opens chat, More lists sections, drill-down keeps the bar, zero horizontal overflow.
- **Android native (Pixel 7, Android 15):** renders with real data + correct top safe area (status bar no longer overlaps the title).
- **iOS (iPhone 16, iOS 26.3):** app bundles + renders with notch-safe inset.

## Known follow-ups (tracked under #238)
- Minor Android cosmetic: a faint teal band shows above the tab bar from the elevated ⊕ (fix in the polish pass, #240).
- Per-screen restructure (#240), type/spacing baseline (#241), propagate to macro-engine + hevy2garmin (#242).
