### PR TITLE
Running: recent-routes gallery (SVG route thumbnails)

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits, useHrPace } from "../../lib/api";
+import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits, useHrPace, useRecentRoutes } from "../../lib/api";
 import { RunningMileage } from "../../components/running-mileage";
 import { RunningDeepTrends } from "../../components/running-deep-trends";
 import { RunningFitnessScores } from "../../components/running-fitness-scores";
 import { RunningSplits } from "../../components/running-splits";
 import { RunningHrPace } from "../../components/running-hr-pace";
+import { RunningRoutes } from "../../components/running-routes";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -161,6 +162,7 @@ export default function RunningScreen() {
   const { data: fitScores } = useFitnessScores("1y");
   const { data: splits } = useRunningSplits("1y");
   const { data: hrPace } = useHrPace("1y");
+  const { data: routes } = useRecentRoutes();
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const stats = data?.stats;
@@ -324,6 +326,9 @@ export default function RunningScreen() {
 
         {/* Monthly mileage bar chart (web parity) */}
         <RunningMileage mileage={trends?.mileage} />
+
+        {/* Recent route thumbnails (SVG shapes from /api/running/recent-routes) */}
+        <RunningRoutes routes={routes} />
 
         {/* Training load/ACWR + cadence trends (new /api/running/trends) */}
         <RunningDeepTrends trends={runTrends} />

--- a/universal/src/components/running-routes.tsx
+++ b/universal/src/components/running-routes.tsx
@@ -1,0 +1,56 @@
+import { View } from "react-native";
+import Svg, { Polyline } from "react-native-svg";
+import { Text, Card } from "soma-style";
+import type { RouteItem, RoutePoint } from "../lib/api";
+
+function shortDate(iso: string): string {
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+/** One route's GPS path as a normalized SVG polyline (north up), no map tiles. */
+function RouteThumb({ points }: { points: RoutePoint[] }) {
+  const pts = points.filter((p) => isFinite(p.lat) && isFinite(p.lng));
+  // sample down to ~80 points for perf
+  const step = Math.max(1, Math.floor(pts.length / 80));
+  const s = pts.filter((_, i) => i % step === 0);
+  if (s.length < 2) return <View className="h-24 rounded-lg bg-surface-subtle" />;
+  const lats = s.map((p) => p.lat), lngs = s.map((p) => p.lng);
+  const minLa = Math.min(...lats), maxLa = Math.max(...lats);
+  const minLo = Math.min(...lngs), maxLo = Math.max(...lngs);
+  const rLa = maxLa - minLa || 1e-6, rLo = maxLo - minLo || 1e-6;
+  // keep aspect roughly square, pad to 4..96
+  const poly = s
+    .map((p) => `${((p.lng - minLo) / rLo) * 92 + 4},${(1 - (p.lat - minLa) / rLa) * 92 + 4}`)
+    .join(" ");
+  return (
+    <View className="h-24 rounded-lg bg-surface-subtle overflow-hidden">
+      <Svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
+        <Polyline points={poly} fill="none" stroke="#77c8d1" strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
+      </Svg>
+    </View>
+  );
+}
+
+/** Recent-runs route gallery (SVG route shapes), fed by /api/running/recent-routes. */
+export function RunningRoutes({ routes }: { routes: RouteItem[] }) {
+  const withGps = (routes ?? []).filter((r) => (r.gps_points?.length ?? 0) >= 2);
+  if (!withGps.length) return null;
+
+  return (
+    <Card className="gap-3">
+      <Text variant="eyebrow">Recent routes</Text>
+      <View className="flex-row flex-wrap gap-3">
+        {withGps.slice(0, 6).map((r) => (
+          <View key={r.activity_id} className="min-w-[46%] flex-1 gap-1">
+            <RouteThumb points={r.gps_points} />
+            <Text variant="micro" className="text-text-secondary" numberOfLines={1}>{r.name || "Run"}</Text>
+            <Text variant="micro" className="text-text-muted">
+              {shortDate(r.date)}{r.distance_km != null ? ` · ${r.distance_km.toFixed(1)} km` : ""}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </Card>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -304,6 +304,27 @@ export function useFitnessScores(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Recent route GPS paths (for SVG route thumbnails) ----
+export interface RoutePoint { lat: number; lng: number }
+export interface RouteItem {
+  activity_id: string; date: string; name: string | null;
+  distance_km: number | null; duration_s: number | null; gps_points: RoutePoint[];
+}
+
+/** Recent runs with GPS paths from /api/running/recent-routes (route thumbnails). */
+export function useRecentRoutes() {
+  const [data, setData] = useState<RouteItem[]>([]);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<RouteItem[]>("/api/running/recent-routes")
+      .then((d) => alive && setData(Array.isArray(d) ? d : []))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- HR-vs-pace scatter points ----
 export interface HrPacePoint { date: string; name: string | null; pace: number | null; hr: number | null; distance: number | null }
 


### PR DESCRIPTION
## Running: recent-routes gallery (SVG route thumbnails)

Renders recent runs' GPS paths as normalized SVG polyline thumbnails (route shapes, north-up, **no map tiles and no native maps dependency**) from the existing `/api/running/recent-routes`. Mobile-adapted version of the web route heatmap/gallery. This completes the app↔web parity pass.

Validated: 6 route-shape thumbnails (Athens Running, actual GPS outlines) with name/date/distance render; `tsc` clean; 0 console errors.

Closes #310
Closes #311
Closes #312
