### PR TITLE
Running: per-km splits + fastest splits

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores } from "../../lib/api";
+import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits } from "../../lib/api";
 import { RunningMileage } from "../../components/running-mileage";
 import { RunningDeepTrends } from "../../components/running-deep-trends";
 import { RunningFitnessScores } from "../../components/running-fitness-scores";
+import { RunningSplits } from "../../components/running-splits";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -157,6 +158,7 @@ export default function RunningScreen() {
   const { data, error, refetch } = useRunning();
   const { data: runTrends } = useRunningTrends("180d");
   const { data: fitScores } = useFitnessScores("1y");
+  const { data: splits } = useRunningSplits("1y");
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const stats = data?.stats;
@@ -326,6 +328,9 @@ export default function RunningScreen() {
 
         {/* Endurance + hill fitness scores (new /api/running/fitness-scores) */}
         <RunningFitnessScores scores={fitScores} />
+
+        {/* Per-km splits + fastest splits (new /api/running/splits) */}
+        <RunningSplits data={splits} />
 
         {/* Training Intensity Distribution (approximated with ProgressBars) */}
         {zones.length > 0 ? (

--- a/universal/src/components/running-splits.tsx
+++ b/universal/src/components/running-splits.tsx
@@ -1,0 +1,69 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import type { RunningSplits } from "../lib/api";
+
+/** Decimal minutes → "M:SS". */
+function pace(mins: number | null | undefined): string {
+  if (mins == null || !isFinite(mins)) return "—";
+  const m = Math.floor(mins);
+  const s = Math.round((mins - m) * 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+function shortDate(iso: string): string {
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+const MEDAL = ["#e0c458", "#c0c0c8", "#b17850"]; // gold / silver / bronze
+
+/** Per-km pace bars + fastest single-km splits, fed by /api/running/splits. */
+export function RunningSplits({ data }: { data: RunningSplits | null | undefined }) {
+  if (!data) return null;
+  const perKm = data.perKm.filter((k) => k.avg_pace != null);
+  const paces = perKm.map((k) => Number(k.avg_pace));
+  const minP = Math.min(...paces);
+  const maxP = Math.max(...paces);
+  const rangeP = maxP - minP || 1;
+
+  return (
+    <View className="gap-4">
+      {perKm.length >= 2 ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Average pace by km</Text>
+          {perKm.map((k) => {
+            const p = Number(k.avg_pace);
+            const t = (p - minP) / rangeP; // 0 fastest → 1 slowest
+            const color = t < 0.4 ? "#6ad4a0" : t < 0.7 ? "#e0c458" : "#e0a458";
+            return (
+              <View key={k.km} className="flex-row items-center gap-2 py-1">
+                <Text variant="micro" className="tabular-nums text-text-muted w-8">km{k.km}</Text>
+                <View className="flex-1 h-3 rounded-full bg-surface-subtle overflow-hidden">
+                  <View className="h-full rounded-full" style={{ width: `${Math.max(6, (1 - t) * 100)}%`, backgroundColor: color }} />
+                </View>
+                <Text variant="caption" className="tabular-nums text-text w-16 text-right">{pace(p)}/km</Text>
+              </View>
+            );
+          })}
+          <Text variant="micro" className="text-text-muted">avg over ≥10 runs per km</Text>
+        </Card>
+      ) : null}
+
+      {data.best.length ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Fastest km splits</Text>
+          {data.best.map((b, i) => (
+            <View key={`${b.date}-${b.km}`} className="flex-row items-center gap-3 border-b border-border-subtle py-2">
+              <View className="h-6 w-6 items-center justify-center rounded-full" style={{ backgroundColor: (MEDAL[i] ?? "#2f4a58") + "33" }}>
+                <Text variant="micro" style={{ color: MEDAL[i] ?? "#8aa0ac" }}>{i + 1}</Text>
+              </View>
+              <View className="flex-1">
+                <Text variant="body" className="text-text" numberOfLines={1}>{b.activity_name || `km ${b.km}`}</Text>
+                <Text variant="micro" className="text-text-muted">km{b.km} · {shortDate(b.date)}</Text>
+              </View>
+              <Text variant="body" className="tabular-nums text-teal">{pace(b.pace)}/km</Text>
+            </View>
+          ))}
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -304,6 +304,25 @@ export function useFitnessScores(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Per-km split analysis + fastest splits ----
+export interface KmSplit { km: number; runs: number | string; avg_pace: number | null; avg_hr: number | null; avg_cadence: number | null; fast_pace: number | null; slow_pace: number | null }
+export interface BestSplit { km: number; pace: number; date: string; activity_name: string | null }
+export interface RunningSplits { perKm: KmSplit[]; best: BestSplit[] }
+
+/** Per-km split analysis + fastest splits from /api/running/splits. */
+export function useRunningSplits(range: string) {
+  const [data, setData] = useState<RunningSplits | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<RunningSplits>(`/api/running/splits?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Strength-training data (volume, stats, recent, top exercises) ----
 export interface WorkoutSummary {
   stats: {

--- a/web/app/api/running/splits/route.ts
+++ b/web/app/api/running/splits/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Per-km split analysis + fastest single-km splits as JSON for the app running
+ * screen (the web reads garmin_activity_raw server-side). Mirrors
+ * getSplitAnalysis + getBestSplits in app/running/page.tsx.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "1y";
+  const days = range === "90d" ? 90 : range === "6m" ? 182 : range === "2y" ? 730 : 365;
+
+  const sql = getDb();
+
+  const perKm = (await sql`
+    WITH recent_activities AS (
+      SELECT activity_id FROM garmin_activity_raw
+      WHERE endpoint_name = 'summary'
+        AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+        AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
+    ),
+    split_data AS (
+      SELECT (lap->>'lapIndex')::int as lap_index,
+        (lap->>'distance')::float as distance,
+        (lap->>'duration')::float as duration,
+        (lap->>'averageHR')::float as avg_hr,
+        (lap->>'averageRunCadence')::float * 2 as cadence
+      FROM garmin_activity_raw s, jsonb_array_elements(s.raw_json->'lapDTOs') as lap
+      WHERE s.endpoint_name = 'splits'
+        AND s.activity_id IN (SELECT activity_id FROM recent_activities)
+        AND (lap->>'distance')::float BETWEEN 800 AND 1200
+        AND (lap->>'duration')::float > 0
+    )
+    SELECT lap_index as km, COUNT(*) as runs,
+      AVG(duration / NULLIF(distance / 1000.0, 0) / 60.0) as avg_pace,
+      AVG(avg_hr) as avg_hr, AVG(cadence) as avg_cadence,
+      PERCENTILE_CONT(0.1) WITHIN GROUP (ORDER BY duration / NULLIF(distance / 1000.0, 0) / 60.0) as fast_pace,
+      PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY duration / NULLIF(distance / 1000.0, 0) / 60.0) as slow_pace
+    FROM split_data WHERE lap_index < 15
+    GROUP BY lap_index HAVING COUNT(*) >= 10 ORDER BY lap_index ASC
+  `) as { km: number; runs: number; avg_pace: number | null; avg_hr: number | null; avg_cadence: number | null; fast_pace: number | null; slow_pace: number | null }[];
+
+  const best = (await sql`
+    WITH recent_activities AS (
+      SELECT activity_id FROM garmin_activity_raw
+      WHERE endpoint_name = 'summary'
+        AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+        AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
+    ),
+    split_data AS (
+      SELECT s.activity_id, (lap->>'lapIndex')::int as lap_index,
+        (lap->>'distance')::float as distance, (lap->>'duration')::float as duration
+      FROM garmin_activity_raw s, jsonb_array_elements(s.raw_json->'lapDTOs') as lap
+      WHERE s.endpoint_name = 'splits'
+        AND s.activity_id IN (SELECT activity_id FROM recent_activities)
+        AND (lap->>'distance')::float BETWEEN 800 AND 1200
+        AND (lap->>'duration')::float > 0
+    ),
+    with_pace AS (SELECT *, duration / NULLIF(distance / 1000.0, 0) / 60.0 as pace FROM split_data)
+    SELECT wp.lap_index as km, wp.pace,
+      (sm.raw_json->>'startTimeLocal')::text as date,
+      (sm.raw_json->>'activityName')::text as activity_name
+    FROM with_pace wp
+    JOIN garmin_activity_raw sm ON sm.activity_id = wp.activity_id AND sm.endpoint_name = 'summary'
+    WHERE wp.pace BETWEEN 2.5 AND 10
+    ORDER BY wp.pace ASC LIMIT 5
+  `) as { km: number; pace: number; date: string; activity_name: string | null }[];
+
+  return NextResponse.json({ perKm, best });
+}


### PR DESCRIPTION
## Running: per-km splits + fastest splits

New `/api/running/splits` endpoint computing per-km average-pace analysis (fast/slow percentiles, ≥10 runs/km) and the fastest single-km splits from garmin `lapDTOs`. App RunningSplits renders pace-by-km bars (green fast → orange slow) and a fastest-splits leaderboard with medals.

Validated: km bars (km7 5:16 fastest) + fastest splits (3:49/km Knoxville 5K) render; `tsc` clean; 0 console errors.

Closes #298
Closes #299
Closes #300
