### PR TITLE
Activities: monthly distribution + kite deep-dive + filterable list

### DIFF
--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh } from "../../lib/api";
+import { fetchJson, usePullRefresh, useActivitiesDeep } from "../../lib/api";
+import { ActivitiesMonthly, KiteDeepDive, ActivitiesList } from "../../components/activities-deep";
 
 /** Daily activity-count series (per-day sessions) for the Sessions trend. */
 function useSessionsTrend() {
@@ -116,6 +117,7 @@ function fmtDate(iso: string): string {
 export default function ActivitiesScreen() {
   const [range, setRange] = useState<RangeKey>("1y");
   const { data, loading, error, refetch } = useActivities(range);
+  const { data: deep } = useActivitiesDeep(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const totals = data?.totals;
@@ -285,36 +287,14 @@ export default function ActivitiesScreen() {
           </Card>
         ) : null}
 
-        {/* Recent activity log */}
-        {data && data.recent.length > 0 ? (
-          <Card className="gap-2">
-            <Text variant="eyebrow">Recent activities</Text>
-            {data.recent.slice(0, 15).map((a) => (
-              <View
-                key={a.activity_id}
-                className="flex-row items-center justify-between border-b border-border-subtle py-2"
-              >
-                <View className="mr-2 flex-1 gap-0.5">
-                  <Text variant="caption" className="text-text" numberOfLines={1}>
-                    {a.name || a.label}
-                  </Text>
-                  <Text variant="micro" className="text-text-muted">
-                    {a.label} · {fmtDate(a.date)}
-                  </Text>
-                </View>
-                <View className="items-end gap-0.5">
-                  <Text variant="caption" className="tabular-nums text-text">
-                    {a.distance_km > 0 ? `${a.distance_km.toFixed(1)} km` : fmtDuration(a.duration_min)}
-                  </Text>
-                  <Text variant="micro" className="tabular-nums text-text-muted">
-                    {fmtDuration(a.duration_min)}
-                    {a.avg_hr ? ` · ${Math.round(a.avg_hr)} bpm` : ""}
-                  </Text>
-                </View>
-              </View>
-            ))}
-          </Card>
-        ) : null}
+        {/* Monthly distribution — stacked columns by sport (web parity) */}
+        {deep ? <ActivitiesMonthly monthly={deep.monthly} /> : null}
+
+        {/* Kite deep dive — speed progression + top spots + jump records */}
+        {deep ? <KiteDeepDive sessions={deep.kite.sessions} /> : null}
+
+        {/* Full activity list with sport filter + paging (replaces the recent log) */}
+        {deep ? <ActivitiesList all={deep.all} /> : null}
       </View>
     </ScrollView>
   );

--- a/universal/src/components/activities-deep.tsx
+++ b/universal/src/components/activities-deep.tsx
@@ -1,0 +1,213 @@
+import { useMemo, useState } from "react";
+import { View, Pressable } from "react-native";
+import Svg, { Circle, Polyline } from "react-native-svg";
+import { Text, Card } from "soma-style";
+import type { ActivitiesDeep, ActivityRow, KiteSession } from "../lib/api";
+
+/* Sport → colour, mirroring the web activities palette. */
+const SPORT_COLOR: Record<string, string> = {
+  Kiteboarding: "#22d3ee",
+  Snowboarding: "#93c5fd",
+  Hiking: "#6ad4a0",
+  "E-Bike": "#c084fc",
+  Swimming: "#6aa0e0",
+  Walking: "#cbe896",
+  Cycling: "#e0a458",
+  Cardio: "#e06060",
+  SUP: "#f0abfc",
+  Other: "#5a7a8a",
+};
+const sportColor = (s: string) => SPORT_COLOR[s] ?? "#5a7a8a";
+
+function shortMonth(ym: string): string {
+  const [y, m] = ym.split("-").map(Number);
+  return new Date(y, (m ?? 1) - 1, 1).toLocaleDateString(undefined, { month: "short" });
+}
+function shortDate(iso: string): string {
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+function hm(mins: number | null | undefined): string {
+  if (mins == null || !isFinite(mins)) return "—";
+  const h = Math.floor(mins / 60);
+  const m = Math.round(mins % 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+/** Monthly activity distribution — stacked columns by sport. */
+export function ActivitiesMonthly({ monthly }: { monthly: ActivitiesDeep["monthly"] }) {
+  const data = (monthly ?? []).slice(-12);
+  if (data.length < 2) return null;
+  const totals = data.map((m) => Object.values(m.sports).reduce((a, b) => a + b, 0));
+  const max = Math.max(...totals) || 1;
+  const sports = [...new Set(data.flatMap((m) => Object.keys(m.sports)))];
+
+  return (
+    <Card className="gap-2">
+      <Text variant="eyebrow">Monthly activity</Text>
+      <View className="h-28 flex-row items-end gap-1">
+        {data.map((m, i) => {
+          const total = totals[i];
+          return (
+            <View key={m.month} className="flex-1 items-center justify-end self-stretch gap-0.5">
+              <View className="w-full overflow-hidden rounded-t-sm" style={{ height: `${Math.max(3, (total / max) * 100)}%` }}>
+                {Object.entries(m.sports).map(([s, c]) => (
+                  <View key={s} style={{ height: `${(c / total) * 100}%`, backgroundColor: sportColor(s) }} />
+                ))}
+              </View>
+              <Text variant="micro" className="text-text-muted" style={{ fontSize: 8 }}>{shortMonth(m.month)}</Text>
+            </View>
+          );
+        })}
+      </View>
+      <View className="flex-row flex-wrap gap-x-3 gap-y-1">
+        {sports.map((s) => (
+          <View key={s} className="flex-row items-center gap-1">
+            <View className="h-2 w-2 rounded-full" style={{ backgroundColor: sportColor(s) }} />
+            <Text variant="micro" className="text-text-muted">{s}</Text>
+          </View>
+        ))}
+      </View>
+    </Card>
+  );
+}
+
+/** Kite deep-dive: speed progression (dots + moving avg), top spots, jump records. */
+export function KiteDeepDive({ sessions }: { sessions: KiteSession[] }) {
+  const withSpeed = (sessions ?? []).filter((s) => s.maxSpeedKts != null && s.maxSpeedKts > 0);
+  const spots = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const s of sessions ?? []) if (s.spot) m.set(s.spot, (m.get(s.spot) ?? 0) + 1);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5);
+  }, [sessions]);
+  const jumps = useMemo(
+    () => (sessions ?? []).filter((s) => (s.jumpM ?? 0) > 0).sort((a, b) => (b.jumpM ?? 0) - (a.jumpM ?? 0)).slice(0, 5),
+    [sessions],
+  );
+  if (!withSpeed.length && !spots.length) return null;
+
+  // moving-average line over max speeds (window ≈ sessions/4, ≤5)
+  const speeds = withSpeed.map((s) => s.maxSpeedKts as number);
+  const win = Math.max(2, Math.min(5, Math.ceil(speeds.length / 4)));
+  const ma = speeds.map((_, i) => {
+    const from = Math.max(0, i - win + 1);
+    const slice = speeds.slice(from, i + 1);
+    return slice.reduce((a, b) => a + b, 0) / slice.length;
+  });
+  const minS = Math.min(...speeds), maxS = Math.max(...speeds), rS = maxS - minS || 1;
+  const H = 90;
+  const x = (i: number) => (i / Math.max(1, speeds.length - 1)) * 96 + 2;
+  const y = (v: number) => H - ((v - minS) / rS) * (H - 10) - 5;
+
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Kite deep dive</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">top {maxS.toFixed(1)} kts</Text>
+      </View>
+
+      {speeds.length >= 3 ? (
+        <View className="gap-1">
+          <Svg width="100%" height={H} viewBox={`0 0 100 ${H}`} preserveAspectRatio="none">
+            <Polyline points={ma.map((v, i) => `${x(i)},${y(v)}`).join(" ")} fill="none" stroke="#22d3ee" strokeWidth={1.4} opacity={0.9} />
+            {speeds.map((v, i) => (
+              <Circle key={i} cx={x(i)} cy={y(v)} r={2} fill="#22d3ee" fillOpacity={0.5} />
+            ))}
+          </Svg>
+          <Text variant="micro" className="text-text-muted">max speed per session · line = moving avg</Text>
+        </View>
+      ) : null}
+
+      {spots.length ? (
+        <View className="gap-1.5">
+          <Text variant="micro" className="text-text-muted">TOP SPOTS</Text>
+          {spots.map(([spot, count]) => (
+            <View key={spot} className="flex-row items-center gap-2">
+              <Text variant="body" className="text-text-secondary flex-1" numberOfLines={1}>{spot}</Text>
+              <View className="h-2 rounded-full bg-surface-subtle overflow-hidden" style={{ width: 90 }}>
+                <View className="h-full rounded-full" style={{ width: `${(count / spots[0][1]) * 100}%`, backgroundColor: "#22d3ee" }} />
+              </View>
+              <Text variant="caption" className="tabular-nums text-text-muted w-8 text-right">{count}×</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {jumps.length ? (
+        <View className="gap-1.5 border-t border-border-subtle pt-2.5">
+          <Text variant="micro" className="text-text-muted">JUMP RECORDS</Text>
+          {jumps.map((j, i) => (
+            <View key={`${j.date}-${i}`} className="flex-row items-center justify-between">
+              <Text variant="body" className="text-text-secondary">{j.spot ?? "Session"} · {shortDate(j.date)}</Text>
+              <Text variant="body" className="tabular-nums text-teal">{(j.jumpM as number).toFixed(1)} m</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </Card>
+  );
+}
+
+const PAGE = 15;
+
+/** Full activity list: sport-filter pills + load-more paging. */
+export function ActivitiesList({ all }: { all: ActivityRow[] }) {
+  const [filter, setFilter] = useState<string | null>(null);
+  const [shown, setShown] = useState(PAGE);
+  const sports = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const a of all ?? []) m.set(a.sport, (m.get(a.sport) ?? 0) + 1);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]);
+  }, [all]);
+  const filtered = (all ?? []).filter((a) => !filter || a.sport === filter);
+  const page = filtered.slice(0, shown);
+  if (!all?.length) return null;
+
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">All activities</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{filtered.length} total</Text>
+      </View>
+      {sports.length > 1 ? (
+        <View className="flex-row flex-wrap gap-2">
+          <Pressable onPress={() => { setFilter(null); setShown(PAGE); }} hitSlop={6}>
+            <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: filter == null ? "#77c8d122" : "#142530" }}>
+              <Text variant="micro" style={{ color: filter == null ? "#77c8d1" : "#8aa0ac" }}>All</Text>
+            </View>
+          </Pressable>
+          {sports.map(([s, c]) => (
+            <Pressable key={s} onPress={() => { setFilter(filter === s ? null : s); setShown(PAGE); }} hitSlop={6}>
+              <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: filter === s ? sportColor(s) + "33" : "#142530" }}>
+                <Text variant="micro" style={{ color: filter === s ? sportColor(s) : "#8aa0ac" }}>{s} {c}</Text>
+              </View>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+      {page.map((a) => (
+        <View key={a.activity_id} className="border-b border-border-subtle py-2">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-row items-center gap-2 flex-1 pr-2">
+              <View className="h-2 w-2 rounded-full" style={{ backgroundColor: sportColor(a.sport) }} />
+              <Text variant="body" className="text-text" numberOfLines={1} style={{ flex: 1 }}>{a.name || a.sport}</Text>
+            </View>
+            <Text variant="micro" className="text-text-muted">{shortDate(a.date)}</Text>
+          </View>
+          <Text variant="micro" className="text-text-muted ml-4">
+            {a.distance_km != null && a.distance_km > 0 ? `${a.distance_km.toFixed(1)} km · ` : ""}{hm(a.duration_min)}
+            {a.avg_hr != null ? ` · ${Math.round(a.avg_hr)} bpm` : ""}
+            {a.elev_gain > 0 ? ` · ↑${Math.round(a.elev_gain)}m` : ""}
+          </Text>
+        </View>
+      ))}
+      {filtered.length > shown ? (
+        <Pressable onPress={() => setShown((n) => n + PAGE)} hitSlop={6}>
+          <View className="items-center rounded-lg bg-surface-subtle py-2">
+            <Text variant="caption" className="text-teal">Show {Math.min(PAGE, filtered.length - shown)} more</Text>
+          </View>
+        </Pressable>
+      ) : null}
+    </Card>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -304,6 +304,37 @@ export function useFitnessScores(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Deep activities data (monthly distribution, kite deep-dive, full list) ----
+export interface MonthSports { month: string; sports: Record<string, number> }
+export interface KiteSession {
+  date: string; spot: string | null; maxSpeedKts: number | null;
+  distanceKm: number | null; jumpM: number | null; windKts: number | null; gustKts: number | null;
+}
+export interface ActivityRow {
+  activity_id: string; type_key: string; sport: string; date: string; name: string | null;
+  distance_km: number | null; duration_min: number | null; avg_hr: number | null;
+  calories: number | null; elev_gain: number;
+}
+export interface ActivitiesDeep {
+  monthly: MonthSports[];
+  kite: { sessions: KiteSession[] };
+  all: ActivityRow[];
+}
+
+/** Deep activities data from /api/activities/deep. */
+export function useActivitiesDeep(range: string) {
+  const [data, setData] = useState<ActivitiesDeep | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<ActivitiesDeep>(`/api/activities/deep?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Recent route GPS paths (for SVG route thumbnails) ----
 export interface RoutePoint { lat: number; lng: number }
 export interface RouteItem {

--- a/web/app/api/activities/deep/route.ts
+++ b/web/app/api/activities/deep/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/* Sport grouping — mirrors SPORT_GROUPS in app/activities/page.tsx. */
+const SPORT_OF: Record<string, string> = {
+  kiteboarding_v2: "Kiteboarding", wind_kite_surfing: "Kiteboarding",
+  resort_snowboarding: "Snowboarding", resort_skiing_snowboarding_ws: "Snowboarding",
+  hiking: "Hiking", e_bike_fitness: "E-Bike",
+  lap_swimming: "Swimming", swimming: "Swimming", open_water_swimming: "Swimming",
+  walking: "Walking", cycling: "Cycling", indoor_cardio: "Cardio",
+  stand_up_paddleboarding_v2: "SUP",
+};
+const sportOf = (t: string): string => SPORT_OF[t] ?? "Other";
+
+/**
+ * Deep activities data as JSON for the app: monthly sport distribution, kite
+ * deep-dive (speed points, spots, jumps, wind), and the full activity list.
+ * Mirrors getMonthlyDistribution / getKiteSessions / getAllActivities in
+ * app/activities/page.tsx (non-run/gym activities).
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "1y";
+  const days =
+    range === "1m" || range === "30d" ? 30 :
+    range === "3m" || range === "90d" ? 91 :
+    range === "6m" ? 182 :
+    range === "all" ? 3650 : 365;
+
+  const sql = getDb();
+
+  const monthlyRows = (await sql`
+    SELECT TO_CHAR(DATE_TRUNC('month', (raw_json->>'startTimeLocal')::timestamp), 'YYYY-MM') as month,
+      raw_json->'activityType'->>'typeKey' as type_key, COUNT(*) as count
+    FROM garmin_activity_raw
+    WHERE endpoint_name = 'summary'
+      AND raw_json->'activityType'->>'typeKey' NOT IN ('running', 'treadmill_running', 'strength_training', 'indoor_cycling')
+      AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
+    GROUP BY 1, 2 ORDER BY 1 ASC
+  `) as { month: string; type_key: string; count: number | string }[];
+
+  // pivot: month → {sport: count}
+  const monthMap = new Map<string, Record<string, number>>();
+  for (const r of monthlyRows) {
+    const m = monthMap.get(r.month) ?? {};
+    const s = sportOf(r.type_key);
+    m[s] = (m[s] ?? 0) + Number(r.count);
+    monthMap.set(r.month, m);
+  }
+  const monthly = [...monthMap.entries()].map(([month, sports]) => ({ month, sports }));
+
+  const kiteRows = (await sql`
+    SELECT s.raw_json->>'activityName' as name,
+      (s.raw_json->>'startTimeLocal')::text as date,
+      (s.raw_json->>'maxSpeed')::float * 1.94384 as max_speed_kts,
+      (s.raw_json->>'distance')::float / 1000.0 as distance_km,
+      (w.raw_json->>'windSpeed')::float as wind_speed_mps,
+      (w.raw_json->>'windGust')::float as wind_gust_mps
+    FROM garmin_activity_raw s
+    LEFT JOIN garmin_activity_raw w ON w.activity_id = s.activity_id AND w.endpoint_name = 'weather'
+    WHERE s.endpoint_name = 'summary'
+      AND s.raw_json->'activityType'->>'typeKey' IN ('kiteboarding_v2', 'wind_kite_surfing')
+      AND (s.raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
+    ORDER BY (s.raw_json->>'startTimeLocal')::text ASC
+  `) as { name: string | null; date: string; max_speed_kts: number | null; distance_km: number | null; wind_speed_mps: number | null; wind_gust_mps: number | null }[];
+
+  // parse spot + jump out of the activity name (same regexes as the web page)
+  const kiteSessions = kiteRows.map((k) => {
+    const name = k.name ?? "";
+    const spotMatch = name.match(/Spot: '([^']+)'/) ?? name.match(/^([A-Za-zÀ-ž .-]+?) Kiteboarding/);
+    const jumpMatch = name.match(/Highest Jump: ([\d.]+) ?m/);
+    return {
+      date: k.date,
+      spot: spotMatch ? spotMatch[1].trim() : null,
+      maxSpeedKts: k.max_speed_kts,
+      distanceKm: k.distance_km,
+      jumpM: jumpMatch ? Number(jumpMatch[1]) : null,
+      windKts: k.wind_speed_mps != null ? k.wind_speed_mps * 1.94384 : null,
+      gustKts: k.wind_gust_mps != null ? k.wind_gust_mps * 1.94384 : null,
+    };
+  });
+
+  const all = (await sql`
+    SELECT activity_id, raw_json->'activityType'->>'typeKey' as type_key,
+      (raw_json->>'startTimeLocal')::text as date,
+      raw_json->>'activityName' as name,
+      (raw_json->>'distance')::float / 1000.0 as distance_km,
+      (raw_json->>'duration')::float / 60.0 as duration_min,
+      (raw_json->>'averageHR')::float as avg_hr,
+      (raw_json->>'calories')::float as calories,
+      COALESCE((raw_json->>'elevationGain')::float, 0) as elev_gain
+    FROM garmin_activity_raw
+    WHERE endpoint_name = 'summary'
+      AND raw_json->'activityType'->>'typeKey' NOT IN ('running', 'treadmill_running', 'strength_training', 'indoor_cycling')
+      AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
+    ORDER BY (raw_json->>'startTimeLocal')::text DESC
+    LIMIT 200
+  `) as { activity_id: string; type_key: string; date: string; name: string | null; distance_km: number | null; duration_min: number | null; avg_hr: number | null; calories: number | null; elev_gain: number }[];
+
+  return NextResponse.json({
+    monthly,
+    kite: { sessions: kiteSessions },
+    all: all.map((a) => ({ ...a, sport: sportOf(a.type_key) })),
+  });
+}


### PR DESCRIPTION
## Activities: monthly distribution + kite deep-dive + filterable list

New `/api/activities/deep` endpoint: monthly sport distribution (grouped server-side with the web's SPORT_GROUPS mapping), kite sessions with parsed spot/jump/wind, and the full activity list. App renders:
- **ActivitiesMonthly** — stacked monthly columns colored by sport + legend
- **KiteDeepDive** — max-speed progression (dots + moving-average line), top spots ranked, jump records (conditional)
- **ActivitiesList** — sport-filter pills + load-more paging (replaces the fixed 15-row recent log)

Validated on the Expo web build: monthly chart (Aug–Jul), kite top 40.6 kts with spots (Artemida/Rafina 6x), filter pill tap correctly narrows to Hiking (2); `tsc` clean; 0 console errors.

Closes #314
