### PR TITLE
Sleep: blood-oxygen (SpO2) + respiration trends

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary } from "../../lib/api";
+import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory } from "../../lib/api";
 import { SleepDashboard } from "../../components/sleep-dashboard";
 import { RecoveryVitals } from "../../components/recovery-vitals";
+import { SleepRespiratory } from "../../components/sleep-respiratory";
 
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
@@ -102,6 +103,7 @@ export default function SleepScreen() {
     useSleepRecovery(range);
   const { data: sleepSum } = useSleepSummary(range);
   const { data: recoveryVitals } = useRecoverySummary(range);
+  const { data: respiratory } = useRespiratory(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const lastSleep = last(sleep);
@@ -218,6 +220,9 @@ export default function SleepScreen() {
 
         {/* Recovery vitals — HRV + training readiness (new /api/recovery/summary) */}
         <RecoveryVitals summary={recoveryVitals} />
+
+        {/* Blood oxygen + respiration (new /api/sleep/respiratory) */}
+        <SleepRespiratory data={respiratory} />
 
         {/* Sleep duration trend (bar approximation) */}
         <Card className="gap-3">

--- a/universal/src/components/sleep-respiratory.tsx
+++ b/universal/src/components/sleep-respiratory.tsx
@@ -1,0 +1,57 @@
+import { View } from "react-native";
+import { Text, Card, Sparkline } from "soma-style";
+import type { Respiratory } from "../lib/api";
+
+function avg(vals: (number | null)[]): number | null {
+  const nn = vals.filter((v): v is number => v != null && isFinite(v));
+  return nn.length ? nn.reduce((a, b) => a + b, 0) / nn.length : null;
+}
+
+/** SpO2 + respiration cards for the sleep screen, fed by /api/sleep/respiratory. */
+export function SleepRespiratory({ data }: { data: Respiratory | null | undefined }) {
+  if (!data) return null;
+  const spo2 = data.spo2.latest;
+  const resp = data.respiration.latest;
+  const spo2Series = data.spo2.trend.map((p) => p.avg_spo2).filter((v): v is number => v != null);
+  const respSeries = data.respiration.trend.map((p) => p.sleep_resp ?? p.awake_resp).filter((v): v is number => v != null);
+  const spo2Avg = avg(data.spo2.trend.slice(-7).map((p) => p.avg_spo2));
+
+  if (!spo2 && !resp) return null;
+
+  return (
+    <View className="gap-4">
+      {spo2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Blood oxygen (SpO₂)</Text>
+            {spo2.low_spo2 != null ? <Text variant="micro" className="text-text-muted">low {spo2.low_spo2}%</Text> : null}
+          </View>
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="text-teal">{spo2.avg_spo2 != null ? Math.round(spo2.avg_spo2) : "—"}</Text>
+            <Text variant="caption" className="text-text-muted mb-1">% avg</Text>
+            {spo2Avg != null ? <Text variant="micro" className="text-text-muted mb-1">· 7d avg {Math.round(spo2Avg)}%</Text> : null}
+          </View>
+          {spo2Series.length >= 2 ? <Sparkline data={spo2Series} color="#6aa0e0" height={34} baseline /> : null}
+        </Card>
+      ) : null}
+
+      {resp ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Respiration rate</Text>
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="text-indigo">
+              {resp.sleep_resp != null ? Math.round(resp.sleep_resp) : resp.awake_resp != null ? Math.round(resp.awake_resp) : "—"}
+            </Text>
+            <Text variant="caption" className="text-text-muted mb-1">br/min {resp.sleep_resp != null ? "sleeping" : "awake"}</Text>
+          </View>
+          <View className="flex-row flex-wrap gap-x-5 gap-y-1">
+            {resp.awake_resp != null ? <Text variant="micro" className="text-text-secondary">Awake {Math.round(resp.awake_resp)}</Text> : null}
+            {resp.low_resp != null ? <Text variant="micro" className="text-text-secondary">Low {Math.round(resp.low_resp)}</Text> : null}
+            {resp.high_resp != null ? <Text variant="micro" className="text-text-secondary">High {Math.round(resp.high_resp)}</Text> : null}
+          </View>
+          {respSeries.length >= 2 ? <Sparkline data={respSeries} color="#a5b4fc" height={34} baseline /> : null}
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -366,6 +366,28 @@ export function useRecoverySummary(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Blood-oxygen (SpO2) + respiration trends ----
+export interface Spo2Point { date: string; avg_spo2: number | null; low_spo2: number | null; sleep_spo2: number | null }
+export interface RespPoint { date: string; awake_resp: number | null; sleep_resp: number | null; low_resp: number | null; high_resp: number | null }
+export interface Respiratory {
+  spo2: { trend: Spo2Point[]; latest: Spo2Point | null };
+  respiration: { trend: RespPoint[]; latest: RespPoint | null };
+}
+
+/** SpO2 + respiration trends from /api/sleep/respiratory. */
+export function useRespiratory(range: string) {
+  const [data, setData] = useState<Respiratory | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<Respiratory>(`/api/sleep/respiratory?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Training computation graph (nodes → the mobile pace-computation breakdown) ----
 export interface GraphNode { id: string; label: string; value: number | null }
 

--- a/web/app/api/sleep/respiratory/route.ts
+++ b/web/app/api/sleep/respiratory/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Blood-oxygen (SpO2) + respiration-rate trends as JSON for the app sleep screen
+ * (the web reads garmin_raw_data server-side). Mirrors getSpO2Trend +
+ * getRespirationTrend in app/sleep/page.tsx.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "30d";
+  const days = range === "7d" ? 7 : range === "14d" ? 14 : range === "90d" ? 90 : range === "1y" ? 365 : 30;
+
+  const sql = getDb();
+
+  // SpO2: combine sleep_data (historical) with spo2_data (recent, richer); spo2_data wins.
+  const spo2 = (await sql`
+    SELECT COALESCE(s.date, p.date)::text as date,
+      COALESCE((p.raw_json->>'averageSpO2')::float, (s.raw_json->'dailySleepDTO'->>'averageSpO2Value')::float) as avg_spo2,
+      COALESCE((p.raw_json->>'lowestSpO2')::int, (s.raw_json->'dailySleepDTO'->>'lowestSpO2Value')::int) as low_spo2,
+      (p.raw_json->>'avgSleepSpO2')::float as sleep_spo2
+    FROM garmin_raw_data s
+    FULL OUTER JOIN garmin_raw_data p
+      ON s.date = p.date AND p.endpoint_name = 'spo2_data' AND p.raw_json->>'averageSpO2' IS NOT NULL
+      AND p.date >= CURRENT_DATE - ${days}::int
+    WHERE s.endpoint_name = 'sleep_data'
+      AND (s.raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::int > 0
+      AND s.date >= CURRENT_DATE - ${days}::int
+      AND (s.raw_json->'dailySleepDTO'->>'averageSpO2Value' IS NOT NULL OR p.raw_json->>'averageSpO2' IS NOT NULL)
+    ORDER BY 1 ASC
+  `) as { date: string; avg_spo2: number | null; low_spo2: number | null; sleep_spo2: number | null }[];
+
+  const respiration = (await sql`
+    SELECT date::text as date,
+      (raw_json->>'avgWakingRespirationValue')::float as awake_resp,
+      (raw_json->>'avgSleepRespirationValue')::float  as sleep_resp,
+      (raw_json->>'lowestRespirationValue')::float    as low_resp,
+      (raw_json->>'highestRespirationValue')::float   as high_resp
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'respiration_data'
+      AND raw_json->>'avgWakingRespirationValue' IS NOT NULL
+      AND date >= CURRENT_DATE - ${days}::int
+    ORDER BY date ASC
+  `) as { date: string; awake_resp: number | null; sleep_resp: number | null; low_resp: number | null; high_resp: number | null }[];
+
+  return NextResponse.json({
+    spo2: { trend: spo2, latest: spo2.length ? spo2[spo2.length - 1] : null },
+    respiration: { trend: respiration, latest: respiration.length ? respiration[respiration.length - 1] : null },
+  });
+}


### PR DESCRIPTION
## Sleep: blood-oxygen (SpO2) + respiration

New `/api/sleep/respiratory` endpoint exposing SpO2 (combined `sleep_data` + `spo2_data`) and `respiration_data` from garmin. App SleepRespiratory renders an SpO2 card (avg + low + 7d avg + sparkline) and a respiration card (sleeping/awake + low/high + sparkline).

Validated on the Expo web build: SpO2 92% (low 85, 7d avg 94), respiration 12 br/min render; `tsc` clean post-rebase; 0 console errors.

Closes #286
Closes #287
Closes #288
