### PR TITLE
chore(bridge): bump garmin-auth ^0.1.0 -> ^0.4.1

### DIFF
--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "adm-zip": "^0.5.18",
-        "garmin-auth": "^0.1.0",
+        "garmin-auth": "^0.4.1",
         "oauth-1.0a": "^2.2.6",
         "pg": "^8.11.0",
         "playwright": "^1.48.0"
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/garmin-auth": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.1.0.tgz",
-      "integrity": "sha512-hE8LSgVqjxz2wI3AQSWE7gofVmVTr04Oz3lefhyXkV2h0IEl7azKXzxfO22jCT2N6BRniczg4TpxY8SMPZVZnw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.4.1.tgz",
+      "integrity": "sha512-Z3Nlh3UpoilqWpjrY4jfgQ8DImzD5vJ4yOdi5Gui3m0w7mc8ReoNESUp6GoKZD9RDzuwsekZuuqAeImTtI7ytw==",
       "license": "MIT",
       "peerDependencies": {
         "pg": "^8.0.0"

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.5.18",
-    "garmin-auth": "^0.1.0",
+    "garmin-auth": "^0.4.1",
     "oauth-1.0a": "^2.2.6",
     "pg": "^8.11.0",
     "playwright": "^1.48.0"


### PR DESCRIPTION
## What

Bumps `garmin-auth` in `bridge/` from `^0.1.0` to `^0.4.1`, aligning the Strava bridge with the rest of the ecosystem (soma/web already runs `garmin-auth@0.4.1`).

## Why

The bridge was the last consumer pinned to the old 0.1.x line. One garmin-auth version across the ecosystem.

## Compatibility

Verified against 0.4.1's type surface — the bridge only uses `GarminAuth({store}).client()`, `client.connectapi<T>(path)`, and the public `client.di_token`, all unchanged in 0.4.1. (0.4.1 also adds `getBytes()` for the FIT-download zip, a possible future simplification of `downloadFit`, left out of scope here.)

## Verification

- `npm install` resolves `garmin-auth@0.4.1`.
- `tsc` build: 0 errors.
- Bridge vitest suite: 4 files / 12 tests pass.

Closes #378
