### PR TITLE
feat(app): make the soma Expo app build + run on Android

### DIFF
--- a/universal/app.json
+++ b/universal/app.json
@@ -11,6 +11,7 @@
       "bundleIdentifier": "dev.gkos.soma"
     },
     "android": {
+      "package": "dev.gkos.soma",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/universal/eas.json
+++ b/universal/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": { "simulator": true },
+      "android": { "buildType": "apk" }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": { "simulator": true },
+      "android": { "buildType": "apk" }
+    },
+    "production": {
+      "autoIncrement": true,
+      "android": { "buildType": "app-bundle" }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}


### PR DESCRIPTION
## What

Makes the soma Expo app a real **Android** build target — it was iOS-only (no `android.package`, no `eas.json`, never built for Android).

- `app.json`: add `android.package` = `dev.gkos.soma`.
- `eas.json`: build profiles (development/preview/production) for **ios + android**.

Native dirs (`ios/`, `android/`) stay gitignored — managed workflow, `expo prebuild` regenerates them.

## Validation (end-to-end on a real Android emulator)

- `expo prebuild --platform android` → generated `android/`.
- Gradle debug build → **BUILD SUCCESSFUL**, produced `app-debug.apk` (243 MB).
- Installed + launched on a headless **android-35 arm64** emulator (Pixel 7), Metro pointed at `soma.gkos.dev` with the API token.
- The app renders with **real API data** across three screens, all with the shared soma-style bottom tab bar — full parity with the iOS build:
  - **Nutrition** (kcal/macros + the "82d in deficit / diet-break" adaptive card)
  - **Overview** (steps 5,791, active-cal 238, RHR 54, stress 33, sleep/weight — with sparklines)
  - **Training** (PMC: Fitness 37.2 / Fatigue 9.7 / Form 27.5 + the Week-1 plan schedule)

## Toolchain note
`sdkmanager`/`avdmanager` require JDK 17; installed `openjdk@17` via the Homebrew **formula** (no sudo). The gradle build uses JDK 17.

Follow-ups (separate): an Android **Glance widget** (the iOS widget is WidgetKit-only), and APK distribution via EAS / GitHub releases.

Closes #389
