### PR TITLE
fix(training): readiness comparison as bounded 0-100 percentile

### DIFF
--- a/universal/src/components/training-trends.tsx
+++ b/universal/src/components/training-trends.tsx
@@ -46,6 +46,23 @@ interface Comparison {
 const n = (v: unknown): number => Number(v);
 const last = (a: ComparisonPoint[]): ComparisonPoint | undefined => (a.length ? a[a.length - 1] : undefined);
 
+// Our readiness ourScore is a SIGNED z-composite (roughly -3.5..+2), not a 0-100
+// score — multiplying it by 100 produced nonsense like "-123". Map the z to its
+// normal-distribution percentile (0-100) so it's on the same honest scale as
+// Garmin's 0-100 readiness. z=0 -> 50, z=+2 -> ~98, z=-2 -> ~2.
+function erf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const ax = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * ax);
+  const y =
+    1 -
+    ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) *
+      t *
+      Math.exp(-ax * ax);
+  return sign * y;
+}
+const zToPercentile = (z: number): number => 50 * (1 + erf(z / Math.SQRT2));
+
 /** Compact "model vs Garmin" trend cards (mobile-adapted comparison charts). */
 export function TrainingTrends({ comparison }: { comparison: Comparison | null | undefined }) {
   if (!comparison) return null;
@@ -78,11 +95,11 @@ export function TrainingTrends({ comparison }: { comparison: Comparison | null |
     },
     {
       key: "readiness",
-      title: "Readiness — ours vs Garmin",
-      a: rd.map((p) => n(p.ourScore) * 100),
+      title: "Readiness — percentile vs Garmin",
+      a: rd.map((p) => zToPercentile(n(p.ourScore))),
       b: rd.map((p) => n(p.garminScore)),
       colorB: "#5a7a8a",
-      latest: rdL ? `Ours ${Math.round(n(rdL.ourScore) * 100)} · Garmin ${Math.round(n(rdL.garminScore))}` : "",
+      latest: rdL ? `Ours ${Math.round(zToPercentile(n(rdL.ourScore)))} · Garmin ${Math.round(n(rdL.garminScore))}` : "",
     },
     {
       key: "race",

--- a/web/components/comparison-charts.tsx
+++ b/web/components/comparison-charts.tsx
@@ -4,6 +4,23 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "rec
 import { Card, CardContent } from "@/components/ui/card";
 import { estimateHMSeconds } from "@/lib/vdot-utils";
 
+// Normal-distribution percentile of a z-score (0-100), bounded. Keeps our signed
+// readiness z-composite on the same scale as Garmin's 0-100 readiness.
+function erf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const ax = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * ax);
+  const y =
+    1 -
+    ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) *
+      t *
+      Math.exp(-ax * ax);
+  return sign * y;
+}
+function zToPercentile(z: number): number {
+  return 50 * (1 + erf(z / Math.SQRT2));
+}
+
 interface ComparisonData {
   load: { date: string; dailyLoad: number; ctl: number; atl: number }[];
   readiness: { date: string; garminScore: number; ourScore: number }[];
@@ -18,10 +35,13 @@ interface ComparisonChartsProps {
 }
 
 export function ComparisonCharts({ data, hoveredDate, onHoverDate }: ComparisonChartsProps) {
-  // Normalize z-score (-2..+2) to 0-100 scale to match Garmin readiness
+  // Map the signed z-composite to its normal-distribution percentile (0-100) so
+  // it sits on the same honest scale as Garmin's 0-100 readiness. The old linear
+  // `50 + z*25` went negative for z < -2 (our z reaches -3.4). Percentile is
+  // strictly bounded: z=0 → 50, z=+2 → 98, z=-2 → 2.
   const readinessNormalized = data.readiness.map(r => ({
     ...r,
-    ourScoreNorm: Math.round(50 + r.ourScore * 25), // z=0 → 50, z=2 → 100, z=-2 → 0
+    ourScoreNorm: Math.round(zToPercentile(r.ourScore)),
   }));
 
   return (


### PR DESCRIPTION
## What
Our readiness `ourScore` is a signed z-composite (DB range ~-3.4..+2), not a 0-100 score. Two bugs plotted it against Garmin's 0-100 readiness on a shared axis:
- **App** did `ourScore * 100` → "Ours -123 · Garmin 11".
- **Web** did `50 + z*25`, still negative for z < -2 (our z reaches -3.4 → -36).

Both now map the z to its **normal-distribution percentile** (erf-based, strictly 0-100): z=0 → 50, z=+2 → 98, z=-2 → 2. Identical helper in `universal/src/components/training-trends.tsx` and `web/components/comparison-charts.tsx`. App card retitled "Readiness — percentile vs Garmin".

## Verified
- `tsc --noEmit` clean in `universal/` and `web/`.
- App training screen (Playwright :8094): reads "Ours 11 · Garmin 11", both lines on a shared 0-100 band, 0 console errors. Old "-123" gone.
- DB confirmed composite_score min/max = -3.43 / +2.02 over 90d (55/91 days negative), which is why ×100 and the linear map produced negatives.

Closes #329