### PR TITLE
Running: training-load/ACWR + cadence trends

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh } from "../../lib/api";
+import { fetchJson, usePullRefresh, useRunningTrends } from "../../lib/api";
 import { RunningMileage } from "../../components/running-mileage";
+import { RunningDeepTrends } from "../../components/running-deep-trends";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -153,6 +154,7 @@ const ZONE_HEX = ["#77c8d1", "#6ad4a0", "#e0c458", "#e0a458", "#e06060"];
 
 export default function RunningScreen() {
   const { data, error, refetch } = useRunning();
+  const { data: runTrends } = useRunningTrends("180d");
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const stats = data?.stats;
@@ -316,6 +318,9 @@ export default function RunningScreen() {
 
         {/* Monthly mileage bar chart (web parity) */}
         <RunningMileage mileage={trends?.mileage} />
+
+        {/* Training load/ACWR + cadence trends (new /api/running/trends) */}
+        <RunningDeepTrends trends={runTrends} />
 
         {/* Training Intensity Distribution (approximated with ProgressBars) */}
         {zones.length > 0 ? (

--- a/universal/src/components/running-deep-trends.tsx
+++ b/universal/src/components/running-deep-trends.tsx
@@ -1,0 +1,75 @@
+import { View } from "react-native";
+import Svg, { Polyline, Line } from "react-native-svg";
+import { Text, Card, Badge, Sparkline } from "soma-style";
+import type { RunningTrends } from "../lib/api";
+
+/** Two lines on a shared y-scale (acute vs chronic load). */
+function DualLine({ a, b, colorA, colorB, height = 44 }: { a: number[]; b: number[]; colorA: string; colorB: string; height?: number }) {
+  const A = a.filter((v) => isFinite(v));
+  const B = b.filter((v) => isFinite(v));
+  const all = [...A, ...B];
+  if (all.length < 2) return null;
+  const min = Math.min(...all);
+  const max = Math.max(...all);
+  const range = max - min || 1;
+  const W = 100;
+  const line = (s: number[]) => s.map((v, i) => `${(i / Math.max(1, s.length - 1)) * W},${height - ((v - min) / range) * height}`).join(" ");
+  return (
+    <Svg width="100%" height={height} viewBox={`0 0 ${W} ${height}`} preserveAspectRatio="none">
+      {B.length >= 2 ? <Polyline points={line(B)} fill="none" stroke={colorB} strokeWidth={1} opacity={0.6} /> : null}
+      {A.length >= 2 ? <Polyline points={line(A)} fill="none" stroke={colorA} strokeWidth={1.6} /> : null}
+    </Svg>
+  );
+}
+
+const acwrTone = (v: number): "success" | "warm" | "danger" => (v >= 0.8 && v <= 1.3 ? "success" : v > 1.5 ? "danger" : "warm");
+const acwrLabel = (v: number): string => (v >= 0.8 && v <= 1.3 ? "OPTIMAL" : v > 1.5 ? "HIGH" : v > 1.3 ? "ELEVATED" : "LOW");
+
+/** Training load / ACWR + cadence trends for the running screen. */
+export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | undefined }) {
+  if (!trends) return null;
+  const load = trends.loadTrend.filter((p) => p.acute != null || p.chronic != null);
+  const loadLast = load.length ? load[load.length - 1] : null;
+  const acute = load.map((p) => Number(p.acute)).filter(isFinite);
+  const chronic = load.map((p) => Number(p.chronic)).filter(isFinite);
+
+  const cad = trends.cadenceStride.filter((p) => p.cadence != null);
+  const cadLast = cad.length ? cad[cad.length - 1] : null;
+  const cadSeries = cad.map((p) => Number(p.cadence)).filter(isFinite);
+
+  return (
+    <View className="gap-4">
+      {loadLast ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Training load · acute vs chronic</Text>
+            {loadLast.acwr != null ? <Badge label={`ACWR ${loadLast.acwr.toFixed(2)} · ${acwrLabel(loadLast.acwr)}`} tone={acwrTone(loadLast.acwr)} /> : null}
+          </View>
+          <DualLine a={acute} b={chronic} colorA="#77c8d1" colorB="#5a7a8a" />
+          <View className="flex-row justify-between">
+            <Text variant="micro" className="text-text-muted">acute {loadLast.acute != null ? Math.round(loadLast.acute) : "—"}</Text>
+            <Text variant="micro" className="text-text-muted">chronic {loadLast.chronic != null ? Math.round(loadLast.chronic) : "—"}</Text>
+          </View>
+          <View className="flex-row items-center gap-3">
+            <View className="flex-row items-center gap-1"><View className="h-2 w-2 rounded-full bg-teal" /><Text variant="micro" className="text-text-muted">acute (7d)</Text></View>
+            <View className="flex-row items-center gap-1"><View className="h-2 w-2 rounded-full" style={{ backgroundColor: "#5a7a8a" }} /><Text variant="micro" className="text-text-muted">chronic (28d)</Text></View>
+          </View>
+        </Card>
+      ) : null}
+
+      {cadLast && cadSeries.length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Cadence</Text>
+            <Text variant="micro" className="tabular-nums text-text-muted">{cadLast.stride != null ? `stride ${cadLast.stride} cm` : ""}</Text>
+          </View>
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="text-lime">{cadLast.cadence}</Text>
+            <Text variant="caption" className="text-text-muted mb-1">spm</Text>
+          </View>
+          <Sparkline data={cadSeries} color="#cbe896" height={36} baseline />
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -263,6 +263,25 @@ export async function setRuleEnabled(id: number, enabled: boolean): Promise<bool
   return res.ok;
 }
 
+// ---- Running trends: training-load/ACWR + cadence/stride ----
+export interface LoadPoint { date: string; acute: number | null; chronic: number | null; acwr: number | null }
+export interface CadencePoint { date: string; cadence: number | null; stride: number | null }
+export interface RunningTrends { loadTrend: LoadPoint[]; cadenceStride: CadencePoint[] }
+
+/** Training-load/ACWR trend + cadence/stride from /api/running/trends. */
+export function useRunningTrends(range: string) {
+  const [data, setData] = useState<RunningTrends | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<RunningTrends>(`/api/running/trends?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Strength-training data (volume, stats, recent, top exercises) ----
 export interface WorkoutSummary {
   stats: {

--- a/web/app/api/running/trends/route.ts
+++ b/web/app/api/running/trends/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Training-load/ACWR trend + cadence/stride as JSON for the app running screen
+ * (the web reads garmin_raw_data / garmin_activity_raw server-side). Mirrors
+ * getTrainingLoadTrend + getCadenceStride in app/running/page.tsx.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "180d";
+  const days = range === "30d" ? 30 : range === "90d" ? 90 : range === "1y" ? 365 : range === "2y" ? 730 : 180;
+
+  const sql = getDb();
+
+  const loadTrend = (await sql`
+    SELECT date::text as date,
+      (SELECT v->'acuteTrainingLoadDTO'->>'dailyTrainingLoadAcute'
+       FROM jsonb_each(raw_json->'mostRecentTrainingStatus'->'latestTrainingStatusData') AS t(k, v) LIMIT 1)::float as acute,
+      (SELECT v->'acuteTrainingLoadDTO'->>'dailyTrainingLoadChronic'
+       FROM jsonb_each(raw_json->'mostRecentTrainingStatus'->'latestTrainingStatusData') AS t(k, v) LIMIT 1)::float as chronic,
+      (SELECT v->'acuteTrainingLoadDTO'->>'dailyAcuteChronicWorkloadRatio'
+       FROM jsonb_each(raw_json->'mostRecentTrainingStatus'->'latestTrainingStatusData') AS t(k, v) LIMIT 1)::float as acwr
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'training_status'
+      AND raw_json->'mostRecentTrainingStatus' IS NOT NULL
+      AND date >= CURRENT_DATE - ${days}::int
+    ORDER BY date ASC
+  `) as { date: string; acute: number | null; chronic: number | null; acwr: number | null }[];
+
+  const cadenceStride = (await sql`
+    SELECT (raw_json->>'startTimeLocal')::text as date,
+      ROUND((raw_json->>'averageRunningCadenceInStepsPerMinute')::numeric, 0)::int as cadence,
+      ROUND((raw_json->>'avgStrideLength')::numeric, 0)::int as stride
+    FROM garmin_activity_raw
+    WHERE endpoint_name = 'summary'
+      AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+      AND raw_json->>'averageRunningCadenceInStepsPerMinute' IS NOT NULL
+      AND (raw_json->>'averageRunningCadenceInStepsPerMinute')::float >= 120
+      AND (raw_json->>'distance')::float > 1000
+      AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
+    ORDER BY (raw_json->>'startTimeLocal')::timestamp ASC
+  `) as { date: string; cadence: number | null; stride: number | null }[];
+
+  return NextResponse.json({ loadTrend, cadenceStride });
+}


### PR DESCRIPTION
## Running: training-load/ACWR + cadence trends

New `/api/running/trends` endpoint exposing the `training_status` acute/chronic load + ACWR trend (from `garmin_raw_data`) and per-run cadence/stride (from `garmin_activity_raw`). App RunningDeepTrends renders an acute-vs-chronic dual-line chart with an ACWR status badge and a cadence card with sparkline.

Validated on the Expo web build: ACWR 0.80 OPTIMAL, acute/chronic dual-line, cadence 155 spm all render; `tsc` clean; 0 console errors.

Closes #282
Closes #283
Closes #284
