### PR TITLE
Deepen native app screens to web feature parity (overview/training/running/sleep)

### DIFF
--- a/universal/app.json
+++ b/universal/app.json
@@ -4,11 +4,10 @@
     "slug": "universal",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/images/icon.png",
+    "icon": "./assets/images/soma-app-icon.png",
     "scheme": "universal",
     "userInterfaceStyle": "automatic",
     "ios": {
-      "icon": "./assets/expo.icon",
       "bundleIdentifier": "dev.gkos.soma"
     },
     "android": {

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, SegmentedControl, ProgressBar, Button, Modal, Pill, PillGroup, Sparkline } from "soma-style";
-import { useSomaPlan, usePresets, logPresetMeal, useDrinks, logDrink, closeDay, fetchJson, usePullRefresh, type Preset } from "../../lib/api";
+import {
+  useSomaPlan, usePresets, logPresetMeal, deleteMeal, useDrinks, logDrink, closeDay,
+  fetchJson, usePullRefresh, todayLocal, type Preset, type SomaMeal,
+} from "../../lib/api";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -11,14 +14,10 @@ function useCaloriesTrend() {
     fetchJson<{ calories?: number[] }>("/api/overview/trends")
       .then((d) => alive && setSeries((d.calories ?? []).filter((v) => isFinite(v))))
       .catch(() => {});
-    return () => {
-      alive = false;
-    };
+    return () => { alive = false; };
   }, []);
   return series;
 }
