### PR TITLE
fix(training): race prediction from the current (banister) VDOT

### DIFF
--- a/web/components/training-dashboard.tsx
+++ b/web/components/training-dashboard.tsx
@@ -82,6 +82,7 @@ function formatRaceTime(totalSeconds: number): string {
 /** Build reference metrics from separately-queried external data — signals NOT in the formula graph. */
 function buildReferenceMetrics(
   referenceData: ReferenceData,
+  currentVdot: number,
 ): ReferenceMetric[] {
   const { readinessHistory, fitnessHistory, weightHistory } = referenceData;
 
@@ -100,9 +101,15 @@ function buildReferenceMetrics(
     }
   }
 
-  // Determine latest race prediction value
+  // Determine the latest race prediction from the CURRENT (banister) VDOT via the
+  // same Daniels VO2 model, so it matches the displayed VDOT and the app. The
+  // fitness_trajectory race_prediction_seconds / vdot_adjusted are stale (an
+  // older, higher VDOT) and disagreed \u2014 e.g. banister 43.2 \u2192 1:43:49 (app match),
+  // vs the stale 57.7 \u2192 1:20:50. Keep the stale values only as a fallback.
   let latestRacePrediction: string = "\u2014";
-  if (latestFitness?.race_prediction_seconds != null) {
+  if (currentVdot && currentVdot > 0) {
+    latestRacePrediction = formatRaceTime(estimateHMSeconds(currentVdot));
+  } else if (latestFitness?.race_prediction_seconds != null) {
     latestRacePrediction = formatRaceTime(Number(latestFitness.race_prediction_seconds));
   } else if (latestFitness?.vdot_adjusted != null && Number(latestFitness.vdot_adjusted) > 0) {
     latestRacePrediction = formatRaceTime(estimateHMSeconds(Number(latestFitness.vdot_adjusted)));
@@ -490,8 +497,8 @@ export function TrainingDashboard({
 
   // Reference metrics from server-queried external data
   const referenceMetrics = useMemo<ReferenceMetric[]>(() => {
-    return buildReferenceMetrics(referenceData);
-  }, [referenceData]);
+    return buildReferenceMetrics(referenceData, currentVdot);
+  }, [referenceData, currentVdot]);
 
   // Dynamic VDOT: prefer graph node value, fall back to server-provided currentVdot prop
   const dynamicVdot = useMemo(() => {


### PR DESCRIPTION
Web /training showed Race Prediction **1:29:40** while displaying **VDOT 43.2**; the app showed **1:43:50** for the same VDOT. `estimateHMSeconds` is correct (`43.2 → 1:43:49`), but the prediction was fed `fitness_trajectory.vdot_adjusted`/`race_prediction_seconds` — **stale** (2026-06-10, ~57.7 → 1:20:50) — instead of the current banister `current_vdot` (43.245, 2026-07-16) that the page displays.

Compute the headline from `currentVdot` via the same model, matching the displayed VDOT and the app. Stale fitness_trajectory values kept as a fallback.

## Verified (Playwright)
- Web Race Prediction now **1:43:44** (was 1:29:40) — matches the app's 1:43:50 and VDOT 43.2. tsc clean, 0 console errors.
- Confirmed via node: `estimateHMSeconds(43.2)=1:43:49` vs the stale `estimateHMSeconds(57.7)=1:20:50`.

Found by the `soma-adversarial-audit` workflow (cross-page-consistency bucket).

Closes #368