### PR TITLE
feat(universal): repoint tab bar at soma-style@1.2.0 shared chrome

### DIFF
--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -34,7 +34,7 @@
         "react-native-svg": "15.15.4",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.10.0",
-        "soma-style": "^1.0.0"
+        "soma-style": "^1.2.0"
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
@@ -9171,9 +9171,9 @@
       }
     },
     "node_modules/soma-style": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-1.0.0.tgz",
-      "integrity": "sha512-ZjcvcQuhJW/xPmCteBz0u5MGXNvd6lU4wsC8tS1bpNqu4UXprYeYxU7xkVln1If4CodTjrr2C+HyfkTtwaBu1g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-1.2.0.tgz",
+      "integrity": "sha512-TGoM6DtP+nEoFkyPe5N4uctOIhow5Fk6Pk7iG8AeH4+NupR3SFG2JCUfQJ8BBEtPx30YnCYjBycmsgE5cgh9TA==",
       "license": "MIT",
       "peerDependencies": {
         "nativewind": ">=4.0.0",

--- a/universal/package.json
+++ b/universal/package.json
@@ -29,7 +29,7 @@
     "react-native-svg": "15.15.4",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.10.0",
-    "soma-style": "^1.0.0"
+    "soma-style": "^1.2.0"
   },
   "devDependencies": {
     "@types/react": "~19.2.2",

--- a/universal/src/app/(main)/_layout.tsx
+++ b/universal/src/app/(main)/_layout.tsx
@@ -1,17 +1,10 @@
 import { Tabs } from "expo-router";
-import { Pressable, View, type ColorValue } from "react-native";
+import { type ColorValue } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { tabBarScreenOptions, CenterTabButton } from "soma-style";
 import { ChatProvider, useChat } from "../../components/ChatContext";
 import { ChatSheet } from "../../components/ChatSheet";
-
-/* soma-style tokens (mirrored from soma-style/preset.js — the tab bar is native
-   chrome so it reads them directly rather than via NativeWind classes). */
-const TEAL = "#77c8d1";
-const MUTED = "#5a7a8a";
-const SURFACE = "#0e1a26";
-const BORDER = "#1a3040";
-const INK = "#0a1720";
 
 type IconName = React.ComponentProps<typeof Ionicons>["name"];
 const tabIcon =
@@ -20,35 +13,16 @@ const tabIcon =
     <Ionicons name={name} size={size} color={color as string} />
   );
 
-/** Center ⊕ — opens the Claude chat as a quick log/ask action (not a route). */
+/** Center ⊕ — opens the Claude chat as a quick log/ask action (not a route).
+    Uses the shared soma-style CenterTabButton, wired to the chat context. */
 function CenterLogButton() {
   const { openChat } = useChat();
-  return (
-    <View className="flex-1 items-center justify-center">
-      <Pressable
-        onPress={openChat}
-        accessibilityLabel="Log or ask Claude"
-        className="h-14 w-14 items-center justify-center rounded-full border-2 border-base bg-teal"
-        style={{ marginTop: -14 }}
-      >
-        <Ionicons name="add" size={30} color={INK} />
-      </Pressable>
-    </View>
-  );
+  return <CenterTabButton onPress={openChat} accessibilityLabel="Log or ask Claude" />;
 }
 
 function TabsNav() {
   return (
-    <Tabs
-      screenOptions={{
-        headerShown: false,
-        tabBarActiveTintColor: TEAL,
-        tabBarInactiveTintColor: MUTED,
-        tabBarStyle: { backgroundColor: SURFACE, borderTopColor: BORDER, borderTopWidth: 1 },
-        tabBarLabelStyle: { fontSize: 11, fontWeight: "600" },
-        sceneStyle: { backgroundColor: "#0a1720" },
-      }}
-    >
+    <Tabs screenOptions={tabBarScreenOptions}>
       <Tabs.Screen name="overview" options={{ title: "Home", tabBarIcon: tabIcon("home-outline") }} />
       <Tabs.Screen name="training" options={{ title: "Training", tabBarIcon: tabIcon("barbell-outline") }} />
       <Tabs.Screen name="log" options={{ title: "", tabBarButton: () => <CenterLogButton /> }} />


### PR DESCRIPTION
Repoints the universal app's bottom tab bar at the shared chrome now in `soma-style@1.2.0` (drkostas/soma-style#6).

## Changes
- `universal/src/app/(main)/_layout.tsx`: import `tabBarScreenOptions` + `CenterTabButton` from `soma-style`; remove the local token constants, the inline `screenOptions` object, and the local ⊕ button markup. `CenterLogButton` now wraps the shared `CenterTabButton`, still opening the chat via `useChat().openChat`. Routing (full `Tabs.Screen` set + per-screen icons) unchanged.
- Bump `soma-style` dep to `^1.2.0` (net -26 lines).

No visual change intended — the shared bar is identical to the extracted one (same tokens, same layout, same base-ring ⊕).

## Verified
- `tsc --noEmit` clean against the registry `soma-style@1.2.0`.

Closes #250
