### PR TITLE
feat(universal): per-screen mobile pass — clean ⊕ + running tier-1 sparklines

### DIFF
--- a/universal/src/app/(main)/_layout.tsx
+++ b/universal/src/app/(main)/_layout.tsx
@@ -28,8 +28,8 @@ function CenterLogButton() {
       <Pressable
         onPress={openChat}
         accessibilityLabel="Log or ask Claude"
-        className="h-14 w-14 items-center justify-center rounded-full bg-teal"
-        style={{ marginTop: -18, shadowColor: TEAL, shadowOpacity: 0.4, shadowRadius: 8, elevation: 6 }}
+        className="h-14 w-14 items-center justify-center rounded-full border-2 border-base bg-teal"
+        style={{ marginTop: -14 }}
       >
         <Ionicons name="add" size={30} color={INK} />
       </Pressable>

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -1,18 +1,48 @@
+import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card } from "soma-style";
 import { useToday } from "../../lib/api";
+import { Sparkline } from "../../components/Sparkline";
+
+const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+
+interface OverviewTrends {
+  steps: number[];
+  calories: number[];
+  rhr: number[];
+  stress: number[];
+  bodyBattery: number[];
+  intensity: number[];
+}
+
+/** 14-day trend series for the Home KPI sparklines. */
+function useOverviewTrends() {
+  const [trends, setTrends] = useState<OverviewTrends | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetch(`${API_BASE}/api/overview/trends`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((d: OverviewTrends) => alive && setTrends(d))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return trends;
+}
 
 export default function OverviewScreen() {
   const { data, error } = useToday();
+  const trends = useOverviewTrends();
 
   const km = data?.total_distance_meters ? (data.total_distance_meters / 1000).toFixed(1) : "—";
-  const stats: { label: string; value: string; sub: string; cls: string }[] = [
-    { label: "Steps", value: (data?.total_steps ?? 0).toLocaleString(), sub: `${km} km`, cls: "text-teal" },
-    { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm" },
-    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger" },
-    { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning" },
-    { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${data?.body_battery_drained ?? 0} drained`, cls: "text-lime" },
-    { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo" },
+  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string }[] = [
+    { label: "Steps", value: (data?.total_steps ?? 0).toLocaleString(), sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1" },
+    { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850" },
+    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060" },
+    { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458" },
+    { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${data?.body_battery_drained ?? 0} drained`, cls: "text-lime", spark: trends?.bodyBattery, color: "#cbe896" },
+    { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0" },
   ];
 
   return (
@@ -29,6 +59,11 @@ export default function OverviewScreen() {
               <Text variant="eyebrow">{s.label}</Text>
               <Text variant="headline" className={s.cls}>{s.value}</Text>
               <Text variant="micro">{s.sub}</Text>
+              {s.spark && s.spark.length >= 2 ? (
+                <View className="mt-1">
+                  <Sparkline data={s.spark} color={s.color} height={26} baseline />
+                </View>
+              ) : null}
             </Card>
           ))}
         </View>

--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, ProgressBar } from "soma-style";
+import { Sparkline } from "../../components/Sparkline";
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
@@ -84,6 +85,7 @@ interface RunningPayload {
   records: Records | null;
   shoeMileage: ShoeMileage[];
   recentRuns: RecentRun[];
+  trends: { pace: number[]; vo2max: number[]; mileage: number[] } | null;
 }
 
 /* ------------------------------------------------------------------ */
@@ -161,19 +163,28 @@ export default function RunningScreen() {
   const recent = data?.recentRuns ?? [];
 
   const zoneTotal = zones.reduce((s, z) => s + num(z.count), 0);
+  const trends = data?.trends;
 
-  const summaryCards: { label: string; value: string; sub: string; cls: string }[] = [
+  const summaryCards: {
+    label: string;
+    value: string;
+    sub: string;
+    cls: string;
+    spark?: { data: number[]; color: string };
+  }[] = [
     {
       label: "Total Distance",
       value: stats?.total_km != null ? `${num(stats.total_km).toFixed(0)} km` : "—",
       sub: `${num(stats?.total_runs)} runs`,
       cls: "text-teal",
+      spark: trends?.mileage?.length ? { data: trends.mileage, color: "#77c8d1" } : undefined,
     },
     {
       label: "Avg Pace",
       value: stats?.avg_pace != null ? `${formatPace(num(stats.avg_pace))}/km` : "—",
       sub: "per kilometre",
       cls: "text-lime",
+      spark: trends?.pace?.length ? { data: trends.pace, color: "#cbe896" } : undefined,
     },
     {
       label: "Avg Heart Rate",
@@ -186,6 +197,7 @@ export default function RunningScreen() {
       value: stats?.peak_vo2max != null ? num(stats.peak_vo2max).toFixed(1) : "—",
       sub: "ml/kg/min",
       cls: "text-warning",
+      spark: trends?.vo2max?.length ? { data: trends.vo2max, color: "#e0a458" } : undefined,
     },
   ];
 
@@ -224,6 +236,11 @@ export default function RunningScreen() {
                 {s.value}
               </Text>
               <Text variant="micro">{s.sub}</Text>
+              {s.spark ? (
+                <View className="mt-1">
+                  <Sparkline data={s.spark.data} color={s.spark.color} height={28} baseline />
+                </View>
+              ) : null}
             </Card>
           ))}
         </View>

--- a/universal/src/components/Sparkline.tsx
+++ b/universal/src/components/Sparkline.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { View, type LayoutChangeEvent } from "react-native";
+import Svg, { Polyline, Circle, Line } from "react-native-svg";
+
+/* A tiny axis-less trend line for tier-1 KPI cards (brief §3: "sparkline + big
+   number", ~40px tall, no ticks). Measures its own width via onLayout so it fills
+   the card, and plots the series normalized to the box. */
+
+interface SparklineProps {
+  data: (number | null | undefined)[];
+  color?: string;
+  height?: number;
+  /** Draw a faint baseline at the series mean (helps read above/below-trend). */
+  baseline?: boolean;
+  /** Dot on the last point. */
+  showLast?: boolean;
+}
+
+export function Sparkline({
+  data,
+  color = "#77c8d1",
+  height = 40,
+  baseline = false,
+  showLast = true,
+}: SparklineProps) {
+  const [w, setW] = useState(0);
+  const onLayout = (e: LayoutChangeEvent) => setW(e.nativeEvent.layout.width);
+
+  const nums = data.filter((v): v is number => typeof v === "number" && isFinite(v));
+  const canDraw = w > 0 && nums.length >= 2;
+
+  let points = "";
+  let lastX = 0;
+  let lastY = 0;
+  let meanY = 0;
+  if (canDraw) {
+    const min = Math.min(...nums);
+    const max = Math.max(...nums);
+    const span = max - min || 1;
+    const pad = 3; // keep the stroke off the edges
+    const stepX = (w - pad * 2) / (nums.length - 1);
+    const toY = (v: number) => pad + (1 - (v - min) / span) * (height - pad * 2);
+    points = nums.map((v, i) => `${pad + i * stepX},${toY(v)}`).join(" ");
+    lastX = pad + (nums.length - 1) * stepX;
+    lastY = toY(nums[nums.length - 1]);
+    meanY = toY(nums.reduce((s, v) => s + v, 0) / nums.length);
+  }
+
+  return (
+    <View onLayout={onLayout} style={{ height, width: "100%" }}>
+      {canDraw ? (
+        <Svg width={w} height={height}>
+          {baseline ? (
+            <Line x1={0} y1={meanY} x2={w} y2={meanY} stroke={color} strokeOpacity={0.18} strokeWidth={1} />
+          ) : null}
+          <Polyline
+            points={points}
+            fill="none"
+            stroke={color}
+            strokeWidth={2}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+          {showLast ? <Circle cx={lastX} cy={lastY} r={2.5} fill={color} /> : null}
+        </Svg>
+      ) : null}
+    </View>
+  );
+}

--- a/web/app/api/overview/trends/route.ts
+++ b/web/app/api/overview/trends/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+export const revalidate = 300;
+
+/* 14-day trend series for the universal app's Home (overview) tier-1 KPI cards.
+   One pass over daily_health_summary, returned as value-only arrays (chronological)
+   the RN Sparkline consumes. Nulls are dropped per-series by the sparkline. */
+
+const n = (v: unknown): number | null => (v == null ? null : Number(v));
+
+export async function GET() {
+  const sql = getDb();
+  try {
+    const rows = await sql`
+      SELECT
+        date::text as date,
+        total_steps,
+        active_kilocalories,
+        resting_heart_rate,
+        avg_stress_level,
+        body_battery_max,
+        COALESCE(moderate_intensity_minutes, 0) + COALESCE(vigorous_intensity_minutes, 0) as intensity
+      FROM daily_health_summary
+      WHERE date >= CURRENT_DATE - make_interval(days => 14)
+      ORDER BY date ASC
+    `;
+    const pick = (k: string) =>
+      rows.map((r) => n(r[k])).filter((v): v is number => v != null && isFinite(v) && v > 0);
+    return NextResponse.json({
+      steps: pick("total_steps"),
+      calories: pick("active_kilocalories"),
+      rhr: pick("resting_heart_rate"),
+      stress: pick("avg_stress_level"),
+      bodyBattery: pick("body_battery_max"),
+      intensity: rows.map((r) => n(r.intensity)).filter((v): v is number => v != null && isFinite(v)),
+    });
+  } catch (err) {
+    console.error("overview/trends error:", err);
+    return NextResponse.json({ error: "Failed to load trends" }, { status: 500 });
+  }
+}

--- a/web/app/api/running/stats/route.ts
+++ b/web/app/api/running/stats/route.ts
@@ -16,7 +16,8 @@ export async function GET() {
   const sql = getDb();
 
   try {
-    const [statsRows, trainingRows, hrRows, recentRows, shoeRows, ...records] = await Promise.all([
+    const [statsRows, trainingRows, hrRows, recentRows, shoeRows, paceRows, vo2Rows, mileageRows, ...records] =
+      await Promise.all([
       // Aggregate stats
       sql`
         SELECT
@@ -129,6 +130,38 @@ export async function GET() {
         GROUP BY gear_pk, shoe_name, status, max_km
         ORDER BY total_km DESC
       `,
+      // Trend series for tier-1 sparklines (recent → chronological), value-only.
+      sql`
+        SELECT (raw_json->>'duration')::float / NULLIF((raw_json->>'distance')::float / 1000.0, 0) / 60.0 as v
+        FROM garmin_activity_raw
+        WHERE endpoint_name = 'summary'
+          AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+          AND (raw_json->>'distance')::float > 1000
+        ORDER BY (raw_json->>'startTimeLocal')::text DESC LIMIT 40
+      `,
+      sql`
+        SELECT v FROM (
+          SELECT DISTINCT ON (LEFT((raw_json->>'startTimeLocal')::text, 10))
+            LEFT((raw_json->>'startTimeLocal')::text, 10) as d,
+            (raw_json->>'vO2MaxValue')::float as v
+          FROM garmin_activity_raw
+          WHERE endpoint_name = 'summary'
+            AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+            AND raw_json->>'vO2MaxValue' IS NOT NULL
+          ORDER BY LEFT((raw_json->>'startTimeLocal')::text, 10) DESC
+          LIMIT 40
+        ) t ORDER BY d ASC
+      `,
+      sql`
+        SELECT v FROM (
+          SELECT TO_CHAR((raw_json->>'startTimeLocal')::timestamp, 'YYYY-MM') as m,
+            SUM((raw_json->>'distance')::float) / 1000.0 as v
+          FROM garmin_activity_raw
+          WHERE endpoint_name = 'summary'
+            AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+          GROUP BY m ORDER BY m DESC LIMIT 12
+        ) t ORDER BY m ASC
+      `,
       // Personal records — six independent one-row queries
       sql`
         SELECT (raw_json->>'startTimeLocal')::text as date, (raw_json->>'activityName')::text as name,
@@ -200,6 +233,12 @@ export async function GET() {
       },
       shoeMileage: shoeRows,
       recentRuns: recentRows,
+      trends: {
+        // pace query is recent-first; reverse to chronological for the sparkline
+        pace: paceRows.map((r) => Number(r.v)).reverse(),
+        vo2max: vo2Rows.map((r) => Number(r.v)),
+        mileage: mileageRows.map((r) => Number(r.v)),
+      },
     });
   } catch (err) {
     console.error("running/stats error:", err);


### PR DESCRIPTION
Refs #240, #238. The per-screen mobile pass (batch 1).

## Changes
1. **Fix the Android FAB-cradle band** on the center ⊕ tab (drop elevation + teal shadow → base-colored ring). Clean ⊕ on web/iOS/Android.
2. **Shared `Sparkline`** (react-native-svg, self-measuring width, mean baseline + last-point dot) — the brief's "sparkline + big number" tier-1 primitive.
3. **Running tier-1:** sparklines on Total Distance (12-mo mileage), Avg Pace (last-40 runs), VO2max (VO2-by-date). `GET /api/running/stats` gains a `trends` block.
4. **Home/overview tier-1:** sparklines on Steps, Calories, RHR, Stress, Intensity via new `GET /api/overview/trends` (14-day series from daily_health_summary).

## Validation
- Android emulator: clean ⊕, no band; Overview renders natively with safe area + tab bar.
- Mobile web (390px): running + Home KPI cards each show trend lines under the big numbers.
- tsc clean (web + universal); both new/extended endpoints return live data.
