### PR TITLE
Workouts: render actual training data (volume, stats, recent, top exercises)

### DIFF
--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,7 +1,8 @@
 import { ScrollView, View, RefreshControl } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh } from "../../lib/api";
+import { fetchJson, usePullRefresh, useWorkoutsSummary } from "../../lib/api";
+import { WorkoutsDashboard } from "../../components/workouts-dashboard";
 
 interface RecentWorkout {
   title: string;
@@ -56,6 +57,7 @@ function formatDate(dateStr: string): string {
 
 export default function WorkoutsScreen() {
   const { data, error, refetch } = useWorkouts();
+  const { data: wkSum } = useWorkoutsSummary("90d");
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const recent = data?.recent ?? [];
@@ -154,6 +156,9 @@ export default function WorkoutsScreen() {
             </Card>
           ))}
         </View>
+
+        {/* Workout data — volume, stats, top exercises, recent (new /api/workouts/summary) */}
+        <WorkoutsDashboard summary={wkSum} />
 
         {/* Sync coverage bar */}
         {recent.length > 0 ? (

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -1,0 +1,102 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import type { WorkoutSummary } from "../lib/api";
+
+const num = (v: unknown): number => {
+  const n = Number(v);
+  return isFinite(n) ? n : 0;
+};
+function shortDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+function kvol(v: number): string {
+  return v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${v}`;
+}
+
+/** Weekly training-volume bars, peak highlighted. */
+function VolumeChart({ weeks }: { weeks: WorkoutSummary["weeklyVolume"] }) {
+  const data = weeks.map((w) => num(w.total_volume)).filter((v) => v > 0).slice(-16);
+  if (data.length < 2) return null;
+  const max = Math.max(...data) || 1;
+  const maxIdx = data.indexOf(max);
+  return (
+    <View className="h-24 flex-row items-end gap-1">
+      {data.map((v, i) => (
+        <View key={i} className="flex-1 items-center justify-end self-stretch">
+          <View className="w-full rounded-t-sm" style={{ height: `${Math.max(3, (v / max) * 100)}%`, backgroundColor: i === maxIdx ? "#77c8d1" : "#2f4a58" }} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+/** Workouts dashboard: summary stats + weekly volume + top exercises + recent list. */
+export function WorkoutsDashboard({ summary }: { summary: WorkoutSummary | null | undefined }) {
+  if (!summary) return null;
+  const s = summary.stats;
+  const stats: { label: string; value: string; sub: string }[] = s
+    ? [
+        { label: "Workouts", value: `${num(s.total_workouts)}`, sub: `${num(s.training_days)} days` },
+        { label: "Avg duration", value: `${Math.round(num(s.avg_duration_min))}`, sub: "min" },
+        { label: "Avg exercises", value: num(s.avg_exercises).toFixed(1), sub: "per session" },
+      ]
+    : [];
+  const peakVol = Math.max(0, ...summary.weeklyVolume.map((w) => num(w.total_volume)));
+
+  return (
+    <View className="gap-4">
+      {stats.length ? (
+        <View className="flex-row flex-wrap gap-3">
+          {stats.map((st) => (
+            <Card key={st.label} className="min-w-[30%] flex-1 gap-1">
+              <Text variant="eyebrow">{st.label}</Text>
+              <Text variant="headline" className="text-teal">{st.value}</Text>
+              <Text variant="micro">{st.sub}</Text>
+            </Card>
+          ))}
+        </View>
+      ) : null}
+
+      {summary.weeklyVolume.length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Weekly volume</Text>
+            <Text variant="micro" className="tabular-nums text-text-muted">peak {kvol(peakVol)} kg</Text>
+          </View>
+          <VolumeChart weeks={summary.weeklyVolume} />
+          <Text variant="micro" className="text-text-muted">weight × reps, normal sets</Text>
+        </Card>
+      ) : null}
+
+      {summary.topExercises.length ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Top exercises</Text>
+          {summary.topExercises.map((e) => (
+            <View key={e.name} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+              <Text variant="body" className="text-text-secondary flex-1" numberOfLines={1}>{e.name}</Text>
+              <Text variant="caption" className="tabular-nums text-text-muted ml-2">{e.sessions}×</Text>
+            </View>
+          ))}
+        </Card>
+      ) : null}
+
+      {summary.recent.length ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Recent workouts</Text>
+          {summary.recent.slice(0, 10).map((w) => (
+            <View key={w.id} className="border-b border-border-subtle py-2">
+              <View className="flex-row items-center justify-between">
+                <Text variant="body" className="text-text flex-1" numberOfLines={1}>{w.title || "Workout"}</Text>
+                <Text variant="micro" className="text-text-muted ml-2">{shortDate(w.start_time)}</Text>
+              </View>
+              <Text variant="micro" className="text-text-muted">
+                {w.exercise_count} exercises{w.duration_min ? ` · ${w.duration_min} min` : ""}{w.volume > 0 ? ` · ${kvol(w.volume)} kg` : ""}
+              </Text>
+            </View>
+          ))}
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -253,6 +253,33 @@ export async function setDayCompletion(
   return res.ok;
 }
 
+// ---- Strength-training data (volume, stats, recent, top exercises) ----
+export interface WorkoutSummary {
+  stats: {
+    total_workouts: number | string;
+    training_days: number | string;
+    avg_duration_min: number | string | null;
+    avg_exercises: number | string | null;
+  } | null;
+  weeklyVolume: { week: string; total_volume: number | string }[];
+  recent: { id: string; title: string; start_time: string; exercise_count: number; duration_min: number | null; volume: number }[];
+  topExercises: { name: string; sessions: number }[];
+}
+
+/** Strength-training summary from /api/workouts/summary. */
+export function useWorkoutsSummary(range: string) {
+  const [data, setData] = useState<WorkoutSummary | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<WorkoutSummary>(`/api/workouts/summary?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Per-night sleep data (stages, score, sleep HR, SpO2) for the sleep dashboard ----
 export interface SleepNight {
   date: string;

--- a/web/app/api/workouts/summary/route.ts
+++ b/web/app/api/workouts/summary/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Strength-training data as JSON so the native app can render the workouts
+ * dashboard (the web page reads hevy_raw_data server-side). Mirrors the queries
+ * in app/workouts/page.tsx: weekly volume, summary stats, recent list, top exercises.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "90d";
+  const days = range === "30d" ? 30 : range === "1y" ? 365 : range === "6m" ? 182 : 90;
+
+  const sql = getDb();
+
+  // weekly training volume (normal sets: weight_kg * reps)
+  const weeklyVolume = (await sql`
+    WITH s AS (
+      SELECT DATE_TRUNC('week', (raw_json->>'start_time')::timestamp)::date as week,
+             (st->>'weight_kg')::float * (st->>'reps')::int as volume
+      FROM hevy_raw_data,
+        jsonb_array_elements(raw_json->'exercises') as e,
+        jsonb_array_elements(e->'sets') as st
+      WHERE endpoint_name = 'workout'
+        AND (raw_json->>'start_time')::timestamp >= CURRENT_DATE - ${days}::int
+        AND st->>'type' = 'normal'
+        AND (st->>'weight_kg')::float > 0
+        AND (st->>'reps')::int > 0
+    )
+    SELECT week, ROUND(SUM(volume)::numeric) as total_volume
+    FROM s GROUP BY week ORDER BY week ASC
+  `) as { week: string; total_volume: number }[];
+
+  // summary stats over the window
+  const statsRows = (await sql`
+    SELECT COUNT(*) as total_workouts,
+      COUNT(DISTINCT (raw_json->>'start_time')::date) as training_days,
+      AVG(EXTRACT(EPOCH FROM ((raw_json->>'end_time')::timestamp - (raw_json->>'start_time')::timestamp)) / 60) as avg_duration_min,
+      AVG(jsonb_array_length(raw_json->'exercises')) as avg_exercises
+    FROM hevy_raw_data
+    WHERE endpoint_name = 'workout'
+      AND (raw_json->>'start_time')::timestamp >= CURRENT_DATE - ${days}::int
+  `) as { total_workouts: number; training_days: number; avg_duration_min: number | null; avg_exercises: number | null }[];
+
+  // recent workouts (with exercises to compute per-workout volume + top exercises)
+  const recentRows = (await sql`
+    SELECT raw_json->>'id' as id, raw_json->>'title' as title,
+      raw_json->>'start_time' as start_time, raw_json->>'end_time' as end_time,
+      jsonb_array_length(raw_json->'exercises') as exercise_count,
+      raw_json->'exercises' as exercises
+    FROM hevy_raw_data
+    WHERE endpoint_name = 'workout'
+      AND (raw_json->>'start_time')::timestamp >= CURRENT_DATE - ${days}::int
+    ORDER BY (raw_json->>'start_time') DESC
+    LIMIT 20
+  `) as { id: string; title: string; start_time: string; end_time: string; exercise_count: number; exercises: unknown }[];
+
+  type Ex = { title?: string; sets?: { type?: string; weight_kg?: number; reps?: number }[] };
+  const exCount: Record<string, number> = {};
+  const recent = recentRows.map((w) => {
+    const exs: Ex[] = Array.isArray(w.exercises)
+      ? (w.exercises as Ex[])
+      : typeof w.exercises === "string"
+      ? (JSON.parse(w.exercises) as Ex[])
+      : [];
+    let volume = 0;
+    for (const e of exs) {
+      if (e.title) exCount[e.title] = (exCount[e.title] ?? 0) + 1;
+      for (const st of e.sets ?? []) {
+        if (st.type === "normal" && (st.weight_kg ?? 0) > 0 && (st.reps ?? 0) > 0) {
+          volume += (st.weight_kg as number) * (st.reps as number);
+        }
+      }
+    }
+    const durMin =
+      w.start_time && w.end_time
+        ? Math.round((new Date(w.end_time).getTime() - new Date(w.start_time).getTime()) / 60000)
+        : null;
+    return {
+      id: w.id, title: w.title, start_time: w.start_time,
+      exercise_count: w.exercise_count, duration_min: durMin, volume: Math.round(volume),
+    };
+  });
+
+  const topExercises = Object.entries(exCount)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([name, sessions]) => ({ name, sessions }));
+
+  return NextResponse.json({ stats: statsRows[0] ?? null, weeklyVolume, recent, topExercises });
+}


### PR DESCRIPTION
## Workouts: render actual training data

The app workouts screen showed only Hevy/Garmin sync status. This adds the real strength-training data the web page renders, via the same backend-unlock pattern as the sleep dashboard.

- **New endpoint** `web/app/api/workouts/summary/route.ts` — weekly training volume, summary stats (total workouts, training days, avg duration, avg exercises), recent workouts (with per-workout volume), and top exercises from `hevy_raw_data`.
- **App screen** — WorkoutsDashboard: volume bar chart, stat cards, top-exercises list, recent-workouts list.

Playwright-validated on the Expo web build (weekly volume peak 36k kg, top exercises, recent list all render); `tsc --noEmit` clean on both packages; 0 console errors.

Closes #270
Closes #271
Closes #272
