### PR TITLE
chore(web): bump soma-style to 1.3.1 + trim per-app token override

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -13,24 +13,16 @@
    text-success, …) are generated even though they only appear in node_modules. */
 @source "../node_modules/soma-style/src";
 
-/* Repair the border token. soma-style@1.1.0's shadcn-compat.css defines
-   `--color-border: var(--color-border)` (self-referential → cyclic → invalid),
-   which voids the token so every `border`/`border-border` fell back to
-   currentColor (the near-white text colour). A plain :root declaration lands the
-   value that Tailwind's @theme merge refused to emit.
-
-   Also: shadcn-compat maps tokens under `@theme inline`, which inlines them into
-   Tailwind utilities but never emits :root custom properties. Components that use
-   the bare shadcn names as *raw* CSS values (recharts fills, tooltip/cursor
-   styles, axis colours) read `var(--primary)`, `var(--card)`, … which were
-   therefore empty — bar fills fell back to black and vanished on the dark
-   background. Define the bare aliases here, mapped to the base soma palette.
-   Remove once the package ships these on :root. */
+/* Bare shadcn token aliases. soma-style's shadcn-compat maps tokens under
+   `@theme inline`, which inlines them into Tailwind utilities but never emits
+   :root custom properties. Components that read the bare shadcn names as *raw*
+   CSS values (recharts fills, tooltip/cursor styles, axis colours) reference
+   `var(--primary)`, `var(--card)`, … which were therefore empty — bar fills fell
+   back to black and vanished on the dark background. Define the bare aliases
+   here, mapped to the base soma palette.
+   (The `--color-border` self-reference that voided borders was fixed in
+   soma-style 1.3.1, so those pins are no longer needed here.) */
 :root {
-  --color-border: #1a3040;
-  --color-input: #1a3040;
-  --color-sidebar-border: #1a3040;
-
   --background: var(--color-base);
   --foreground: var(--color-text);
   --card: var(--color-surface);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -36,7 +36,7 @@
         "recharts": "^3.7.0",
         "remark-gfm": "^4.0.1",
         "run-dj": "^0.3.0",
-        "soma-style": "^1.1.0",
+        "soma-style": "^1.3.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "web-push": "^3.6.7"
@@ -17376,9 +17376,9 @@
       "license": "MIT"
     },
     "node_modules/soma-style": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-1.1.0.tgz",
-      "integrity": "sha512-Z2YEeIl3tr6OjDf5SGPPpYfncPMMkjI9bHpKOkpzJFvC0+tw97gGA1bVXGLb4ZdKrknTEjzX706WCVod1P8spg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-1.3.1.tgz",
+      "integrity": "sha512-xiJEjssLyjQOF/PfRpeg+HDrVDIWtoutyFxUNXR389NpNIhBdDvf3vS41F1xo2oh5cuLX6FB/EWOAA1Io6/bkw==",
       "license": "MIT",
       "peerDependencies": {
         "nativewind": ">=4.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,7 @@
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
     "run-dj": "^0.3.0",
-    "soma-style": "^1.1.0",
+    "soma-style": "^1.3.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "web-push": "^3.6.7"


### PR DESCRIPTION
soma-style **1.3.1** is published with the root fix for the self-referential `--color-border` (my earlier per-app `:root` pin was the workaround). Bump `^1.1.0 → ^1.3.1` and drop the now-redundant border pins, keeping only the bare shadcn aliases (`--primary`, `--card`, …) the package still doesn't emit for raw `var()` usage in recharts.

## Verified (Playwright, soma-style@1.3.1 installed)
- `--color-border` resolves to **#1a3040** from the *package* (not the app pin).
- Card borders `rgb(26,48,64)` (dark), chart bars teal (not black) — no regression with the pins removed. 0 console errors.

**Ecosystem note:** macro-engine/web pins `^0.5.0` (a major behind — a separate careful upgrade; its token issue is latent/unused). hevy2garmin has no soma-style dependency.

Closes #370