### PR TITLE
fix(web): mobile chart overflow, demo-banner/logo overlap, playlist mobile

### DIFF
--- a/web/components/demo-banner.tsx
+++ b/web/components/demo-banner.tsx
@@ -2,7 +2,7 @@ export const DEMO_URL = "https://soma-demo.gkos.dev";
 
 export function DemoBanner({ repoUrl }: { repoUrl: string }) {
   return (
-    <div className="fixed left-16 right-0 top-0 z-50 flex items-center justify-center gap-3 bg-primary/10 px-4 py-1.5 text-xs text-primary backdrop-blur-sm border-b border-primary/20">
+    <div className="fixed left-0 lg:left-56 right-0 top-0 z-50 flex items-center justify-center gap-3 bg-primary/10 px-4 py-1.5 text-xs text-primary backdrop-blur-sm border-b border-primary/20">
       <span className="font-medium">Demo</span>
       <span className="text-primary/60">·</span>
       <span className="text-primary/80">sample data — not real health records</span>

--- a/web/components/expandable-chart-card.tsx
+++ b/web/components/expandable-chart-card.tsx
@@ -52,7 +52,11 @@ export function ExpandableChartCard({
             <Maximize2 className="h-3.5 w-3.5 ml-auto opacity-40 md:opacity-30 md:group-hover:opacity-60 transition-opacity duration-200 shrink-0" />
           </CardTitle>
         </CardHeader>
-        <CardContent className="[&_.recharts-responsive-container]:!h-[200px] sm:[&_.recharts-responsive-container]:!h-auto">
+        {/* No mobile height clamp: forcing the container to 200px didn't shrink
+            the recharts SVG (which keeps its numeric `height` prop), so the SVG
+            spilled 100px below the card and overlapped the next card. Let the
+            container match the chart's natural height on every breakpoint. */}
+        <CardContent>
           {renderChildren(false)}
         </CardContent>
       </Card>

--- a/web/components/playlist-builder.tsx
+++ b/web/components/playlist-builder.tsx
@@ -647,9 +647,10 @@ export default function PlaylistBuilder() {
   return (
     <div className="flex flex-col h-full">
       <PlaylistTopBar sources={sources} onSourcesChange={setSources} genres={genres} onGenresChange={setGenres} genreThreshold={genreThreshold} onThresholdChange={setGenreThreshold} workoutName={workoutName} onChangeRun={() => { if (hasSongsPlaced) { setChangeRunConfirm(true); } else { resetRun(); } }} onOpenBank={() => setPumpUpModalOpen(true)} onOpenShortcuts={() => setShortcutsOpen(true)} />
-      <div className="flex flex-1 overflow-hidden">
-        {/* Left: run selector (first time) or run timeline */}
-        <div ref={leftRef} className="w-[40%] border-r overflow-y-auto">
+      <div className="flex flex-col lg:flex-row flex-1 overflow-hidden">
+        {/* Left: run selector (first time) or run timeline. Full-width stacked on
+            mobile — the desktop w-[40%] crushed it to ~150px on a phone. */}
+        <div ref={leftRef} className="w-full lg:w-[40%] border-b lg:border-b-0 lg:border-r overflow-y-auto">
           {!hasRun ? (
             <div className="h-full flex flex-col">
               <div className="px-3 py-2 border-b text-xs font-medium text-muted-foreground">Select a run to get started</div>


### PR DESCRIPTION
Three responsive defects (audit responsive-regression bucket).

1. **Mobile chart overflow** — `expandable-chart-card` clamped the recharts container to 200px on mobile but recharts keeps its numeric `height` prop, so the SVG spilled ~100px and overlapped the next card. Removed the broken clamp.
2. **Demo banner covered the sidebar logo** — `left-16` (64px) vs the 224px sidebar; now `left-0 lg:left-56`.
3. **Playlist Builder crushed at 390px** — two-pane `w-[40%]` squeezed the run list to ~150px; stack on mobile (`flex-col lg:flex-row`, `w-full lg:w-[40%]`).

## Verified (Playwright)
- 390px: chart cards show **0** SVG spill (was 100px).
- 1440px: banner starts at **x=224**, logo at x=130 — no overlap.
- tsc clean, 0 console errors.

Closes #357