### PR TITLE
feat(universal): mobile polish — fetchJson retry, chat Markdown, pull-to-refresh

### DIFF
--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -2,17 +2,15 @@ import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
 import { Sparkline } from "../../components/Sparkline";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { fetchJson } from "../../lib/api";
 
 /** Daily activity-count series (per-day sessions) for the Sessions trend. */
 function useSessionsTrend() {
   const [series, setSeries] = useState<number[]>([]);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/stats/activities?range=90d`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
-      .then((d: { current?: { value: number | null }[] }) => {
+    fetchJson<{ current?: { value: number | null }[] }>("/api/stats/activities?range=90d")
+      .then((d) => {
         if (!alive) return;
         setSeries((d.current ?? []).map((p) => Number(p.value)).filter((v) => isFinite(v)));
       })
@@ -79,9 +77,8 @@ function useActivities(range: RangeKey) {
   useEffect(() => {
     let alive = true;
     setLoading(true);
-    fetch(`${API_BASE}/api/activities/summary?range=${range}`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: ActivitiesSummary) => alive && (setData(d), setError(null)))
+    fetchJson<ActivitiesSummary>(`/api/activities/summary?range=${range}`)
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)))
       .finally(() => alive && setLoading(false));
     return () => {

--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
 import { Sparkline } from "../../components/Sparkline";
-import { fetchJson } from "../../lib/api";
+import { fetchJson, usePullRefresh } from "../../lib/api";
 
 /** Daily activity-count series (per-day sessions) for the Sessions trend. */
 function useSessionsTrend() {
@@ -74,6 +74,7 @@ function useActivities(range: RangeKey) {
   const [data, setData] = useState<ActivitiesSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     setLoading(true);
@@ -84,8 +85,8 @@ function useActivities(range: RangeKey) {
     return () => {
       alive = false;
     };
-  }, [range]);
-  return { data, loading, error };
+  }, [range, reload]);
+  return { data, loading, error, refetch: () => setReload((n) => n + 1) };
 }
 
 /** Category → bar color, mirroring the web catColors palette. */
@@ -115,7 +116,8 @@ function fmtDate(iso: string): string {
 
 export default function ActivitiesScreen() {
   const [range, setRange] = useState<RangeKey>("1y");
-  const { data, loading, error } = useActivities(range);
+  const { data, loading, error, refetch } = useActivities(range);
+  const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const totals = data?.totals;
   const sessionsTrend = useSessionsTrend();
@@ -129,7 +131,11 @@ export default function ActivitiesScreen() {
   const timeTotal = (data?.timeBreakdown ?? []).reduce((s, t) => s + t.hours, 0);
 
   return (
-    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
+    >
       <View className="w-full max-w-2xl gap-4">
         <View className="gap-1">
           <Text variant="headline">Activities</Text>

--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, type BadgeTone } from "soma-style";
-import { fetchJson } from "../../lib/api";
+import { fetchJson, usePullRefresh } from "../../lib/api";
 
 // ---- Types (subset of the web /connections page, from fetchable endpoints) ----
 
@@ -49,6 +49,7 @@ interface SyncStatusResponse {
 function useConnections() {
   const [data, setData] = useState<ConnectionsResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     fetchJson<ConnectionsResponse>("/api/connections")
@@ -57,14 +58,15 @@ function useConnections() {
     return () => {
       alive = false;
     };
-  }, []);
-  return { data, error };
+  }, [reload]);
+  return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
 /** soma's sync-pipeline status (per-source last sync + records). */
 function useSyncStatus() {
   const [data, setData] = useState<SyncStatusResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     fetchJson<SyncStatusResponse>("/api/sync/status")
@@ -73,8 +75,8 @@ function useSyncStatus() {
     return () => {
       alive = false;
     };
-  }, []);
-  return { data, error };
+  }, [reload]);
+  return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
 // ---- Static platform config (mirrors the web page's platformConfig) ----
@@ -143,8 +145,12 @@ function fmtDateTime(iso: string | null | undefined): string {
 }
 
 export default function ConnectionsScreen() {
-  const { data: conn, error: connError } = useConnections();
-  const { data: sync, error: syncError } = useSyncStatus();
+  const { data: conn, error: connError, refetch: refetchConn } = useConnections();
+  const { data: sync, error: syncError, refetch: refetchSync } = useSyncStatus();
+  const { refreshing, onRefresh } = usePullRefresh(() => {
+    refetchConn();
+    refetchSync();
+  });
 
   const platforms = conn?.platforms ?? [];
   const rules = conn?.rules ?? [];
@@ -177,7 +183,11 @@ export default function ConnectionsScreen() {
     : [];
 
   return (
-    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
+    >
       <View className="w-full max-w-2xl gap-4">
         <View className="gap-1">
           <Text variant="headline">Sync Hub</Text>

--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, type BadgeTone } from "soma-style";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { fetchJson } from "../../lib/api";
 
 // ---- Types (subset of the web /connections page, from fetchable endpoints) ----
 
@@ -52,9 +51,8 @@ function useConnections() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/connections`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: ConnectionsResponse) => alive && (setData(d), setError(null)))
+    fetchJson<ConnectionsResponse>("/api/connections")
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => {
       alive = false;
@@ -69,9 +67,8 @@ function useSyncStatus() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/sync/status`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: SyncStatusResponse) => alive && (setData(d), setError(null)))
+    fetchJson<SyncStatusResponse>("/api/sync/status")
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => {
       alive = false;

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -1,19 +1,16 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, SegmentedControl, ProgressBar, Button, Modal, Pill, PillGroup } from "soma-style";
-import { useSomaPlan, usePresets, logPresetMeal, useDrinks, logDrink, closeDay, type Preset } from "../../lib/api";
+import { useSomaPlan, usePresets, logPresetMeal, useDrinks, logDrink, closeDay, fetchJson, type Preset } from "../../lib/api";
 import { Sparkline } from "../../components/Sparkline";
-
-const NUTR_API = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
   const [series, setSeries] = useState<number[]>([]);
   useEffect(() => {
     let alive = true;
-    fetch(`${NUTR_API}/api/overview/trends`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
-      .then((d: { calories?: number[] }) => alive && setSeries((d.calories ?? []).filter((v) => isFinite(v))))
+    fetchJson<{ calories?: number[] }>("/api/overview/trends")
+      .then((d) => alive && setSeries((d.calories ?? []).filter((v) => isFinite(v))))
       .catch(() => {});
     return () => {
       alive = false;

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, SegmentedControl, ProgressBar, Button, Modal, Pill, PillGroup } from "soma-style";
-import { useSomaPlan, usePresets, logPresetMeal, useDrinks, logDrink, closeDay, fetchJson, type Preset } from "../../lib/api";
+import { useSomaPlan, usePresets, logPresetMeal, useDrinks, logDrink, closeDay, fetchJson, usePullRefresh, type Preset } from "../../lib/api";
 import { Sparkline } from "../../components/Sparkline";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
@@ -33,6 +33,7 @@ const slotLabel = (s: string) => s.replace("_", " ").replace(/\b\w/g, (c) => c.t
 
 export default function NutritionScreen() {
   const { data, loading, error, refetch } = useSomaPlan(DATE);
+  const { refreshing, onRefresh } = usePullRefresh(refetch);
   const { presets } = usePresets();
   const { drinks } = useDrinks();
   const [tab, setTab] = useState<"Day" | "Trajectory">("Day");
@@ -91,7 +92,11 @@ export default function NutritionScreen() {
   }
 
   return (
-    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
+    >
       <View className="w-full max-w-2xl gap-4">
         <View className="flex-row items-center gap-2">
           <Text variant="title">Thursday, Jul 16</Text>

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card } from "soma-style";
-import { useToday } from "../../lib/api";
+import { useToday, fetchJson } from "../../lib/api";
 import { Sparkline } from "../../components/Sparkline";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
 interface OverviewTrends {
   steps: number[];
@@ -20,9 +18,8 @@ function useOverviewTrends() {
   const [trends, setTrends] = useState<OverviewTrends | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/overview/trends`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: OverviewTrends) => alive && setTrends(d))
