### PR TITLE
Sleep: schedule + regularity (bedtime/wake consistency)

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory } from "../../lib/api";
+import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule } from "../../lib/api";
 import { SleepDashboard } from "../../components/sleep-dashboard";
 import { RecoveryVitals } from "../../components/recovery-vitals";
 import { SleepRespiratory } from "../../components/sleep-respiratory";
+import { SleepRegularity } from "../../components/sleep-regularity";
 
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
@@ -104,6 +105,7 @@ export default function SleepScreen() {
   const { data: sleepSum } = useSleepSummary(range);
   const { data: recoveryVitals } = useRecoverySummary(range);
   const { data: respiratory } = useRespiratory(range);
+  const { data: schedule } = useSleepSchedule(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const lastSleep = last(sleep);
@@ -223,6 +225,9 @@ export default function SleepScreen() {
 
         {/* Blood oxygen + respiration (new /api/sleep/respiratory) */}
         <SleepRespiratory data={respiratory} />
+
+        {/* Sleep regularity — bedtime/wake consistency (new /api/sleep/schedule) */}
+        <SleepRegularity data={schedule} />
 
         {/* Sleep duration trend (bar approximation) */}
         <Card className="gap-3">

--- a/universal/src/components/sleep-regularity.tsx
+++ b/universal/src/components/sleep-regularity.tsx
@@ -1,0 +1,54 @@
+import { View } from "react-native";
+import { Text, Card, Badge } from "soma-style";
+import type { SleepScheduleData } from "../lib/api";
+
+/** Decimal hour (may be >24 for after-midnight bedtimes) → "H:MM AM/PM". */
+function fmtHour(h: number): string {
+  const hh = ((h % 24) + 24) % 24;
+  const whole = Math.floor(hh);
+  const mins = Math.round((hh - whole) * 60);
+  const ampm = whole < 12 ? "AM" : "PM";
+  const h12 = whole % 12 === 0 ? 12 : whole % 12;
+  return `${h12}:${String(mins).padStart(2, "0")} ${ampm}`;
+}
+function scoreLabel(s: number): { label: string; tone: "success" | "warm" | "danger" } {
+  if (s >= 80) return { label: "Consistent", tone: "success" };
+  if (s >= 60) return { label: "Moderate", tone: "warm" };
+  return { label: "Irregular", tone: "danger" };
+}
+
+/** Sleep regularity card (bedtime/wake consistency), fed by /api/sleep/schedule. */
+export function SleepRegularity({ data }: { data: SleepScheduleData | null | undefined }) {
+  const r = data?.regularity;
+  if (!r || r.regularity_score == null) return null;
+  const sl = scoreLabel(r.regularity_score);
+  const rows: { label: string; value: string; varMin: number }[] = [
+    { label: "Avg bedtime", value: fmtHour(r.avg_bedtime), varMin: Math.round(r.bedtime_stddev * 60) },
+    { label: "Avg wake", value: fmtHour(r.avg_waketime), varMin: Math.round(r.waketime_stddev * 60) },
+    { label: "Avg duration", value: `${r.avg_duration.toFixed(1)}h`, varMin: Math.round(r.duration_stddev * 60) },
+  ];
+
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Sleep regularity</Text>
+        <Badge label={sl.label} tone={sl.tone} />
+      </View>
+      <View className="flex-row items-end gap-2">
+        <Text variant="display" className="text-teal">{r.regularity_score}</Text>
+        <Text variant="caption" className="text-text-muted mb-1">/ 100 consistency</Text>
+      </View>
+      <View className="gap-2">
+        {rows.map((row) => (
+          <View key={row.label} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+            <Text variant="body" className="text-text-secondary">{row.label}</Text>
+            <View className="flex-row items-baseline gap-2">
+              <Text variant="body" className="tabular-nums text-text">{row.value}</Text>
+              <Text variant="micro" className="text-text-muted">±{row.varMin}m</Text>
+            </View>
+          </View>
+        ))}
+      </View>
+    </Card>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -388,6 +388,31 @@ export function useRespiratory(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Sleep schedule + regularity (bedtime/wake variability) ----
+export interface SchedulePoint { date: string; bedtimeHour: number; wakeHour: number; durationHour: number }
+export interface SleepScheduleData {
+  schedule: SchedulePoint[];
+  regularity: {
+    avg_bedtime: number; avg_waketime: number; avg_duration: number;
+    bedtime_stddev: number; waketime_stddev: number; duration_stddev: number;
+    regularity_score: number | null;
+  } | null;
+}
+
+/** Sleep schedule + regularity from /api/sleep/schedule. */
+export function useSleepSchedule(range: string) {
+  const [data, setData] = useState<SleepScheduleData | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<SleepScheduleData>(`/api/sleep/schedule?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Training computation graph (nodes → the mobile pace-computation breakdown) ----
 export interface GraphNode { id: string; label: string; value: number | null }
 

--- a/web/app/api/sleep/schedule/route.ts
+++ b/web/app/api/sleep/schedule/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+const mean = (a: number[]) => (a.length ? a.reduce((x, y) => x + y, 0) / a.length : 0);
+const stddev = (a: number[]) => {
+  if (a.length < 2) return 0;
+  const m = mean(a);
+  return Math.sqrt(mean(a.map((v) => (v - m) ** 2)));
+};
+
+/**
+ * Sleep schedule (bedtime/wake per night) + regularity stats as JSON for the app
+ * (the web computes these from sleep_data timestamps server-side). Mirrors
+ * getSleepSchedule + getSleepRegularity in app/sleep/page.tsx.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "30d";
+  const days = range === "7d" ? 7 : range === "14d" ? 14 : range === "90d" ? 90 : range === "1y" ? 365 : 30;
+
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT date::text as date,
+      (raw_json->'dailySleepDTO'->>'sleepStartTimestampLocal')::bigint as start_ts,
+      (raw_json->'dailySleepDTO'->>'sleepEndTimestampLocal')::bigint   as end_ts
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'sleep_data'
+      AND (raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::int > 0
+      AND raw_json->'dailySleepDTO'->>'sleepStartTimestampLocal' IS NOT NULL
+      AND date >= CURRENT_DATE - ${days}::int
+    ORDER BY date ASC
+  `) as { date: string; start_ts: string | number; end_ts: string | number }[];
+
+  // Garmin stores local time encoded as UTC timestamps → use UTC getters.
+  const schedule = rows.map((r) => {
+    const s = new Date(Number(r.start_ts));
+    const e = new Date(Number(r.end_ts));
+    let bed = s.getUTCHours() + s.getUTCMinutes() / 60;
+    if (bed < 12) bed += 24; // early-morning bedtimes count as late-night
+    const wake = e.getUTCHours() + e.getUTCMinutes() / 60;
+    const dur = (Number(r.end_ts) - Number(r.start_ts)) / 3_600_000;
+    return { date: r.date, bedtimeHour: bed, wakeHour: wake, durationHour: dur };
+  });
+
+  const beds = schedule.map((x) => x.bedtimeHour);
+  const wakes = schedule.map((x) => x.wakeHour);
+  const durs = schedule.map((x) => x.durationHour);
+  const bStd = stddev(beds);
+  const wStd = stddev(wakes);
+  const regularityScore = schedule.length >= 3 ? Math.max(0, Math.min(100, Math.round(100 - ((bStd + wStd) / 2) * 30))) : null;
+
+  return NextResponse.json({
+    schedule,
+    regularity: schedule.length >= 3
+      ? {
+          avg_bedtime: mean(beds), avg_waketime: mean(wakes), avg_duration: mean(durs),
+          bedtime_stddev: bStd, waketime_stddev: wStd, duration_stddev: stddev(durs),
+          regularity_score: regularityScore,
+        }
+      : null,
+  });
+}


### PR DESCRIPTION
## Sleep: schedule + regularity

New `/api/sleep/schedule` endpoint computing bedtime/wake per night + regularity stats (stddev, consistency score) from `sleep_data` timestamps. App SleepRegularity card shows the consistency score plus avg bedtime/wake/duration with variability.

Validated: regularity 72/100 MODERATE, avg bedtime 5:16 AM ±20m, wake 9:02 AM ±91m render; `tsc` clean; 0 console errors.

Closes #290
Closes #291
Closes #292
