### PR TITLE
feat(universal): tier-1 sparklines on Sleep, Activities, Workouts, Nutrition

### DIFF
--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -1,8 +1,28 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
+import { Sparkline } from "../../components/Sparkline";
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+
+/** Daily activity-count series (per-day sessions) for the Sessions trend. */
+function useSessionsTrend() {
+  const [series, setSeries] = useState<number[]>([]);
+  useEffect(() => {
+    let alive = true;
+    fetch(`${API_BASE}/api/stats/activities?range=90d`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+      .then((d: { current?: { value: number | null }[] }) => {
+        if (!alive) return;
+        setSeries((d.current ?? []).map((p) => Number(p.value)).filter((v) => isFinite(v)));
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return series;
+}
 
 type RangeKey = "30d" | "90d" | "1y" | "all";
 const RANGES: readonly RangeKey[] = ["30d", "90d", "1y", "all"] as const;
@@ -101,8 +121,9 @@ export default function ActivitiesScreen() {
   const { data, loading, error } = useActivities(range);
 
   const totals = data?.totals;
-  const overview: { label: string; value: string; cls: string }[] = [
-    { label: "Sessions", value: `${totals?.sessions ?? "—"}`, cls: "text-teal" },
+  const sessionsTrend = useSessionsTrend();
+  const overview: { label: string; value: string; cls: string; spark?: { data: number[]; color: string } }[] = [
+    { label: "Sessions", value: `${totals?.sessions ?? "—"}`, cls: "text-teal", spark: { data: sessionsTrend, color: "#77c8d1" } },
     { label: "Distance", value: totals && totals.km > 0 ? `${totals.km.toFixed(0)} km` : "—", cls: "text-indigo" },
     { label: "Time", value: totals && totals.hours > 0 ? `${totals.hours.toFixed(0)}h` : "—", cls: "text-lime" },
     { label: "Calories", value: totals && totals.cal > 0 ? `${Math.round(totals.cal).toLocaleString()}` : "—", cls: "text-warm" },
@@ -146,6 +167,11 @@ export default function ActivitiesScreen() {
             <Card key={s.label} className="min-w-[46%] flex-1 gap-1">
               <Text variant="eyebrow">{s.label}</Text>
               <Text variant="headline" className={s.cls}>{s.value}</Text>
+              {s.spark && s.spark.data.length >= 2 ? (
+                <View className="mt-1">
+                  <Sparkline data={s.spark.data} color={s.spark.color} height={24} baseline />
+                </View>
+              ) : null}
             </Card>
           ))}
         </View>

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -1,7 +1,26 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, SegmentedControl, ProgressBar, Button, Modal, Pill, PillGroup } from "soma-style";
 import { useSomaPlan, usePresets, logPresetMeal, useDrinks, logDrink, closeDay, type Preset } from "../../lib/api";
+import { Sparkline } from "../../components/Sparkline";
+
+const NUTR_API = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+
+/** 14-day daily-calories series for the adherence trend sparkline. */
+function useCaloriesTrend() {
+  const [series, setSeries] = useState<number[]>([]);
+  useEffect(() => {
+    let alive = true;
+    fetch(`${NUTR_API}/api/overview/trends`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+      .then((d: { calories?: number[] }) => alive && setSeries((d.calories ?? []).filter((v) => isFinite(v))))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return series;
+}
 
 const DATE = "2026-07-16";
 
@@ -37,6 +56,7 @@ export default function NutritionScreen() {
   const remaining = data?.remaining;
   const adaptive = data?.adaptive;
   const adherence = data?.trend7d?.adherence;
+  const caloriesTrend = useCaloriesTrend();
   const targetCal = plan?.target_calories ?? 0;
 
   const availSlots = SLOT_ORDER.filter((s) => data?.slotBudgets?.[s] != null);
@@ -135,9 +155,15 @@ export default function NutritionScreen() {
             <Text variant="eyebrow">Weekly adherence</Text>
             <ProgressBar pct={Math.min(adherence.ratio, 1)} color="#6ad4a0" />
             <View className="flex-row justify-between">
-              <Text variant="caption" className="text-text-secondary">{adherence.weeklyActual} / {adherence.weeklyGoal} kcal</Text>
-              <Text variant="caption" className="text-warning">{adherence.status.replace("_", " ")} · {Math.round(adherence.ratio * 100)}%</Text>
+              <Text variant="caption" className="text-text-secondary tabular-nums">{adherence.weeklyActual} / {adherence.weeklyGoal} kcal</Text>
+              <Text variant="caption" className="text-warning tabular-nums">{adherence.status.replace("_", " ")} · {Math.round(adherence.ratio * 100)}%</Text>
             </View>
+            {caloriesTrend.length >= 2 ? (
+              <View className="mt-1 gap-1">
+                <Text variant="micro" className="text-text-muted">14-day calories</Text>
+                <Sparkline data={caloriesTrend} color="#b17850" height={28} baseline />
+              </View>
+            ) : null}
           </Card>
         ) : null}
 

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,8 +1,15 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
+import { Sparkline } from "../../components/Sparkline";
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+
+/** Value series from a StatSeries.current, dropping nulls (for sparklines). */
+const seriesVals = (pts?: { value: number | null }[]) =>
+  (pts ?? []).map((p) => Number(p.value)).filter((v) => isFinite(v));
+const series2Vals = (pts?: { value2?: number | null }[]) =>
+  (pts ?? []).map((p) => Number(p.value2)).filter((v) => isFinite(v));
 
 /** One point on a metric series from /api/stats/[metric]. */
 interface StatPoint {
@@ -117,12 +124,14 @@ export default function SleepScreen() {
     value: string;
     sub: string;
     cls: string;
+    spark?: { data: number[]; color: string };
   }[] = [
     {
       label: "Avg Sleep",
       value: fmt1(sleep?.summary.current_avg, "h"),
       sub: `${fmt1(sleep?.summary.current_min, "h")}–${fmt1(sleep?.summary.current_max, "h")}`,
       cls: "text-indigo",
+      spark: { data: seriesVals(sleep?.current), color: "#6366b0" },
     },
     {
       label: "Last Night",
@@ -138,12 +147,14 @@ export default function SleepScreen() {
           ? "avg"
           : `${rhrDelta >= 0 ? "+" : ""}${rhrDelta.toFixed(1)} vs prev`,
       cls: "text-danger",
+      spark: { data: seriesVals(rhr?.current), color: "#e06060" },
     },
     {
       label: "HRV (weekly)",
       value: fmt0(lastRecovery?.value2, " ms"),
       sub: "last night",
       cls: "text-lime",
+      spark: { data: series2Vals(recovery?.current), color: "#cbe896" },
     },
   ];
 
@@ -191,6 +202,11 @@ export default function SleepScreen() {
                 {s.value}
               </Text>
               <Text variant="micro">{s.sub}</Text>
+              {s.spark && s.spark.data.length >= 2 ? (
+                <View className="mt-1">
+                  <Sparkline data={s.spark.data} color={s.spark.color} height={26} baseline />
+                </View>
+              ) : null}
             </Card>
           ))}
         </View>

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,6 +1,7 @@
 import { ScrollView, View } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar } from "soma-style";
+import { Sparkline } from "../../components/Sparkline";
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
@@ -75,7 +76,13 @@ export default function WorkoutsScreen() {
     return Math.round(withEx.reduce((s, w) => s + w.exercises, 0) / withEx.length);
   })();
 
-  const stats: { label: string; value: string; sub: string; cls: string }[] = [
+  // Per-session calories, oldest→newest, for the Avg-Calories trend sparkline.
+  const kcalTrend = recent
+    .map((w) => w.kcal)
+    .filter((k) => k > 0)
+    .reverse();
+
+  const stats: { label: string; value: string; sub: string; cls: string; spark?: { data: number[]; color: string } }[] = [
     {
       label: "Total Synced",
       value: `${totalSynced}`,
@@ -93,6 +100,7 @@ export default function WorkoutsScreen() {
       value: avgKcal != null ? `${avgKcal}` : "—",
       sub: "kcal via Garmin HR",
       cls: "text-warm",
+      spark: { data: kcalTrend, color: "#b17850" },
     },
     {
       label: "Avg Exercises",
@@ -135,6 +143,11 @@ export default function WorkoutsScreen() {
                 {s.value}
               </Text>
               <Text variant="micro">{s.sub}</Text>
+              {s.spark && s.spark.data.length >= 2 ? (
+                <View className="mt-1">
+                  <Sparkline data={s.spark.data} color={s.spark.color} height={24} baseline />
+                </View>
+              ) : null}
             </Card>
           ))}
         </View>


### PR DESCRIPTION
Refs #240, #238. Continues the per-screen tier-1 sparkline pass.

Adds trend sparklines to the remaining metric screens (matching Home/Running/Training from earlier):
- **Sleep** — Avg Sleep (duration), Resting HR, HRV (from the `/api/stats` series it already fetches).
- **Activities** — Sessions trend (from `/api/stats/activities`).
- **Workouts** — per-session Calories trend (from `/api/hevy/status` recent list).

All six metric dashboards (Home, Running, Training, Sleep, Activities, Workouts) now show current value + trend at a glance. Validated on mobile web (390px); tsc clean.
