### PR TITLE
fix(web): headline soma's model readiness, Garmin as comparison

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -16,6 +16,7 @@ import { InteractiveThisWeek } from "@/components/interactive-this-week";
 import { TimeRangeSelector } from "@/components/time-range-selector";
 import { rangeToDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
+import { readinessScore, trafficLightText } from "@/lib/readiness";
 import {
   Footprints,
   Flame,
@@ -440,8 +441,9 @@ async function getWeightTrend(cutoff: string) {
 
 async function getRecoverySummary() {
   const sql = getDb();
-  // Get latest body battery, HRV, and training readiness
-  const [bb, hrv, tr] = await Promise.all([
+  // Get latest body battery, HRV, Garmin training readiness, and soma's own
+  // model readiness (headlined; Garmin is shown as the secondary comparison).
+  const [bb, hrv, tr, model] = await Promise.all([
     sql`
       SELECT
         (raw_json->>'bodyBatteryChargedValue')::int as charged,
@@ -471,11 +473,17 @@ async function getRecoverySummary() {
         AND raw_json->0->>'score' IS NOT NULL
       ORDER BY date DESC LIMIT 1
     `,
+    sql`
+      SELECT traffic_light, composite_score
+      FROM daily_readiness
+      ORDER BY date DESC LIMIT 1
+    `,
   ]);
   return {
     bodyBattery: bb[0] || null,
     hrv: hrv[0] || null,
     readiness: tr[0] || null,
+    model: model[0] || null,
   };
 }
 
@@ -921,18 +929,32 @@ export default async function HomePage({
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                {recovery.readiness && (
+                {(recovery.model || recovery.readiness) && (
                   <div>
-                    <div className="text-xs text-muted-foreground mb-1">Training Readiness</div>
-                    <div className={`text-2xl font-bold ${
-                      Number(recovery.readiness.score) >= 70 ? "text-green-400" :
-                      Number(recovery.readiness.score) >= 40 ? "text-yellow-400" : "text-red-400"
-                    }`}>
-                      {recovery.readiness.score}
-                    </div>
-                    <div className="text-xs text-muted-foreground capitalize">
-                      {recovery.readiness.level?.toLowerCase().replace(/_/g, " ")}
-                    </div>
+                    <div className="text-xs text-muted-foreground mb-1">Readiness</div>
+                    {recovery.model?.composite_score != null ? (
+                      // soma's own model readiness (headlined); Garmin below as the comparison.
+                      <>
+                        <div className={`text-2xl font-bold ${trafficLightText(recovery.model.traffic_light)}`}>
+                          {readinessScore(Number(recovery.model.composite_score))}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {recovery.readiness ? `Garmin ${recovery.readiness.score}` : "model"}
+                        </div>
+                      </>
+                    ) : recovery.readiness ? (
+                      <>
+                        <div className={`text-2xl font-bold ${
+                          Number(recovery.readiness.score) >= 70 ? "text-green-400" :
+                          Number(recovery.readiness.score) >= 40 ? "text-yellow-400" : "text-red-400"
+                        }`}>
+                          {recovery.readiness.score}
+                        </div>
+                        <div className="text-xs text-muted-foreground capitalize">
+                          {recovery.readiness.level?.toLowerCase().replace(/_/g, " ")}
+                        </div>
+                      </>
+                    ) : null}
                   </div>
                 )}
                 {recovery.bodyBattery && (

--- a/web/components/comparison-charts.tsx
+++ b/web/components/comparison-charts.tsx
@@ -3,23 +3,8 @@
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import { Card, CardContent } from "@/components/ui/card";
 import { estimateHMSeconds } from "@/lib/vdot-utils";
-
-// Normal-distribution percentile of a z-score (0-100), bounded. Keeps our signed
-// readiness z-composite on the same scale as Garmin's 0-100 readiness.
-function erf(x: number): number {
-  const sign = x < 0 ? -1 : 1;
-  const ax = Math.abs(x);
-  const t = 1 / (1 + 0.3275911 * ax);
-  const y =
-    1 -
-    ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) *
-      t *
-      Math.exp(-ax * ax);
-  return sign * y;
-}
-function zToPercentile(z: number): number {
-  return 50 * (1 + erf(z / Math.SQRT2));
-}
+// Shared with the home Recovery card + the app, so a given z reads the same everywhere.
+import { readinessScore as zToPercentile } from "@/lib/readiness";
 
 interface ComparisonData {
   load: { date: string; dailyLoad: number; ctl: number; atl: number }[];

--- a/web/components/training-dashboard.tsx
+++ b/web/components/training-dashboard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { Loader2, Save, Check, X, AlertTriangle, ShieldAlert } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { readinessScore } from "@/lib/readiness";
 import { ComputationGraphView } from "@/components/computation-graph";
 import { TrajectorySection } from "@/components/trajectory-section";
 import { ReferencePanel, type ReferenceMetric } from "@/components/reference-panel";
@@ -109,20 +110,23 @@ function buildReferenceMetrics(
 
   return [
     {
-      id: "garmin-readiness",
-      label: "Garmin Training Readiness",
-      value: latestReadiness?.garmin_readiness_score != null
-        ? String(Math.round(Number(latestReadiness.garmin_readiness_score)))
+      id: "readiness",
+      label: "Readiness",
+      // soma's own model readiness (0-100 percentile of the recovery z-composite),
+      // headlined; Garmin's readiness is the comparison. Was showing the raw
+      // z-composite ("4.3") next to Garmin's 0-100 ("66") \u2014 different scales.
+      value: latestReadiness?.composite_score != null
+        ? String(readinessScore(Number(latestReadiness.composite_score)))
         : "\u2014",
       sparkline: readinessHistory
-        .filter((r) => r.garmin_readiness_score != null)
-        .map((r) => Number(r.garmin_readiness_score)),
-      color: "oklch(65% 0.15 250)",
+        .filter((r) => r.composite_score != null)
+        .map((r) => readinessScore(Number(r.composite_score))),
+      color: "oklch(65% 0.15 142)",
       tooltip:
-        "Garmin\u2019s composite readiness score. Compare with our model\u2019s composite to see if they agree.",
+        "soma\u2019s model readiness \u2014 the 0-100 percentile of today\u2019s recovery z-composite. Garmin\u2019s own readiness is shown for comparison.",
       comparison: {
         ours: latestReadiness?.composite_score != null
-          ? Number(latestReadiness.composite_score).toFixed(1)
+          ? String(readinessScore(Number(latestReadiness.composite_score)))
           : "\u2014",
         garmin: latestReadiness?.garmin_readiness_score != null
           ? String(Math.round(Number(latestReadiness.garmin_readiness_score)))

--- a/web/lib/readiness.ts
+++ b/web/lib/readiness.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical readiness helpers (web), mirroring universal/src/lib/readiness.ts so
+ * soma's model readiness renders the same 0-100 number on every surface.
+ *
+ * The model readiness is a signed z-composite; map it to its normal-distribution
+ * percentile for a bounded, interpretable 0-100 score. Garmin's own readiness is
+ * shown separately (comparison / secondary line), never mixed into this number.
+ */
+function erf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const ax = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * ax);
+  const y =
+    1 -
+    ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) *
+      t *
+      Math.exp(-ax * ax);
+  return sign * y;
+}
+
+/** Normal-distribution percentile (0-100) of a readiness z-composite. */
+export function readinessScore(z: number): number {
+  return Math.round(50 * (1 + erf(z / Math.SQRT2)));
+}
+
+/** Tailwind text-color class for a model traffic light. */
+export function trafficLightText(light: string | null | undefined): string {
+  switch (light) {
+    case "green":
+      return "text-green-400";
+    case "yellow":
+      return "text-yellow-400";
+    case "red":
+      return "text-red-400";
+    default:
+      return "text-foreground";
+  }
+}


### PR DESCRIPTION
Per your decision (soma's model is canonical readiness everywhere, Garmin in the comparison), reconciled the web to match the app.

The web headlined Garmin's readiness (66) on the home Recovery card and mixed scales on /training ("Ours: 4.3" raw z-composite vs "Garmin: 66").

- New `web/lib/readiness.ts` (`readinessScore` percentile + `trafficLightText`), mirroring the app helper so a z reads the same everywhere; `comparison-charts` imports it (DRY).
- **Home Recovery**: headline `readinessScore(composite)` + model traffic-light colour, Garmin as the secondary line (one light `daily_readiness` query added to the existing recovery batch).
- **/training** readiness card headlines the model percentile; Ours-vs-Garmin now **100 vs 66** (both 0-100), not 4.3 vs 66.
- **/sleep** "Training Readiness" stays Garmin (it's the explicit Garmin breakdown, like the app's RecoveryVitals).

## Verified (Playwright)
- Home: **"Readiness 100 · Garmin 66"**; /training: **"Ours: 100 | Garmin: 66"** — both match the app overview (100). tsc clean, 0 console errors.

Found by the `soma-adversarial-audit` workflow (cross-page-consistency bucket).

Closes #364