### PR TITLE
fix(web): backfill home KPI today-row so cards aren't "—" beside a delta

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -42,12 +42,24 @@ export const revalidate = 300;
 
 async function getTodayHealth() {
   const sql = getDb();
+  // Pull the last 7 days, not just today. Today's row is often partial (Garmin
+  // syncs fields at different times), so a field can be null while its weekly
+  // delta is live — the KPI then rendered "—" next to "↑ +50%". Backfill each
+  // null field from the most recent older day so the value matches the delta.
   const rows = await sql`
     SELECT * FROM daily_health_summary
     ORDER BY date DESC
-    LIMIT 1
+    LIMIT 7
   `;
-  return rows[0] || null;
+  if (!rows.length) return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const merged: Record<string, any> = { ...rows[0] };
+  for (const row of rows.slice(1)) {
+    for (const key of Object.keys(row)) {
+      if (merged[key] == null && row[key] != null) merged[key] = row[key];
+    }
+  }
+  return merged;
 }
 
 async function getWeeklyAverages() {


### PR DESCRIPTION
## What
The home Overview KPI cards read `getTodayHealth()`, which returned only the most recent `daily_health_summary` row (`LIMIT 1`). Today's row is often partial (Garmin syncs fields at different times), so `total_steps`/`active_kilocalories`/`resting_heart_rate`/`avg_stress_level` were null — the KPI rendered "—" while its weekly delta showed "↑ +50%". Contradictory dead cards.

Pull the last 7 rows and backfill each null field from the most recent older day (same approach as the app-side `/api/health/today` fix). A field null across all 7 days stays "—".

## Verified (Playwright)
- Steps `12,771`, Active Cal `792`, RHR `55`, Stress `42` — all now show values matching their deltas (were all "—"). Page dash count dropped from 5 to 1.
- `tsc --noEmit` clean; 0 console errors.

Closes #343