### PR TITLE
ci(bridge): PR-gate the Strava bridge (tsc + vitest)

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -1,0 +1,30 @@
+name: bridge-ci
+
+on:
+  pull_request:
+    paths:
+      - "bridge/**"
+      - ".github/workflows/bridge-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bridge/**"
+
+jobs:
+  test:
+    name: Bridge — Typecheck + Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bridge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install
+        run: npm ci || npm install
+      - name: Build (tsc)
+        run: npm run build
+      - name: Unit tests
+        run: npm test


### PR DESCRIPTION
## What

Adds `.github/workflows/bridge-ci.yml` — runs the Strava bridge's `tsc` build + vitest suite on any PR (and push to main) touching `bridge/**`.

## Why

The bridge had no PR gate of its own. On #379 (a bridge dependency bump) the only checks were the Vercel web deploys; the bridge's own 12 tests never ran in CI. This closes that gap so bridge changes are gated by the bridge's own build + tests.

## Verification

Mirrors the existing `universal-ci.yml` pattern (path-filtered `pull_request`, `working-directory: bridge`, Node 22, `npm run build` = tsc, `npm test` = vitest). The workflow itself will run on this PR (it touches `.github/workflows/bridge-ci.yml`, which is in the path filter).

Closes #382
