### PR TITLE
fix(web): VO2max shows the latest value, range-independent

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -146,7 +146,16 @@ async function getRunningStats(cutoff: string) {
     SELECT
       COUNT(*) as total_runs,
       SUM((raw_json->>'distance')::float) / 1000.0 as total_km,
-      MAX((raw_json->>'vO2MaxValue')::float) as vo2max
+      -- VO2max is a point-in-time fitness metric, not a range aggregate: show the
+      -- latest value regardless of the selected range (was MAX-over-range, which
+      -- made it read 54 at 6M but 57 at "All").
+      (SELECT (a.raw_json->>'vO2MaxValue')::float
+         FROM garmin_activity_raw a
+        WHERE a.endpoint_name = 'summary'
+          AND a.raw_json->>'vO2MaxValue' IS NOT NULL
+          AND a.raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+        ORDER BY a.activity_id DESC
+        LIMIT 1) as vo2max
     FROM garmin_activity_raw
     WHERE endpoint_name = 'summary'
       AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')

--- a/web/app/running/page.tsx
+++ b/web/app/running/page.tsx
@@ -604,7 +604,19 @@ export default async function RunningPage({
         />
         <StatCard
           title="VO2max"
-          value={stats?.peak_vo2max ? `${Number(stats.peak_vo2max).toFixed(1)}` : "—"}
+          /* Latest VO2max (current fitness), not the range peak — matches the
+             dashboard KPI. Read from the already-fetched trend (ordered date-ASC,
+             so the last entry is the most recent) to avoid adding a DB query on
+             this already query-heavy page. Falls back to the range max. */
+          value={(() => {
+            const trend = vo2max as { vo2max: number | null }[] | null;
+            const latest = trend?.length ? Number(trend[trend.length - 1]?.vo2max) : null;
+            return latest
+              ? latest.toFixed(1)
+              : stats?.peak_vo2max
+                ? `${Number(stats.peak_vo2max).toFixed(1)}`
+                : "—";
+          })()}
           subtitle="ml/kg/min"
           icon={<Zap className="h-4 w-4 text-yellow-400" />}
         />


### PR DESCRIPTION
The home VO2max KPI used `MAX(vO2MaxValue)` over the range (54.0 at 6M, 57.0 at All), and /running used the same range peak. VO2max is point-in-time — per the maintainer's decision, show the **latest**, range-independent.

- **Home**: latest run's VO2max via `ORDER BY activity_id DESC LIMIT 1` (activity_id is monotonic with time — cheap, avoids sorting the JSON `startTimeLocal`).
- **/running**: read the latest entry of the already-fetched VO2max trend instead of adding a query. This page runs ~15 parallel queries; my first attempt (an extra whole-table sort) caused a **Neon out-of-memory** (intermittent 500s) — the zero-query approach is stable.

## Verified (Playwright)
- Home VO2max: **52.0 at both 6m and All** (was 54.0 / 57.0).
- /running: **52.0** (matches home + the app's ~52.9); stable across 4 repeated loads (no OOM). tsc clean, 0 console errors.

Found by the `soma-adversarial-audit` workflow (cross-page-consistency bucket).

Closes #361