### PR TITLE
Running: endurance + hill fitness scores

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useRunningTrends } from "../../lib/api";
+import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores } from "../../lib/api";
 import { RunningMileage } from "../../components/running-mileage";
 import { RunningDeepTrends } from "../../components/running-deep-trends";
+import { RunningFitnessScores } from "../../components/running-fitness-scores";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -155,6 +156,7 @@ const ZONE_HEX = ["#77c8d1", "#6ad4a0", "#e0c458", "#e0a458", "#e06060"];
 export default function RunningScreen() {
   const { data, error, refetch } = useRunning();
   const { data: runTrends } = useRunningTrends("180d");
+  const { data: fitScores } = useFitnessScores("1y");
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const stats = data?.stats;
@@ -321,6 +323,9 @@ export default function RunningScreen() {
 
         {/* Training load/ACWR + cadence trends (new /api/running/trends) */}
         <RunningDeepTrends trends={runTrends} />
+
+        {/* Endurance + hill fitness scores (new /api/running/fitness-scores) */}
+        <RunningFitnessScores scores={fitScores} />
 
         {/* Training Intensity Distribution (approximated with ProgressBars) */}
         {zones.length > 0 ? (

--- a/universal/src/components/running-fitness-scores.tsx
+++ b/universal/src/components/running-fitness-scores.tsx
@@ -1,0 +1,49 @@
+import { View } from "react-native";
+import { Text, Card, Sparkline } from "soma-style";
+import type { FitnessScores } from "../lib/api";
+
+const ENDURANCE_CLASS: Record<number, string> = {
+  1: "Novice", 2: "Trained", 3: "Well trained", 4: "Expert", 5: "Superior", 6: "Elite",
+};
+
+/** Endurance + hill fitness score cards, fed by /api/running/fitness-scores. */
+export function RunningFitnessScores({ scores }: { scores: FitnessScores | null | undefined }) {
+  if (!scores) return null;
+  const end = scores.endurance.latest;
+  const hill = scores.hill.latest;
+  const endSeries = scores.endurance.trend.map((p) => p.score).filter((v): v is number => v != null);
+  const hillSeries = scores.hill.trend.map((p) => p.score).filter((v): v is number => v != null);
+
+  if (!end && !hill) return null;
+
+  return (
+    <View className="gap-4">
+      {end ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Endurance score</Text>
+            {end.classification != null ? (
+              <Text variant="micro" className="text-text-muted">{ENDURANCE_CLASS[end.classification] ?? `class ${end.classification}`}</Text>
+            ) : null}
+          </View>
+          <Text variant="display" className="text-teal">{end.score != null ? end.score.toLocaleString() : "—"}</Text>
+          {endSeries.length >= 2 ? <Sparkline data={endSeries} color="#77c8d1" height={34} baseline /> : null}
+        </Card>
+      ) : null}
+
+      {hill ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Hill score</Text>
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="text-lime">{hill.score ?? "—"}</Text>
+            <View className="mb-1 flex-row gap-3">
+              {hill.strength != null ? <Text variant="micro" className="text-text-muted">strength {hill.strength}</Text> : null}
+              {hill.endurance != null ? <Text variant="micro" className="text-text-muted">endurance {hill.endurance}</Text> : null}
+            </View>
+          </View>
+          {hillSeries.length >= 2 ? <Sparkline data={hillSeries} color="#cbe896" height={34} baseline /> : null}
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -282,6 +282,28 @@ export function useRunningTrends(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Running fitness scores (endurance + hill) ----
+export interface EndurancePoint { date: string; score: number | null; classification: number | null }
+export interface HillPoint { date: string; score: number | null; strength: number | null; endurance: number | null }
+export interface FitnessScores {
+  endurance: { trend: EndurancePoint[]; latest: EndurancePoint | null };
+  hill: { trend: HillPoint[]; latest: HillPoint | null };
+}
+
+/** Endurance + hill fitness scores from /api/running/fitness-scores. */
+export function useFitnessScores(range: string) {
+  const [data, setData] = useState<FitnessScores | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<FitnessScores>(`/api/running/fitness-scores?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Strength-training data (volume, stats, recent, top exercises) ----
 export interface WorkoutSummary {
   stats: {

--- a/web/app/api/running/fitness-scores/route.ts
+++ b/web/app/api/running/fitness-scores/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Endurance + hill fitness scores as JSON for the app running screen (the web
+ * reads garmin_raw_data server-side). Mirrors getFitnessScores in
+ * app/running/page.tsx.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "1y";
+  const days = range === "90d" ? 90 : range === "6m" ? 182 : range === "2y" ? 730 : 365;
+
+  const sql = getDb();
+
+  const endurance = (await sql`
+    SELECT date::text as date,
+      (raw_json->>'overallScore')::int  as score,
+      (raw_json->>'classification')::int as classification
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'endurance_score'
+      AND date >= CURRENT_DATE - ${days}::int
+    ORDER BY date ASC
+  `) as { date: string; score: number | null; classification: number | null }[];
+
+  const hill = (await sql`
+    SELECT date::text as date,
+      (raw_json->>'overallScore')::int   as score,
+      (raw_json->>'strengthScore')::int  as strength,
+      (raw_json->>'enduranceScore')::int as endurance
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'hill_score'
+      AND date >= CURRENT_DATE - ${days}::int
+    ORDER BY date ASC
+  `) as { date: string; score: number | null; strength: number | null; endurance: number | null }[];
+
+  return NextResponse.json({
+    endurance: { trend: endurance, latest: endurance.length ? endurance[endurance.length - 1] : null },
+    hill: { trend: hill, latest: hill.length ? hill[hill.length - 1] : null },
+  });
+}


### PR DESCRIPTION
## Running: endurance + hill fitness scores

New `/api/running/fitness-scores` endpoint exposing `endurance_score` + `hill_score` from garmin. App RunningFitnessScores renders an endurance card (score + classification + sparkline) and a hill card (score + strength/endurance + sparkline).

Validated: Endurance 6,167 (Well trained), Hill 29 (strength 13, endurance 4) render; `tsc` clean; 0 console errors.

Closes #294
Closes #295
Closes #296