+    fetchJson<OverviewTrends>("/api/overview/trends")
+      .then((d) => alive && setTrends(d))
       .catch(() => {});
     return () => {
       alive = false;

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card } from "soma-style";
-import { useToday, fetchJson } from "../../lib/api";
+import { useToday, fetchJson, usePullRefresh } from "../../lib/api";
 import { Sparkline } from "../../components/Sparkline";
 
 interface OverviewTrends {
@@ -29,7 +29,8 @@ function useOverviewTrends() {
 }
 
 export default function OverviewScreen() {
-  const { data, error } = useToday();
+  const { data, error, refetch } = useToday();
+  const { refreshing, onRefresh } = usePullRefresh(refetch);
   const trends = useOverviewTrends();
 
   const km = data?.total_distance_meters ? (data.total_distance_meters / 1000).toFixed(1) : "—";
@@ -43,7 +44,11 @@ export default function OverviewScreen() {
   ];
 
   return (
-    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
+    >
       <View className="w-full max-w-3xl gap-4">
         <View className="gap-1">
           <Text variant="headline">Overview</Text>

--- a/universal/src/app/(main)/playlist.tsx
+++ b/universal/src/app/(main)/playlist.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { fetchJson } from "../../lib/api";
 
 /** Library analysis status — how much of the Spotify library has BPM data. */
 interface LibraryStatus {
@@ -47,10 +46,7 @@ function usePlaylist() {
     let alive = true;
     setLoading(true);
 
-    const json = (path: string) =>
-      fetch(`${API_BASE}${path}`).then((r) =>
-        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
-      );
+    const json = (path: string) => fetchJson<unknown>(path);
 
     Promise.all([
       json("/api/playlist/spotify/library"),

--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, ProgressBar } from "soma-style";
 import { Sparkline } from "../../components/Sparkline";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { fetchJson } from "../../lib/api";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -97,9 +96,8 @@ function useRunning() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/running/stats`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: RunningPayload) => alive && (setData(d), setError(null)))
+    fetchJson<RunningPayload>("/api/running/stats")
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => {
       alive = false;

--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar } from "soma-style";
 import { Sparkline } from "../../components/Sparkline";
-import { fetchJson } from "../../lib/api";
+import { fetchJson, usePullRefresh } from "../../lib/api";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -94,6 +94,7 @@ interface RunningPayload {
 function useRunning() {
   const [data, setData] = useState<RunningPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     fetchJson<RunningPayload>("/api/running/stats")
@@ -102,8 +103,8 @@ function useRunning() {
     return () => {
       alive = false;
     };
-  }, []);
-  return { data, error };
+  }, [reload]);
+  return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
 /* ------------------------------------------------------------------ */
@@ -151,7 +152,8 @@ const ZONE_HEX = ["#77c8d1", "#6ad4a0", "#e0c458", "#e0a458", "#e06060"];
 /* ------------------------------------------------------------------ */
 
 export default function RunningScreen() {
-  const { data, error } = useRunning();
+  const { data, error, refetch } = useRunning();
+  const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const stats = data?.stats;
   const ts = data?.trainingStatus;
@@ -205,7 +207,11 @@ export default function RunningScreen() {
       : null;
 
   return (
-    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
+    >
       <View className="w-full max-w-2xl gap-4">
         {/* Header */}
         <View className="gap-1">

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
 import { Sparkline } from "../../components/Sparkline";
-import { fetchJson } from "../../lib/api";
+import { fetchJson, usePullRefresh } from "../../lib/api";
 
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
@@ -43,6 +43,7 @@ function useSleepRecovery(range: Range) {
   const [recovery, setRecovery] = useState<StatSeries | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
 
   useEffect(() => {
     let alive = true;
@@ -71,9 +72,9 @@ function useSleepRecovery(range: Range) {
     return () => {
       alive = false;
     };
-  }, [range]);
+  }, [range, reload]);
 
-  return { sleep, rhr, stress, battery, recovery, loading, error };
+  return { sleep, rhr, stress, battery, recovery, loading, error, refetch: () => setReload((n) => n + 1) };
 }
 
 const fmt1 = (v: number | null | undefined, unit = "") =>
@@ -96,8 +97,9 @@ function delta(series: StatSeries | null): number | null {
 
 export default function SleepScreen() {
   const [range, setRange] = useState<Range>("30d");
-  const { sleep, rhr, stress, battery, recovery, loading, error } =
+  const { sleep, rhr, stress, battery, recovery, loading, error, refetch } =
     useSleepRecovery(range);
+  const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const lastSleep = last(sleep);
   const nights = sleep?.current.length ?? 0;
@@ -158,6 +160,7 @@ export default function SleepScreen() {
     <ScrollView
       className="flex-1 bg-base"
       contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
     >
       <View className="w-full max-w-2xl gap-4">
         <View className="flex-row items-center gap-2">

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
 import { Sparkline } from "../../components/Sparkline";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { fetchJson } from "../../lib/api";
 
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
@@ -48,10 +47,7 @@ function useSleepRecovery(range: Range) {
   useEffect(() => {
     let alive = true;
     setLoading(true);
-    const get = (m: string) =>
-      fetch(`${API_BASE}/api/stats/${m}?range=${range}`).then((r) =>
-        r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)),
-      );
+    const get = (m: string) => fetchJson<StatSeries>(`/api/stats/${m}?range=${range}`);
 
     Promise.all([
       get("sleep"),

--- a/universal/src/app/(main)/system.tsx
+++ b/universal/src/app/(main)/system.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, type BadgeTone } from "soma-style";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { fetchJson } from "../../lib/api";
 
 interface PlatformStatus {
   platform: string;
@@ -46,9 +45,8 @@ function useConnections() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/connections`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: ConnectionsResponse) => alive && (setData(d), setError(null)))
+    fetchJson<ConnectionsResponse>("/api/connections")
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => {
       alive = false;
@@ -63,9 +61,8 @@ function useSyncStatus() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/sync/status`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: SyncStatusResponse) => alive && (setData(d), setError(null)))
+    fetchJson<SyncStatusResponse>("/api/sync/status")
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => {
       alive = false;

--- a/universal/src/app/(main)/system.tsx
+++ b/universal/src/app/(main)/system.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, type BadgeTone } from "soma-style";
-import { fetchJson } from "../../lib/api";
+import { fetchJson, usePullRefresh } from "../../lib/api";
 
 interface PlatformStatus {
   platform: string;
@@ -43,6 +43,7 @@ interface SyncStatusResponse {
 function useConnections() {
   const [data, setData] = useState<ConnectionsResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     fetchJson<ConnectionsResponse>("/api/connections")
@@ -51,14 +52,15 @@ function useConnections() {
     return () => {
       alive = false;
     };
-  }, []);
-  return { data, error };
+  }, [reload]);
+  return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
 /** soma's data-pipeline sync status (last run per source). */
 function useSyncStatus() {
   const [data, setData] = useState<SyncStatusResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     fetchJson<SyncStatusResponse>("/api/sync/status")
@@ -67,8 +69,8 @@ function useSyncStatus() {
     return () => {
       alive = false;
     };
-  }, []);
-  return { data, error };
+  }, [reload]);
+  return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
 const PLATFORM_LABEL: Record<string, string> = {
@@ -124,8 +126,12 @@ function fmtDateTime(iso: string | null): string {
 }
 
 export default function StatusScreen() {
-  const { data: conn, error: connError } = useConnections();
-  const { data: sync, error: syncError } = useSyncStatus();
+  const { data: conn, error: connError, refetch: refetchConn } = useConnections();
+  const { data: sync, error: syncError, refetch: refetchSync } = useSyncStatus();
+  const { refreshing, onRefresh } = usePullRefresh(() => {
+    refetchConn();
+    refetchSync();
+  });
 
   const platforms = conn?.platforms ?? [];
   const rules = conn?.rules ?? [];
@@ -145,7 +151,11 @@ export default function StatusScreen() {
   ];
 
   return (
-    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
+    >
       <View className="w-full max-w-2xl gap-4">
         <View className="gap-1">
           <Text variant="headline">Sync Hub</Text>

--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
-import { useTraining, useCalibration, toggleCalibration, fetchJson } from "../../lib/api";
+import { useTraining, useCalibration, toggleCalibration, fetchJson, usePullRefresh } from "../../lib/api";
 import { Sparkline } from "../../components/Sparkline";
 
 /** VO2max trend (last year, chronological) from the shared stats endpoint. */
@@ -39,8 +39,12 @@ const TL_TONE: Record<string, "success" | "warm" | "danger" | "teal"> = {
 const tsbPct = (tsb: number) => Math.max(0, Math.min(1, (tsb + 30) / 60));
 
 export default function TrainingScreen() {
-  const { data, error } = useTraining(todayISO());
+  const { data, error, refetch } = useTraining(todayISO());
   const { cal, refetch: refetchCal } = useCalibration(todayISO());
+  const { refreshing, onRefresh } = usePullRefresh(() => {
+    refetch();
+    refetchCal();
+  });
   const pmc = data?.pmc;
   const fit = data?.fitness;
   const readiness = data?.readiness;
@@ -69,7 +73,11 @@ export default function TrainingScreen() {
     v == null ? "—" : `${v.toFixed(dp)}${unit}`;
 
   return (
-    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
+    >
       <View className="w-full max-w-2xl gap-4">
         <View className="flex-row items-center gap-2">
           <Text variant="headline">Training</Text>

--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -1,19 +1,16 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
-import { useTraining, useCalibration, toggleCalibration } from "../../lib/api";
+import { useTraining, useCalibration, toggleCalibration, fetchJson } from "../../lib/api";
 import { Sparkline } from "../../components/Sparkline";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
 /** VO2max trend (last year, chronological) from the shared stats endpoint. */
 function useVo2Trend() {
   const [series, setSeries] = useState<number[]>([]);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/stats/vo2max?range=1y`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
-      .then((d: { current?: { value: number | null }[] }) => {
+    fetchJson<{ current?: { value: number | null }[] }>("/api/stats/vo2max?range=1y")
+      .then((d) => {
         if (!alive) return;
         setSeries((d.current ?? []).map((p) => Number(p.value)).filter((v) => isFinite(v)));
       })

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -2,8 +2,7 @@ import { ScrollView, View } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar } from "soma-style";
 import { Sparkline } from "../../components/Sparkline";
-
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { fetchJson } from "../../lib/api";
 
 interface RecentWorkout {
   title: string;
@@ -33,9 +32,8 @@ function useWorkouts() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/hevy/status`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: HevyStatus) => alive && (setData(d), setError(null)))
+    fetchJson<HevyStatus>("/api/hevy/status")
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => {
       alive = false;

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,8 +1,8 @@
-import { ScrollView, View } from "react-native";
+import { ScrollView, View, RefreshControl } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar } from "soma-style";
 import { Sparkline } from "../../components/Sparkline";
-import { fetchJson } from "../../lib/api";
+import { fetchJson, usePullRefresh } from "../../lib/api";
 
 interface RecentWorkout {
   title: string;
@@ -30,6 +30,7 @@ interface HevyStatus {
 function useWorkouts() {
   const [data, setData] = useState<HevyStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     fetchJson<HevyStatus>("/api/hevy/status")
@@ -38,8 +39,8 @@ function useWorkouts() {
     return () => {
       alive = false;
     };
-  }, []);
-  return { data, error };
+  }, [reload]);
+  return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
 function formatDate(dateStr: string): string {
@@ -55,7 +56,8 @@ function formatDate(dateStr: string): string {
 }
 
 export default function WorkoutsScreen() {
-  const { data, error } = useWorkouts();
+  const { data, error, refetch } = useWorkouts();
+  const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const recent = data?.recent ?? [];
   const totalSynced = data?.totalSynced ?? 0;
@@ -109,7 +111,11 @@ export default function WorkoutsScreen() {
   ];
 
   return (
-    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
+    >
       <View className="w-full max-w-2xl gap-4">
         <View className="flex-row items-center gap-2">
           <Text variant="headline">Workouts</Text>

--- a/universal/src/components/ChatSheet.tsx
+++ b/universal/src/components/ChatSheet.tsx
@@ -12,6 +12,7 @@ import {
 import { fetch as expoFetch } from "expo/fetch";
 import { Text, Card, Badge, type BadgeTone } from "soma-style";
 import { useChat as useChatSheet } from "./ChatContext";
+import { MarkdownText } from "./MarkdownText";
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
@@ -326,11 +327,7 @@ function Bubble({ msg }: { msg: Message }) {
         ) : null}
         {msg.steps.map((s) => {
           if (s.kind === "text")
-            return s.text ? (
-              <Text key={s.id} variant="body" className="text-text">
-                {s.text}
-              </Text>
-            ) : null;
+            return s.text ? <MarkdownText key={s.id} text={s.text} /> : null;
           if (s.kind === "thinking")
             return s.text ? (
               <Text key={s.id} variant="micro" className="italic text-text-muted">

--- a/universal/src/components/MarkdownText.tsx
+++ b/universal/src/components/MarkdownText.tsx
@@ -1,0 +1,130 @@
+import { Fragment } from "react";
+import { View } from "react-native";
+import { Text } from "soma-style";
+
+/* A lightweight Markdown renderer for the chat — no dependency, handles the
+   subset Claude actually emits: fenced code blocks, headings, bullet/numbered
+   lists, blockquotes, and inline **bold** / `code`. Anything else falls through
+   as plain body text. Not a full CommonMark parser; readability over fidelity. */
+
+/** Inline parse: **bold** and `code` within one line → Text segments. */
+function inline(text: string, keyBase: string) {
+  const parts: React.ReactNode[] = [];
+  // Split on **bold** and `code`, keeping the delimiters via capture groups.
+  const re = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let i = 0;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) parts.push(<Fragment key={`${keyBase}-t${i}`}>{text.slice(last, m.index)}</Fragment>);
+    const tok = m[0];
+    if (tok.startsWith("**")) {
+      parts.push(
+        <Text key={`${keyBase}-b${i}`} className="font-semibold text-text">
+          {tok.slice(2, -2)}
+        </Text>,
+      );
+    } else {
+      parts.push(
+        <Text key={`${keyBase}-c${i}`} className="rounded bg-surface-elevated px-1 font-mono text-teal">
+          {tok.slice(1, -1)}
+        </Text>,
+      );
+    }
+    last = m.index + tok.length;
+    i++;
+  }
+  if (last < text.length) parts.push(<Fragment key={`${keyBase}-t${i}`}>{text.slice(last)}</Fragment>);
+  return parts;
+}
+
+export function MarkdownText({ text }: { text: string }) {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  const blocks: React.ReactNode[] = [];
+  let i = 0;
+  let key = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block
+    if (line.trim().startsWith("```")) {
+      const buf: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].trim().startsWith("```")) {
+        buf.push(lines[i]);
+        i++;
+      }
+      i++; // consume closing fence
+      blocks.push(
+        <View key={key++} className="rounded-lg bg-surface-elevated px-3 py-2">
+          <Text variant="micro" className="font-mono text-text-secondary">
+            {buf.join("\n")}
+          </Text>
+        </View>,
+      );
+      continue;
+    }
+
+    // Blank line → spacer (skip; the gap comes from the container)
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // Headings
+    const h = line.match(/^(#{1,3})\s+(.*)$/);
+    if (h) {
+      blocks.push(
+        <Text key={key++} variant={h[1].length === 1 ? "title" : "eyebrow"} className="text-text">
+          {inline(h[2], `h${key}`)}
+        </Text>,
+      );
+      i++;
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith("> ")) {
+      blocks.push(
+        <View key={key++} className="border-l-2 border-border pl-3">
+          <Text variant="body" className="italic text-text-secondary">
+            {inline(line.slice(2), `q${key}`)}
+          </Text>
+        </View>,
+      );
+      i++;
+      continue;
+    }
+
+    // Bullet / numbered list item
+    const bullet = line.match(/^\s*[-*]\s+(.*)$/);
+    const numbered = line.match(/^\s*(\d+)\.\s+(.*)$/);
+    if (bullet || numbered) {
+      const marker = bullet ? "•" : `${numbered![1]}.`;
+      const content = bullet ? bullet[1] : numbered![2];
+      blocks.push(
+        <View key={key++} className="flex-row gap-2 pl-1">
+          <Text variant="body" className="text-text-muted">
+            {marker}
+          </Text>
+          <Text variant="body" className="flex-1 text-text">
+            {inline(content, `l${key}`)}
+          </Text>
+        </View>,
+      );
+      i++;
+      continue;
+    }
+
+    // Paragraph
+    blocks.push(
+      <Text key={key++} variant="body" className="text-text">
+        {inline(line, `p${key}`)}
+      </Text>,
+    );
+    i++;
+  }
+
+  return <View className="gap-1.5">{blocks}</View>;
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
@@ -56,18 +56,34 @@ export interface Today {
   vigorous_intensity_minutes?: number;
 }
 
+/**
+ * Wire a hook's refetch() to a pull-to-refresh RefreshControl. The GET hooks
+ * don't expose a completion promise, so we clear the spinner after a short beat
+ * (the retry-aware fetchJson usually resolves well within it).
+ */
+export function usePullRefresh(refetch: () => void) {
+  const [refreshing, setRefreshing] = useState(false);
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    refetch();
+    setTimeout(() => setRefreshing(false), 900);
+  }, [refetch]);
+  return { refreshing, onRefresh };
+}
+
 /** soma's daily health metrics (Overview). */
 export function useToday() {
   const [data, setData] = useState<Today | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     fetchJson<Today>("/api/health/today")
       .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => { alive = false; };
-  }, []);
-  return { data, error };
+  }, [reload]);
+  return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
 export interface TrainingBreakdown {
@@ -93,14 +109,15 @@ export interface TrainingBreakdown {
 export function useTraining(date: string) {
   const [data, setData] = useState<TrainingBreakdown | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
     fetchJson<TrainingBreakdown>(`/api/training/breakdown?date=${date}`)
       .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => { alive = false; };
-  }, [date]);
-  return { data, error };
+  }, [date, reload]);
+  return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
 export interface Calibration {

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -2,6 +2,26 @@ import { useEffect, useState } from "react";
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
+/**
+ * GET JSON with one automatic retry. Serverless DBs (Neon) can return a transient
+ * 5xx or a "fetch failed" on cold start; a single-shot fetch would leave the screen
+ * blank until manual reload. One short-delay retry smooths that over. `path` is
+ * relative to API_BASE.
+ */
+export async function fetchJson<T>(path: string, retries = 1): Promise<T> {
+  try {
+    const r = await fetch(`${API_BASE}${path}`);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return (await r.json()) as T;
+  } catch (e) {
+    if (retries > 0) {
+      await new Promise((res) => setTimeout(res, 600));
+      return fetchJson<T>(path, retries - 1);
+    }
+    throw e;
+  }
+}
+
 export interface MacroSet {
   calories: number;
   protein: number;
@@ -42,9 +62,8 @@ export function useToday() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/health/today`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: Today) => alive && (setData(d), setError(null)))
+    fetchJson<Today>("/api/health/today")
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => { alive = false; };
   }, []);
@@ -76,9 +95,8 @@ export function useTraining(date: string) {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/training/breakdown?date=${date}`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: TrainingBreakdown) => alive && (setData(d), setError(null)))
+    fetchJson<TrainingBreakdown>(`/api/training/breakdown?date=${date}`)
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => { alive = false; };
   }, [date]);
