### PR TITLE
Connections: interactive sync-rule toggles

### DIFF
--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View, RefreshControl } from "react-native";
+import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, type BadgeTone } from "soma-style";
-import { fetchJson, usePullRefresh } from "../../lib/api";
+import { fetchJson, usePullRefresh, setRuleEnabled } from "../../lib/api";
 
 // ---- Types (subset of the web /connections page, from fetchable endpoints) ----
 
@@ -153,7 +153,17 @@ export default function ConnectionsScreen() {
   });
 
   const platforms = conn?.platforms ?? [];
-  const rules = conn?.rules ?? [];
+  // optimistic enable/disable overrides so the toggle flips instantly
+  const [ruleOverride, setRuleOverride] = useState<Record<number, boolean>>({});
+  const rules = (conn?.rules ?? []).map((r) =>
+    r.id in ruleOverride ? { ...r, enabled: ruleOverride[r.id] } : r,
+  );
+  async function toggleRule(id: number, current: boolean) {
+    const next = !current;
+    setRuleOverride((m) => ({ ...m, [id]: next }));
+    const ok = await setRuleEnabled(id, next);
+    if (!ok) setRuleOverride((m) => ({ ...m, [id]: current })); // revert on failure
+  }
   const credMap: Record<string, PlatformStatus> = Object.fromEntries(
     platforms.map((p) => [p.platform, p]),
   );
@@ -284,10 +294,12 @@ export default function ConnectionsScreen() {
                     {Object.keys(r.destinations ?? {}).join(", ") || r.activity_type}
                   </Text>
                 </View>
-                <Badge
-                  label={r.enabled ? "On" : "Off"}
-                  tone={r.enabled ? "success" : "neutral"}
-                />
+                <Pressable onPress={() => toggleRule(r.id, r.enabled)} hitSlop={8}>
+                  <Badge
+                    label={r.enabled ? "On" : "Off"}
+                    tone={r.enabled ? "success" : "neutral"}
+                  />
+                </Pressable>
               </View>
             ))
           )}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -253,6 +253,16 @@ export async function setDayCompletion(
   return res.ok;
 }
 
+/** Toggle a sync rule on/off (PATCH /api/connections/rules/[id]). Returns true on success. */
+export async function setRuleEnabled(id: number, enabled: boolean): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/connections/rules/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify({ enabled }),
+  });
+  return res.ok;
+}
+
 // ---- Strength-training data (volume, stats, recent, top exercises) ----
 export interface WorkoutSummary {
   stats: {


### PR DESCRIPTION
## Connections: interactive sync-rule toggles

The app connections screen displayed sync rules read-only. Each rule's On/Off badge is now tappable to enable/disable it via `PATCH /api/connections/rules/[id]`, with optimistic UI (flips instantly, reverts on failure). Endpoint already existed; this is the app-side wiring.

Validated: rules render with tappable ON/OFF badges (Playwright), PATCH endpoint confirmed via curl, `tsc --noEmit` clean, 0 console errors. Did not click-test in-browser because localhost hits the live DB and a toggle mutates a real sync rule.

Closes #274
Closes #275
Closes #276
