### PR TITLE
fix(sync): wire Hevy→Garmin upload into the pipeline (#387)

### DIFF
--- a/web/lib/hevy-upload.ts
+++ b/web/lib/hevy-upload.ts
@@ -12,8 +12,9 @@
  *   3. Garmin itself returns 409 on a duplicate FIT; that is caught and matched
  *      via populateGarminIds instead of creating a duplicate.
  *
- * This module does NOT fire on a schedule. It is invoked deliberately, and the
- * dedup selection is unit-tested below before any live use.
+ * Wired into the sync pipeline (web/scripts/sync-pipeline.mts) so newly-enriched
+ * workouts upload automatically; the three dedup layers above make that safe. It is
+ * also exposed as a manual, dry-run-default route (api/cron/hevy-upload) for inspection.
  */
 import { generateFit, uploadFit, renameActivity } from "hevy2garmin";
 import type { GarminClient } from "garmin-auth";

--- a/web/lib/notify.ts
+++ b/web/lib/notify.ts
@@ -29,7 +29,7 @@ export async function notifyPendingWorkouts(sql: QueryFn): Promise<NotifyResult>
     SELECT we.hevy_id, we.hevy_title, we.workout_date::text AS workout_date, h.raw_json
     FROM workout_enrichment we
     JOIN hevy_raw_data h ON h.hevy_id = we.hevy_id AND h.endpoint_name = 'workout'
-    WHERE we.status IN ('enriched', 'uploaded')
+    WHERE we.status = 'uploaded'
       AND we.hevy_id NOT IN (
         SELECT source_id FROM activity_sync_log
         WHERE source_platform = 'hevy' AND destination = 'telegram' AND status = 'sent'

--- a/web/scripts/sync-pipeline.mts
+++ b/web/scripts/sync-pipeline.mts
@@ -16,6 +16,7 @@ import { computeHevyLoads } from "../lib/training-load";
 import { backfillLoadFromHistory, computeAndStorePmc } from "../lib/pmc-stream";
 import { pushPlanToGarmin } from "../lib/garmin-workout-builder";
 import { enrichGarminRunActivities } from "../lib/garmin-run-enrich";
+import { uploadEnrichedToGarmin } from "../lib/hevy-upload";
 import { notifyPendingWorkouts } from "../lib/notify";
 
 const databaseUrl = process.env.DATABASE_URL;
@@ -65,9 +66,15 @@ if (garminClient) {
     return { activePlan: planId, ...(await pushPlanToGarmin(sql, garminClient!, planId)) };
   });
   await step("garmin-enrich", () => enrichGarminRunActivities(sql, garminClient!, webBaseUrl));
+  // Upload newly-enriched Hevy workouts to Garmin as strength activities, so they then
+  // forward to Strava via the bridge (strava-bridge-ts.yml). dryRun:false is safe here:
+  // uploadEnrichedToGarmin's three dedup layers (match→demote, append-only garmin ledger,
+  // Garmin 409) plus the bridge's own ledger guarantee no activity is uploaded or
+  // forwarded twice. Runs before notify so "Synced" reflects an actual upload.
+  await step("hevy-upload", () => uploadEnrichedToGarmin(sql, garminClient!, { dryRun: false }));
 }
 
-// 5. Telegram + push notifications for new activities/workouts.
+// 5. Telegram + push notifications for workouts now on Garmin.
 await step("notify", () => notifyPendingWorkouts(sql));
 
 console.log("[sync] pipeline complete");


### PR DESCRIPTION
Fixes the flow where a Hevy workout gets a "Synced" notification but never lands on Garmin (and so never reaches Strava).

## Root cause

The Hevy→Garmin upload step was not wired into any automated path: `api/cron/hevy-upload` is deliberately unscheduled, and the active `sync.yml` TS pipeline (`sync-pipeline.mts`, the #187 cutover) never called `uploadEnrichedToGarmin`. Meanwhile `notify` fired "Synced" off `status IN ('enriched','uploaded')`, before any upload. So the workout sat enriched-only in the DB, and the bridge had nothing on Garmin to forward.

## Changes

- `web/scripts/sync-pipeline.mts`: call `uploadEnrichedToGarmin(sql, client, { dryRun: false })` inside the Garmin-client block, before `notify`. The uploader's three dedup layers (match→demote, append-only garmin ledger, Garmin 409) plus the bridge ledger keep it duplicate-safe.
- `web/lib/notify.ts`: notify only on `status='uploaded'`, so "Synced" means the workout is actually on Garmin.
- `web/lib/hevy-upload.ts`: doc comment updated (it's now scheduled via the pipeline).

## Verification

- Full web suite: 177/177 green. `tsc --noEmit` clean.
- Production dry-run of the uploader: exactly 1 candidate (today's Pull), Garmin auth healthy, 69 historical workouts correctly matched so they won't re-upload.

Closes #387
