### PR TITLE
test(web): add Playwright smoke e2e — every page renders

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,0 +1,45 @@
+name: web-e2e
+
+# Playwright smoke suite for soma/web. Runs against the live soma-demo
+# deployment (DEMO_MODE, no login), so no DB service is needed — it validates
+# that every main page renders without a 5xx or an error boundary.
+
+on:
+  pull_request:
+    paths:
+      - "web/**"
+      - ".github/workflows/web-e2e.yml"
+  workflow_dispatch:
+  schedule:
+    # Daily at 06:00 UTC — catch demo-deploy render regressions independent of PRs.
+    - cron: "0 6 * * *"
+
+jobs:
+  smoke:
+    name: Playwright smoke (desktop)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: web
+    env:
+      BASE_URL: https://soma-demo.gkos.dev
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+      - name: Run smoke suite (desktop)
+        run: npm run e2e:desktop
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 7

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -13,6 +13,11 @@
 # testing
 /coverage
 
+# playwright
+/playwright-report/
+/test-results/
+/playwright/.cache/
+
 # next.js
 /.next/
 /out/

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,6 +42,7 @@
         "web-push": "^3.6.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/pg": "^8.20.0",
@@ -2910,6 +2911,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -15451,6 +15468,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "e2e": "playwright test",
+    "e2e:desktop": "playwright test --project=desktop"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",
@@ -53,6 +55,7 @@
     "@types/react-dom": "^19",
     "@types/spotify-web-playback-sdk": "^0.1.19",
     "@types/web-push": "^3.6.4",
+    "@playwright/test": "^1.59.1",
     "@vitest/ui": "^4.1.5",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Smoke-test config for soma/web.
