### PR TITLE
feat(web): more legible + dynamically-sized sidebar

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -55,7 +55,7 @@ export default function RootLayout({
           )}
           <NavProgress />
           <Sidebar />
-          <main className={`min-h-screen bg-background pb-[env(safe-area-inset-bottom,0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+3rem)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] lg:pl-56 lg:pt-6${isDemo ? " md:pt-8" : ""}`}>
+          <main className={`min-h-screen bg-background pb-[env(safe-area-inset-bottom,0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+3rem)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] lg:pl-56 2xl:pl-64 lg:pt-6${isDemo ? " md:pt-8" : ""}`}>
             {children}
           </main>
           <Toaster richColors />

--- a/web/components/demo-banner.tsx
+++ b/web/components/demo-banner.tsx
@@ -2,7 +2,7 @@ export const DEMO_URL = "https://soma-demo.gkos.dev";
 
 export function DemoBanner({ repoUrl }: { repoUrl: string }) {
   return (
-    <div className="fixed left-0 lg:left-56 right-0 top-0 z-50 flex items-center justify-center gap-3 bg-primary/10 px-4 py-1.5 text-xs text-primary backdrop-blur-sm border-b border-primary/20">
+    <div className="fixed left-0 lg:left-56 2xl:left-64 right-0 top-0 z-50 flex items-center justify-center gap-3 bg-primary/10 px-4 py-1.5 text-xs text-primary backdrop-blur-sm border-b border-primary/20">
       <span className="font-medium">Demo</span>
       <span className="text-primary/60">·</span>
       <span className="text-primary/80">sample data — not real health records</span>

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -102,7 +102,7 @@ export function Sidebar() {
       {/* Slide-out drawer */}
       <aside
         className={cn(
-          "fixed left-0 top-0 z-40 h-screen w-56 flex flex-col border-r border-border bg-sidebar transition-transform duration-200 safe-area-pt safe-area-pl safe-area-pb",
+          "fixed left-0 top-0 z-40 h-screen w-56 2xl:w-64 flex flex-col border-r border-border bg-sidebar transition-transform duration-200 safe-area-pt safe-area-pl safe-area-pb",
           // Slide-in drawer on mobile; always visible on desktop (lg+).
           drawerOpen ? "translate-x-0" : "-translate-x-full",
           "lg:translate-x-0"
@@ -117,7 +117,7 @@ export function Sidebar() {
             aria-label="Go to home"
           >
             <SomaLogo size={24} />
-            <span className="text-sm font-semibold">Soma</span>
+            <span className="text-base font-semibold">Soma</span>
           </Link>
         </div>
 
@@ -135,7 +135,7 @@ export function Sidebar() {
                 onClick={() => { if (!isActive) setNavigatingTo(item.href); }}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
-                  "flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all text-sm active:scale-[0.96] active:opacity-70",
+                  "flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all text-[15px] active:scale-[0.96] active:opacity-70",
                   isActive
                     ? "bg-accent text-accent-foreground font-medium"
                     : isLoading
@@ -149,7 +149,7 @@ export function Sidebar() {
                   <Icon className="h-4 w-4 shrink-0" />
                 )}
                 <span>{item.label}</span>
-                <span className="ml-auto text-[10px] text-muted-foreground/50 hidden md:inline">
+                <span className="ml-auto text-xs text-muted-foreground/50 hidden md:inline">
                   ⌘{item.shortcut}
                 </span>
               </Link>


### PR DESCRIPTION
Addresses your sidebar review (#363) — the nav text was too small and the width was a single fixed value.

- **Legibility**: nav labels 14→15px, ⌘ shortcut hints **10→12px** (the smallest, most affected), "Soma" logo 14→16px.
- **Dynamic width**: `w-56` → `2xl:w-64` (224px on lg desktops, **256px** on very large screens like your 2144px display), with the content offset (`lg:pl-56 2xl:pl-64`) and demo banner (`lg:left-56 2xl:left-64`) kept in sync.

## Verified (Playwright)
- 1280px → sidebar 224px + content offset 224px (**match**); 1600px → 256px + 256px.
- labels 15px, shortcuts 12px, logo 16px; no overlap or double-offset at either breakpoint. 0 console errors, tsc clean.

Partial for #363 — a hover-expand icon-rail is a possible further iteration; this delivers the legibility + a proportional dynamic width now.

Refs #363