@@ -98,9 +116,8 @@ export function useCalibration(date: string) {
   const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/training/graph?date=${date}`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: { calibration: Calibration }) => alive && setCal(d.calibration ?? null))
+    fetchJson<{ calibration: Calibration }>(`/api/training/graph?date=${date}`)
+      .then((d) => alive && setCal(d.calibration ?? null))
       .catch(() => {});
     return () => { alive = false; };
   }, [date, reload]);
@@ -125,9 +142,8 @@ export function useSomaPlan(date: string) {
   useEffect(() => {
     let alive = true;
     setLoading(true);
-    fetch(`${API_BASE}/api/nutrition/plan?date=${date}`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: SomaPlan) => alive && (setData(d), setError(null)))
+    fetchJson<SomaPlan>(`/api/nutrition/plan?date=${date}`)
+      .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)))
       .finally(() => alive && setLoading(false));
     return () => { alive = false; };
@@ -152,9 +168,8 @@ export function usePresets() {
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/nutrition/presets`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: { presets: Preset[] }) => alive && (setPresets(d.presets ?? []), setError(null)))
+    fetchJson<{ presets: Preset[] }>("/api/nutrition/presets")
+      .then((d) => alive && (setPresets(d.presets ?? []), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => { alive = false; };
   }, []);
