### PR TITLE
fix(web): persistent desktop sidebar + repair white border token

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -13,6 +13,18 @@
    text-success, …) are generated even though they only appear in node_modules. */
 @source "../node_modules/soma-style/src";
 
+/* Repair the border token. soma-style@1.1.0's shadcn-compat.css defines
+   `--color-border: var(--color-border)` (self-referential → cyclic → invalid),
+   which voids the token so every `border`/`border-border` fell back to
+   currentColor (the near-white text colour). A plain :root declaration lands the
+   value that Tailwind's @theme merge refused to emit, and the base fallback
+   covers bare `border`. Remove once the package ships a fix. */
+:root {
+  --color-border: #1a3040;
+  --color-input: #1a3040;
+  --color-sidebar-border: #1a3040;
+}
+
 
 @layer base {
   * {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -55,7 +55,7 @@ export default function RootLayout({
           )}
           <NavProgress />
           <Sidebar />
-          <main className={`min-h-screen bg-background pb-[env(safe-area-inset-bottom,0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+3rem)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)]${isDemo ? " md:pt-8" : ""}`}>
+          <main className={`min-h-screen bg-background pb-[env(safe-area-inset-bottom,0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+3rem)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] lg:pl-56 lg:pt-6${isDemo ? " md:pt-8" : ""}`}>
             {children}
           </main>
           <Toaster richColors />

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -68,8 +68,9 @@ export function Sidebar() {
 
   return (
     <>
-      {/* App header bar — solid background covering status bar + notch */}
-      <header className="fixed top-0 left-0 right-0 z-50 bg-background border-b border-border">
+      {/* App header bar — mobile only. On desktop the sidebar is always visible
+          (lg:translate-x-0 below), so the hamburger header is hidden. */}
+      <header className="fixed top-0 left-0 right-0 z-50 bg-background border-b border-border lg:hidden">
         {/* Status bar spacer — solid fill behind clock/notch/icons */}
         <div className="safe-area-pt" />
         {/* Header content */}
@@ -101,8 +102,10 @@ export function Sidebar() {
       {/* Slide-out drawer */}
       <aside
         className={cn(
-          "fixed left-0 top-0 z-40 h-screen w-56 flex-col border-r border-border bg-sidebar transition-transform duration-200 safe-area-pt safe-area-pl safe-area-pb",
-          drawerOpen ? "translate-x-0" : "-translate-x-full"
+          "fixed left-0 top-0 z-40 h-screen w-56 flex flex-col border-r border-border bg-sidebar transition-transform duration-200 safe-area-pt safe-area-pl safe-area-pb",
+          // Slide-in drawer on mobile; always visible on desktop (lg+).
+          drawerOpen ? "translate-x-0" : "-translate-x-full",
+          "lg:translate-x-0"
         )}
       >
         {/* Logo + close area */}

--- a/web/components/ui/card.tsx
+++ b/web/components/ui/card.tsx
@@ -7,7 +7,10 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm transition-all duration-200 hover:shadow-md hover:border-primary/20",
+        // Explicit border-border: Tailwind v4's bare `border` defaults the
+        // color to currentColor, and cards set text-card-foreground (near-white),
+        // so the resting border rendered WHITE. Pin it to the dark border token.
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-border py-6 shadow-sm transition-all duration-200 hover:shadow-md hover:border-primary/20",
         className
       )}
       {...props}


### PR DESCRIPTION
Two desktop-web regressions the maintainer reported.

## 1. Sidebar hidden on laptop
The nav `<aside>` was a drawer (`-translate-x-full` unless `drawerOpen`, toggled by the mobile hamburger) with no `lg:` breakpoint, so on desktop it sat permanently off-screen (x = -224). Added `lg:translate-x-0` (persistent on desktop), `lg:hidden` on the hamburger header, and `lg:pl-56` on `<main>`.

## 2. White outlines on every card / bordered element
`soma-style@1.1.0`'s `shadcn-compat.css` defines `--color-border: var(--color-border)` — self-referential, which CSS voids as cyclic, so borders fell back to `currentColor` (`#fdf8f2`, near-white). Pinned the border tokens in a plain `:root` block in `globals.css` (Tailwind v4's `@theme` merge refused to emit them).

## Verified (Playwright)
- Desktop 1440: sidebar visible at x=0 (224px), header `display:none`, `<main>` `padding-left: 224px`.
- Mobile 390: sidebar off-screen drawer, hamburger visible, tap opens it to x=0.
- Card + sidebar border at rest = `rgb(26,48,64)` (`#1a3040`), no longer white. `--color-border` resolves on `:root`.
- `tsc --noEmit` clean; 0 console errors.

Follow-up (separate): fix the self-reference in the soma-style package so all ecosystem apps get it without the per-app override.

Closes #335