### PR TITLE
fix(security): make DEMO_MODE read-only — block anonymous /api mutations

### DIFF
--- a/web/components/pipeline-operations.tsx
+++ b/web/components/pipeline-operations.tsx
@@ -251,7 +251,7 @@ export function PipelineOperations({
     }
   }
 
-  const isDemo = process.env.NEXT_PUBLIC_IS_DEMO === "true";
+  const isDemo = process.env.NEXT_PUBLIC_IS_DEMO?.trim() === "true";
 
   return (
     <div className="space-y-4">

--- a/web/components/sync-button.tsx
+++ b/web/components/sync-button.tsx
@@ -35,7 +35,7 @@ function relativeTime(iso: string | null): string {
 }
 
 export function SyncButton() {
-  const isDemo = process.env.NEXT_PUBLIC_IS_DEMO === "true";
+  const isDemo = process.env.NEXT_PUBLIC_IS_DEMO?.trim() === "true";
 
   const [state, setState] = useState<SyncState>({
     status: "never",

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -42,8 +42,20 @@ export default auth((req) => {
   // Personal API token: native apps + widgets reach /api/* without a session.
   if (isApi && hasApiToken(req)) return withTokenCors(NextResponse.next());
 
-  // Demo mode: no auth required
-  if (process.env.DEMO_MODE?.trim() === "true") return withDevCors(NextResponse.next(), isApi);
+  // Demo mode: READ-ONLY. Reads and page views need no auth, but every /api/*
+  // handler runs auth-less here, so an anonymous visitor could otherwise POST/
+  // DELETE straight into the shared DB (log/close-day/delete-rule/…). Block all
+  // mutating methods on /api/* at this single choke point.
+  if (process.env.DEMO_MODE?.trim() === "true") {
+    const isMutation = ["POST", "PUT", "PATCH", "DELETE"].includes(req.method);
+    if (isApi && isMutation) {
+      return withDevCors(
+        NextResponse.json({ error: "This is a read-only demo." }, { status: 403 }),
+        true,
+      );
+    }
+    return withDevCors(NextResponse.next(), isApi);
+  }
 
   // Always allow auth routes, login page, and image API (used by sync pipeline)
   if (


### PR DESCRIPTION
**Critical, live vulnerability.** `middleware.ts:46` bypassed all auth in demo mode including mutating `/api/*` routes, and no handler had its own guard — so an anonymous visitor to `soma-demo.gkos.dev` could write/delete rows in the shared production DB.

## Fix
- Block `POST/PUT/PATCH/DELETE` on `/api/*` at the middleware choke point when `DEMO_MODE=true` → 403. Reads (GET) and page views unaffected.
- Harden the `NEXT_PUBLIC_IS_DEMO` comparisons with `.trim()` (the demo env value has a trailing newline, which made `isDemo` false at build time and rendered the sync controls on the public demo). The env-var newline cleanup itself is tracked separately.

Confirmed no read-only-compute endpoint uses POST (the what-if/forward-sim is a GET); of 47 mutation-method routes the 12 non-SQL POSTs are chat/Spotify/DJ/sync triggers a public visitor should not reach either.

## Verified (local DEMO_MODE=true)
- `POST /api/nutrition/close-day` → **403** (was 400, handler reached)
- `DELETE /api/connections/rules/999999` → **403** (was reaching `DELETE FROM sync_rules`)
- `DELETE /api/nutrition/log-meal?id=999999` → **403**
- `GET /api/sync/status` → **200**, `GET /` → **200**
- `tsc --noEmit` clean.

Found by the `soma-adversarial-audit` workflow (demo-write-safety bucket).

Closes #345