### PR TITLE
Time-range selectors on running + workouts

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
-import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
+import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
 import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits, useHrPace, useRecentRoutes } from "../../lib/api";
 import { RunningMileage } from "../../components/running-mileage";
 import { RunningDeepTrends } from "../../components/running-deep-trends";
@@ -158,10 +158,12 @@ const ZONE_HEX = ["#77c8d1", "#6ad4a0", "#e0c458", "#e0a458", "#e06060"];
 
 export default function RunningScreen() {
   const { data, error, refetch } = useRunning();
-  const { data: runTrends } = useRunningTrends("180d");
-  const { data: fitScores } = useFitnessScores("1y");
-  const { data: splits } = useRunningSplits("1y");
-  const { data: hrPace } = useHrPace("1y");
+  // Range drives the trend sections (all four endpoints accept 90d/1y/2y).
+  const [range, setRange] = useState<"90d" | "1y" | "2y">("1y");
+  const { data: runTrends } = useRunningTrends(range);
+  const { data: fitScores } = useFitnessScores(range);
+  const { data: splits } = useRunningSplits(range);
+  const { data: hrPace } = useHrPace(range);
   const { data: routes } = useRecentRoutes();
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
@@ -233,6 +235,11 @@ export default function RunningScreen() {
           </Text>
         </View>
 
+        <SegmentedControl
+          options={["90d", "1y", "2y"] as const}
+          value={range}
+          onChange={(v) => setRange(v as "90d" | "1y" | "2y")}
+        />
         {error ? (
           <Card>
             <Text variant="body" className="text-danger">

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,6 +1,6 @@
 import { ScrollView, View, RefreshControl } from "react-native";
 import { useEffect, useState } from "react";
-import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
+import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
 import { fetchJson, usePullRefresh, useWorkoutsSummary } from "../../lib/api";
 import { WorkoutsDashboard } from "../../components/workouts-dashboard";
 
@@ -57,7 +57,8 @@ function formatDate(dateStr: string): string {
 
 export default function WorkoutsScreen() {
   const { data, error, refetch } = useWorkouts();
-  const { data: wkSum } = useWorkoutsSummary("90d");
+  const [range, setRange] = useState<"30d" | "90d" | "1y">("90d");
+  const { data: wkSum } = useWorkoutsSummary(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const recent = data?.recent ?? [];
@@ -158,6 +159,11 @@ export default function WorkoutsScreen() {
         </View>
 
         {/* Workout data — volume, stats, top exercises, recent (new /api/workouts/summary) */}
+        <SegmentedControl
+          options={["30d", "90d", "1y"] as const}
+          value={range}
+          onChange={(v) => setRange(v as "30d" | "90d" | "1y")}
+        />
         <WorkoutsDashboard summary={wkSum} />
 
         {/* Sync coverage bar */}

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -37,9 +37,9 @@ export function WorkoutsDashboard({ summary }: { summary: WorkoutSummary | null 
   const s = summary.stats;
   const stats: { label: string; value: string; sub: string }[] = s
     ? [
-        { label: "Workouts", value: `${num(s.total_workouts)}`, sub: `${num(s.training_days)} days` },
-        { label: "Avg duration", value: `${Math.round(num(s.avg_duration_min))}`, sub: "min" },
-        { label: "Avg exercises", value: num(s.avg_exercises).toFixed(1), sub: "per session" },
+        { label: "Sessions", value: `${num(s.total_workouts)}`, sub: `${num(s.training_days)} days` },
+        { label: "Duration", value: `${Math.round(num(s.avg_duration_min))}`, sub: "min avg" },
+        { label: "Exercise", value: num(s.avg_exercises).toFixed(1), sub: "avg / session" },
       ]
     : [];
   const peakVol = Math.max(0, ...summary.weeklyVolume.map((w) => num(w.total_volume)));


### PR DESCRIPTION
## Time-range selectors on running + workouts

The trend sections on both screens were hardcoded to fixed windows. Running now has a **90d / 1y / 2y** selector driving all four trend endpoints (load/ACWR, fitness scores, per-km splits, HR-vs-pace); workouts has **30d / 90d / 1y** for the summary dashboard. Also fixes wrapped eyebrow labels in the workouts stat cards (caught in validation, Ralph-looped to fit).

Validated on the Expo web build: selectors render, switching running to 90d refetches (HR-vs-pace 91 → 12 runs), labels single-line; `tsc` clean; 0 console errors.

Closes #315
