### PR TITLE
Workouts: dedupe recent/stats + uncap top exercises

### DIFF
--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -104,12 +104,6 @@ export default function WorkoutsScreen() {
       cls: "text-warm",
       spark: { data: kcalTrend, color: "#b17850" },
     },
-    {
-      label: "Avg Exercises",
-      value: avgExercises != null ? `${avgExercises}` : "—",
-      sub: "per session",
-      cls: "text-indigo",
-    },
   ];
 
   return (
@@ -184,45 +178,6 @@ export default function WorkoutsScreen() {
           </Card>
         ) : null}
 
-        {/* Recent workouts */}
-        <Card className="gap-2">
-          <Text variant="eyebrow">Recent workouts</Text>
-          {!data && !error ? (
-            <Text variant="micro">Loading…</Text>
-          ) : recent.length === 0 ? (
-            <Text variant="micro">No workouts yet.</Text>
-          ) : (
-            recent.map((w, i) => (
-              <View
-                key={`${w.date}-${w.title}-${i}`}
-                className="gap-1 border-b border-border-subtle py-2"
-              >
-                <View className="flex-row items-center justify-between">
-                  <Text variant="body" className="mr-2 flex-1 text-text" numberOfLines={1}>
-                    {w.title || "Workout"}
-                  </Text>
-                  <Badge
-                    label={w.synced ? "synced" : w.status || "pending"}
-                    tone={w.synced ? "success" : "warm"}
-                  />
-                </View>
-                <View className="flex-row items-center gap-3">
-                  <Text variant="micro" className="text-text-secondary">
-                    {formatDate(w.date)}
-                  </Text>
-                  <Text variant="micro" className="tabular-nums text-text-muted">
-                    {w.exercises} ex · {w.sets} sets
-                  </Text>
-                  {w.kcal > 0 ? (
-                    <Text variant="micro" className="tabular-nums text-warm">
-                      {w.kcal} kcal
-                    </Text>
-                  ) : null}
-                </View>
-              </View>
-            ))
-          )}
-        </Card>
       </View>
     </ScrollView>
   );

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -31,8 +31,9 @@ function VolumeChart({ weeks }: { weeks: WorkoutSummary["weeklyVolume"] }) {
   );
 }
 
-/** Workouts dashboard: summary stats + weekly volume + top exercises + recent list. */
-export function WorkoutsDashboard({ summary }: { summary: WorkoutSummary | null | undefined }) {
+/** Workouts dashboard: summary stats + weekly volume + top exercises (+ optional
+    recent list — hidden on the workouts screen, which has its own sync-status list). */
+export function WorkoutsDashboard({ summary, showRecent = true }: { summary: WorkoutSummary | null | undefined; showRecent?: boolean }) {
   if (!summary) return null;
   const s = summary.stats;
   const stats: { label: string; value: string; sub: string }[] = s
@@ -81,7 +82,7 @@ export function WorkoutsDashboard({ summary }: { summary: WorkoutSummary | null 
         </Card>
       ) : null}
 
-      {summary.recent.length ? (
+      {showRecent && summary.recent.length ? (
         <Card className="gap-2">
           <Text variant="eyebrow">Recent workouts</Text>
           {summary.recent.slice(0, 10).map((w) => (

--- a/web/app/api/workouts/summary/route.ts
+++ b/web/app/api/workouts/summary/route.ts
@@ -58,7 +58,6 @@ export async function GET(request: Request) {
   `) as { id: string; title: string; start_time: string; end_time: string; exercise_count: number; exercises: unknown }[];
 
   type Ex = { title?: string; sets?: { type?: string; weight_kg?: number; reps?: number }[] };
-  const exCount: Record<string, number> = {};
   const recent = recentRows.map((w) => {
     const exs: Ex[] = Array.isArray(w.exercises)
       ? (w.exercises as Ex[])
@@ -67,7 +66,6 @@ export async function GET(request: Request) {
       : [];
     let volume = 0;
     for (const e of exs) {
-      if (e.title) exCount[e.title] = (exCount[e.title] ?? 0) + 1;
       for (const st of e.sets ?? []) {
         if (st.type === "normal" && (st.weight_kg ?? 0) > 0 && (st.reps ?? 0) > 0) {
           volume += (st.weight_kg as number) * (st.reps as number);
@@ -84,10 +82,17 @@ export async function GET(request: Request) {
     };
   });
 
-  const topExercises = Object.entries(exCount)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 8)
-    .map(([name, sessions]) => ({ name, sessions }));
+  // Count across the WHOLE range in SQL — the old JS loop only counted the
+  // 20 most-recent workouts, capping every exercise at the same number.
+  const topRows = (await sql`
+    SELECT e->>'title' as name, COUNT(*) as sessions
+    FROM hevy_raw_data, jsonb_array_elements(raw_json->'exercises') as e
+    WHERE endpoint_name = 'workout'
+      AND (raw_json->>'start_time')::timestamp >= CURRENT_DATE - ${days}::int
+      AND e->>'title' IS NOT NULL
+    GROUP BY 1 ORDER BY 2 DESC LIMIT 8
+  `) as { name: string; sessions: number | string }[];
+  const topExercises = topRows.map((r) => ({ name: r.name, sessions: Number(r.sessions) }));
 
   return NextResponse.json({ stats: statsRows[0] ?? null, weeklyVolume, recent, topExercises });
 }


### PR DESCRIPTION
## Workouts: dedupe + uncap top exercises

Audit findings fixed:
- **Two "Recent workouts" sections** collapsed to one — removed the old sync-badge list (the WorkoutsDashboard list has duration + volume, richer). Verified exactly 1 header remains.
- **Duplicate exercises stat** — removed the old "Avg Exercises 4" card (dashboard already shows "Exercise 3.9").
- **Top exercises capped at "4×"** — the endpoint counted only the 20 most-recent workouts, so everything tied at the LIMIT. Now counted across the whole range in SQL: **6× Bench Press, 6× Incline Bench, 5× Chest Press...** (verified).

Validated on the Expo web build; `tsc` clean; 0 console errors.

Closes #325
