### PR TITLE
Training: activity-match drill-in + Garmin push/retry

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -6,6 +6,7 @@ import {
   useCalibration,
   useForwardSim,
   useTrainingGraph,
+  useActivityMatches,
   setDayCompletion,
   toggleCalibration,
   fetchJson,
@@ -57,6 +58,7 @@ export default function TrainingScreen() {
   const { cal, refetch: refetchCal } = useCalibration(todayISO());
   const { data: sim, refetch: refetchSim } = useForwardSim(todayISO());
   const { nodes: graphNodes } = useTrainingGraph(todayISO());
+  const { byDay: matches } = useActivityMatches();
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
     refetchCal();
@@ -149,6 +151,7 @@ export default function TrainingScreen() {
           <TrainingSchedule
             planDays={planDays}
             today={sim?.today ?? todayISO()}
+            matches={matches}
             onToggleComplete={onToggleComplete}
           />
         ) : null}

--- a/universal/src/components/training-schedule.tsx
+++ b/universal/src/components/training-schedule.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { View, Pressable } from "react-native";
 import { Text, Card } from "soma-style";
-import type { PlanDay, WorkoutStep } from "../lib/api";
+import { requestGarminPush, type ActivityMatch, type PlanDay, type WorkoutStep } from "../lib/api";
 
 /* Run-type → colour, matching the web training plan (easy green, quality orange,
    long blue, rest grey). Used for the small type pill on each day row. */
@@ -39,19 +39,40 @@ function stepLine(s: WorkoutStep): string {
   return parts.join(" · ");
 }
 
+/** Seconds/km → "M:SS". */
+function paceStr(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = Math.round(sec % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+const scoreColor = (s: number) => (s >= 80 ? "#6ad4a0" : s >= 60 ? "#e0c458" : "#e06060");
+
 function DayRow({
   day,
   isToday,
+  match,
   onToggleComplete,
 }: {
   day: PlanDay;
   isToday: boolean;
+  match?: ActivityMatch;
   onToggleComplete: (day: PlanDay) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [pushOverride, setPushOverride] = useState<string | null>(null);
   const steps = day.workoutSteps ?? [];
-  const pushed = day.garminPushStatus === "pushed" || day.garminPushStatus === "success";
-  const pending = day.garminPushStatus === "pending";
+  const status = pushOverride ?? day.garminPushStatus;
+  const pushed = status === "pushed" || status === "success";
+  const pending = status === "pending";
+  const failed = status === "failed" || status === "error";
+  const canPush = steps.length > 0 && !pushed && !pending;
+  const act = match?.matched ? match.activity : null;
+
+  async function onPush() {
+    setPushOverride("pending"); // optimistic; the plan-push cron completes it
+    const ok = await requestGarminPush(day.id);
+    if (!ok) setPushOverride(day.garminPushStatus ?? null);
+  }
 
   return (
     <View className="border-b border-border-subtle py-2.5">
@@ -69,8 +90,8 @@ function DayRow({
           {day.completed ? <Text style={{ color: "#6ad4a0", fontSize: 13 }}>✓</Text> : null}
         </Pressable>
 
-        {/* main tap target: expand steps */}
-        <Pressable className="flex-1" onPress={() => steps.length && setOpen((o) => !o)}>
+        {/* main tap target: expand steps + match details */}
+        <Pressable className="flex-1" onPress={() => (steps.length || act) && setOpen((o) => !o)}>
           <View className="flex-row items-center gap-2">
             <Text variant="micro" className={isToday ? "text-teal" : "text-text-muted"}>
               {isToday ? "TODAY" : shortDate(day.dayDate)}
@@ -78,6 +99,11 @@ function DayRow({
             <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: runColor(day.runType) + "22" }}>
               <Text variant="micro" style={{ color: runColor(day.runType) }}>{day.runType}</Text>
             </View>
+            {match?.matched && match.completionScore != null ? (
+              <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: scoreColor(match.completionScore) + "22" }}>
+                <Text variant="micro" style={{ color: scoreColor(match.completionScore) }}>{match.completionScore}%</Text>
+              </View>
+            ) : null}
             {day.gymWorkout ? (
               <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: "#6366b022" }}>
                 <Text variant="micro" style={{ color: "#8a8dd0" }}>🏋 {day.gymWorkout}</Text>
@@ -97,17 +123,25 @@ function DayRow({
               <Text variant="caption" className="tabular-nums text-text-secondary ml-2">{day.targetDistanceKm} km</Text>
             ) : null}
           </View>
-          {/* garmin sync status */}
+          {/* garmin sync status + manual push/retry (queues for the plan-push cron) */}
           {pushed ? (
             <Text variant="micro" className="text-success mt-0.5">✓ On Garmin</Text>
           ) : pending ? (
             <Text variant="micro" className="text-warning mt-0.5">⏳ Syncing to Garmin</Text>
+          ) : failed ? (
+            <Pressable onPress={onPush} hitSlop={6}>
+              <Text variant="micro" className="text-danger mt-0.5">✕ Push failed — tap to retry</Text>
+            </Pressable>
+          ) : canPush ? (
+            <Pressable onPress={onPush} hitSlop={6}>
+              <Text variant="micro" className="text-teal mt-0.5">↑ Push to Garmin</Text>
+            </Pressable>
           ) : null}
         </Pressable>
       </View>
 
-      {/* expandable workout steps */}
-      {open && steps.length ? (
+      {/* expandable workout steps + matched-activity detail */}
+      {open ? (
         <View className="mt-2 ml-9 gap-1">
           {steps.map((s, i) => (
             <View key={i} className="flex-row items-start gap-2">
@@ -116,6 +150,26 @@ function DayRow({
             </View>
           ))}
           {day.gymNotes ? <Text variant="micro" className="text-text-muted mt-1">Gym: {day.gymNotes}</Text> : null}
+          {act ? (
+            <View className="mt-1.5 rounded-lg bg-surface-subtle px-2.5 py-2 gap-0.5">
+              <View className="flex-row items-center justify-between">
+                <Text variant="micro" className="text-text-muted">MATCHED GARMIN ACTIVITY</Text>
+                {match?.completionScore != null ? (
+                  <Text variant="micro" style={{ color: scoreColor(match.completionScore) }}>{match.completionScore}% of plan</Text>
+                ) : null}
+              </View>
+              <Text variant="micro" className="text-text-secondary">
+                {act.distance_km != null ? `${Number(act.distance_km).toFixed(1)} km` : ""}
+                {act.duration_min != null ? ` · ${Math.round(Number(act.duration_min))} min` : ""}
+                {act.avg_pace_sec_km != null ? ` · ${paceStr(act.avg_pace_sec_km)}/km` : ""}
+              </Text>
+              <Text variant="micro" className="text-text-muted">
+                {act.avg_hr != null ? `HR ${act.avg_hr}` : ""}
+                {act.max_hr != null ? ` (max ${act.max_hr})` : ""}
+                {act.calories != null ? ` · ${act.calories} kcal` : ""}
+              </Text>
+            </View>
+          ) : null}
         </View>
       ) : null}
     </View>
@@ -125,10 +179,12 @@ function DayRow({
 export function TrainingSchedule({
   planDays,
   today,
+  matches,
   onToggleComplete,
 }: {
   planDays: PlanDay[];
   today: string;
+  matches?: Record<number, ActivityMatch>;
   onToggleComplete: (day: PlanDay) => void;
 }) {
   // group by week
@@ -190,7 +246,7 @@ export function TrainingSchedule({
             {isOpen ? (
               <View className="mt-1">
                 {days.map((d) => (
-                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} onToggleComplete={onToggleComplete} />
+                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} match={matches?.[d.id]} onToggleComplete={onToggleComplete} />
                 ))}
               </View>
             ) : null}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -238,6 +238,47 @@ export function useForwardSim(date: string) {
   return { data, loading, error, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Activity match: per plan-day matched Garmin activity + completion score ----
+export interface MatchedActivity {
+  distance_km: number | string | null; duration_min: number | string | null;
+  avg_pace_sec_km: number | null; avg_hr: number | null; max_hr: number | null;
+  calories: number | null; garmin_id: number | null;
+}
+export interface ActivityMatch {
+  dayId: number; dayDate: string; matched: boolean;
+  completionScore: number | null; activity: MatchedActivity | null;
+}
+
+/** Matched Garmin activities per plan day, keyed by dayId. */
+export function useActivityMatches() {
+  const [byDay, setByDay] = useState<Record<number, ActivityMatch>>({});
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<ActivityMatch[]>("/api/training/activity-match")
+      .then((d) => {
+        if (!alive) return;
+        const map: Record<number, ActivityMatch> = {};
+        for (const m of d ?? []) map[m.dayId] = m;
+        setByDay(map);
+      })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [reload]);
+  return { byDay, refetch: () => setReload((n) => n + 1) };
+}
+
+/** Queue a plan day's workout for Garmin push (the plan-push cron completes it).
+    Mirrors the web GarminPushButton: PATCH garmin_push_status → "pending". */
+export async function requestGarminPush(dayId: number): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/training/day/${dayId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify({ garmin_push_status: "pending" }),
+  });
+  return res.ok;
+}
+
 /** Toggle a plan day's completion. Passes the existing actual distance through so
     the PATCH route (which nulls it when omitted) doesn't wipe matched-activity data. */
 export async function setDayCompletion(


### PR DESCRIPTION
## Training: activity-match drill-in + Garmin push/retry

- **Completion chips** — day rows show color-coded completion-score chips (green ≥80, yellow ≥60, red below) from `/api/training/activity-match`.
- **Drill-in** — expanding a matched day reveals the matched Garmin activity: distance, duration, pace, HR (avg/max), calories, and "% of plan".
- **Push/retry** — days with workout steps that aren't pushed/pending get a "Push to Garmin" affordance (failed days get retry), mirroring the web GarminPushButton exactly: `PATCH garmin_push_status=pending`, optimistic UI, the plan-push cron completes the actual push.

Validated on the Expo web build: chips render on all matched days (49–100%), expanded Cruise Intervals shows the match block (10.9 km · 59 min · 5:26/km · HR 156/188 · 812 kcal · 49% of plan); `tsc` clean; 0 console errors. Push button not click-tested (queues a real Garmin push); its PATCH path is the same verified endpoint the completion toggle uses.

Closes #316