-
-const DATE = "2026-07-16";
 
 const MACROS = [
   { key: "protein", label: "Protein", color: "#b17850", tKey: "target_protein" },
@@ -27,23 +26,34 @@ const MACROS = [
   { key: "fiber", label: "Fiber", color: "#82d0c8", tKey: "target_fiber" },
 ] as const;
 
-const SLOT_ORDER = ["breakfast", "lunch", "dinner", "pre_sleep", "during_workout"];
-const slotLabel = (s: string) => s.replace("_", " ").replace(/\b\w/g, (c) => c.toUpperCase());
+const SLOT_ORDER = ["breakfast", "lunch", "during_workout", "dinner", "pre_sleep"];
+const slotLabel = (s: string) => s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+function mealName(m: SomaMeal): string {
+  const names = (m.items ?? []).map((i) => i.name).filter(Boolean) as string[];
+  if (names.length) return names.slice(0, 3).join(", ") + (names.length > 3 ? "…" : "");
+  return m.source ? slotLabel(m.source) : "Meal";
+}
+
+function niceDate(iso: string): string {
+  const [y, mo, d] = iso.split("-").map(Number);
+  const dt = new Date(y, (mo ?? 1) - 1, d ?? 1);
+  return dt.toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" });
+}
 
 export default function NutritionScreen() {
+  const DATE = todayLocal();
   const { data, loading, error, refetch } = useSomaPlan(DATE);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
   const { presets } = usePresets();
   const { drinks } = useDrinks();
-  const [tab, setTab] = useState<"Day" | "Trajectory">("Day");
-  const [refeed, setRefeed] = useState(false);
+  const [tab, setTab] = useState<"Day" | "Trend">("Day");
   const [logOpen, setLogOpen] = useState(false);
   const [slot, setSlot] = useState("lunch");
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [loggedId, setLoggedId] = useState<string | null>(null);
+  const [delId, setDelId] = useState<number | null>(null);
   const [drinkOpen, setDrinkOpen] = useState(false);
   const [drinkBusy, setDrinkBusy] = useState<string | null>(null);
-  const [drinkLogged, setDrinkLogged] = useState<string | null>(null);
   const [closeOpen, setCloseOpen] = useState(false);
   const [closing, setClosing] = useState(false);
   const [closeStatus, setCloseStatus] = useState<string | null>(null);
@@ -53,42 +63,57 @@ export default function NutritionScreen() {
   const remaining = data?.remaining;
   const adaptive = data?.adaptive;
   const adherence = data?.trend7d?.adherence;
+  const days = data?.trend7d?.days ?? [];
+  const bd = data?.breakdown;
+  const meals = data?.meals ?? [];
   const caloriesTrend = useCaloriesTrend();
   const targetCal = plan?.target_calories ?? 0;
 
   const availSlots = SLOT_ORDER.filter((s) => data?.slotBudgets?.[s] != null);
-  const slots = availSlots.length ? availSlots : SLOT_ORDER;
+  const slots = availSlots.length ? availSlots : SLOT_ORDER.filter((s) => s !== "during_workout");
+  // presets for the picker, ordered so the picked slot's meals surface first
+  const pickerPresets = [...presets].sort((a, b) =>
+    (a.meal_slot === slot ? 0 : 1) - (b.meal_slot === slot ? 0 : 1));
 
   async function onLog(preset: Preset) {
     setBusyId(preset.id);
     const ok = await logPresetMeal(DATE, slot, preset);
     setBusyId(null);
-    if (ok) {
-      setLoggedId(preset.id);
-      refetch();
-    }
+    if (ok) refetch();
   }
-
+  async function onDelete(id: number) {
+    setDelId(id);
+    const ok = await deleteMeal(id);
+    setDelId(null);
+    if (ok) refetch();
+  }
   async function onLogDrink(key: string) {
     setDrinkBusy(key);
     const ok = await logDrink(DATE, key);
     setDrinkBusy(null);
-    if (ok) {
-      setDrinkLogged(key);
-      refetch();
-    }
+    if (ok) refetch();
   }
-
   async function onCloseDay() {
     setClosing(true);
     const status = await closeDay(DATE);
     setClosing(false);
     setCloseStatus(status);
-    if (status) {
-      setCloseOpen(false);
-      refetch();
-    }
+    if (status) { setCloseOpen(false); refetch(); }
   }
+
+  const burnRow = (label: string, value?: number, opts?: { amber?: boolean; bold?: boolean }) =>
+    value == null ? null : (
+      <View className="flex-row items-center justify-between py-1">
+        <Text variant={opts?.bold ? "body" : "caption"} className={opts?.bold ? "text-text" : "text-text-secondary"}>{label}</Text>
+        <Text variant={opts?.bold ? "body" : "caption"} className={`tabular-nums ${opts?.amber ? "text-warm" : opts?.bold ? "text-teal" : "text-text"}`}>
+          {Math.round(value)} kcal
+        </Text>
+      </View>
+    );
+
+  const totalBurn = bd?.totalBurn ?? (
+    (bd?.bmr ?? 0) + (bd?.stepCalories ?? 0) + (bd?.runActual ?? bd?.runPredicted ?? bd?.runCalories ?? 0) + (bd?.gymCalories ?? 0)
+  );
 
   return (
     <ScrollView
@@ -98,31 +123,41 @@ export default function NutritionScreen() {
     >
       <View className="w-full max-w-2xl gap-4">
         <View className="flex-row items-center gap-2">
-          <Text variant="title">Thursday, Jul 16</Text>
-          <Badge label="Nutrition" tone="teal" />
+          <Text variant="title">{niceDate(DATE)}</Text>
+          {closeStatus === "closed" ? <Badge label="Closed" tone="success" /> : <Badge label="Nutrition" tone="teal" />}
         </View>
 
         {error ? (
-          <Card><Text variant="body" className="text-danger">API: {error} — is soma running on :3456?</Text></Card>
+          <Card><Text variant="body" className="text-danger">Couldn&apos;t reach soma: {error}</Text></Card>
         ) : null}
 
         <Card variant="glow" className="gap-4">
-          <SegmentedControl options={["Day", "Trajectory"] as const} value={tab} onChange={setTab} />
+          <SegmentedControl options={["Day", "Trend"] as const} value={tab} onChange={setTab} />
           <View className="items-center gap-1">
-            <Text variant="display">{loading ? "…" : ((consumed?.calories ?? 0)).toLocaleString()}</Text>
-            <Text variant="caption" className="text-text-muted">/ {targetCal.toLocaleString()} kcal · {(remaining?.calories ?? 0).toLocaleString()} remaining</Text>
+            {plan ? (
+              <>
+                <Text variant="display">{loading ? "…" : (remaining?.calories ?? 0).toLocaleString()}</Text>
+                <Text variant="caption" className="text-text-muted">
+                  kcal left · {(consumed?.calories ?? 0).toLocaleString()} of {targetCal.toLocaleString()} eaten
+                </Text>
+              </>
+            ) : (
+              <>
+                <Text variant="display">{loading ? "…" : (consumed?.calories ?? 0).toLocaleString()}</Text>
+                <Text variant="caption" className="text-text-muted">kcal eaten today</Text>
+              </>
+            )}
           </View>
 
-          {/* Macro bars */}
           <View className="gap-2.5">
             {MACROS.map((m) => {
-              const target = (plan as Record<string, number> | undefined)?.[m.tKey] ?? 0;
+              const target = (plan as Record<string, number> | null | undefined)?.[m.tKey] ?? 0;
               const eaten = (consumed as Record<string, number> | undefined)?.[m.key] ?? 0;
               return (
                 <View key={m.key} className="gap-1">
                   <View className="flex-row justify-between">
                     <Text variant="caption" className="text-text-secondary">{m.label}</Text>
-                    <Text variant="caption" className="tabular-nums text-text-muted">{Math.round(eaten)} / {Math.round(target)}g</Text>
+                    <Text variant="caption" className="tabular-nums text-text-muted">{Math.round(eaten)}{target > 0 ? ` / ${Math.round(target)}` : ""}g</Text>
                   </View>
                   <ProgressBar pct={target > 0 ? eaten / target : 0} color={m.color} />
                 </View>
@@ -131,137 +166,165 @@ export default function NutritionScreen() {
           </View>
         </Card>
 
-        {/* Adaptive (the #68 feature, display-only) */}
-        {adaptive && (adaptive.driftFlag || adaptive.dietBreakLevel !== "none") ? (
-          <Card className="gap-1">
-            <Text variant="eyebrow">Adaptive</Text>
-            {adaptive.dietBreakLevel !== "none" ? (
-              <View className="flex-row justify-between">
-                <Text variant="caption" className="font-semibold text-warning">
-                  Diet break {adaptive.dietBreakLevel}
-                </Text>
-                <Text variant="caption" className="text-text-muted tabular-nums">{adaptive.deficitDurationDays}d in deficit</Text>
+        {tab === "Day" ? (
+          <>
+            {/* Burn breakdown — why today's target is what it is */}
+            {bd ? (
+              <Card className="gap-0.5">
+                <Text variant="eyebrow" className="mb-1">Burn breakdown</Text>
+                {burnRow("Passive (BMR)", bd.bmr)}
+                {burnRow(`Steps${bd.actualSteps ? ` · ${bd.actualSteps.toLocaleString()}` : ""}`, bd.stepCalories)}
+                {bd.runEnabled ? burnRow(`Run${bd.runActual ? "" : " (planned)"}`, bd.runActual ?? bd.runPredicted ?? bd.runCalories, { amber: !bd.runActual }) : null}
+                {burnRow("Gym", bd.gymCalories)}
+                {(bd.drinkCalories ?? 0) > 0 ? burnRow("Drinks", bd.drinkCalories, { amber: true }) : null}
+                {burnRow("Total burn", totalBurn, { bold: true })}
+              </Card>
+            ) : null}
+
+            {/* Adaptive (display-only) */}
+            {adaptive && (adaptive.driftFlag || adaptive.dietBreakLevel !== "none") ? (
+              <Card className="gap-1">
+                <Text variant="eyebrow">Adaptive</Text>
+                {adaptive.dietBreakLevel !== "none" ? (
+                  <View className="flex-row justify-between">
+                    <Text variant="caption" className="font-semibold text-warning">Diet break {adaptive.dietBreakLevel}</Text>
+                    <Text variant="caption" className="text-text-muted tabular-nums">{adaptive.deficitDurationDays}d in deficit</Text>
+                  </View>
+                ) : null}
+                {adaptive.driftFlag ? (
+                  <Text variant="caption" className="text-warning">TDEE drift: ~{Math.round(adaptive.effectiveTdee)} vs {Math.round(adaptive.reportedTdee)}</Text>
+                ) : null}
+                <Text variant="micro">Informational — your targets are unchanged.</Text>
+              </Card>
+            ) : null}
+
+            {/* Per-slot meal cards — itemized logged meals + delete + quick-log */}
+            {slots.map((s) => {
+              const slotMeals = meals.filter((m) => m.meal_slot === s);
+              const budget = data?.slotBudgets?.[s]?.calories ?? 0;
+              const eatenInSlot = slotMeals.reduce((sum, m) => sum + (m.calories ?? 0), 0);
+              if (budget <= 0 && slotMeals.length === 0) return null;
+              return (
+                <Card key={s} className="gap-2">
+                  <View className="flex-row items-center justify-between">
+                    <Text variant="title">{slotLabel(s)}</Text>
+                    <Text variant="caption" className="tabular-nums text-text-muted">
+                      {Math.round(eatenInSlot)}{budget > 0 ? ` / ${Math.round(budget)}` : ""} kcal
+                    </Text>
+                  </View>
+                  {budget > 0 ? <ProgressBar pct={Math.min(eatenInSlot / budget, 1)} color={eatenInSlot > budget ? "#e0a458" : "#77c8d1"} /> : null}
+                  {slotMeals.map((m) => (
+                    <View key={m.id} className="flex-row items-center gap-2 border-b border-border-subtle py-1.5">
+                      <View className="flex-1">
+                        <Text variant="body" className="text-text" numberOfLines={1}>{mealName(m)}</Text>
+                        <Text variant="micro" className="tabular-nums">
+                          {Math.round(m.calories)} kcal · P{Math.round(m.protein)} C{Math.round(m.carbs)} F{Math.round(m.fat)}
+                        </Text>
+                      </View>
+                      <Button label={delId === m.id ? "…" : "Remove"} variant="ghost" size="sm" disabled={delId != null} onPress={() => onDelete(m.id)} />
+                    </View>
+                  ))}
+                  <Button label={`+ Log ${slotLabel(s)}`} variant="secondary" size="sm" className="self-start" onPress={() => { setSlot(s); setLogOpen(true); }} />
+                </Card>
+              );
+            })}
+
+            {closeStatus ? (
+              <View className="flex-row items-center justify-center">
+                <Badge label={closeStatus === "closed" ? "Day closed" : "Already closed"} tone="success" />
               </View>
             ) : null}
-            {adaptive.driftFlag ? (
-              <Text variant="caption" className="text-warning">TDEE drift: ~{Math.round(adaptive.effectiveTdee)} vs {Math.round(adaptive.reportedTdee)}</Text>
-            ) : null}
-            <Text variant="micro">Informational — your targets are unchanged.</Text>
-          </Card>
-        ) : null}
 
-        {/* Adherence (the #69 feature) */}
-        {adherence ? (
-          <Card className="gap-2">
-            <Text variant="eyebrow">Weekly adherence</Text>
-            <ProgressBar pct={Math.min(adherence.ratio, 1)} color="#6ad4a0" />
-            <View className="flex-row justify-between">
-              <Text variant="caption" className="text-text-secondary tabular-nums">{adherence.weeklyActual} / {adherence.weeklyGoal} kcal</Text>
-              <Text variant="caption" className="text-warning tabular-nums">{adherence.status.replace("_", " ")} · {Math.round(adherence.ratio * 100)}%</Text>
+            <View className="flex-row gap-3">
+              <Button label="Log a drink" variant="secondary" className="flex-1" onPress={() => setDrinkOpen(true)} />
+              <Button label="Close day" variant="secondary" className="flex-1" onPress={() => setCloseOpen(true)} />
             </View>
-            {caloriesTrend.length >= 2 ? (
-              <View className="mt-1 gap-1">
-                <Text variant="micro" className="text-text-muted">14-day calories</Text>
-                <Sparkline data={caloriesTrend} color="#b17850" height={28} baseline />
-              </View>
+          </>
+        ) : (
+          <>
+            {/* Trend tab — adherence + 7-day table */}
+            {adherence ? (
+              <Card className="gap-2">
+                <Text variant="eyebrow">Weekly adherence</Text>
+                <ProgressBar pct={Math.min(adherence.ratio, 1)} color="#6ad4a0" />
+                <View className="flex-row justify-between">
+                  <Text variant="caption" className="text-text-secondary tabular-nums">{adherence.weeklyActual} / {adherence.weeklyGoal} kcal</Text>
+                  <Text variant="caption" className="text-warning tabular-nums">{adherence.status.replace(/_/g, " ")} · {Math.round(adherence.ratio * 100)}%</Text>
+                </View>
+                {caloriesTrend.length >= 2 ? (
+                  <View className="mt-1 gap-1">
+                    <Text variant="micro" className="text-text-muted">14-day calories</Text>
+                    <Sparkline data={caloriesTrend} color="#b17850" height={28} baseline />
+                  </View>
+                ) : null}
+              </Card>
             ) : null}
-          </Card>
-        ) : null}
 
-        {/* Meal slots (soma budgets are per-slot kcal) */}
-        <Card className="gap-2">
-          <Text variant="eyebrow">Per-meal kcal</Text>
-          {Object.entries(data?.slotBudgets ?? {})
-            .filter(([, v]) => (v?.calories ?? 0) > 0)
-            .map(([s, v]) => (
-              <View key={s} className="flex-row items-center justify-between border-b border-border-subtle py-2">
-                <Text variant="body" className="capitalize text-text-secondary">{s.replace("_", " ")}</Text>
-                <Text variant="body" className="tabular-nums text-text">{Math.round(v.calories)} kcal</Text>
-              </View>
-            ))}
-        </Card>
-
-        {closeStatus ? (
-          <View className="flex-row items-center justify-center gap-2">
-            <Badge label={closeStatus === "closed" ? "Day closed" : "Already closed"} tone="success" />
-          </View>
-        ) : null}
-
-        <Button label="Log a meal" variant="primary" onPress={() => setLogOpen(true)} />
-        <View className="flex-row gap-3">
-          <Button label="Log a drink" variant="secondary" className="flex-1" onPress={() => setDrinkOpen(true)} />
-          <Button label="Close day" variant="secondary" className="flex-1" onPress={() => setCloseOpen(true)} />
-        </View>
-        <Button label="Plan a refeed" variant="ghost" onPress={() => setRefeed(true)} />
+            {days.length ? (
+              <Card className="gap-0.5">
+                <View className="flex-row justify-between pb-1">
+                  <Text variant="eyebrow">7-day trend</Text>
+                  <Text variant="micro" className="text-text-muted">ate / burn · deficit</Text>
+                </View>
+                {days.map((d) => (
+                  <View key={d.date} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+                    <Text variant="caption" className={d.isToday ? "font-semibold text-teal" : "text-text-secondary"}>
+                      {niceDate(d.date).replace(/,.*/, "").slice(0, 3)} {d.date.slice(8)}
+                    </Text>
+                    <Text variant="caption" className="tabular-nums text-text-muted">{Math.round(d.ate)} / {Math.round(d.burn)}</Text>
+                    <Text variant="caption" className={`w-16 text-right tabular-nums ${d.deficit >= 0 ? "text-success" : "text-warm"}`}>
+                      {d.deficit > 0 ? "+" : ""}{Math.round(d.deficit)}
+                    </Text>
+                  </View>
+                ))}
+              </Card>
+            ) : (
+              <Card><Text variant="body" className="text-text-secondary">No trend data yet.</Text></Card>
+            )}
+          </>
+        )}
       </View>
 
-      {/* Log-meal modal — preset-based (soma logs saved meals, not free foods) */}
-      <Modal visible={logOpen} onClose={() => setLogOpen(false)} title="Log a meal">
-        <Text variant="caption" className="mb-2 text-text-secondary">Add a saved meal to a slot.</Text>
+      {/* Log-meal modal — preset picker, prefilled to the tapped slot */}
+      <Modal visible={logOpen} onClose={() => setLogOpen(false)} title={`Log ${slotLabel(slot)}`}>
         <PillGroup className="mb-3">
           {slots.map((s) => (
             <Pill key={s} label={slotLabel(s)} active={slot === s} onPress={() => setSlot(s)} />
           ))}
         </PillGroup>
         <ScrollView className="max-h-80">
-          {presets.map((p) => {
-            const done = loggedId === p.id;
-            return (
-              <View key={p.id} className="flex-row items-center gap-2 border-b border-border-subtle py-2.5">
-                <View className="flex-1">
-                  <Text variant="body" className="text-text" numberOfLines={1}>{p.name}</Text>
-                  <Text variant="micro" className="tabular-nums">
-                    {Math.round(p.total_calories)} kcal · P{Math.round(p.total_protein)} C{Math.round(p.total_carbs)} F{Math.round(p.total_fat)}
-                  </Text>
-                </View>
-                {done ? (
-                  <Badge label="Logged" tone="success" />
-                ) : (
-                  <Button
-                    label={busyId === p.id ? "…" : "Log"}
-                    variant="secondary"
-                    size="sm"
-                    disabled={busyId != null}
-                    onPress={() => onLog(p)}
-                  />
-                )}
+          {pickerPresets.map((p) => (
+            <View key={p.id} className="flex-row items-center gap-2 border-b border-border-subtle py-2.5">
+              <View className="flex-1">
+                <Text variant="body" className="text-text" numberOfLines={1}>{p.name}</Text>
+                <Text variant="micro" className="tabular-nums">
+                  {p.meal_slot ? slotLabel(p.meal_slot) + " · " : ""}{Math.round(p.total_calories)} kcal · P{Math.round(p.total_protein)} C{Math.round(p.total_carbs)} F{Math.round(p.total_fat)}
+                </Text>
               </View>
-            );
-          })}
+              <Button label={busyId === p.id ? "…" : "Log"} variant="secondary" size="sm" disabled={busyId != null} onPress={() => onLog(p)} />
+            </View>
+          ))}
         </ScrollView>
         <View className="mt-4 flex-row justify-end">
           <Button label="Done" variant="primary" onPress={() => setLogOpen(false)} />
         </View>
       </Modal>
 
-      {/* Log-drink modal — soma's alcohol tracking */}
+      {/* Log-drink modal */}
       <Modal visible={drinkOpen} onClose={() => setDrinkOpen(false)} title="Log a drink">
         <Text variant="caption" className="mb-2 text-text-secondary">One default serving is logged per tap.</Text>
         <ScrollView className="max-h-80">
-          {drinks.map((d) => {
-            const done = drinkLogged === d.key;
-            return (
-              <View key={d.key} className="flex-row items-center gap-2 border-b border-border-subtle py-2.5">
-                <View className="flex-1">
-                  <Text variant="body" className="text-text" numberOfLines={1}>{d.name}</Text>
-                  <Text variant="micro" className="tabular-nums">
-                    {Math.round((d.calories_per_100ml * d.default_ml) / 100)} kcal · {d.alcohol_pct}% · {d.default_ml}ml
-                  </Text>
-                </View>
-                {done ? (
-                  <Badge label="Logged" tone="success" />
-                ) : (
-                  <Button
-                    label={drinkBusy === d.key ? "…" : "Log"}
-                    variant="secondary"
-                    size="sm"
-                    disabled={drinkBusy != null}
-                    onPress={() => onLogDrink(d.key)}
-                  />
-                )}
+          {drinks.map((d) => (
+            <View key={d.key} className="flex-row items-center gap-2 border-b border-border-subtle py-2.5">
+              <View className="flex-1">
+                <Text variant="body" className="text-text" numberOfLines={1}>{d.name}</Text>
+                <Text variant="micro" className="tabular-nums">
+                  {Math.round((d.calories_per_100ml * d.default_ml) / 100)} kcal · {d.alcohol_pct}% · {d.default_ml}ml
+                </Text>
               </View>
-            );
-          })}
+              <Button label={drinkBusy === d.key ? "…" : "Log"} variant="secondary" size="sm" disabled={drinkBusy != null} onPress={() => onLogDrink(d.key)} />
+            </View>
+          ))}
         </ScrollView>
         <View className="mt-4 flex-row justify-end">
           <Button label="Done" variant="primary" onPress={() => setDrinkOpen(false)} />
@@ -274,14 +337,6 @@ export default function NutritionScreen() {
         <View className="mt-4 flex-row justify-end gap-2">
           <Button label="Cancel" variant="ghost" onPress={() => setCloseOpen(false)} />
           <Button label={closing ? "Closing…" : "Close day"} variant="primary" disabled={closing} onPress={onCloseDay} />
-        </View>
-      </Modal>
-
-      <Modal visible={refeed} onClose={() => setRefeed(false)} title="Plan a refeed">
-        <Text variant="body" className="text-text-secondary">A refeed raises carbs for a day to ease a long deficit.</Text>
-        <View className="mt-4 flex-row justify-end gap-2">
-          <Button label="Cancel" variant="ghost" onPress={() => setRefeed(false)} />
-          <Button label="Add refeed" variant="primary" onPress={() => setRefeed(false)} />
         </View>
       </Modal>
     </ScrollView>

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
-import { Text, Card, Sparkline } from "soma-style";
-import { useToday, fetchJson, usePullRefresh } from "../../lib/api";
+import { Text, Card, Badge, Sparkline } from "soma-style";
+import {
+  useToday,
+  useTraining,
+  useSomaPlan,
+  fetchJson,
+  usePullRefresh,
+  todayLocal,
+} from "../../lib/api";
 
 interface OverviewTrends {
   steps: number[];
@@ -27,12 +34,88 @@ function useOverviewTrends() {
   return trends;
 }
 
+interface WeightRow { date: string; weight_kg: number | null; bmi: number | null; body_fat_pct: number | null }
+/** Last 30 days of weigh-ins (ascending) for the weight glance + sparkline. */
+function useWeightTrend() {
+  const [rows, setRows] = useState<WeightRow[]>([]);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<WeightRow[]>("/api/health/weight?days=30")
+      .then((d) => alive && setRows(Array.isArray(d) ? d : []))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return rows;
+}
+
+interface StatPoint { date: string; value: number | null }
+interface StatSeries { current: StatPoint[]; summary: { current_avg: number | null } }
+/** Last 7 days of sleep score for the sleep glance. */
+function useSleepGlance() {
+  const [s, setS] = useState<StatSeries | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<StatSeries>("/api/stats/sleep?range=7d")
+      .then((d) => alive && setS(d))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return s;
+}
+
+const TL_TONE: Record<string, "success" | "warm" | "danger" | "teal"> = {
+  green: "success",
+  amber: "warm",
+  yellow: "warm",
+  red: "danger",
+};
+const TL_COLOR: Record<string, string> = {
+  green: "#6ad4a0",
+  amber: "#e0a458",
+  yellow: "#e0a458",
+  red: "#e06060",
+};
+
+function formDescriptor(tsb: number): string {
+  if (tsb >= 15) return "Fresh — well recovered, ready for a hard session.";
+  if (tsb >= 5) return "Balanced — moderate freshness.";
+  if (tsb >= -10) return "Productive — building fitness under load.";
+  return "Fatigued — prioritise recovery.";
+}
+
 export default function OverviewScreen() {
   const { data, error, refetch } = useToday();
-  const { refreshing, onRefresh } = usePullRefresh(refetch);
+  const { data: training, refetch: refetchTraining } = useTraining(todayLocal());
+  const { data: plan, refetch: refetchPlan } = useSomaPlan(todayLocal());
+  const weight = useWeightTrend();
+  const sleep = useSleepGlance();
   const trends = useOverviewTrends();
+  const { refreshing, onRefresh } = usePullRefresh(() => {
+    refetch();
+    refetchTraining();
+    refetchPlan();
+  });
+
+  const readiness = training?.readiness;
+  const tsb = training?.pmc?.tsb ?? null;
 
   const km = data?.total_distance_meters ? (data.total_distance_meters / 1000).toFixed(1) : "—";
+
+  // Weight glance: latest value + 30-day delta + spark
+  const wSeries = weight.map((r) => Number(r.weight_kg)).filter((v) => isFinite(v));
+  const wLatest = wSeries.length ? wSeries[wSeries.length - 1] : null;
+  const wDelta = wSeries.length >= 2 ? wLatest! - wSeries[0] : null;
+  const bfLatest = weight.length ? weight[weight.length - 1].body_fat_pct : null;
+
+  // Sleep glance: latest night's score + 7-day series
+  const sleepSeries = (sleep?.current ?? []).map((p) => Number(p.value)).filter((v) => isFinite(v));
+  const sleepLatest = sleepSeries.length ? sleepSeries[sleepSeries.length - 1] : null;
+  const sleepAvg = sleep?.summary?.current_avg ?? null;
+
   const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string }[] = [
     { label: "Steps", value: (data?.total_steps ?? 0).toLocaleString(), sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1" },
     { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850" },
@@ -51,9 +134,67 @@ export default function OverviewScreen() {
       <View className="w-full max-w-3xl gap-4">
         <View className="gap-1">
           <Text variant="headline">Overview</Text>
-          <Text variant="caption" className="text-text-secondary">Latest health metrics</Text>
+          <Text variant="caption" className="text-text-secondary">Today at a glance</Text>
         </View>
+
         {error ? <Card><Text variant="body" className="text-danger">API: {error}</Text></Card> : null}
+
+        {/* Readiness hero — the "what should I do today" signal */}
+        {readiness ? (
+          <Card className="gap-3">
+            <View
+              className="rounded-xl px-4 py-4 gap-2"
+              style={{ backgroundColor: (TL_COLOR[readiness.traffic_light] ?? "#77c8d1") + "1f" }}
+            >
+              <View className="flex-row items-center justify-between">
+                <Text variant="eyebrow" className="text-text-secondary">Readiness</Text>
+                <Badge label={readiness.traffic_light.toUpperCase()} tone={TL_TONE[readiness.traffic_light] ?? "teal"} />
+              </View>
+              <View className="flex-row items-end gap-2">
+                <Text variant="display" style={{ color: TL_COLOR[readiness.traffic_light] ?? "#77c8d1" }}>
+                  {readiness.composite_score == null ? "—" : Math.round(readiness.composite_score * 100)}
+                </Text>
+                <Text variant="caption" className="text-text-muted mb-1">readiness score</Text>
+              </View>
+              {tsb != null ? (
+                <Text variant="micro" className="text-text-secondary">
+                  Form {tsb >= 0 ? "+" : ""}{tsb.toFixed(0)} · {formDescriptor(tsb)}
+                </Text>
+              ) : null}
+            </View>
+          </Card>
+        ) : null}
+
+        {/* Cross-domain glance row */}
+        <View className="flex-row flex-wrap gap-3">
+          <Card className="min-w-[30%] flex-1 gap-1">
+            <Text variant="eyebrow">Kcal left</Text>
+            <Text variant="headline" className="text-teal">
+              {plan?.remaining?.calories != null ? Math.round(plan.remaining.calories) : "—"}
+            </Text>
+            <Text variant="micro">
+              {plan?.plan ? `of ${Math.round(plan.plan.target_calories)} target` : "no plan today"}
+            </Text>
+          </Card>
+          <Card className="min-w-[30%] flex-1 gap-1">
+            <Text variant="eyebrow">Sleep</Text>
+            <Text variant="headline" className="text-indigo">{sleepLatest != null ? sleepLatest.toFixed(0) : "—"}</Text>
+            <Text variant="micro">{sleepAvg != null ? `7d avg ${sleepAvg.toFixed(0)}` : "score"}</Text>
+          </Card>
+          <Card className="min-w-[30%] flex-1 gap-1">
+            <Text variant="eyebrow">Weight</Text>
+            <Text variant="headline" className="text-warm">{wLatest != null ? wLatest.toFixed(1) : "—"}</Text>
+            <Text variant="micro">
+              {wDelta != null ? `${wDelta >= 0 ? "+" : ""}${wDelta.toFixed(1)} kg/30d` : bfLatest != null ? `${bfLatest.toFixed(1)}% bf` : "kg"}
+            </Text>
+            {wSeries.length >= 2 ? (
+              <View className="mt-1"><Sparkline data={wSeries} color="#b17850" height={22} baseline /></View>
+            ) : null}
+          </Card>
+        </View>
+
+        {/* Today's health KPIs */}
+        <Text variant="eyebrow" className="text-text-muted mt-1">Today's metrics</Text>
         <View className="flex-row flex-wrap gap-3">
           {stats.map((s) => (
             <Card key={s.label} className="min-w-[46%] flex-1 gap-1">

--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
 import { fetchJson, usePullRefresh } from "../../lib/api";
+import { RunningMileage } from "../../components/running-mileage";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -312,6 +313,9 @@ export default function RunningScreen() {
             </View>
           </Card>
         ) : null}
+
+        {/* Monthly mileage bar chart (web parity) */}
+        <RunningMileage mileage={trends?.mileage} />
 
         {/* Training Intensity Distribution (approximated with ProgressBars) */}
         {zones.length > 0 ? (

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh } from "../../lib/api";
+import { fetchJson, usePullRefresh, useSleepSummary } from "../../lib/api";
+import { SleepDashboard } from "../../components/sleep-dashboard";
 
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
@@ -98,6 +99,7 @@ export default function SleepScreen() {
   const [range, setRange] = useState<Range>("30d");
   const { sleep, rhr, stress, battery, recovery, loading, error, refetch } =
     useSleepRecovery(range);
+  const { data: sleepSum } = useSleepSummary(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const lastSleep = last(sleep);
@@ -208,6 +210,9 @@ export default function SleepScreen() {
             </Card>
           ))}
         </View>
+
+        {/* Sleep dashboard — last night + stages + score (new /api/sleep/summary) */}
+        <SleepDashboard summary={sleepSum} />
 
         {/* Sleep duration trend (bar approximation) */}
         <Card className="gap-3">

--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -1,7 +1,22 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { useTraining, useCalibration, toggleCalibration, fetchJson, usePullRefresh } from "../../lib/api";
+import {
+  useTraining,
+  useCalibration,
+  useForwardSim,
+  useTrainingGraph,
+  setDayCompletion,
+  toggleCalibration,
+  fetchJson,
+  usePullRefresh,
+  type PlanDay,
+} from "../../lib/api";
+import { TrainingSchedule } from "../../components/training-schedule";
+import { TrainingPaces } from "../../components/training-paces";
+import { RaceProtocol } from "../../components/race-protocol";
+import { TrainingTrends } from "../../components/training-trends";
+import { PaceComputation } from "../../components/pace-computation";
 
 /** VO2max trend (last year, chronological) from the shared stats endpoint. */
 function useVo2Trend() {
@@ -40,13 +55,32 @@ const tsbPct = (tsb: number) => Math.max(0, Math.min(1, (tsb + 30) / 60));
 export default function TrainingScreen() {
   const { data, error, refetch } = useTraining(todayISO());
   const { cal, refetch: refetchCal } = useCalibration(todayISO());
+  const { data: sim, refetch: refetchSim } = useForwardSim(todayISO());
+  const { nodes: graphNodes } = useTrainingGraph(todayISO());
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
     refetchCal();
+    refetchSim();
   });
-  const pmc = data?.pmc;
+
+  // Optimistic completion overrides so the checkbox flips instantly (the
+  // forward-sim recompute is heavy — we don't refetch on every tap).
+  const [doneOverride, setDoneOverride] = useState<Record<number, boolean>>({});
+  const planDays: PlanDay[] = (sim?.planDays ?? []).map((d) =>
+    d.id in doneOverride ? { ...d, completed: doneOverride[d.id] } : d,
+  );
+  async function onToggleComplete(day: PlanDay) {
+    const next = !day.completed;
+    setDoneOverride((m) => ({ ...m, [day.id]: next }));
+    const ok = await setDayCompletion(day.id, next, day.actualDistanceKm);
+    if (!ok) setDoneOverride((m) => ({ ...m, [day.id]: day.completed })); // revert on failure
+  }
+  // breakdown can return null pmc on days the daily cron hasn't filled; the
+  // forward-sim always computes it, so fall back to that (same {ctl,atl,tsb} shape).
+  const pmc = data?.pmc ?? sim?.pmc ?? null;
   const fit = data?.fitness;
   const readiness = data?.readiness;
+  const vdot = fit?.vdot_adjusted ?? sim?.fitness?.vdotAdjusted ?? null;
   const vo2Trend = useVo2Trend();
 
   async function onToggleWeighting(mode: "Adaptive" | "Equal") {
@@ -110,6 +144,15 @@ export default function TrainingScreen() {
           </Text>
         </Card>
 
+        {/* Training plan schedule — weeks → days → workout steps (Tier 1 parity) */}
+        {planDays.length ? (
+          <TrainingSchedule
+            planDays={planDays}
+            today={sim?.today ?? todayISO()}
+            onToggleComplete={onToggleComplete}
+          />
+        ) : null}
+
         <View className="flex-row gap-3">
           <Card className="flex-1 gap-1">
             <Text variant="eyebrow">VO2max</Text>
@@ -128,6 +171,12 @@ export default function TrainingScreen() {
           </Card>
         </View>
 
+        {/* Training paces (VDOT → Daniels zones + A/B/C HM goals) */}
+        <TrainingPaces vdot={vdot} />
+
+        {/* Pace computation breakdown — mobile replacement for the web DAG */}
+        <PaceComputation nodes={graphNodes} />
+
         {vo2Trend.length >= 2 ? (
           <Card className="gap-2">
             <View className="flex-row items-center justify-between">
@@ -137,6 +186,9 @@ export default function TrainingScreen() {
             <Sparkline data={vo2Trend} color="#77c8d1" height={44} baseline />
           </Card>
         ) : null}
+
+        {/* Compact model-vs-Garmin comparison trends (Tier 2/3 adapted) */}
+        <TrainingTrends comparison={sim?.comparison} />
 
         {readiness ? (
           <Card className="gap-2">
@@ -195,6 +247,9 @@ export default function TrainingScreen() {
             </Text>
           </Card>
         ) : null}
+
+        {/* Race day protocol */}
+        <RaceProtocol />
       </View>
     </ScrollView>
   );

--- a/universal/src/components/pace-computation.tsx
+++ b/universal/src/components/pace-computation.tsx
@@ -1,0 +1,89 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import type { GraphNode } from "../lib/api";
+import { paceStr } from "../lib/vdot";
+
+/**
+ * Mobile-native replacement for the web's draggable computation-graph DAG.
+ * Shows the same signals → factors → adjusted-pace flow as a compact breakdown:
+ * raw signals, then the multiplicative factors that bend today's pace.
+ */
+export function PaceComputation({ nodes }: { nodes: Record<string, GraphNode> }) {
+  const val = (id: string): number | null => {
+    const v = nodes[id]?.value;
+    return v == null || !isFinite(Number(v)) ? null : Number(v);
+  };
+
+  const adjusted = val("adjusted_pace"); // seconds/km
+  const vdot = val("vdot");
+
+  const factors = [
+    { label: "Readiness", v: val("readiness_factor"), color: "#6ad4a0" },
+    { label: "Fatigue", v: val("fatigue_factor"), color: "#e0a458" },
+    { label: "Weight", v: val("weight_factor"), color: "#b17850" },
+    { label: "Intensity", v: val("slider_factor"), color: "#6366b0" },
+  ].filter((f) => f.v != null);
+
+  const signals = [
+    { label: "HRV", v: val("hrv_z"), z: true },
+    { label: "Sleep", v: val("sleep_z"), z: true },
+    { label: "RHR", v: val("rhr_z"), z: true },
+    { label: "Body Batt", v: val("bb_z"), z: true },
+    { label: "TSB", v: val("tsb"), z: false },
+  ].filter((s) => s.v != null);
+
+  if (adjusted == null && !factors.length) return null;
+
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Pace computation</Text>
+        {vdot != null ? <Text variant="micro" className="tabular-nums text-text-muted">VDOT {vdot.toFixed(1)}</Text> : null}
+      </View>
+
+      {/* adjusted (output) pace */}
+      {adjusted != null ? (
+        <View className="flex-row items-end gap-2">
+          <Text variant="display" className="text-teal">{paceStr(adjusted)}</Text>
+          <Text variant="caption" className="text-text-muted mb-1">/km adjusted</Text>
+        </View>
+      ) : null}
+
+      {/* multiplicative factors that bend the base pace */}
+      <View className="gap-2">
+        {factors.map((f) => {
+          const pct = Math.round(((f.v as number) - 1) * 100); // deviation from neutral
+          return (
+            <View key={f.label} className="flex-row items-center justify-between">
+              <View className="flex-row items-center gap-2">
+                <View className="h-2 w-2 rounded-full" style={{ backgroundColor: f.color }} />
+                <Text variant="body" className="text-text-secondary">{f.label}</Text>
+              </View>
+              <Text variant="body" className="tabular-nums text-text">
+                ×{(f.v as number).toFixed(2)}
+                <Text variant="micro" className="text-text-muted">{pct === 0 ? " (neutral)" : ` (${pct > 0 ? "+" : ""}${pct}%)`}</Text>
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+
+      {/* raw readiness signals feeding the factors */}
+      {signals.length ? (
+        <View className="flex-row flex-wrap gap-2 border-t border-border-subtle pt-2.5">
+          {signals.map((s) => (
+            <View key={s.label} className="rounded-full bg-surface-subtle px-2.5 py-1">
+              <Text variant="micro" className="tabular-nums text-text-secondary">
+                {s.label} {(s.v as number) >= 0 ? "+" : ""}{(s.v as number).toFixed(s.z ? 2 : 0)}{s.z ? " z" : ""}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      <Text variant="micro" className="text-text-muted">
+        Base VDOT pace bent by readiness, fatigue and weight to today&apos;s target.
+      </Text>
+    </Card>
+  );
+}

--- a/universal/src/components/race-protocol.tsx
+++ b/universal/src/components/race-protocol.tsx
@@ -1,0 +1,51 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+
+/* Ported verbatim from web/components/race-day-protocol.tsx so the app shows the
+   same race-day plan. Static content. */
+interface Step { time: string; action: string; section: "prep" | "morning" | "race" }
+const PROTOCOL: Step[] = [
+  { time: "D-1", action: "Carb load: 8-10 g/kg (~640-800g CHO). Pasta, rice, bread, sports drink. Avoid fiber/fat.", section: "prep" },
+  { time: "D-1 PM", action: "Lay out race kit. Pin bib. Charge watch. Set 2 alarms.", section: "prep" },
+  { time: "T-3.5h", action: "Wake (4:30 AM for 8:00 start).", section: "morning" },
+  { time: "T-3h", action: "Breakfast: 120-160g CHO — toast + jam + banana + sports drink. No new foods.", section: "morning" },
+  { time: "T-1.5h", action: "Coffee (240mg caffeine / 3 mg/kg). Bathroom stop.", section: "morning" },
+  { time: "T-1h", action: "Arrive venue. Light jog 5 min. Dynamic stretches.", section: "morning" },
+  { time: "T-30m", action: "Stop drinking. Find start corral.", section: "morning" },
+  { time: "T-15m", action: "Strides: 3x15s. Shake out legs.", section: "morning" },
+  { time: "Start", action: "B-pace (4:44/km). Stay controlled. DO NOT chase A-goal.", section: "race" },
+  { time: "5K", action: "Check: breathing controlled? Effort sustainable? Hold B-pace.", section: "race" },
+  { time: "~40m", action: "GEL #1 (caffeinated, ~25g CHO + 50mg caffeine) with water.", section: "race" },
+  { time: "10K", action: "If strong + breathing easy → shift to A-pace (4:30/km). If tired → hold B.", section: "race" },
+  { time: "~75m", action: "GEL #2 (regular, ~25g CHO) with water. Skip if <10 min to finish.", section: "race" },
+  { time: "15K", action: "Commit to current pace. No acceleration if not already at A.", section: "race" },
+  { time: "20K", action: "Last push. If feeling good, slight negative split.", section: "race" },
+  { time: "Finish", action: "Empty the tank last 1.1 km.", section: "race" },
+];
+const SECTION_LABEL: Record<Step["section"], string> = {
+  prep: "Day before",
+  morning: "Race morning",
+  race: "Race",
+};
+const SECTIONS: Step["section"][] = ["prep", "morning", "race"];
+
+export function RaceProtocol() {
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center gap-2">
+        <Text variant="eyebrow">🏆 Race day protocol</Text>
+      </View>
+      {SECTIONS.map((sec) => (
+        <View key={sec} className="gap-1.5">
+          <Text variant="micro" className="text-text-muted uppercase">{SECTION_LABEL[sec]}</Text>
+          {PROTOCOL.filter((s) => s.section === sec).map((s, i) => (
+            <View key={i} className="flex-row gap-2">
+              <Text variant="micro" className="tabular-nums text-teal w-14 text-right">{s.time}</Text>
+              <Text variant="micro" className="text-text-secondary flex-1">{s.action}</Text>
+            </View>
+          ))}
+        </View>
+      ))}
+    </Card>
+  );
+}

--- a/universal/src/components/running-mileage.tsx
+++ b/universal/src/components/running-mileage.tsx
@@ -1,0 +1,35 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+
+/** Monthly mileage bar chart (last N months), peak month highlighted — the
+    web's dedicated monthly-mileage chart, adapted to a compact mobile bar row. */
+export function RunningMileage({ mileage }: { mileage: number[] | null | undefined }) {
+  const data = (mileage ?? []).filter((v) => isFinite(v));
+  if (data.length < 2) return null;
+  const max = Math.max(...data) || 1;
+  const maxIdx = data.indexOf(max);
+  const total = data.reduce((a, b) => a + b, 0);
+
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Monthly mileage</Text>
+        <Text variant="micro" className="text-text-muted">last {data.length} mo</Text>
+      </View>
+      <View className="h-24 flex-row items-end gap-1">
+        {data.map((m, i) => (
+          <View key={i} className="flex-1 items-center justify-end self-stretch">
+            <View
+              className="w-full rounded-t-sm"
+              style={{ height: `${Math.max(3, (m / max) * 100)}%`, backgroundColor: i === maxIdx ? "#77c8d1" : "#2f4a58" }}
+            />
+          </View>
+        ))}
+      </View>
+      <View className="flex-row justify-between">
+        <Text variant="micro" className="text-text-muted">peak {Math.round(max)} km</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(total)} km total</Text>
+      </View>
+    </Card>
+  );
+}

--- a/universal/src/components/sleep-dashboard.tsx
+++ b/universal/src/components/sleep-dashboard.tsx
@@ -1,0 +1,130 @@
+import { View } from "react-native";
+import { Text, Card, Sparkline } from "soma-style";
+import type { SleepSummary, SleepNight } from "../lib/api";
+
+const DEEP = "#4f46e5";
+const LIGHT = "#a5b4fc";
+const REM = "#c084fc";
+const AWAKE = "#f87171";
+
+function hm(sec: number | null | undefined): string {
+  if (sec == null) return "—";
+  const h = Math.floor(sec / 3600);
+  const m = Math.round((sec % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+function shortDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+}
+
+/** Horizontal stacked stage bar (deep/light/rem/awake proportions of one night). */
+function StageBar({ n, height = 14 }: { n: SleepNight; height?: number }) {
+  const total = (n.deep ?? 0) + (n.light ?? 0) + (n.rem ?? 0) + (n.awake ?? 0);
+  if (total <= 0) return null;
+  const seg = (v: number | null, c: string) =>
+    v ? <View key={c} style={{ width: `${(v / total) * 100}%`, backgroundColor: c }} /> : null;
+  return (
+    <View className="flex-row overflow-hidden rounded-md" style={{ height }}>
+      {seg(n.deep, DEEP)}
+      {seg(n.light, LIGHT)}
+      {seg(n.rem, REM)}
+      {seg(n.awake, AWAKE)}
+    </View>
+  );
+}
+
+/** Per-night stacked stage columns (last N nights), heights scaled to max total. */
+function StagesTrend({ nights }: { nights: SleepNight[] }) {
+  const data = nights.filter((n) => (n.total ?? 0) > 0).slice(-30);
+  if (data.length < 2) return null;
+  const maxTotal = Math.max(...data.map((n) => n.total ?? 0)) || 1;
+  return (
+    <View className="h-28 flex-row items-end gap-0.5">
+      {data.map((n, i) => {
+        const total = n.total ?? 0;
+        const colH = (total / maxTotal) * 100;
+        const seg = (v: number | null, c: string) =>
+          v ? <View key={c} style={{ height: `${(v / total) * 100}%`, backgroundColor: c }} /> : null;
+        return (
+          <View key={i} className="flex-1 justify-end self-stretch">
+            <View className="w-full overflow-hidden rounded-t-sm" style={{ height: `${Math.max(3, colH)}%` }}>
+              {/* stacked top→bottom: awake, rem, light, deep (deep at the base) */}
+              {seg(n.awake, AWAKE)}
+              {seg(n.rem, REM)}
+              {seg(n.light, LIGHT)}
+              {seg(n.deep, DEEP)}
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function Legend() {
+  const items: [string, string][] = [["Deep", DEEP], ["Light", LIGHT], ["REM", REM], ["Awake", AWAKE]];
+  return (
+    <View className="flex-row flex-wrap gap-3">
+      {items.map(([label, c]) => (
+        <View key={label} className="flex-row items-center gap-1">
+          <View className="h-2 w-2 rounded-full" style={{ backgroundColor: c }} />
+          <Text variant="micro" className="text-text-muted">{label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+/** Sleep dashboard: last-night detail + stages trend + score trend. Fed by /api/sleep/summary. */
+export function SleepDashboard({ summary }: { summary: SleepSummary | null | undefined }) {
+  if (!summary) return null;
+  const ln = summary.lastNight;
+  const scores = summary.trend.map((n) => n.score).filter((v): v is number => v != null);
+
+  return (
+    <View className="gap-4">
+      {ln ? (
+        <Card className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Last night</Text>
+            <Text variant="micro" className="text-text-muted">{shortDate(ln.date)}</Text>
+          </View>
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="text-indigo">{hm(ln.total)}</Text>
+            {ln.score != null ? <Text variant="caption" className="text-text-muted mb-1">score {ln.score}</Text> : null}
+          </View>
+          <StageBar n={ln} />
+          <View className="flex-row flex-wrap gap-x-5 gap-y-1">
+            <Text variant="micro" className="text-text-secondary">Deep {hm(ln.deep)}</Text>
+            <Text variant="micro" className="text-text-secondary">REM {hm(ln.rem)}</Text>
+            <Text variant="micro" className="text-text-secondary">Light {hm(ln.light)}</Text>
+            {ln.hr != null ? <Text variant="micro" className="text-text-secondary">HR {Math.round(ln.hr)} bpm</Text> : null}
+            {ln.spo2 != null ? <Text variant="micro" className="text-text-secondary">SpO₂ {Math.round(ln.spo2)}%</Text> : null}
+          </View>
+        </Card>
+      ) : null}
+
+      <Card className="gap-2">
+        <View className="flex-row items-center justify-between">
+          <Text variant="eyebrow">Sleep stages</Text>
+          <Text variant="micro" className="text-text-muted">last {Math.min(30, summary.trend.length)} nights</Text>
+        </View>
+        <StagesTrend nights={summary.trend} />
+        <Legend />
+      </Card>
+
+      {scores.length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Sleep score</Text>
+            <Text variant="micro" className="tabular-nums text-text-muted">
+              avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"}
+            </Text>
+          </View>
+          <Sparkline data={scores} color="#a5b4fc" height={40} baseline />
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/components/training-paces.tsx
+++ b/universal/src/components/training-paces.tsx
@@ -1,0 +1,61 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import { pacesForVdot, paceStr, timeStr, hmPace } from "../lib/vdot";
+
+/** VDOT → training paces + A/B/C half-marathon goals, matching the web card. */
+export function TrainingPaces({ vdot }: { vdot: number | null | undefined }) {
+  if (vdot == null || !isFinite(vdot)) return null;
+  const p = pacesForVdot(vdot);
+  const b = hmPace(p); // predicted HM pace
+  const zones: { label: string; pace: string; color: string }[] = [
+    { label: "Easy", pace: paceStr(p.easy), color: "#6ad4a0" },
+    { label: "Marathon", pace: paceStr(p.marathon), color: "#6aa0e0" },
+    { label: "Threshold", pace: paceStr(p.threshold), color: "#e0a458" },
+    { label: "Interval", pace: paceStr(p.interval), color: "#e06060" },
+    { label: "Repetition", pace: paceStr(p.repetition), color: "#c77dff" },
+  ];
+  const goals: { tag: string; label: string; pace: number }[] = [
+    { tag: "A", label: "Threshold push", pace: p.threshold },
+    { tag: "B", label: "Predicted HM", pace: b },
+    { tag: "C", label: "Conservative (+3%)", pace: b * 1.03 },
+  ];
+
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Training paces</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">VDOT {vdot.toFixed(1)}</Text>
+      </View>
+
+      <View className="gap-2">
+        {zones.map((z) => (
+          <View key={z.label} className="flex-row items-center justify-between">
+            <View className="flex-row items-center gap-2">
+              <View className="h-2 w-2 rounded-full" style={{ backgroundColor: z.color }} />
+              <Text variant="body" className="text-text-secondary">{z.label}</Text>
+            </View>
+            <Text variant="body" className="tabular-nums text-text">{z.pace}<Text variant="micro" className="text-text-muted"> /km</Text></Text>
+          </View>
+        ))}
+      </View>
+
+      <View className="gap-2 border-t border-border-subtle pt-2.5">
+        <View className="flex-row items-center justify-between">
+          <Text variant="micro" className="text-text-muted">Half-marathon goals</Text>
+          <Text variant="micro" className="tabular-nums text-text-muted">pred. {timeStr(p.hmSeconds)}</Text>
+        </View>
+        {goals.map((g) => (
+          <View key={g.tag} className="flex-row items-center justify-between">
+            <View className="flex-row items-center gap-2">
+              <View className="h-5 w-5 items-center justify-center rounded-full bg-surface-subtle">
+                <Text variant="micro" className="text-teal">{g.tag}</Text>
+              </View>
+              <Text variant="body" className="text-text-secondary">{g.label}</Text>
+            </View>
+            <Text variant="body" className="tabular-nums text-text">{paceStr(g.pace)}<Text variant="micro" className="text-text-muted"> /km</Text></Text>
+          </View>
+        ))}
+      </View>
+    </Card>
+  );
+}

--- a/universal/src/components/training-schedule.tsx
+++ b/universal/src/components/training-schedule.tsx
@@ -1,0 +1,202 @@
+import { useMemo, useState } from "react";
+import { View, Pressable } from "react-native";
+import { Text, Card } from "soma-style";
+import type { PlanDay, WorkoutStep } from "../lib/api";
+
+/* Run-type → colour, matching the web training plan (easy green, quality orange,
+   long blue, rest grey). Used for the small type pill on each day row. */
+const RUN_COLOR: Record<string, string> = {
+  easy: "#6ad4a0",
+  recovery: "#6ad4a0",
+  tempo: "#e0a458",
+  threshold: "#e0a458",
+  intervals: "#e0a458",
+  interval: "#e0a458",
+  repetition: "#e0a458",
+  long: "#6aa0e0",
+  race: "#c77dff",
+  rest: "#5a7a8a",
+};
+const runColor = (t: string) => RUN_COLOR[t?.toLowerCase()] ?? "#77c8d1";
+
+function shortDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(y, (m ?? 1) - 1, d ?? 1);
+  return dt.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+}
+
+/** One workout step rendered as "warmup · Easy run · 6.5 km · Z2". */
+function stepLine(s: WorkoutStep): string {
+  const parts: string[] = [];
+  if (s.step_type) parts.push(s.step_type);
+  if (s.description) parts.push(s.description);
+  if (s.duration_type === "distance" && s.duration_value != null) {
+    parts.push(s.duration_value >= 1000 ? `${(s.duration_value / 1000).toFixed(s.duration_value % 1000 ? 1 : 0)} km` : `${s.duration_value} m`);
+  } else if (s.duration_type === "time" && s.duration_value != null) {
+    parts.push(`${Math.round(s.duration_value / 60)} min`);
+  }
+  if (s.hr_zone != null) parts.push(`Z${s.hr_zone}`);
+  return parts.join(" · ");
+}
+
+function DayRow({
+  day,
+  isToday,
+  onToggleComplete,
+}: {
+  day: PlanDay;
+  isToday: boolean;
+  onToggleComplete: (day: PlanDay) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const steps = day.workoutSteps ?? [];
+  const pushed = day.garminPushStatus === "pushed" || day.garminPushStatus === "success";
+  const pending = day.garminPushStatus === "pending";
+
+  return (
+    <View className="border-b border-border-subtle py-2.5">
+      <View className="flex-row items-center gap-3">
+        {/* completion checkbox */}
+        <Pressable
+          onPress={() => onToggleComplete(day)}
+          hitSlop={8}
+          className="h-6 w-6 items-center justify-center rounded-full border"
+          style={{
+            borderColor: day.completed ? "#6ad4a0" : "#2a3a48",
+            backgroundColor: day.completed ? "#6ad4a022" : "transparent",
+          }}
+        >
+          {day.completed ? <Text style={{ color: "#6ad4a0", fontSize: 13 }}>✓</Text> : null}
+        </Pressable>
+
+        {/* main tap target: expand steps */}
+        <Pressable className="flex-1" onPress={() => steps.length && setOpen((o) => !o)}>
+          <View className="flex-row items-center gap-2">
+            <Text variant="micro" className={isToday ? "text-teal" : "text-text-muted"}>
+              {isToday ? "TODAY" : shortDate(day.dayDate)}
+            </Text>
+            <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: runColor(day.runType) + "22" }}>
+              <Text variant="micro" style={{ color: runColor(day.runType) }}>{day.runType}</Text>
+            </View>
+            {day.gymWorkout ? (
+              <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: "#6366b022" }}>
+                <Text variant="micro" style={{ color: "#8a8dd0" }}>🏋 {day.gymWorkout}</Text>
+              </View>
+            ) : null}
+          </View>
+          <View className="flex-row items-center justify-between mt-0.5">
+            <Text
+              variant="body"
+              className={day.completed ? "text-text-muted line-through" : "text-text"}
+              numberOfLines={1}
+              style={{ flex: 1 }}
+            >
+              {day.runTitle}
+            </Text>
+            {day.targetDistanceKm != null ? (
+              <Text variant="caption" className="tabular-nums text-text-secondary ml-2">{day.targetDistanceKm} km</Text>
+            ) : null}
+          </View>
+          {/* garmin sync status */}
+          {pushed ? (
+            <Text variant="micro" className="text-success mt-0.5">✓ On Garmin</Text>
+          ) : pending ? (
+            <Text variant="micro" className="text-warning mt-0.5">⏳ Syncing to Garmin</Text>
+          ) : null}
+        </Pressable>
+      </View>
+
+      {/* expandable workout steps */}
+      {open && steps.length ? (
+        <View className="mt-2 ml-9 gap-1">
+          {steps.map((s, i) => (
+            <View key={i} className="flex-row items-start gap-2">
+              <View className="mt-1.5 h-1.5 w-1.5 rounded-full" style={{ backgroundColor: runColor(day.runType) }} />
+              <Text variant="micro" className="text-text-secondary flex-1">{stepLine(s)}</Text>
+            </View>
+          ))}
+          {day.gymNotes ? <Text variant="micro" className="text-text-muted mt-1">Gym: {day.gymNotes}</Text> : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export function TrainingSchedule({
+  planDays,
+  today,
+  onToggleComplete,
+}: {
+  planDays: PlanDay[];
+  today: string;
+  onToggleComplete: (day: PlanDay) => void;
+}) {
+  // group by week
+  const weeks = useMemo(() => {
+    const map = new Map<number, PlanDay[]>();
+    for (const d of planDays) {
+      const arr = map.get(d.weekNumber) ?? [];
+      arr.push(d);
+      map.set(d.weekNumber, arr);
+    }
+    return [...map.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([week, days]) => ({ week, days: days.sort((a, b) => a.dayDate.localeCompare(b.dayDate)) }));
+  }, [planDays]);
+
+  const currentWeek = useMemo(
+    () => planDays.find((d) => d.dayDate === today)?.weekNumber ?? weeks[0]?.week,
+    [planDays, today, weeks],
+  );
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set(currentWeek != null ? [currentWeek] : []));
+
+  const toggleWeek = (w: number) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(w) ? next.delete(w) : next.add(w);
+      return next;
+    });
+
+  if (!planDays.length) return null;
+
+  return (
+    <View className="gap-3">
+      <Text variant="eyebrow" className="text-text-muted">Training plan</Text>
+      {weeks.map(({ week, days }) => {
+        const done = days.filter((d) => d.completed).length;
+        const runDays = days.filter((d) => d.runType !== "rest").length;
+        const km = days.reduce((s, d) => s + (d.targetDistanceKm ?? 0), 0);
+        const pct = days.length ? done / days.length : 0;
+        const isOpen = expanded.has(week);
+        const isCurrent = week === currentWeek;
+        return (
+          <Card key={week} className="gap-2">
+            <Pressable onPress={() => toggleWeek(week)} className="flex-row items-center justify-between">
+              <View className="flex-row items-center gap-2">
+                {isCurrent ? <View className="h-2 w-2 rounded-full" style={{ backgroundColor: "#77c8d1" }} /> : null}
+                <Text variant="body" className="text-text">Week {week}</Text>
+              </View>
+              <View className="flex-row items-center gap-2">
+                <Text variant="micro" className="tabular-nums text-text-muted">
+                  {km.toFixed(0)} km · {runDays} runs · {done}/{days.length} done
+                </Text>
+                <Text variant="micro" className="text-text-muted">{isOpen ? "▲" : "▼"}</Text>
+              </View>
+            </Pressable>
+            {/* completion progress */}
+            <View className="h-1.5 rounded-full bg-surface-subtle overflow-hidden">
+              <View className="h-full rounded-full" style={{ width: `${Math.round(pct * 100)}%`, backgroundColor: pct >= 1 ? "#6ad4a0" : "#6366b0" }} />
+            </View>
+            {isOpen ? (
+              <View className="mt-1">
+                {days.map((d) => (
+                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} onToggleComplete={onToggleComplete} />
+                ))}
+              </View>
+            ) : null}
+          </Card>
+        );
+      })}
+    </View>
+  );
+}

--- a/universal/src/components/training-trends.tsx
+++ b/universal/src/components/training-trends.tsx
@@ -1,0 +1,109 @@
+import { View } from "react-native";
+import Svg, { Polyline } from "react-native-svg";
+import { Text, Card } from "soma-style";
+import type { ComparisonPoint } from "../lib/api";
+import { pacesForVdot, timeStr } from "../lib/vdot";
+
+/** Two lines on a SHARED y-scale (so the comparison is honest), scaled to width. */
+function DualLine({
+  a,
+  b,
+  colorA,
+  colorB,
+  height = 40,
+}: {
+  a: number[];
+  b: number[];
+  colorA: string;
+  colorB: string;
+  height?: number;
+}) {
+  const A = a.filter((v) => isFinite(v));
+  const B = b.filter((v) => isFinite(v));
+  const all = [...A, ...B];
+  if (all.length < 2) return null;
+  const min = Math.min(...all);
+  const max = Math.max(...all);
+  const range = max - min || 1;
+  const W = 100;
+  const line = (s: number[]) =>
+    s.map((v, i) => `${(i / Math.max(1, s.length - 1)) * W},${height - ((v - min) / range) * height}`).join(" ");
+  return (
+    <Svg width="100%" height={height} viewBox={`0 0 ${W} ${height}`} preserveAspectRatio="none">
+      {B.length >= 2 ? <Polyline points={line(B)} fill="none" stroke={colorB} strokeWidth={1} opacity={0.55} /> : null}
+      {A.length >= 2 ? <Polyline points={line(A)} fill="none" stroke={colorA} strokeWidth={1.6} /> : null}
+    </Svg>
+  );
+}
+
+interface Comparison {
+  fitness: ComparisonPoint[];
+  load: ComparisonPoint[];
+  readiness: ComparisonPoint[];
+  racePrediction: ComparisonPoint[];
+}
+
+const n = (v: unknown): number => Number(v);
+const last = (a: ComparisonPoint[]): ComparisonPoint | undefined => (a.length ? a[a.length - 1] : undefined);
+
+/** Compact "model vs Garmin" trend cards (mobile-adapted comparison charts). */
+export function TrainingTrends({ comparison }: { comparison: Comparison | null | undefined }) {
+  if (!comparison) return null;
+
+  const fit = comparison.fitness ?? [];
+  const load = comparison.load ?? [];
+  const rd = comparison.readiness ?? [];
+  const rp = comparison.racePrediction ?? [];
+  const fitL = last(fit);
+  const loadL = last(load);
+  const rdL = last(rd);
+  const rpL = last(rp);
+
+  const cards = [
+    {
+      key: "fitness",
+      title: "Fitness — VDOT vs Garmin VO₂max",
+      a: fit.map((p) => n(p.ourVdot)),
+      b: fit.map((p) => n(p.garminVo2max)),
+      colorB: "#5a7a8a",
+      latest: fitL ? `Ours ${n(fitL.ourVdot).toFixed(1)} · Garmin ${n(fitL.garminVo2max).toFixed(1)}` : "",
+    },
+    {
+      key: "load",
+      title: "Training load — CTL vs ATL",
+      a: load.map((p) => n(p.ctl)),
+      b: load.map((p) => n(p.atl)),
+      colorB: "#e0a458",
+      latest: loadL ? `CTL ${n(loadL.ctl).toFixed(0)} · ATL ${n(loadL.atl).toFixed(0)}` : "",
+    },
+    {
+      key: "readiness",
+      title: "Readiness — ours vs Garmin",
+      a: rd.map((p) => n(p.ourScore) * 100),
+      b: rd.map((p) => n(p.garminScore)),
+      colorB: "#5a7a8a",
+      latest: rdL ? `Ours ${Math.round(n(rdL.ourScore) * 100)} · Garmin ${Math.round(n(rdL.garminScore))}` : "",
+    },
+    {
+      key: "race",
+      title: "Race prediction — HM time",
+      a: rp.map((p) => pacesForVdot(n(p.ourVdot)).hmSeconds),
+      b: rp.map((p) => n(p.garminSeconds)),
+      colorB: "#5a7a8a",
+      latest: rpL ? `Ours ${timeStr(pacesForVdot(n(rpL.ourVdot)).hmSeconds)} · Garmin ${timeStr(n(rpL.garminSeconds))}` : "",
+    },
+  ];
+
+  return (
+    <View className="gap-3">
+      <Text variant="eyebrow" className="text-text-muted">Model vs Garmin</Text>
+      {cards.map((c) => (
+        <Card key={c.key} className="gap-1.5">
+          <Text variant="micro" className="text-text-secondary">{c.title}</Text>
+          <DualLine a={c.a} b={c.b} colorA="#77c8d1" colorB={c.colorB} />
+          <Text variant="micro" className="tabular-nums text-text-muted">{c.latest}</Text>
+        </Card>
+      ))}
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -179,6 +179,134 @@ export async function toggleCalibration(forceEqual: boolean): Promise<boolean> {
   return res.ok;
 }
 
+// ---- Forward simulation: full training-plan schedule + PMC/readiness/fitness/comparison ----
+export interface WorkoutStep {
+  step_type: string;
+  description?: string | null;
+  hr_zone?: number | null;
+  target_type?: string | null;
+  duration_type?: string | null;
+  duration_value?: number | null;
+}
+export interface PlanDay {
+  id: number;
+  dayDate: string;
+  weekNumber: number;
+  runType: string;
+  runTitle: string;
+  targetDistanceKm: number | null;
+  workoutSteps: WorkoutStep[] | null;
+  loadLevel?: string | null;
+  gymWorkout?: string | null;
+  gymNotes?: string | null;
+  completed: boolean;
+  garminWorkoutId?: string | null;
+  garminPushStatus?: string | null;
+  actualDistanceKm?: number | null;
+}
+export interface ComparisonPoint { date: string; [k: string]: number | string }
+export interface ForwardSim {
+  today: string;
+  pmc: { ctl: number; atl: number; tsb: number } | null;
+  readiness: { compositeZ: number | null; trafficLight: string } | null;
+  calibration: Calibration | null;
+  fitness: { vo2max: number | null; vdotAdjusted: number | null; weightKg: number | null } | null;
+  planDays: PlanDay[];
+  comparison: {
+    load: ComparisonPoint[];
+    readiness: ComparisonPoint[];
+    fitness: ComparisonPoint[];
+    racePrediction: ComparisonPoint[];
+  } | null;
+}
+
+/** The full forward-simulation payload: schedule + PMC + readiness + fitness + comparison. */
+export function useForwardSim(date: string) {
+  const [data, setData] = useState<ForwardSim | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    fetchJson<ForwardSim>(`/api/training/forward-sim?date=${date}`)
+      .then((d) => alive && (setData(d), setError(null)))
+      .catch((e) => alive && setError(String(e.message ?? e)))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [date, reload]);
+  return { data, loading, error, refetch: () => setReload((n) => n + 1) };
+}
+
+/** Toggle a plan day's completion. Passes the existing actual distance through so
+    the PATCH route (which nulls it when omitted) doesn't wipe matched-activity data. */
+export async function setDayCompletion(
+  dayId: number,
+  completed: boolean,
+  actualDistanceKm?: number | null,
+): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/training/day/${dayId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify({ completed, actual_distance_km: actualDistanceKm ?? null }),
+  });
+  return res.ok;
+}
+
+// ---- Per-night sleep data (stages, score, sleep HR, SpO2) for the sleep dashboard ----
+export interface SleepNight {
+  date: string;
+  total: number | null; deep: number | null; light: number | null; rem: number | null; awake: number | null;
+  score: number | null; hr: number | null; spo2: number | null;
+}
+export interface SleepSummary {
+  trend: SleepNight[];
+  stats: {
+    nights: number;
+    avg_hours: number | null; avg_score: number | null;
+    avg_deep_pct: number | null; avg_rem_pct: number | null;
+    avg_sleep_hr: number | null; avg_spo2: number | null;
+  };
+  lastNight: SleepNight | null;
+}
+
+/** Per-night sleep stages + score + sleep HR/SpO2 from /api/sleep/summary. */
+export function useSleepSummary(range: string) {
+  const [data, setData] = useState<SleepSummary | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<SleepSummary>(`/api/sleep/summary?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
+// ---- Training computation graph (nodes → the mobile pace-computation breakdown) ----
+export interface GraphNode { id: string; label: string; value: number | null }
+
+/** The computation-graph nodes keyed by id (readiness_factor, tsb, adjusted_pace, …). */
+export function useTrainingGraph(date: string) {
+  const [nodes, setNodes] = useState<Record<string, GraphNode>>({});
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<{ graph?: { nodes?: GraphNode[] }; nodes?: GraphNode[] }>(`/api/training/graph?date=${date}`)
+      .then((d) => {
+        if (!alive) return;
+        const arr = d.graph?.nodes ?? d.nodes ?? [];
+        const map: Record<string, GraphNode> = {};
+        for (const nd of arr) map[nd.id] = nd;
+        setNodes(map);
+      })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [date, reload]);
+  return { nodes, refetch: () => setReload((n) => n + 1) };
+}
+
 export function useSomaPlan(date: string) {
   const [data, setData] = useState<SomaPlan | null>(null);
   const [loading, setLoading] = useState(true);

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -35,14 +35,37 @@ export interface MacroSet {
   fiber: number;
 }
 
+export interface SomaMealItem { name?: string; grams?: number }
+export interface SomaMeal {
+  id: number;
+  meal_slot: string;
+  source?: string | null;
+  preset_meal_id?: string | null;
+  calories: number; protein: number; carbs: number; fat: number; fiber: number;
+  items?: SomaMealItem[];
+  logged_at?: string;
+}
+export interface SomaBreakdown {
+  totalBurn?: number; bmr?: number;
+  stepCalories?: number; stepCaloriesPredicted?: number; expectedSteps?: number; actualSteps?: number;
+  runCalories?: number; runActual?: number; runPredicted?: number; runEnabled?: boolean; runActualDistKm?: number; runDistanceKm?: number;
+  gymCalories?: number; gymBreakdown?: { title: string; calories: number; predicted?: number; actual?: number }[];
+  drinkCalories?: number; deficit?: number;
+}
+export interface TrendDay { date: string; ate: number; burn: number; deficit: number; closed: boolean; isToday: boolean }
 export interface SomaPlan {
-  plan: { target_calories: number; target_protein: number; target_carbs: number; target_fat: number; target_fiber: number };
+  plan: { target_calories: number; target_protein: number; target_carbs: number; target_fat: number; target_fiber: number } | null;
   consumed: MacroSet;
-  remaining: MacroSet;
-  slotBudgets: Record<string, { calories: number; protein?: number; carbs?: number; fat?: number; fiber?: number }>;
-  breakdown?: { totalBurn?: number; bmr?: number };
+  remaining: MacroSet | null;
+  slotBudgets: Record<string, { calories: number; protein?: number; carbs?: number; fat?: number; fiber?: number }> | null;
+  meals?: SomaMeal[];
+  breakdown?: SomaBreakdown | null;
   adaptive: { effectiveTdee: number; reportedTdee: number; driftFlag: boolean; deficitDurationDays: number; dietBreakLevel: string } | null;
-  trend7d?: { adherence?: { ratio: number; status: string; weeklyActual: number; weeklyGoal: number } | null };
+  trend7d?: {
+    adherence?: { ratio: number; status: string; weeklyActual: number; weeklyGoal: number } | null;
+    days?: TrendDay[];
+    totalDeficit?: number; goalDeficit?: number;
+  };
 }
 
 export interface Today {
@@ -268,4 +291,20 @@ export async function logPresetMeal(
     }),
   });
   return res.ok;
+}
+
+/** Delete a logged meal by its id. */
+export async function deleteMeal(mealId: number): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/nutrition/log-meal?id=${mealId}`, {
+    method: "DELETE",
+    headers: AUTH_HEADERS,
+  });
+  return res.ok;
+}
+
+/** Today's date as YYYY-MM-DD in the device's local timezone. */
+export function todayLocal(): string {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }

--- a/universal/src/lib/vdot.ts
+++ b/universal/src/lib/vdot.ts
@@ -1,0 +1,82 @@
+/**
+ * VDOT pace zones — ported from web/lib/vdot-pace-zones.ts (Daniels' Running
+ * Formula, 3rd ed.). Same table so the app's paces match the website exactly.
+ */
+export interface VdotPaces {
+  easy: number;
+  marathon: number;
+  threshold: number;
+  interval: number;
+  repetition: number;
+  /** Half-marathon prediction, seconds. */
+  hmSeconds: number;
+}
+
+const VDOT_TABLE: Record<number, VdotPaces> = {
+  35: { easy: 421, marathon: 364, threshold: 340, interval: 312, repetition: 298, hmSeconds: 7453 },
+  36: { easy: 412, marathon: 356, threshold: 333, interval: 305, repetition: 288, hmSeconds: 7279 },
+  37: { easy: 403, marathon: 348, threshold: 325, interval: 300, repetition: 282, hmSeconds: 7114 },
+  38: { easy: 395, marathon: 341, threshold: 319, interval: 294, repetition: 275, hmSeconds: 6955 },
+  39: { easy: 387, marathon: 334, threshold: 312, interval: 288, repetition: 270, hmSeconds: 6804 },
+  40: { easy: 379, marathon: 327, threshold: 306, interval: 282, repetition: 265, hmSeconds: 6659 },
+  41: { easy: 372, marathon: 320, threshold: 300, interval: 276, repetition: 260, hmSeconds: 6520 },
+  42: { easy: 365, marathon: 314, threshold: 294, interval: 271, repetition: 255, hmSeconds: 6387 },
+  43: { easy: 358, marathon: 308, threshold: 289, interval: 266, repetition: 250, hmSeconds: 6260 },
+  44: { easy: 352, marathon: 302, threshold: 283, interval: 261, repetition: 245, hmSeconds: 6137 },
+  45: { easy: 346, marathon: 296, threshold: 278, interval: 256, repetition: 240, hmSeconds: 6020 },
+  46: { easy: 340, marathon: 291, threshold: 273, interval: 252, repetition: 235, hmSeconds: 5907 },
+  47: { easy: 334, marathon: 286, threshold: 269, interval: 247, repetition: 230, hmSeconds: 5798 },
+  48: { easy: 328, marathon: 281, threshold: 264, interval: 243, repetition: 225, hmSeconds: 5693 },
+  49: { easy: 323, marathon: 276, threshold: 260, interval: 239, repetition: 222, hmSeconds: 5592 },
+  50: { easy: 318, marathon: 272, threshold: 255, interval: 235, repetition: 218, hmSeconds: 5495 },
+  51: { easy: 313, marathon: 267, threshold: 251, interval: 231, repetition: 215, hmSeconds: 5402 },
+  52: { easy: 308, marathon: 262, threshold: 247, interval: 228, repetition: 212, hmSeconds: 5311 },
+  53: { easy: 304, marathon: 258, threshold: 244, interval: 224, repetition: 210, hmSeconds: 5224 },
+  54: { easy: 299, marathon: 254, threshold: 240, interval: 221, repetition: 205, hmSeconds: 5140 },
+  55: { easy: 295, marathon: 250, threshold: 236, interval: 217, repetition: 202, hmSeconds: 5058 },
+  56: { easy: 290, marathon: 247, threshold: 233, interval: 214, repetition: 200, hmSeconds: 4980 },
+  57: { easy: 286, marathon: 243, threshold: 230, interval: 211, repetition: 198, hmSeconds: 4903 },
+  58: { easy: 282, marathon: 239, threshold: 225, interval: 208, repetition: 192, hmSeconds: 4830 },
+  59: { easy: 278, marathon: 236, threshold: 223, interval: 205, repetition: 190, hmSeconds: 4758 },
+  60: { easy: 275, marathon: 232, threshold: 220, interval: 203, repetition: 188, hmSeconds: 4689 },
+};
+
+/** Interpolated pace set for a (possibly fractional) VDOT, clamped to [35,60]. */
+export function pacesForVdot(vdot: number): VdotPaces {
+  const v = Math.max(35, Math.min(60, vdot));
+  const lo = Math.floor(v);
+  const hi = Math.ceil(v);
+  const t = v - lo;
+  const a = VDOT_TABLE[lo];
+  const b = VDOT_TABLE[hi];
+  const l = (x: number, y: number) => x + (y - x) * t;
+  return {
+    easy: l(a.easy, b.easy),
+    marathon: l(a.marathon, b.marathon),
+    threshold: l(a.threshold, b.threshold),
+    interval: l(a.interval, b.interval),
+    repetition: l(a.repetition, b.repetition),
+    hmSeconds: l(a.hmSeconds, b.hmSeconds),
+  };
+}
+
+/** Seconds/km → "M:SS". */
+export function paceStr(secPerKm: number): string {
+  const m = Math.floor(secPerKm / 60);
+  const s = Math.round(secPerKm % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/** Total seconds → "H:MM:SS" (or "M:SS" under an hour). */
+export function timeStr(totalSec: number): string {
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = Math.round(totalSec % 60);
+  return h > 0
+    ? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
+    : `${m}:${String(s).padStart(2, "0")}`;
+}
+
+const HM_KM = 21.0975;
+/** Predicted HM race pace (sec/km) from the VDOT hm prediction. */
+export const hmPace = (p: VdotPaces): number => p.hmSeconds / HM_KM;

--- a/web/app/api/health/weight/route.ts
+++ b/web/app/api/health/weight/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
   const rows = await sql`
     SELECT date, weight_grams / 1000.0 as weight_kg, bmi, body_fat_pct
     FROM weight_log
-    WHERE date >= CURRENT_DATE - ${days}
+    WHERE date >= CURRENT_DATE - ${days}::int
     ORDER BY date ASC
   `;
 

--- a/web/app/api/sleep/summary/route.ts
+++ b/web/app/api/sleep/summary/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Per-night sleep data as JSON so the native app can render the sleep dashboard
+ * (the web page reads garmin_raw_data server-side; the RN app has no DB). Mirrors
+ * the sleep_data queries in app/sleep/page.tsx: stages, score, sleep HR, SpO2.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "30d";
+  const days = range === "7d" ? 7 : range === "14d" ? 14 : range === "90d" ? 90 : range === "1y" ? 365 : 30;
+
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT date,
+      (raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::int         as total,
+      (raw_json->'dailySleepDTO'->>'deepSleepSeconds')::int         as deep,
+      (raw_json->'dailySleepDTO'->>'lightSleepSeconds')::int        as light,
+      (raw_json->'dailySleepDTO'->>'remSleepSeconds')::int          as rem,
+      (raw_json->'dailySleepDTO'->>'awakeSleepSeconds')::int        as awake,
+      (raw_json->'dailySleepDTO'->'sleepScores'->'overall'->>'value')::int as score,
+      (raw_json->'dailySleepDTO'->>'avgHeartRate')::float           as hr,
+      (raw_json->'dailySleepDTO'->>'averageSpO2Value')::float       as spo2
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'sleep_data'
+      AND (raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::int > 0
+      AND date >= CURRENT_DATE - ${days}::int
+    ORDER BY date ASC
+  `) as {
+    date: string; total: number | null; deep: number | null; light: number | null;
+    rem: number | null; awake: number | null; score: number | null; hr: number | null; spo2: number | null;
+  }[];
+
+  // aggregate stats over the window (nulls ignored per-field)
+  const avg = (vals: (number | null | undefined)[]) => {
+    const nn = vals.filter((v): v is number => v != null && isFinite(v));
+    return nn.length ? nn.reduce((a, b) => a + b, 0) / nn.length : null;
+  };
+  const stats = {
+    nights: rows.length,
+    avg_hours: avg(rows.map((r) => (r.total != null ? r.total / 3600 : null))),
+    avg_score: avg(rows.map((r) => r.score)),
+    avg_deep_pct: avg(rows.map((r) => (r.total ? ((r.deep ?? 0) / r.total) * 100 : null))),
+    avg_rem_pct: avg(rows.map((r) => (r.total ? ((r.rem ?? 0) / r.total) * 100 : null))),
+    avg_sleep_hr: avg(rows.map((r) => r.hr)),
+    avg_spo2: avg(rows.map((r) => r.spo2)),
+  };
+  const lastNight = rows.length ? rows[rows.length - 1] : null;
+
+  return NextResponse.json({ trend: rows, stats, lastNight });
+}

--- a/web/components/pwa-install-prompt.tsx
+++ b/web/components/pwa-install-prompt.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { X, Download, Share } from "lucide-react";
+import { X, Download, Share, Apple, Smartphone } from "lucide-react";
+
+/** GitHub releases host the sideloadable native builds (widgets need native). */
+const RELEASES_URL = "https://github.com/drkostas/soma/releases/latest";
 
 interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
@@ -121,6 +124,30 @@ export function PWAInstallPrompt() {
               Install
             </button>
           )}
+          {/* Native app (home-screen widgets need a real native build). */}
+          <div className="mt-2.5 pt-2.5 border-t border-border/60">
+            <p className="text-[11px] text-muted-foreground mb-1.5">
+              Or get the native app for home-screen widgets:
+            </p>
+            <div className="flex gap-2">
+              <a
+                href={RELEASES_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-[11px] font-medium bg-accent/60 text-foreground px-2.5 py-1 rounded-md hover:bg-accent transition-colors"
+              >
+                <Apple className="h-3 w-3" /> iOS (IPA)
+              </a>
+              <a
+                href={RELEASES_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-[11px] font-medium bg-accent/60 text-foreground px-2.5 py-1 rounded-md hover:bg-accent transition-colors"
+              >
+                <Smartphone className="h-3 w-3" /> Android (APK)
+              </a>
+            </div>
+          </div>
         </div>
         <button
           onClick={handleDismiss}


### PR DESCRIPTION
## Deepen native app screens to web feature parity

Brings the Expo app's overview, training, running, and sleep screens toward parity with the web pages, mobile-adapted and Playwright-validated (390x844 Expo web build). Web stays the source of truth; the app consumes JSON endpoints.

### What's in it
- **Overview** — cross-domain dashboard: readiness hero, kcal/sleep/weight glance row, KPI sparklines. Fixes a pre-existing `/api/health/weight` 500 (`date - int` cast).
- **Training** — full parity: schedule (weeks/days/steps/completion/Garmin status), VDOT paces + A/B/C goals, pace-computation breakdown (mobile-native replacement for the desktop DAG), model-vs-Garmin trend charts, race protocol, PMC fallback.
- **Running** — monthly mileage bar chart.
- **Sleep** — new `/api/sleep/summary` endpoint exposing per-night stages/score/HR/SpO2 from `garmin_raw_data`, plus the app SleepDashboard (last-night stage bar, stages trend, score sparkline).
- **Install popup** — PWA install plus native IPA/APK links.

Also carries the previously-unmerged nutrition-depth commit (`0b8373e`) from the same screen-deepening effort.

### Validation
`tsc --noEmit` clean on both `universal/` and `web/`; each screen screenshotted and read back, 0 console errors.

### Follow-ups (need backend endpoints, tracked in #263)
Sleep HRV/readiness/SpO2/respiration/schedule/regularity; running load-trend/scatters/splits/cadence/fitness-scores; workouts exercise-history; training what-if slider.

Closes #263
Closes #264
Closes #265
Closes #266
Closes #267
Closes #268
