### PR TITLE
fix(web): guard WeightTrend empty-weights + trajectory rest-day sentinel

### DIFF
--- a/web/components/trajectory-chart.tsx
+++ b/web/components/trajectory-chart.tsx
@@ -323,7 +323,11 @@ function makeCustomTooltip(projectedDays?: ProjectedDay[] | null, goalVdot?: num
               <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Formula</div>
               <div className="text-xs grid grid-cols-2 gap-x-3 gap-y-0.5">
                 <span className="text-muted-foreground">Readiness</span>
-                <span className="font-mono">{projectedDay.readinessFactor.toFixed(4)}x</span>
+                <span className="font-mono">
+                  {/* -1 is a REST-day sentinel (critically low readiness), not a
+                      real multiplier — render it as REST rather than "-1.0000x". */}
+                  {projectedDay.readinessFactor === -1 ? "rest" : `${projectedDay.readinessFactor.toFixed(4)}x`}
+                </span>
                 <span className="text-muted-foreground">Fatigue</span>
                 <span className="font-mono">{projectedDay.fatigueFactor.toFixed(4)}x</span>
                 <span className="text-muted-foreground">Weight</span>

--- a/web/components/weight-trend-chart.tsx
+++ b/web/components/weight-trend-chart.tsx
@@ -25,6 +25,9 @@ export function WeightTrendChart({ data }: { data: WeightPoint[] }) {
   const recent = data.slice(-60);
 
   const weights = recent.map((d) => d.weight_kg).filter((w) => w > 0);
+  // weight_kg can be 0/absent even when rows exist; without valid weights,
+  // Math.min(...[]) is Infinity (broken axis) and reduce/0 is NaN (avg label).
+  if (weights.length === 0) return null;
   const minW = Math.floor(Math.min(...weights) - 1);
   const maxW = Math.ceil(Math.max(...weights) + 1);
 


### PR DESCRIPTION
Two boundary-condition defects (audit state-boundary-math bucket).

- **WeightTrendChart**: guarded only `data.length===0`; when rows exist but all `weight_kg` are 0, the post-filter `weights=[]` gave `Math.min(...[])`=Infinity (broken axis) and `reduce/0`=NaN (avg label). Early-return when empty.
- **Trajectory tooltip**: `readinessFactor === -1` is a REST-day sentinel; rendered "-1.0000x" as a real multiplier. Now shows "rest".

Defensive guards — no change to the normal render path. tsc clean.

Closes #355