### PR TITLE
Fix: pace formatters rendering ":60" seconds

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -118,15 +118,17 @@ function useRunning() {
 
 function formatPace(mins: number | null | undefined): string {
   if (mins == null || !isFinite(mins)) return "—";
-  const m = Math.floor(mins);
-  const s = Math.round((mins - m) * 60);
+  const t = Math.round(mins * 60); // round total seconds so :60 can never render
+  const m = Math.floor(t / 60);
+  const s = t % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 function formatSeconds(secs: number | null | undefined): string {
   if (secs == null || !isFinite(secs)) return "—";
-  const m = Math.floor(secs / 60);
-  const s = Math.round(secs % 60);
+  const t = Math.round(secs);
+  const m = Math.floor(t / 60);
+  const s = t % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 

--- a/universal/src/components/running-hr-pace.tsx
+++ b/universal/src/components/running-hr-pace.tsx
@@ -4,8 +4,9 @@ import { Text, Card } from "soma-style";
 import type { HrPacePoint } from "../lib/api";
 
 function pace(mins: number): string {
-  const m = Math.floor(mins);
-  const s = Math.round((mins - m) * 60);
+  const t = Math.round(mins * 60);
+  const m = Math.floor(t / 60);
+  const s = t % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 

--- a/universal/src/components/running-splits.tsx
+++ b/universal/src/components/running-splits.tsx
@@ -5,8 +5,9 @@ import type { RunningSplits } from "../lib/api";
 /** Decimal minutes → "M:SS". */
 function pace(mins: number | null | undefined): string {
   if (mins == null || !isFinite(mins)) return "—";
-  const m = Math.floor(mins);
-  const s = Math.round((mins - m) * 60);
+  const t = Math.round(mins * 60);
+  const m = Math.floor(t / 60);
+  const s = t % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 function shortDate(iso: string): string {

--- a/universal/src/lib/vdot.ts
+++ b/universal/src/lib/vdot.ts
@@ -60,18 +60,20 @@ export function pacesForVdot(vdot: number): VdotPaces {
   };
 }
 
-/** Seconds/km → "M:SS". */
+/** Seconds/km → "M:SS". Rounds total seconds first so :60 can never render. */
 export function paceStr(secPerKm: number): string {
-  const m = Math.floor(secPerKm / 60);
-  const s = Math.round(secPerKm % 60);
+  const t = Math.round(secPerKm);
+  const m = Math.floor(t / 60);
+  const s = t % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 /** Total seconds → "H:MM:SS" (or "M:SS" under an hour). */
 export function timeStr(totalSec: number): string {
-  const h = Math.floor(totalSec / 3600);
-  const m = Math.floor((totalSec % 3600) / 60);
-  const s = Math.round(totalSec % 60);
+  const t = Math.round(totalSec);
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  const s = t % 60;
   return h > 0
     ? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
     : `${m}:${String(s).padStart(2, "0")}`;

--- a/web/app/running/page.tsx
+++ b/web/app/running/page.tsx
@@ -33,8 +33,9 @@ import {
 export const revalidate = 300;
 
 function formatPace(mins: number) {
-  const m = Math.floor(mins);
-  const s = Math.round((mins - m) * 60);
+  const t = Math.round(mins * 60); // round total seconds so :60 can never render
+  const m = Math.floor(t / 60);
+  const s = t % 60;
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
@@ -970,8 +971,9 @@ export default async function RunningPage({
                   <div className="text-2xl font-bold text-green-400">
                     {(() => {
                       const secs = Number(records.fastest5k.est_5k_seconds);
-                      const m = Math.floor(secs / 60);
-                      const s = Math.round(secs % 60);
+                      const t = Math.round(secs);
+                      const m = Math.floor(t / 60);
+                      const s = t % 60;
                       return `${m}:${s.toString().padStart(2, "0")}`;
                     })()}
                   </div>
@@ -991,8 +993,9 @@ export default async function RunningPage({
                   <div className="text-2xl font-bold text-blue-400">
                     {(() => {
                       const secs = Number(records.fastest10k.est_10k_seconds);
-                      const m = Math.floor(secs / 60);
-                      const s = Math.round(secs % 60);
+                      const t = Math.round(secs);
+                      const m = Math.floor(t / 60);
+                      const s = t % 60;
                       return `${m}:${s.toString().padStart(2, "0")}`;
                     })()}
                   </div>


### PR DESCRIPTION
## Fix: pace formatters rendering ":60" seconds

Adversarial audit found "**5:60/km**" on /running (Athens Running, Jun 8 — pace 5.9917 min). Every pace/time formatter rounded the seconds component independently. Fix rounds **total seconds first** then splits, so a :60 is mathematically impossible. Applied to all 9 sites (7 app + 2 web).

Verified: `node` check — input 5.9917 min: old `5:60`, new `6:00`; `tsc` clean both packages.

Closes #321
