### PR TITLE
Sleep: weekday vs weekend comparison

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule } from "../../lib/api";
+import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule, useWeekdayWeekend } from "../../lib/api";
 import { SleepDashboard } from "../../components/sleep-dashboard";
 import { RecoveryVitals } from "../../components/recovery-vitals";
 import { SleepRespiratory } from "../../components/sleep-respiratory";
 import { SleepRegularity } from "../../components/sleep-regularity";
+import { SleepWeekdayWeekend } from "../../components/sleep-weekday-weekend";
 
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
@@ -106,6 +107,7 @@ export default function SleepScreen() {
   const { data: recoveryVitals } = useRecoverySummary(range);
   const { data: respiratory } = useRespiratory(range);
   const { data: schedule } = useSleepSchedule(range);
+  const { data: weekdayWeekend } = useWeekdayWeekend(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const lastSleep = last(sleep);
@@ -228,6 +230,9 @@ export default function SleepScreen() {
 
         {/* Sleep regularity — bedtime/wake consistency (new /api/sleep/schedule) */}
         <SleepRegularity data={schedule} />
+
+        {/* Weekday vs weekend comparison (new /api/sleep/weekday-weekend) */}
+        <SleepWeekdayWeekend data={weekdayWeekend} />
 
         {/* Sleep duration trend (bar approximation) */}
         <Card className="gap-3">

--- a/universal/src/components/sleep-weekday-weekend.tsx
+++ b/universal/src/components/sleep-weekday-weekend.tsx
@@ -1,0 +1,38 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import type { WeekdayWeekend } from "../lib/api";
+
+const n = (v: unknown): number => Number(v);
+
+/** Weekday vs weekend sleep comparison card, fed by /api/sleep/weekday-weekend. */
+export function SleepWeekdayWeekend({ data }: { data: WeekdayWeekend | null | undefined }) {
+  if (!data?.weekday || !data?.weekend) return null;
+  const wd = data.weekday, we = data.weekend;
+  const rows: { label: string; wd: string; we: string; diff: number; unit: string }[] = [
+    { label: "Duration", wd: `${n(wd.avg_hours).toFixed(1)}h`, we: `${n(we.avg_hours).toFixed(1)}h`, diff: n(we.avg_hours) - n(wd.avg_hours), unit: "h" },
+    { label: "Score", wd: `${Math.round(n(wd.avg_score))}`, we: `${Math.round(n(we.avg_score))}`, diff: n(we.avg_score) - n(wd.avg_score), unit: "" },
+    { label: "Deep %", wd: `${Math.round(n(wd.avg_deep_pct))}%`, we: `${Math.round(n(we.avg_deep_pct))}%`, diff: n(we.avg_deep_pct) - n(wd.avg_deep_pct), unit: "%" },
+  ];
+
+  return (
+    <Card className="gap-2">
+      <Text variant="eyebrow">Weekday vs weekend</Text>
+      <View className="flex-row justify-end gap-6 pr-1">
+        <Text variant="micro" className="text-text-muted w-12 text-right">Weekday</Text>
+        <Text variant="micro" className="text-text-muted w-12 text-right">Weekend</Text>
+      </View>
+      {rows.map((r) => (
+        <View key={r.label} className="flex-row items-center border-b border-border-subtle py-1.5">
+          <Text variant="body" className="text-text-secondary flex-1">
+            {r.label}
+            <Text variant="micro" className={r.diff >= 0 ? "text-success" : "text-warning"}>
+              {"  "}{r.diff >= 0 ? "+" : ""}{Math.abs(r.diff) < 0.05 ? "0" : r.diff.toFixed(r.unit === "" ? 0 : 1)}{r.unit} wknd
+            </Text>
+          </Text>
+          <Text variant="body" className="tabular-nums text-text w-12 text-right">{r.wd}</Text>
+          <Text variant="body" className="tabular-nums text-text w-12 text-right">{r.we}</Text>
+        </View>
+      ))}
+    </Card>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -471,6 +471,24 @@ export function useSleepSchedule(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Weekday vs weekend sleep ----
+export interface DayTypeSleep { avg_hours: number | null; avg_score: number | null; avg_deep_pct: number | null; nights: number | string }
+export interface WeekdayWeekend { weekday: DayTypeSleep | null; weekend: DayTypeSleep | null }
+
+/** Weekday vs weekend sleep comparison from /api/sleep/weekday-weekend. */
+export function useWeekdayWeekend(range: string) {
+  const [data, setData] = useState<WeekdayWeekend | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<WeekdayWeekend>(`/api/sleep/weekday-weekend?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Training computation graph (nodes → the mobile pace-computation breakdown) ----
 export interface GraphNode { id: string; label: string; value: number | null }
 

--- a/web/app/api/sleep/weekday-weekend/route.ts
+++ b/web/app/api/sleep/weekday-weekend/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Weekday vs weekend sleep comparison as JSON for the app sleep screen (the web
+ * computes this server-side). Mirrors getWeekdayWeekendSleep in app/sleep/page.tsx.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "90d";
+  const days = range === "30d" ? 30 : range === "1y" ? 365 : 90;
+
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT
+      CASE WHEN EXTRACT(DOW FROM date) IN (0, 6) THEN 'weekend' ELSE 'weekday' END as day_type,
+      AVG((raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::float) / 3600.0 as avg_hours,
+      AVG((raw_json->'dailySleepDTO'->'sleepScores'->'overall'->>'value')::float) as avg_score,
+      AVG((raw_json->'dailySleepDTO'->>'deepSleepSeconds')::float /
+          NULLIF((raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::float, 0) * 100) as avg_deep_pct,
+      COUNT(*) as nights
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'sleep_data'
+      AND (raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::int > 0
+      AND date >= CURRENT_DATE - ${days}::int
+    GROUP BY day_type
+  `) as { day_type: string; avg_hours: number | null; avg_score: number | null; avg_deep_pct: number | null; nights: number | string }[];
+
+  const out: Record<string, unknown> = { weekday: null, weekend: null };
+  for (const r of rows) out[r.day_type] = r;
+  return NextResponse.json(out);
+}


### PR DESCRIPTION
## Sleep: weekday vs weekend comparison

New `/api/sleep/weekday-weekend` endpoint returning avg duration/score/deep% grouped by day type. App SleepWeekdayWeekend card compares the two with color-coded deltas. Final sleep-dashboard parity item.

Validated: Duration 3.4h/4.2h, Score 41/52, Deep% 30/29 render with deltas; `tsc` clean; 0 console errors.

Closes #306
Closes #307
Closes #308
