### PR TITLE
Recovery: HRV + training-readiness in the app

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useSleepSummary } from "../../lib/api";
+import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary } from "../../lib/api";
 import { SleepDashboard } from "../../components/sleep-dashboard";
+import { RecoveryVitals } from "../../components/recovery-vitals";
 
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
@@ -100,6 +101,7 @@ export default function SleepScreen() {
   const { sleep, rhr, stress, battery, recovery, loading, error, refetch } =
     useSleepRecovery(range);
   const { data: sleepSum } = useSleepSummary(range);
+  const { data: recoveryVitals } = useRecoverySummary(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const lastSleep = last(sleep);
@@ -213,6 +215,9 @@ export default function SleepScreen() {
 
         {/* Sleep dashboard — last night + stages + score (new /api/sleep/summary) */}
         <SleepDashboard summary={sleepSum} />
+
+        {/* Recovery vitals — HRV + training readiness (new /api/recovery/summary) */}
+        <RecoveryVitals summary={recoveryVitals} />
 
         {/* Sleep duration trend (bar approximation) */}
         <Card className="gap-3">

--- a/universal/src/components/recovery-vitals.tsx
+++ b/universal/src/components/recovery-vitals.tsx
@@ -1,0 +1,84 @@
+import { View } from "react-native";
+import { Text, Card, Badge, Sparkline } from "soma-style";
+import type { RecoverySummary } from "../lib/api";
+
+const HRV_TONE: Record<string, "success" | "warm" | "danger" | "teal"> = {
+  BALANCED: "success",
+  UNBALANCED: "warm",
+  LOW: "danger",
+};
+const RDY_TONE = (level: string | null): "success" | "warm" | "danger" | "teal" => {
+  const l = (level ?? "").toUpperCase();
+  if (l.includes("PRIME") || l.includes("HIGH") || l.includes("READY")) return "success";
+  if (l.includes("LOW") || l.includes("POOR")) return "danger";
+  return "warm";
+};
+
+/** HRV + training-readiness cards (recovery vitals), fed by /api/recovery/summary. */
+export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | undefined }) {
+  if (!summary) return null;
+  const hrv = summary.hrv.latest;
+  const rdy = summary.readiness.latest;
+  const hrvSeries = summary.hrv.trend.map((p) => p.weekly_avg).filter((v): v is number => v != null);
+
+  const factors: { label: string; v: number | null; color: string }[] = rdy
+    ? [
+        { label: "HRV", v: rdy.hrv_pct, color: "#6ad4a0" },
+        { label: "Stress", v: rdy.stress_pct, color: "#e0a458" },
+        { label: "ACWR", v: rdy.acwr_pct, color: "#6aa0e0" },
+        { label: "Recovery", v: rdy.recovery_pct, color: "#c084fc" },
+        { label: "Sleep hist.", v: rdy.sleep_history_pct, color: "#a5b4fc" },
+      ].filter((f) => f.v != null)
+    : [];
+
+  if (!hrv && !rdy) return null;
+
+  return (
+    <View className="gap-4">
+      {hrv ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Heart rate variability</Text>
+            {hrv.status ? <Badge label={hrv.status} tone={HRV_TONE[hrv.status] ?? "teal"} /> : null}
+          </View>
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="text-teal">{hrv.weekly_avg ?? "—"}</Text>
+            <Text variant="caption" className="text-text-muted mb-1">ms weekly avg</Text>
+            {hrv.last_night_avg != null ? (
+              <Text variant="micro" className="text-text-muted mb-1">· last night {hrv.last_night_avg}</Text>
+            ) : null}
+          </View>
+          {hrvSeries.length >= 2 ? <Sparkline data={hrvSeries} color="#77c8d1" height={36} baseline /> : null}
+        </Card>
+      ) : null}
+
+      {rdy ? (
+        <Card className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Training readiness</Text>
+            {rdy.level ? <Badge label={rdy.level} tone={RDY_TONE(rdy.level)} /> : null}
+          </View>
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="text-lime">{rdy.score ?? "—"}</Text>
+            <Text variant="caption" className="text-text-muted mb-1">/ 100</Text>
+          </View>
+          {factors.length ? (
+            <View className="gap-2">
+              {factors.map((f) => (
+                <View key={f.label} className="gap-1">
+                  <View className="flex-row justify-between">
+                    <Text variant="micro" className="text-text-secondary">{f.label}</Text>
+                    <Text variant="micro" className="tabular-nums text-text-muted">{f.v}%</Text>
+                  </View>
+                  <View className="h-1.5 rounded-full bg-surface-subtle overflow-hidden">
+                    <View className="h-full rounded-full" style={{ width: `${Math.max(0, Math.min(100, f.v as number))}%`, backgroundColor: f.color }} />
+                  </View>
+                </View>
+              ))}
+            </View>
+          ) : null}
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -321,6 +321,32 @@ export function useSleepSummary(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- HRV + training-readiness (recovery vitals) ----
+export interface HrvPoint { date: string; weekly_avg: number | null; last_night_avg: number | null; status: string | null }
+export interface ReadinessPoint {
+  date: string; score: number | null; level: string | null;
+  hrv_pct: number | null; stress_pct: number | null; acwr_pct: number | null;
+  recovery_pct: number | null; sleep_history_pct: number | null;
+}
+export interface RecoverySummary {
+  hrv: { trend: HrvPoint[]; latest: HrvPoint | null };
+  readiness: { trend: ReadinessPoint[]; latest: ReadinessPoint | null };
+}
+
+/** HRV + training-readiness from /api/recovery/summary. */
+export function useRecoverySummary(range: string) {
+  const [data, setData] = useState<RecoverySummary | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<RecoverySummary>(`/api/recovery/summary?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Training computation graph (nodes → the mobile pace-computation breakdown) ----
 export interface GraphNode { id: string; label: string; value: number | null }
 

--- a/web/app/api/recovery/summary/route.ts
+++ b/web/app/api/recovery/summary/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * HRV + training-readiness as JSON so the native app can render them (the web
+ * reads garmin_raw_data server-side). Mirrors the hrv_data / training_readiness
+ * queries in app/sleep/page.tsx.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "30d";
+  const days = range === "7d" ? 7 : range === "14d" ? 14 : range === "90d" ? 90 : range === "1y" ? 365 : 30;
+
+  const sql = getDb();
+
+  const hrv = (await sql`
+    SELECT date,
+      (raw_json->'hrvSummary'->>'weeklyAvg')::int    as weekly_avg,
+      (raw_json->'hrvSummary'->>'lastNightAvg')::int as last_night_avg,
+      raw_json->'hrvSummary'->>'status'              as status
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'hrv_data'
+      AND raw_json->'hrvSummary'->>'weeklyAvg' IS NOT NULL
+      AND date >= CURRENT_DATE - ${days}::int
+    ORDER BY date ASC
+  `) as { date: string; weekly_avg: number | null; last_night_avg: number | null; status: string | null }[];
+
+  const readiness = (await sql`
+    SELECT date,
+      (raw_json->0->>'score')::int                        as score,
+      raw_json->0->>'level'                               as level,
+      (raw_json->0->>'hrvFactorPercent')::int             as hrv_pct,
+      (raw_json->0->>'stressHistoryFactorPercent')::int   as stress_pct,
+      (raw_json->0->>'acwrFactorPercent')::int            as acwr_pct,
+      (raw_json->0->>'recoveryTimeFactorPercent')::int    as recovery_pct,
+      (raw_json->0->>'sleepHistoryFactorPercent')::int    as sleep_history_pct
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'training_readiness'
+      AND raw_json->0->>'score' IS NOT NULL
+      AND date >= CURRENT_DATE - ${days}::int
+    ORDER BY date ASC
+  `) as {
+    date: string; score: number | null; level: string | null;
+    hrv_pct: number | null; stress_pct: number | null; acwr_pct: number | null;
+    recovery_pct: number | null; sleep_history_pct: number | null;
+  }[];
+
+  return NextResponse.json({
+    hrv: { trend: hrv, latest: hrv.length ? hrv[hrv.length - 1] : null },
+    readiness: { trend: readiness, latest: readiness.length ? readiness[readiness.length - 1] : null },
+  });
+}


### PR DESCRIPTION
## Recovery: HRV + training-readiness

New `/api/recovery/summary` endpoint exposing `hrv_data` (weekly/last-night avg, status) and `training_readiness` (score, level, factor percents) from `garmin_raw_data`. App RecoveryVitals renders an HRV card (weekly avg + status badge + sparkline) and a training-readiness card (score + factor bars) in the sleep screen. Same backend-unlock pattern as the sleep-stages endpoint.

Validated on the Expo web build: HRV 74 ms BALANCED, readiness 60/100 with factor bars all render; `tsc` clean; 0 console errors.

Closes #278
Closes #279
Closes #280
