### PR TITLE
feat(api): personal API-token bypass for /api/* (native apps + widgets)

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -13,6 +13,24 @@ function withDevCors(res: NextResponse, isApi: boolean): NextResponse {
   return res;
 }
 
+/** Permissive CORS applied when a request authenticates via the personal API
+    token (the native apps + iOS widgets), so a web client could use it too. */
+function withTokenCors(res: NextResponse): NextResponse {
+  res.headers.set("Access-Control-Allow-Origin", "*");
+  res.headers.set("Access-Control-Allow-Methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
+  res.headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  return res;
+}
+
+/** Does the request carry the valid personal API token? Lets native clients
+    (Expo apps, widgets) reach /api/* without a browser session. Scoped to
+    /api/* only — the web UI stays session-gated. */
+function hasApiToken(req: { headers: Headers }): boolean {
+  const token = process.env.SOMA_API_TOKEN?.trim();
+  if (!token) return false;
+  return req.headers.get("authorization") === `Bearer ${token}`;
+}
+
 export default auth((req) => {
   const { pathname } = req.nextUrl;
   const isApi = pathname.startsWith("/api/");
@@ -20,6 +38,9 @@ export default auth((req) => {
   if (isDev && isApi && req.method === "OPTIONS") {
     return withDevCors(new NextResponse(null, { status: 204 }), true);
   }
+
+  // Personal API token: native apps + widgets reach /api/* without a session.
+  if (isApi && hasApiToken(req)) return withTokenCors(NextResponse.next());
 
   // Demo mode: no auth required
   if (process.env.DEMO_MODE?.trim() === "true") return withDevCors(NextResponse.next(), isApi);


### PR DESCRIPTION
Adds a scoped personal API-token path so the universal Expo apps (and the upcoming iOS widgets) can read the owner's live data from `soma.gkos.dev` without a browser session. The web UI stays session-gated; `DEMO_MODE` is untouched.

## Change
- `web/middleware.ts`: after the OPTIONS/DEMO checks and before the session requirement, if the request is to `/api/*` and carries `Authorization: Bearer <SOMA_API_TOKEN>` matching `process.env.SOMA_API_TOKEN`, allow it (with permissive CORS). Scoped to `/api/*` only.
- `SOMA_API_TOKEN` is set in the `soma-personal` Vercel project (Production).

## Verified
- `tsc --noEmit` clean.
- Post-deploy: `curl -H "Authorization: Bearer <token>" https://soma.gkos.dev/api/hevy/status` will be checked to return 200 with live data (vs the current 307 redirect to /login).

Closes #254
