### PR TITLE
fix(web): eliminate ":60" rounding carry in 12 pace/time formatters

### DIFF
--- a/web/components/clickable-activity-table.tsx
+++ b/web/components/clickable-activity-table.tsx
@@ -57,8 +57,9 @@ interface Activity {
 }
 
 function formatDuration(mins: number) {
-  const h = Math.floor(mins / 60);
-  const m = Math.round(mins % 60);
+  const t = Math.round(mins); // round total minutes first so 60m can't render
+  const h = Math.floor(t / 60);
+  const m = t % 60;
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 

--- a/web/components/clickable-run-table.tsx
+++ b/web/components/clickable-run-table.tsx
@@ -21,8 +21,9 @@ type SortKey = "date" | "distance" | "pace" | "avg_hr" | "calories";
 type SortDir = "asc" | "desc";
 
 function formatPace(mins: number) {
-  const m = Math.floor(mins);
-  const s = Math.round((mins - m) * 60);
+  const t = Math.round(mins * 60); // round total seconds first so :60 can't render
+  const m = Math.floor(t / 60);
+  const s = t % 60;
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 

--- a/web/components/computation-graph.tsx
+++ b/web/components/computation-graph.tsx
@@ -247,10 +247,10 @@ export function ComputationGraphView({
   // Add HM time annotation under adjusted_pace — computed from the pace value itself
   const adjustedPaceNode = graph.nodes.find(n => n.id === "adjusted_pace");
   if (adjustedPaceNode?.value != null && adjustedPaceNode.value > 0) {
-    const hmSec = adjustedPaceNode.value * 21.0975;
+    const hmSec = Math.round(adjustedPaceNode.value * 21.0975); // round total seconds first
     const h = Math.floor(hmSec / 3600);
     const m = Math.floor((hmSec % 3600) / 60);
-    const s = Math.round(hmSec % 60);
+    const s = hmSec % 60;
     const hmStr = h > 0 ? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}` : `${m}:${String(s).padStart(2, "0")}`;
     banisterAnnotations.set("adjusted_pace", `HM ≈ ${hmStr}`);
   }

--- a/web/components/hr-zone-chart.tsx
+++ b/web/components/hr-zone-chart.tsx
@@ -25,9 +25,10 @@ const ZONE_COLORS = [
 const ZONE_NAMES = ["Warm Up", "Easy", "Aerobic", "Threshold", "Maximum"];
 
 function formatTime(seconds: number) {
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  const m = Math.floor(seconds / 60);
-  const s = Math.round(seconds % 60);
+  const t = Math.round(seconds); // round total seconds first so :60 / 60s can't render
+  if (t < 60) return `${t}s`;
+  const m = Math.floor(t / 60);
+  const s = t % 60;
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 

--- a/web/components/pace-waterfall.tsx
+++ b/web/components/pace-waterfall.tsx
@@ -48,7 +48,8 @@ export function PaceWaterfall({ basePace, items, adjustedPace }: {
 }
 
 function formatPaceSeconds(s: number): string {
-  const min = Math.floor(s / 60)
-  const sec = Math.round(s % 60)
+  const t = Math.round(s) // round total seconds first so :60 can't render
+  const min = Math.floor(t / 60)
+  const sec = t % 60
   return `${min}:${sec.toString().padStart(2, "0")}/km`
 }

--- a/web/components/recent-routes-gallery.tsx
+++ b/web/components/recent-routes-gallery.tsx
@@ -29,9 +29,9 @@ interface RouteItem {
 
 function formatPace(distance_km: number, duration_s: number): string {
   if (!distance_km || !duration_s) return "—";
-  const paceMin = duration_s / 60 / distance_km;
-  const m = Math.floor(paceMin);
-  const s = Math.round((paceMin - m) * 60);
+  const secPerKm = Math.round(duration_s / distance_km); // round total sec/km first
+  const m = Math.floor(secPerKm / 60);
+  const s = secPerKm % 60;
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 

--- a/web/components/trajectory-chart.tsx
+++ b/web/components/trajectory-chart.tsx
@@ -43,9 +43,10 @@ interface TrajectoryChartProps {
 // ── VDOT → pace/time conversions (Daniels/Gilbert) ──────────
 
 function formatSeconds(sec: number): string {
-  const h = Math.floor(sec / 3600);
-  const m = Math.floor((sec % 3600) / 60);
-  const s = Math.round(sec % 60);
+  const t = Math.round(sec); // round total seconds first so :60 can't render
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  const s = t % 60;
   return h > 0
     ? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
     : `${m}:${String(s).padStart(2, "0")}`;
@@ -53,15 +54,16 @@ function formatSeconds(sec: number): string {
 
 function vdotToHmPace(vdot: number): string {
   const hmSeconds = estimateHMSeconds(vdot);
-  const paceSecPerKm = hmSeconds / 21.0975;
-  const min = Math.floor(paceSecPerKm / 60);
-  const sec = Math.round(paceSecPerKm % 60);
+  const secPerKm = Math.round(hmSeconds / 21.0975); // round total sec/km first
+  const min = Math.floor(secPerKm / 60);
+  const sec = secPerKm % 60;
   return `${min}:${sec.toString().padStart(2, "0")}`;
 }
 
 function formatPace(secPerKm: number): string {
-  const min = Math.floor(secPerKm / 60);
-  const sec = Math.round(secPerKm % 60);
+  const t = Math.round(secPerKm); // round total seconds first so :60 can't render
+  const min = Math.floor(t / 60);
+  const sec = t % 60;
   return `${min}:${sec.toString().padStart(2, "0")}`;
 }
 
@@ -71,9 +73,9 @@ function formatHmTime(vdot: number): string {
 
 function formatTimeDelta(seconds: number): string {
   const sign = seconds >= 0 ? "+" : "-";
-  const abs = Math.abs(seconds);
+  const abs = Math.round(Math.abs(seconds)); // round total seconds first so :60 can't render
   const m = Math.floor(abs / 60);
-  const s = Math.round(abs % 60);
+  const s = abs % 60;
   return `${sign}${m}:${String(s).padStart(2, "0")}`;
 }
 
@@ -629,8 +631,9 @@ export function TrajectoryChart({
             reversed
             domain={["dataMin - 5", "dataMax + 5"]}
             tickFormatter={(v: number) => {
-              const m = Math.floor(v / 60);
-              const s = Math.round(v % 60);
+              const t = Math.round(v); // round total seconds first so :60 can't render
+              const m = Math.floor(t / 60);
+              const s = t % 60;
               return `${m}:${String(s).padStart(2, "0")}`;
             }}
             width={hasSecondary ? 0 : 40}

--- a/web/lib/garmin-run-enrich.ts
+++ b/web/lib/garmin-run-enrich.ts
@@ -22,9 +22,9 @@ export function generateRunStravaDescription(summary: Record<string, any>, hrZon
   if (dist > 0) parts.push(`📏 ${(dist / 1000).toFixed(2)} km`);
   const avgSpeed = summary.averageSpeed ?? 0;
   if (avgSpeed > 0) {
-    const pace = 1000 / avgSpeed / 60;
-    const m = Math.trunc(pace);
-    parts.push(`⚡ ${m}:${String(r0((pace - m) * 60)).padStart(2, "0")}/km`);
+    const secPerKm = Math.round(1000 / avgSpeed); // round total sec/km first so :60 can't render
+    const m = Math.floor(secPerKm / 60);
+    parts.push(`⚡ ${m}:${String(secPerKm % 60).padStart(2, "0")}/km`);
   }
   const avgHr = summary.averageHR ?? 0;
   if (avgHr > 0) parts.push(`❤️ ${r0(avgHr)} bpm`);


### PR DESCRIPTION
The `:60` carry from #322 recurs in 12 formatters across 8 files the earlier fix didn't cover. Each did `Math.floor(x/60)` + `Math.round(x%60)` on a float input, so a seconds field rounding up rendered `5:60` / `59:60` / `1h 60m`. Round the total unit first, then derive fields via modulo.

Files: trajectory-chart (formatSeconds, vdotToHmPace, formatPace, formatTimeDelta, y-axis tickFormatter), clickable-run-table, recent-routes-gallery, clickable-activity-table ("1h 60m"), pace-waterfall, hr-zone-chart, computation-graph, lib/garmin-run-enrich (Telegram string).

## Verified
- node against the audit's inputs: `runPace(4.999)=5:00`, `routePace(6,1798)=5:00`, `trajPace(299.6)=5:00`, `trajSec(3599.6)` s=0, `dur(119.7)=2h 0m`.
- Live (Playwright, fresh bundle): /running shows 0 ":60" (was "5:60"), /training scans 165 rendered times with 0 ":60". 0 console errors. `tsc` clean.

Found by the `soma-adversarial-audit` workflow (state-boundary-math bucket).

Closes #349