### PR TITLE
16px body-text baseline for the app (type floor)

### DIFF
--- a/universal/tailwind.config.js
+++ b/universal/tailwind.config.js
@@ -2,6 +2,16 @@
 module.exports = {
   content: ["./src/**/*.{ts,tsx}", "./node_modules/soma-style/src/ui/**/*.{ts,tsx}"],
   presets: [require("nativewind/preset"), require("soma-style/preset")],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      /* Mobile type baseline (#241): 16px body floor + slightly larger caption.
+         App-local override of the soma-style preset scale; propagating this into
+         the shared soma-style package for all three apps is #242. */
+      fontSize: {
+        body: ["16px", { lineHeight: "24px", fontWeight: "400" }],
+        caption: ["13px", { lineHeight: "18px", fontWeight: "500" }],
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## 16px body-text baseline (#241)

App-local override of the soma-style type scale per the mobile-UI brief: **body 14 → 16px** (line-height 24) and **caption 12 → 13px** (line-height 18), via `theme.extend.fontSize` over the preset. Card padding is already 16px and numeric columns already use tabular-nums; tap targets use hitSlop'd Pressables.

Verified computationally (computed styles on the training screen: 24 body elements at 16px, zero at 14px) and visually on training + nutrition (no wraps/collisions from the larger type); `tsc` clean; 0 console errors.

Propagating the scale into the shared soma-style package (all three apps) stays tracked in #242.

Closes #241