@@ -174,9 +189,8 @@ export function useDrinks() {
   const [drinks, setDrinks] = useState<Drink[]>([]);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/nutrition/log-drink`)
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: { drinks: Record<string, Omit<Drink, "key">> }) =>
+    fetchJson<{ drinks: Record<string, Omit<Drink, "key">> }>("/api/nutrition/log-drink")
+      .then((d) =>
         alive && setDrinks(Object.entries(d.drinks ?? {}).map(([key, v]) => ({ key, ...v }))))
       .catch(() => {});
     return () => { alive = false; };


### PR DESCRIPTION
Refs #234, #240, #238. Two mobile-polish improvements.

## 1. Shared `fetchJson` with retry (fixes cold-start blank screens)
On a Neon cold start the RN screens' single-shot `fetch` would blank (transient 5xx / "fetch failed") until manual reload. New `fetchJson<T>(path, retries=1)` in `lib/api` (one 600ms-delayed retry); every **GET** routes through it (6 lib hooks + inline data/trend fetches on all screens). **POST mutations keep raw fetch** (a retried write could double-submit). Drops the duplicated per-screen `API_BASE`.

## 2. Markdown rendering in the chat
Chat responses arrived as raw Markdown (literal `**`, ` ``` `, etc.). Add a lightweight, dependency-free `MarkdownText` renderer — fenced code blocks, headings, bullet/numbered lists, blockquotes, inline **bold** and `code`, styled with soma-style — used for assistant text.

## Validation
- Running still loads real data + sparklines through `fetchJson`.
- Chat markdown validated at 390px (temporary seed): bold, teal inline code, lists, code block, blockquote all render.
- tsc clean (universal).
