### PR TITLE
Running: HR-vs-pace scatter

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits } from "../../lib/api";
+import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits, useHrPace } from "../../lib/api";
 import { RunningMileage } from "../../components/running-mileage";
 import { RunningDeepTrends } from "../../components/running-deep-trends";
 import { RunningFitnessScores } from "../../components/running-fitness-scores";
 import { RunningSplits } from "../../components/running-splits";
+import { RunningHrPace } from "../../components/running-hr-pace";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -159,6 +160,7 @@ export default function RunningScreen() {
   const { data: runTrends } = useRunningTrends("180d");
   const { data: fitScores } = useFitnessScores("1y");
   const { data: splits } = useRunningSplits("1y");
+  const { data: hrPace } = useHrPace("1y");
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const stats = data?.stats;
@@ -331,6 +333,9 @@ export default function RunningScreen() {
 
         {/* Per-km splits + fastest splits (new /api/running/splits) */}
         <RunningSplits data={splits} />
+
+        {/* HR vs pace scatter (new /api/running/hr-pace) */}
+        <RunningHrPace data={hrPace} />
 
         {/* Training Intensity Distribution (approximated with ProgressBars) */}
         {zones.length > 0 ? (

--- a/universal/src/components/running-hr-pace.tsx
+++ b/universal/src/components/running-hr-pace.tsx
@@ -1,0 +1,49 @@
+import { View } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+import { Text, Card } from "soma-style";
+import type { HrPacePoint } from "../lib/api";
+
+function pace(mins: number): string {
+  const m = Math.floor(mins);
+  const s = Math.round((mins - m) * 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/**
+ * HR-vs-pace scatter (per run): x = pace (left faster), y = HR (up higher),
+ * dot size ~ distance. Mobile-adapted from the web's year-toggle scatter.
+ */
+export function RunningHrPace({ data }: { data: { points: HrPacePoint[] } | null | undefined }) {
+  const pts = (data?.points ?? []).filter((p) => p.pace != null && p.hr != null);
+  if (pts.length < 4) return null;
+
+  const paces = pts.map((p) => p.pace as number);
+  const hrs = pts.map((p) => p.hr as number);
+  const minP = Math.min(...paces), maxP = Math.max(...paces), rP = maxP - minP || 1;
+  const minH = Math.min(...hrs), maxH = Math.max(...hrs), rH = maxH - minH || 1;
+  const dists = pts.map((p) => p.distance ?? 0);
+  const maxD = Math.max(...dists) || 1;
+  const H = 150;
+
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Heart rate vs pace</Text>
+        <Text variant="micro" className="text-text-muted">{pts.length} runs</Text>
+      </View>
+      <Svg width="100%" height={H} viewBox={`0 0 100 ${H}`} preserveAspectRatio="none">
+        {pts.map((p, i) => {
+          const cx = ((p.pace as number) - minP) / rP * 96 + 2;
+          const cy = H - (((p.hr as number) - minH) / rH) * (H - 8) - 4;
+          const r = 1.5 + ((p.distance ?? 0) / maxD) * 3.5;
+          return <Circle key={i} cx={cx} cy={cy} r={r} fill="#77c8d1" fillOpacity={0.55} />;
+        })}
+      </Svg>
+      <View className="flex-row items-center justify-between">
+        <Text variant="micro" className="text-text-muted">← {pace(minP)} faster</Text>
+        <Text variant="micro" className="text-text-muted">slower {pace(maxP)} →</Text>
+      </View>
+      <Text variant="micro" className="text-text-muted">HR {Math.round(minH)}–{Math.round(maxH)} bpm (up = higher) · dot = distance</Text>
+    </Card>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -304,6 +304,23 @@ export function useFitnessScores(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- HR-vs-pace scatter points ----
+export interface HrPacePoint { date: string; name: string | null; pace: number | null; hr: number | null; distance: number | null }
+
+/** Per-run pace/HR points from /api/running/hr-pace (for the scatter). */
+export function useHrPace(range: string) {
+  const [data, setData] = useState<{ points: HrPacePoint[] } | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<{ points: HrPacePoint[] }>(`/api/running/hr-pace?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Per-km split analysis + fastest splits ----
 export interface KmSplit { km: number; runs: number | string; avg_pace: number | null; avg_hr: number | null; avg_cadence: number | null; fast_pace: number | null; slow_pace: number | null }
 export interface BestSplit { km: number; pace: number; date: string; activity_name: string | null }

--- a/web/app/api/running/hr-pace/route.ts
+++ b/web/app/api/running/hr-pace/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Per-run pace vs heart-rate points as JSON for the app running screen's
+ * HR-vs-pace scatter (the web reads garmin_activity_raw server-side). Mirrors
+ * getHRPaceData in app/running/page.tsx.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "1y";
+  const days = range === "90d" ? 90 : range === "6m" ? 182 : range === "2y" ? 730 : 365;
+
+  const sql = getDb();
+  const points = (await sql`
+    SELECT
+      (raw_json->>'startTimeLocal')::text as date,
+      (raw_json->>'activityName')::text as name,
+      (raw_json->>'duration')::float / NULLIF((raw_json->>'distance')::float / 1000.0, 0) / 60.0 as pace,
+      (raw_json->>'averageHR')::float as hr,
+      (raw_json->>'distance')::float / 1000.0 as distance
+    FROM garmin_activity_raw
+    WHERE endpoint_name = 'summary'
+      AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+      AND (raw_json->>'distance')::float > 1000
+      AND (raw_json->>'averageHR')::float > 60
+      AND (raw_json->>'duration')::float / NULLIF((raw_json->>'distance')::float / 1000.0, 0) / 60.0 BETWEEN 3.0 AND 10.0
+      AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
+    ORDER BY (raw_json->>'startTimeLocal')::text ASC
+  `) as { date: string; name: string | null; pace: number | null; hr: number | null; distance: number | null }[];
+
+  return NextResponse.json({ points });
+}


### PR DESCRIPTION
## Running: HR-vs-pace scatter

New `/api/running/hr-pace` endpoint returning per-run pace/HR/distance from garmin. App RunningHrPace renders a mobile-adapted SVG scatter (x=pace, y=HR, dot size=distance) showing the pace/HR relationship.

Validated: 91-run scatter with axis labels (4:11–7:30 pace, HR 120–177) renders; `tsc` clean; 0 console errors.

Closes #302
Closes #303
Closes #304
