### PR TITLE
fix(web): range-scope the workout stat cards

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -100,14 +100,17 @@ function pctChange(current: number | null, previous: number | null): number | nu
   return ((current - previous) / previous) * 100;
 }
 
-async function getWorkoutStats() {
+async function getWorkoutStats(cutoff: string) {
   const sql = getDb();
+  // Range-scoped so the Gym Frequency headline matches the range-scoped
+  // Activity Breakdown Gym count beside it (was an all-time COUNT(*)).
   const rows = await sql`
     SELECT
       COUNT(*) as total_workouts,
       MAX(raw_json->>'start_time') as last_workout
     FROM hevy_raw_data
     WHERE endpoint_name = 'workout'
+      AND (raw_json->>'start_time')::timestamp >= ${cutoff}::date
   `;
   const recent = await sql`
     SELECT COUNT(*) as count_7d
@@ -737,7 +740,7 @@ export default async function HomePage({
       getTodayHealth(),
       getWeeklyAverages(),
       getPreviousWeekAverages(),
-      getWorkoutStats(),
+      getWorkoutStats(cutoff),
       getGymFrequency(cutoff),
       getRunningStats(cutoff),
       getActivityCounts(cutoff),

--- a/web/app/workouts/page.tsx
+++ b/web/app/workouts/page.tsx
@@ -87,8 +87,11 @@ async function getWeeklyVolume(cutoff: string) {
   return rows;
 }
 
-async function getWorkoutSummaryStats() {
+async function getWorkoutSummaryStats(cutoff: string) {
   const sql = getDb();
+  // Range-scoped so the headline cards (Total Workouts, Avg Duration, Training
+  // Span, avg/week) track the range selector like the charts below them, instead
+  // of showing all-time totals under a filtered view.
   const rows = await sql`
     WITH stats AS (
       SELECT
@@ -100,6 +103,7 @@ async function getWorkoutSummaryStats() {
         MAX((raw_json->>'start_time')::date) as last_workout
       FROM hevy_raw_data
       WHERE endpoint_name = 'workout'
+        AND (raw_json->>'start_time')::timestamp >= ${cutoff}::date
     )
     SELECT * FROM stats
   `;
@@ -487,7 +491,7 @@ export default async function WorkoutsPage({ searchParams }: { searchParams: Pro
       getRecentWorkouts(cutoff, 50),
       getWeeklyVolume(cutoff),
       getConfigurableProgression(cutoff),
-      getWorkoutSummaryStats(),
+      getWorkoutSummaryStats(cutoff),
       getTopExercises(cutoff),
       getProgramSplit(cutoff),
       getExercisePRs(),


### PR DESCRIPTION
Under the range selector, headline stat cards showed all-time totals while the charts beside them were range-scoped — a same-screen contradiction.

- **Home Gym Frequency** used an all-time `COUNT(*)` (329) vs the range-scoped Activity Breakdown Gym (77 at 6M).
- **/workouts** Total Workouts / Training Span / Avg Duration / avg-per-week came from an un-cutoff query, frozen across ranges, next to range-scoped charts.

Threaded the range `cutoff` into `getWorkoutStats` (home) and `getWorkoutSummaryStats` (/workouts) — the correct fix, not just an "all-time" label.

## Verified (Playwright)
- Home Gym Frequency: **0** at 1w, **329** at All — now matches Activity Breakdown Gym (329).
- /workouts: **0 / 0 weeks** at 1w, **127 / 45 weeks / 55m** at 1y (scales with range). 0 console errors, tsc clean.

Found by the `soma-adversarial-audit` workflow (cross-page-consistency bucket).

Closes #353