### PR TITLE
fix(running): honest numbers on running screen

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -237,11 +237,6 @@ export default function RunningScreen() {
           </Text>
         </View>
 
-        <SegmentedControl
-          options={["90d", "1y", "2y"] as const}
-          value={range}
-          onChange={(v) => setRange(v as "90d" | "1y" | "2y")}
-        />
         {error ? (
           <Card>
             <Text variant="body" className="text-danger">
@@ -268,8 +263,9 @@ export default function RunningScreen() {
           ))}
         </View>
 
-        {/* Training Status */}
-        {ts ? (
+        {/* Training Status — only when Garmin actually populated it (else it was
+            a card full of dashes next to the live VO2max + load-trend below). */}
+        {ts && (ts.status_code != null || ts.vo2max != null || ts.acute_load != null) ? (
           <Card className="gap-3">
             <View className="flex-row items-center justify-between">
               <Text variant="eyebrow">Training Status</Text>
@@ -338,6 +334,16 @@ export default function RunningScreen() {
 
         {/* Recent route thumbnails (SVG shapes from /api/running/recent-routes) */}
         <RunningRoutes routes={routes} />
+
+        {/* Range governs the trend charts below (stats above are all-time). */}
+        <View className="gap-1">
+          <Text variant="eyebrow" className="text-text-muted">Trends — last {range}</Text>
+          <SegmentedControl
+            options={["90d", "1y", "2y"] as const}
+            value={range}
+            onChange={(v) => setRange(v as "90d" | "1y" | "2y")}
+          />
+        </View>
 
         {/* Training load/ACWR + cadence trends (new /api/running/trends) */}
         <RunningDeepTrends trends={runTrends} />

--- a/universal/src/components/running-deep-trends.tsx
+++ b/universal/src/components/running-deep-trends.tsx
@@ -43,7 +43,17 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
         <Card className="gap-2">
           <View className="flex-row items-center justify-between">
             <Text variant="eyebrow">Training load · acute vs chronic</Text>
-            {loadLast.acwr != null ? <Badge label={`ACWR ${loadLast.acwr.toFixed(2)} · ${acwrLabel(loadLast.acwr)}`} tone={acwrTone(loadLast.acwr)} /> : null}
+            {(() => {
+              // Derive ACWR from the plotted acute/chronic so the badge and the
+              // chart agree (the raw acwr DB field is computed separately and drifts).
+              const ratio =
+                loadLast.acute != null && loadLast.chronic != null && loadLast.chronic > 0
+                  ? loadLast.acute / loadLast.chronic
+                  : loadLast.acwr;
+              return ratio != null ? (
+                <Badge label={`ACWR ${ratio.toFixed(2)} · ${acwrLabel(ratio)}`} tone={acwrTone(ratio)} />
+              ) : null;
+            })()}
           </View>
           <DualLine a={acute} b={chronic} colorA="#77c8d1" colorB="#5a7a8a" />
           <View className="flex-row justify-between">

--- a/web/app/api/running/splits/route.ts
+++ b/web/app/api/running/splits/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
         (lap->>'distance')::float as distance,
         (lap->>'duration')::float as duration,
         (lap->>'averageHR')::float as avg_hr,
-        (lap->>'averageRunCadence')::float * 2 as cadence
+        (lap->>'averageRunCadence')::float as cadence
       FROM garmin_activity_raw s, jsonb_array_elements(s.raw_json->'lapDTOs') as lap
       WHERE s.endpoint_name = 'splits'
         AND s.activity_id IN (SELECT activity_id FROM recent_activities)

--- a/web/app/running/page.tsx
+++ b/web/app/running/page.tsx
@@ -465,7 +465,7 @@ async function getSplitAnalysis(cutoff: string) {
         (lap->>'distance')::float as distance,
         (lap->>'duration')::float as duration,
         (lap->>'averageHR')::float as avg_hr,
-        (lap->>'averageRunCadence')::float * 2 as cadence,
+        (lap->>'averageRunCadence')::float as cadence,
         (lap->>'averagePower')::float as power
       FROM garmin_activity_raw s,
         jsonb_array_elements(s.raw_json->'lapDTOs') as lap
@@ -509,7 +509,7 @@ async function getBestSplits(cutoff: string) {
         (lap->>'distance')::float as distance,
         (lap->>'duration')::float as duration,
         (lap->>'averageHR')::float as avg_hr,
-        (lap->>'averageRunCadence')::float * 2 as cadence
+        (lap->>'averageRunCadence')::float as cadence
       FROM garmin_activity_raw s,
         jsonb_array_elements(s.raw_json->'lapDTOs') as lap
       WHERE s.endpoint_name = 'splits'


### PR DESCRIPTION
Adversarial-audit fixes for the running page (app + web).

## What
- **Dead Training Status card** hidden unless `status_code`/`vo2max`/`acute_load` has a value (was a card of dashes).
- **ACWR badge** now derives from the plotted acute/chronic (176/301 = 0.58) instead of the raw `acwr` DB field (0.50), so badge and chart agree.
- **Cadence ×2 removed**: lap `averageRunCadence` is already both-legs (~160), was rendering 322 spm. Fixed in `web/app/running/page.tsx` and `web/app/api/running/splits/route.ts`.
- **Range selector relocated** to sit directly above the trend charts it controls, labeled "Trends — last {range}" (previously floated above all-time stat cards it did not filter).

## Verified
- `tsc --noEmit` clean in both `universal/` and `web/`.
- App running screen (Playwright, :8094): Training Status card gone, ACWR badge reads `0.58 · LOW`, cadence chart `155 spm`, "Trends — last 1y" selector renders above the trend cards. 0 console errors.
- Cadence empirically confirmed 320/326 → 160/163 after removing ×2.

Closes #327