### PR TITLE
hotfix(web): guard home readiness query — demo DB lacks daily_readiness

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -477,7 +477,7 @@ async function getRecoverySummary() {
       SELECT traffic_light, composite_score
       FROM daily_readiness
       ORDER BY date DESC LIMIT 1
-    `,
+    `.catch(() => []),  // demo DB has no daily_readiness table — fall back to Garmin readiness
   ]);
   return {
     bodyBattery: bb[0] || null,


### PR DESCRIPTION
**Live regression.** #364 (home Recovery → soma model) added `SELECT … FROM daily_readiness` to `getRecoverySummary`, but the **demo database has no `daily_readiness` table**, so the deployed demo home 500'd (`NeonDbError 42P01 relation "daily_readiness" does not exist`, caught via Vercel runtime logs). The personal DB has the table, so it worked locally + on personal.

`/training`'s daily_readiness queries already use `safeQuery`; the home one didn't. Added `.catch(() => [])` — a missing table falls back to Garmin readiness (the card already renders Garmin when `model == null`).

Verified: tsc clean; local home 200 (table present → model shows). The definitive test is the demo redeploy against its table-less DB — monitoring.

Fast-track: restores the public demo home.