+ *
+ * These tests run against a LIVE deployment (default: the public soma-demo
+ * deployment, which runs in DEMO_MODE with no login required), NOT a local
+ * dev server. soma/web has no committed DB schema, so a hermetic seed is out
+ * of scope — instead we validate that every main page renders without a 5xx
+ * or an error boundary against real demo data.
+ *
+ * Override the target with BASE_URL (e.g. a preview URL) when needed.
+ */
+const baseURL = process.env.BASE_URL || "https://soma-demo.gkos.dev";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  // The demo can cold-start, so one retry smooths over the first slow hit.
+  retries: 1,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  use: {
+    baseURL,
+    // Cold starts on the demo deploy can be slow; give navigation headroom.
+    navigationTimeout: 30_000,
+    actionTimeout: 15_000,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    ignoreHTTPSErrors: true,
+  },
+  projects: [
+    {
+      name: "desktop",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } },
+    },
+    {
+      name: "mobile",
+      use: { ...devices["Pixel 7"], viewport: { width: 390, height: 844 } },
+    },
+  ],
+});

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Smoke suite: every main page must render without a server error or an
+ * error boundary against the live demo deployment.
+ *
+ * Assertions are deliberately STRUCTURAL (page <title>, hardcoded headings,
+ * sidebar nav labels) and never touch dynamic demo data (KPI numbers, dates,
+ * counts) so the suite stays green as the demo data changes.
+ *
+ * Evidence for each stable string is captured in PAGES below (verified against
+ * the live rendered DOM and the page.tsx source).
+ */
+
+type PageSpec = {
+  /** Route path. */
+  path: string;
+  /** Human label (also the nav label unless `navLabel` overrides). */
+  name: string;
+  /** Expected <title> tag text — the app template renders `Soma: <X>`. */
+  title: string;
+  /** A stable body element that this page renders (hardcoded in JSX). */
+  heading: string;
+  /**
+   * ARIA role used to locate `heading`. Defaults to "heading" (h1..h6).
+   * Nutrition's h1 is a live date, so it asserts on the always-present
+   * "Trajectory" tab, which is a link ("link").
+   */
+  headingRole?: "heading" | "link";
+  /** The sidebar nav label for this route (defaults to `name`). */
+  navLabel?: string;
+};
+
+// Each `heading` and `title` below is verbatim from the live rendered DOM.
+const PAGES: PageSpec[] = [
+  { path: "/", name: "Overview", title: "Soma: Dashboard", heading: "Overview" },
+  { path: "/running", name: "Running", title: "Soma: Running", heading: "Running" },
+  { path: "/training", name: "Training", title: "Soma: Training", heading: "Training" },
+  // Nutrition's h1 is a live date; assert on the always-present "Trajectory" tab (a link) instead.
+  { path: "/nutrition", name: "Nutrition", title: "Soma: Nutrition", heading: "Trajectory", headingRole: "link" },
+  { path: "/sleep", name: "Sleep", title: "Soma: Sleep", heading: "Sleep & Recovery" },
+  { path: "/activities", name: "Activities", title: "Soma: Activities", heading: "Activities" },
+  { path: "/workouts", name: "Gym", title: "Soma: Gym", heading: "Workouts", navLabel: "Gym" },
+  { path: "/connections", name: "Sync", title: "Soma: Sync", heading: "Sync Hub", navLabel: "Sync" },
+  { path: "/playlist", name: "Playlist", title: "Soma: Playlist", heading: "Playlist Builder" },
+];
+
+/** Text patterns that indicate a broken page (error boundary, crash, 500). */
+const ERROR_PATTERNS: RegExp[] = [
+  /Application error/i,
+  /Internal Server Error/i,
+  /This page could not be found/i,
+  /Something went wrong/i,
+  /500\s*[:-]/i,
+];
+
+async function assertNoErrorOverlay(page: Page): Promise<void> {
+  const body = (await page.locator("body").innerText()).slice(0, 4000);
+  for (const pattern of ERROR_PATTERNS) {
+    expect(body, `error text ${pattern} should NOT be present`).not.toMatch(pattern);
+  }
+  // Next.js dev/prod error overlay + generic route error boundary.
+  await expect(page.locator("nextjs-portal")).toHaveCount(0);
+}
+
+for (const spec of PAGES) {
+  test(`smoke: ${spec.path} (${spec.name}) renders`, async ({ page }) => {
+    const response = await page.goto(spec.path, { waitUntil: "domcontentloaded" });
+
+    // 1. Response is not a server error (not 5xx). A null response can happen
+    //    for client-side transitions, but a direct goto always yields one.
+    expect(response, `no response for ${spec.path}`).not.toBeNull();
+    const status = response!.status();
+    expect(status, `status for ${spec.path} should not be 5xx`).toBeLessThan(500);
+    expect(status, `status for ${spec.path} should not be 4xx`).toBeLessThan(400);
+
+    // 2. Stable page <title> (proves the right route loaded, not a redirect).
+    await expect(page).toHaveTitle(new RegExp(escapeRegExp(spec.title)));
+
+    // 3. A stable, hardcoded body element is visible. Scope to an ARIA role
+    //    (heading by default) so we never collide with a same-named sidebar
+    //    nav label (e.g. "Activities"/"Running"), which is collapsed/hidden
+    //    on desktop.
+    await expect(
+      page
+        .getByRole(spec.headingRole ?? "heading", { name: new RegExp(escapeRegExp(spec.heading)) })
+        .first(),
+    ).toBeVisible();
+
+    // 4. No error boundary / crash / 500 text on the page.
+    await assertNoErrorOverlay(page);
+  });
+}
+
+test("smoke: app shell (sidebar nav) renders", async ({ page }) => {
+  const response = await page.goto("/", { waitUntil: "domcontentloaded" });
+  expect(response!.status()).toBeLessThan(400);
+
+  // The sidebar is always rendered in the layout. Assert the full nav is present.
+  const navLabels = PAGES.map((p) => p.navLabel ?? p.name);
+  for (const label of navLabels) {
+    await expect(
+      page.getByRole("link", { name: new RegExp(escapeRegExp(label)) }).first(),
+      `nav link "${label}" should be visible`,
+    ).toBeVisible();
+  }
+});
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import path from "path";
 
 // Minimal config: resolve the `@/` path alias (matches tsconfig) so route
@@ -7,5 +7,10 @@ import path from "path";
 export default defineConfig({
   resolve: {
     alias: { "@": path.resolve(__dirname, ".") },
+  },
+  test: {
+    // The Playwright e2e specs under tests/e2e/** use @playwright/test (not
+    // vitest) and run via `npm run e2e` — keep vitest from discovering them.
+    exclude: [...configDefaults.exclude, "tests/e2e/**"],
   },
 });


### PR DESCRIPTION
Adds a Playwright smoke suite validating every main page renders (200 + stable title/heading + no error overlay) against the live soma-demo, wired into CI (PR + daily). App-shell test covers the 9 sidebar nav links. **20/20 pass** (desktop+mobile) against soma-demo; tsc clean. Structural assertions only, so demo-data churn won't flake it. Closes #391
