### PR TITLE
feat(app): Android home-screen widgets (Soma Today + Nutrition quick-log)

### DIFF
--- a/universal/.gitignore
+++ b/universal/.gitignore
@@ -44,3 +44,6 @@ example
 
 # Widget API token (secret — never commit)
 targets/**/token.swift
+
+# Widget API token — Android (secret — never commit)
+plugins/soma-widget/secrets.json

--- a/universal/app.json
+++ b/universal/app.json
@@ -33,7 +33,8 @@
           "imageWidth": 76
         }
       ],
-      "@bacons/apple-targets"
+      "@bacons/apple-targets",
+      "./plugins/soma-widget/withSomaWidget"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/universal/plugins/soma-widget/android/kotlin/SomaNutritionWidget.kt
+++ b/universal/plugins/soma-widget/android/kotlin/SomaNutritionWidget.kt
@@ -1,0 +1,209 @@
+package dev.gkos.soma.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import android.widget.RemoteViews
+import dev.gkos.soma.R
+import org.json.JSONArray
+import org.json.JSONObject
+import kotlin.concurrent.thread
+
+/**
+ * "Soma Nutrition" home-screen widget: calories remaining/eaten + one-tap quick-log
+ * of preset meals for the current slot. Parity with the iOS widget (NutritionWidget.swift):
+ * tapping a preset POSTs /api/nutrition/log-meal and refreshes, no app open needed.
+ */
+class SomaNutritionWidget : AppWidgetProvider() {
+
+    companion object {
+        const val ACTION_LOG = "dev.gkos.soma.widget.ACTION_LOG"
+        const val EX_ID = "preset_id"
+        const val EX_SLOT = "slot"
+        const val EX_CAL = "calories"
+        const val EX_P = "protein"
+        const val EX_C = "carbs"
+        const val EX_F = "fat"
+        const val EX_FIB = "fiber"
+    }
+
+    private data class Preset(
+        val id: String,
+        val name: String,
+        val slot: String,
+        val calories: Double,
+        val protein: Double,
+        val carbs: Double,
+        val fat: Double,
+        val fiber: Double
+    )
+
+    private data class Nutri(
+        val slot: String,
+        val eaten: Int,
+        val target: Int,
+        val remaining: Int,
+        val hasPlan: Boolean,
+        val presets: List<Preset>
+    )
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == ACTION_LOG) {
+            val result = goAsync()
+            thread {
+                try {
+                    logPreset(intent)
+                    updateAll(context)
+                } catch (_: Throwable) {
+                } finally {
+                    result.finish()
+                }
+            }
+            return
+        }
+        super.onReceive(context, intent)
+    }
+
+    override fun onUpdate(context: Context, mgr: AppWidgetManager, ids: IntArray) {
+        val result = goAsync()
+        thread {
+            try {
+                val e = fetch()
+                for (id in ids) mgr.updateAppWidget(id, render(context, e))
+            } catch (_: Throwable) {
+            } finally {
+                result.finish()
+            }
+        }
+    }
+
+    private fun updateAll(context: Context) {
+        val mgr = AppWidgetManager.getInstance(context)
+        val ids = mgr.getAppWidgetIds(ComponentName(context, SomaNutritionWidget::class.java))
+        val e = fetch()
+        for (id in ids) mgr.updateAppWidget(id, render(context, e))
+    }
+
+    private fun logPreset(intent: Intent) {
+        val body = JSONObject()
+        body.put("date", ymd())
+        body.put("meal_slot", intent.getStringExtra(EX_SLOT) ?: currentSlot())
+        body.put("preset_meal_id", intent.getStringExtra(EX_ID) ?: "")
+        body.put("source", "widget")
+        body.put("items", JSONArray())
+        val macros = JSONObject()
+        macros.put("calories", intent.getDoubleExtra(EX_CAL, 0.0))
+        macros.put("protein", intent.getDoubleExtra(EX_P, 0.0))
+        macros.put("carbs", intent.getDoubleExtra(EX_C, 0.0))
+        macros.put("fat", intent.getDoubleExtra(EX_F, 0.0))
+        macros.put("fiber", intent.getDoubleExtra(EX_FIB, 0.0))
+        body.put("preset_macros", macros)
+        Net.post("/api/nutrition/log-meal", body)
+    }
+
+    private fun fetch(): Nutri {
+        val slot = currentSlot()
+        var eaten = 0
+        var target = 0
+        var remaining = 0
+        var hasPlan = false
+        val plan = Net.get("/api/nutrition/plan?date=" + ymd())
+        if (plan != null) {
+            val consumed = plan.optJSONObject("consumed")
+            eaten = jInt(consumed, "calories")
+            val p = plan.optJSONObject("plan")
+            if (p != null && p.has("target_calories")) {
+                target = p.optDouble("target_calories", 0.0).toInt()
+                hasPlan = true
+            }
+            val rem = plan.optJSONObject("remaining")
+            remaining = when {
+                rem != null && rem.has("calories") -> rem.optDouble("calories", 0.0).toInt()
+                hasPlan -> target - eaten
+                else -> 0
+            }
+        }
+
+        val presets = ArrayList<Preset>()
+        val arr: JSONArray? = Net.get("/api/nutrition/presets")?.optJSONArray("presets")
+        if (arr != null) {
+            val all = ArrayList<Preset>()
+            for (i in 0 until arr.length()) {
+                val o = arr.optJSONObject(i) ?: continue
+                all.add(
+                    Preset(
+                        id = o.opt("id")?.toString() ?: "",
+                        name = o.optString("name", "Meal"),
+                        slot = o.optString("meal_slot", ""),
+                        calories = o.optDouble("total_calories", 0.0),
+                        protein = o.optDouble("total_protein", 0.0),
+                        carbs = o.optDouble("total_carbs", 0.0),
+                        fat = o.optDouble("total_fat", 0.0),
+                        fiber = o.optDouble("total_fiber", 0.0)
+                    )
+                )
+            }
+            val forSlot = all.filter { it.slot == slot }
+            val chosen = if (forSlot.isEmpty()) all else forSlot
+            presets.addAll(chosen.sortedBy { it.calories })
+        }
+        return Nutri(slot, eaten, target, remaining, hasPlan, presets)
+    }
+
+    private fun render(context: Context, e: Nutri): RemoteViews {
+        val rv = RemoteViews(context.packageName, R.layout.soma_nutrition)
+        rv.setTextViewText(R.id.slot, " · " + slotLabel(e.slot))
+        if (e.hasPlan) {
+            rv.setTextViewText(R.id.kcal_value, e.remaining.toString())
+            rv.setTextViewText(R.id.kcal_label, " kcal left")
+        } else {
+            rv.setTextViewText(R.id.kcal_value, e.eaten.toString())
+            rv.setTextViewText(R.id.kcal_label, " kcal eaten")
+        }
+        val rows = intArrayOf(R.id.preset_0, R.id.preset_1, R.id.preset_2)
+        val names = intArrayOf(R.id.preset_0_name, R.id.preset_1_name, R.id.preset_2_name)
+        val kcals = intArrayOf(R.id.preset_0_kcal, R.id.preset_1_kcal, R.id.preset_2_kcal)
+        for (i in 0 until 3) {
+            val p = e.presets.getOrNull(i)
+            if (p == null) {
+                rv.setViewVisibility(rows[i], View.GONE)
+            } else {
+                rv.setViewVisibility(rows[i], View.VISIBLE)
+                rv.setTextViewText(names[i], p.name)
+                rv.setTextViewText(kcals[i], p.calories.toInt().toString())
+                rv.setOnClickPendingIntent(rows[i], logIntent(context, i, p, e.slot))
+            }
+        }
+        openApp(context)?.let { rv.setOnClickPendingIntent(R.id.root, it) }
+        return rv
+    }
+
+    private fun logIntent(context: Context, index: Int, p: Preset, slot: String): PendingIntent {
+        val i = Intent(context, SomaNutritionWidget::class.java).apply {
+            action = ACTION_LOG
+            putExtra(EX_ID, p.id)
+            putExtra(EX_SLOT, slot)
+            putExtra(EX_CAL, p.calories)
+            putExtra(EX_P, p.protein)
+            putExtra(EX_C, p.carbs)
+            putExtra(EX_F, p.fat)
+            putExtra(EX_FIB, p.fiber)
+        }
+        return PendingIntent.getBroadcast(
+            context, 100 + index, i,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+
+    private fun openApp(context: Context): PendingIntent? {
+        val i = context.packageManager.getLaunchIntentForPackage(context.packageName) ?: return null
+        return PendingIntent.getActivity(
+            context, 0, i,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+}

--- a/universal/plugins/soma-widget/android/kotlin/SomaNutritionWidget.kt
+++ b/universal/plugins/soma-widget/android/kotlin/SomaNutritionWidget.kt
@@ -6,6 +6,8 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.os.Build
+import android.util.SizeF
 import android.view.View
 import android.widget.RemoteViews
 import dev.gkos.soma.R
@@ -154,8 +156,28 @@ class SomaNutritionWidget : AppWidgetProvider() {
         return Nutri(slot, eaten, target, remaining, hasPlan, presets)
     }
 
+    /**
+     * Responsive: a compact 2x2 layout (headline + 1 quick-log preset) when small,
+     * the full layout (up to 3 presets) when taller. Android 12+ picks the largest
+     * mapped layout that fits; below that we fall back to the full layout.
+     */
     private fun render(context: Context, e: Nutri): RemoteViews {
-        val rv = RemoteViews(context.packageName, R.layout.soma_nutrition)
+        val full = bind(context, R.layout.soma_nutrition, e, 3)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val small = bind(context, R.layout.soma_nutrition_small, e, 1)
+            return RemoteViews(
+                mapOf(
+                    SizeF(120f, 120f) to small,
+                    SizeF(220f, 170f) to full
+                )
+            )
+        }
+        return full
+    }
+
+    /** Binds the headline + up to maxPresets quick-log rows (small layout has only preset_0). */
+    private fun bind(context: Context, layoutId: Int, e: Nutri, maxPresets: Int): RemoteViews {
+        val rv = RemoteViews(context.packageName, layoutId)
         rv.setTextViewText(R.id.slot, " · " + slotLabel(e.slot))
         if (e.hasPlan) {
             rv.setTextViewText(R.id.kcal_value, e.remaining.toString())
@@ -167,7 +189,7 @@ class SomaNutritionWidget : AppWidgetProvider() {
         val rows = intArrayOf(R.id.preset_0, R.id.preset_1, R.id.preset_2)
         val names = intArrayOf(R.id.preset_0_name, R.id.preset_1_name, R.id.preset_2_name)
         val kcals = intArrayOf(R.id.preset_0_kcal, R.id.preset_1_kcal, R.id.preset_2_kcal)
-        for (i in 0 until 3) {
+        for (i in 0 until maxPresets) {
             val p = e.presets.getOrNull(i)
             if (p == null) {
                 rv.setViewVisibility(rows[i], View.GONE)

--- a/universal/plugins/soma-widget/android/kotlin/SomaTodayWidget.kt
+++ b/universal/plugins/soma-widget/android/kotlin/SomaTodayWidget.kt
@@ -4,6 +4,8 @@ import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
+import android.os.Build
+import android.util.SizeF
 import android.widget.RemoteViews
 import dev.gkos.soma.R
 import kotlin.concurrent.thread
@@ -57,15 +59,37 @@ class SomaTodayWidget : AppWidgetProvider() {
         return "unknown"
     }
 
+    /**
+     * Responsive: a compact 2x2 layout when small, the full layout when wider.
+     * Android 12+ (API 31) picks the largest mapped layout that fits; below that
+     * we fall back to the full layout.
+     */
     private fun render(context: Context, t: Today): RemoteViews {
-        val rv = RemoteViews(context.packageName, R.layout.soma_today)
+        val full = bind(context, R.layout.soma_today, t, small = false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val small = bind(context, R.layout.soma_today_small, t, small = true)
+            return RemoteViews(
+                mapOf(
+                    SizeF(120f, 100f) to small,
+                    SizeF(220f, 100f) to full
+                )
+            )
+        }
+        return full
+    }
+
+    /** Binds the fields present in the given layout (small omits stress + readiness label). */
+    private fun bind(context: Context, layoutId: Int, t: Today, small: Boolean): RemoteViews {
+        val rv = RemoteViews(context.packageName, layoutId)
         rv.setTextViewText(R.id.steps, t.steps.toString())
         rv.setTextViewText(R.id.active_kcal, t.activeKcal.toString())
         rv.setTextViewText(R.id.resting_hr, t.restingHr.toString())
-        rv.setTextViewText(R.id.stress, t.stress.toString())
         rv.setTextColor(R.id.readiness_dot, readinessColor(t.readiness))
-        rv.setTextViewText(R.id.readiness_label, t.readiness.replaceFirstChar { it.uppercase() })
-        rv.setTextColor(R.id.readiness_label, readinessColor(t.readiness))
+        if (!small) {
+            rv.setTextViewText(R.id.stress, t.stress.toString())
+            rv.setTextViewText(R.id.readiness_label, t.readiness.replaceFirstChar { it.uppercase() })
+            rv.setTextColor(R.id.readiness_label, readinessColor(t.readiness))
+        }
         openApp(context)?.let { rv.setOnClickPendingIntent(R.id.root, it) }
         return rv
     }

--- a/universal/plugins/soma-widget/android/kotlin/SomaTodayWidget.kt
+++ b/universal/plugins/soma-widget/android/kotlin/SomaTodayWidget.kt
@@ -1,0 +1,80 @@
+package dev.gkos.soma.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.widget.RemoteViews
+import dev.gkos.soma.R
+import kotlin.concurrent.thread
+
+/**
+ * "Soma Today" home-screen widget: steps, active calories, resting HR, avg stress,
+ * and training readiness. Parity with the iOS systemMedium widget (widgets.swift).
+ */
+class SomaTodayWidget : AppWidgetProvider() {
+
+    private data class Today(
+        val steps: Int,
+        val activeKcal: Int,
+        val restingHr: Int,
+        val stress: Int,
+        val readiness: String
+    )
+
+    override fun onUpdate(context: Context, mgr: AppWidgetManager, ids: IntArray) {
+        val result = goAsync()
+        thread {
+            try {
+                val t = fetch()
+                for (id in ids) mgr.updateAppWidget(id, render(context, t))
+            } catch (_: Throwable) {
+            } finally {
+                result.finish()
+            }
+        }
+    }
+
+    private fun fetch(): Today {
+        val h = Net.get("/api/health/today")
+        return Today(
+            steps = jInt(h, "total_steps"),
+            activeKcal = jInt(h, "active_kilocalories"),
+            restingHr = jInt(h, "resting_heart_rate"),
+            stress = jInt(h, "avg_stress_level"),
+            readiness = fetchReadiness()
+        )
+    }
+
+    /** Most recent day that has readiness (fall back up to 2 days, like iOS). */
+    private fun fetchReadiness(): String {
+        for (off in intArrayOf(0, -1, -2)) {
+            val j = Net.get("/api/training/breakdown?date=" + ymd(off)) ?: continue
+            val r = j.optJSONObject("readiness") ?: continue
+            val light = r.optString("traffic_light", "")
+            if (light.isNotEmpty()) return light
+        }
+        return "unknown"
+    }
+
+    private fun render(context: Context, t: Today): RemoteViews {
+        val rv = RemoteViews(context.packageName, R.layout.soma_today)
+        rv.setTextViewText(R.id.steps, t.steps.toString())
+        rv.setTextViewText(R.id.active_kcal, t.activeKcal.toString())
+        rv.setTextViewText(R.id.resting_hr, t.restingHr.toString())
+        rv.setTextViewText(R.id.stress, t.stress.toString())
+        rv.setTextColor(R.id.readiness_dot, readinessColor(t.readiness))
+        rv.setTextViewText(R.id.readiness_label, t.readiness.replaceFirstChar { it.uppercase() })
+        rv.setTextColor(R.id.readiness_label, readinessColor(t.readiness))
+        openApp(context)?.let { rv.setOnClickPendingIntent(R.id.root, it) }
+        return rv
+    }
+
+    private fun openApp(context: Context): PendingIntent? {
+        val i = context.packageManager.getLaunchIntentForPackage(context.packageName) ?: return null
+        return PendingIntent.getActivity(
+            context, 0, i,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+}

--- a/universal/plugins/soma-widget/android/kotlin/SomaWidgetCommon.kt
+++ b/universal/plugins/soma-widget/android/kotlin/SomaWidgetCommon.kt
@@ -1,0 +1,88 @@
+package dev.gkos.soma.widget
+
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+/**
+ * Self-contained networking for the home-screen widgets. Mirrors the iOS widget
+ * (the Swift sources under targets/widget): each widget fetches its own data from
+ * soma's public API with a read-scoped bearer token, so it works even when the
+ * app process is dead.
+ */
+object Net {
+    fun get(path: String): JSONObject? {
+        return try {
+            val c = open(path, "GET")
+            val code = c.responseCode
+            if (code !in 200..299) {
+                c.disconnect()
+                return null
+            }
+            val text = c.inputStream.bufferedReader().use { it.readText() }
+            c.disconnect()
+            JSONObject(text)
+        } catch (e: Throwable) {
+            null
+        }
+    }
+
+    fun post(path: String, body: JSONObject): Int {
+        return try {
+            val c = open(path, "POST")
+            c.doOutput = true
+            c.setRequestProperty("Content-Type", "application/json")
+            c.outputStream.use { it.write(body.toString().toByteArray(Charsets.UTF_8)) }
+            val code = c.responseCode
+            c.disconnect()
+            code
+        } catch (e: Throwable) {
+            -1
+        }
+    }
+
+    private fun open(path: String, method: String): HttpURLConnection {
+        val c = URL(WidgetSecrets.API + path).openConnection() as HttpURLConnection
+        c.requestMethod = method
+        c.setRequestProperty("Authorization", "Bearer " + WidgetSecrets.TOKEN)
+        c.connectTimeout = 15000
+        c.readTimeout = 15000
+        c.useCaches = false
+        return c
+    }
+}
+
+/** JSON number read that tolerates both int and double encodings (API returns either). */
+fun jInt(o: JSONObject?, key: String): Int {
+    if (o == null) return 0
+    return o.optDouble(key, 0.0).toInt()
+}
+
+fun ymd(offsetDays: Int = 0): String {
+    val cal = Calendar.getInstance()
+    cal.add(Calendar.DAY_OF_YEAR, offsetDays)
+    return SimpleDateFormat("yyyy-MM-dd", Locale.US).format(cal.time)
+}
+
+/** Meal slot for the current time of day (matches soma's slots + the iOS widget). */
+fun currentSlot(): String {
+    val h = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+    return when {
+        h < 11 -> "breakfast"
+        h < 16 -> "lunch"
+        h < 21 -> "dinner"
+        else -> "pre_sleep"
+    }
+}
+
+fun slotLabel(s: String): String = s.replace("_", " ").uppercase()
+
+fun readinessColor(r: String): Int = when (r) {
+    "green" -> 0xFF6AD4A0.toInt()
+    "amber", "yellow" -> 0xFFE0A458.toInt()
+    "red" -> 0xFFE06060.toInt()
+    else -> 0xFF5A7A8A.toInt()
+}

--- a/universal/plugins/soma-widget/android/res/drawable/soma_preset_bg.xml
+++ b/universal/plugins/soma-widget/android/res/drawable/soma_preset_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#12202e" />
+    <corners android:radius="10dp" />
+</shape>

--- a/universal/plugins/soma-widget/android/res/drawable/soma_widget_bg.xml
+++ b/universal/plugins/soma-widget/android/res/drawable/soma_widget_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#0a1720" />
+    <corners android:radius="22dp" />
+</shape>

--- a/universal/plugins/soma-widget/android/res/layout/soma_nutrition.xml
+++ b/universal/plugins/soma-widget/android/res/layout/soma_nutrition.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/soma_widget_bg"
+    android:padding="14dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="SOMA"
+            android:textColor="#77c8d1"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:letterSpacing="0.12" />
+        <TextView
+            android:id="@+id/slot"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="5dp"
+            android:text=" · LUNCH"
+            android:textColor="#5a7a8a"
+            android:textSize="10sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="bottom"
+        android:paddingTop="4dp"
+        android:paddingBottom="8dp">
+        <TextView
+            android:id="@+id/kcal_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="—"
+            android:textColor="#ffffff"
+            android:textSize="30sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/kcal_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="4dp"
+            android:paddingBottom="4dp"
+            android:text=" kcal left"
+            android:textColor="#5a7a8a"
+            android:textSize="11sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/preset_0"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:background="@drawable/soma_preset_bg"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="+"
+            android:textColor="#77c8d1"
+            android:textSize="15sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/preset_0_name"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:paddingStart="8dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:text="…"
+            android:textColor="#ffffff"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/preset_0_kcal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="6dp"
+            android:text=""
+            android:textColor="#5a7a8a"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/preset_1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:background="@drawable/soma_preset_bg"
+        android:layout_marginTop="6dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="+"
+            android:textColor="#77c8d1"
+            android:textSize="15sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/preset_1_name"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:paddingStart="8dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:text="…"
+            android:textColor="#ffffff"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/preset_1_kcal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="6dp"
+            android:text=""
+            android:textColor="#5a7a8a"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/preset_2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:background="@drawable/soma_preset_bg"
+        android:layout_marginTop="6dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="+"
+            android:textColor="#77c8d1"
+            android:textSize="15sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/preset_2_name"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:paddingStart="8dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:text="…"
+            android:textColor="#ffffff"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/preset_2_kcal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="6dp"
+            android:text=""
+            android:textColor="#5a7a8a"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+</LinearLayout>

--- a/universal/plugins/soma-widget/android/res/layout/soma_nutrition_small.xml
+++ b/universal/plugins/soma-widget/android/res/layout/soma_nutrition_small.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/soma_widget_bg"
+    android:padding="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="SOMA"
+            android:textColor="#77c8d1"
+            android:textSize="10sp"
+            android:textStyle="bold"
+            android:letterSpacing="0.1" />
+        <TextView
+            android:id="@+id/slot"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="4dp"
+            android:text=" · LUNCH"
+            android:textColor="#5a7a8a"
+            android:textSize="9sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="bottom"
+        android:paddingTop="4dp"
+        android:paddingBottom="6dp">
+        <TextView
+            android:id="@+id/kcal_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="—"
+            android:textColor="#ffffff"
+            android:textSize="26sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/kcal_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="3dp"
+            android:paddingBottom="3dp"
+            android:text=" kcal left"
+            android:textColor="#5a7a8a"
+            android:textSize="10sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/preset_0"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:background="@drawable/soma_preset_bg"
+        android:paddingStart="9dp"
+        android:paddingEnd="9dp"
+        android:paddingTop="7dp"
+        android:paddingBottom="7dp"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="+"
+            android:textColor="#77c8d1"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/preset_0_name"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:paddingStart="7dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:text="…"
+            android:textColor="#ffffff"
+            android:textSize="11sp"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/preset_0_kcal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="5dp"
+            android:text=""
+            android:textColor="#5a7a8a"
+            android:textSize="11sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+</LinearLayout>

--- a/universal/plugins/soma-widget/android/res/layout/soma_today.xml
+++ b/universal/plugins/soma-widget/android/res/layout/soma_today.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/soma_widget_bg"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="SOMA"
+            android:textColor="#77c8d1"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:letterSpacing="0.12" />
+
+        <TextView
+            android:id="@+id/readiness_dot"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="6dp"
+            android:text="●"
+            android:textColor="#5a7a8a"
+            android:textSize="11sp" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:text="today"
+            android:textColor="#5a7a8a"
+            android:textSize="10sp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/steps"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="10dp"
+        android:text="—"
+        android:textColor="#ffffff"
+        android:textSize="34sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="steps"
+        android:textColor="#5a7a8a"
+        android:textSize="11sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="14dp"
+        android:weightSum="4">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/active_kcal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="—"
+                android:textColor="#b17850"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="ACTIVE KCAL"
+                android:textColor="#5a7a8a"
+                android:textSize="8sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/resting_hr"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="—"
+                android:textColor="#77c8d1"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="RESTING HR"
+                android:textColor="#5a7a8a"
+                android:textSize="8sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/stress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="—"
+                android:textColor="#ffffff"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="AVG STRESS"
+                android:textColor="#5a7a8a"
+                android:textSize="8sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/readiness_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="—"
+                android:textColor="#5a7a8a"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="READINESS"
+                android:textColor="#5a7a8a"
+                android:textSize="8sp"
+                android:textStyle="bold" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/universal/plugins/soma-widget/android/res/layout/soma_today_small.xml
+++ b/universal/plugins/soma-widget/android/res/layout/soma_today_small.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/soma_widget_bg"
+    android:padding="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="SOMA"
+            android:textColor="#77c8d1"
+            android:textSize="10sp"
+            android:textStyle="bold"
+            android:letterSpacing="0.1" />
+        <TextView
+            android:id="@+id/readiness_dot"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="5dp"
+            android:text="●"
+            android:textColor="#5a7a8a"
+            android:textSize="10sp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/steps"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="6dp"
+        android:text="—"
+        android:textColor="#ffffff"
+        android:textSize="28sp"
+        android:textStyle="bold" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="steps"
+        android:textColor="#5a7a8a"
+        android:textSize="10sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="10dp"
+        android:weightSum="2">
+        <LinearLayout android:layout_width="0dp" android:layout_weight="1" android:layout_height="wrap_content" android:orientation="vertical">
+            <TextView android:id="@+id/active_kcal" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="—" android:textColor="#b17850" android:textSize="15sp" android:textStyle="bold" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="KCAL" android:textColor="#5a7a8a" android:textSize="8sp" android:textStyle="bold" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="0dp" android:layout_weight="1" android:layout_height="wrap_content" android:orientation="vertical">
+            <TextView android:id="@+id/resting_hr" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="—" android:textColor="#77c8d1" android:textSize="15sp" android:textStyle="bold" />
+            <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="RHR" android:textColor="#5a7a8a" android:textSize="8sp" android:textStyle="bold" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/universal/plugins/soma-widget/android/res/xml/soma_nutrition_info.xml
+++ b/universal/plugins/soma-widget/android/res/xml/soma_nutrition_info.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="250dp"
-    android:minHeight="180dp"
+    android:minWidth="110dp"
+    android:minHeight="110dp"
     android:targetCellWidth="4"
     android:targetCellHeight="3"
+    android:minResizeWidth="100dp"
+    android:minResizeHeight="100dp"
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/soma_nutrition"
     android:previewLayout="@layout/soma_nutrition"

--- a/universal/plugins/soma-widget/android/res/xml/soma_nutrition_info.xml
+++ b/universal/plugins/soma-widget/android/res/xml/soma_nutrition_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/soma_nutrition"
+    android:previewLayout="@layout/soma_nutrition"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/universal/plugins/soma-widget/android/res/xml/soma_today_info.xml
+++ b/universal/plugins/soma-widget/android/res/xml/soma_today_info.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="250dp"
-    android:minHeight="110dp"
+    android:minWidth="110dp"
+    android:minHeight="100dp"
     android:targetCellWidth="4"
     android:targetCellHeight="2"
+    android:minResizeWidth="100dp"
+    android:minResizeHeight="90dp"
     android:updatePeriodMillis="1800000"
     android:initialLayout="@layout/soma_today"
     android:previewLayout="@layout/soma_today"

--- a/universal/plugins/soma-widget/android/res/xml/soma_today_info.xml
+++ b/universal/plugins/soma-widget/android/res/xml/soma_today_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/soma_today"
+    android:previewLayout="@layout/soma_today"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/universal/plugins/soma-widget/withSomaWidget.js
+++ b/universal/plugins/soma-widget/withSomaWidget.js
@@ -1,0 +1,113 @@
+const {
+  withDangerousMod,
+  withAndroidManifest,
+  AndroidConfig,
+} = require("@expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+const PKG = "dev.gkos.soma";
+const WIDGET_PKG_DIR = PKG.replace(/\./g, "/") + "/widget";
+
+function copyDir(src, destDir) {
+  fs.mkdirSync(destDir, { recursive: true });
+  for (const f of fs.readdirSync(src)) {
+    const s = path.join(src, f);
+    if (fs.statSync(s).isFile()) fs.copyFileSync(s, path.join(destDir, f));
+  }
+}
+
+function readSecrets(projectRoot) {
+  const p = path.join(projectRoot, "plugins/soma-widget/secrets.json");
+  if (fs.existsSync(p)) return JSON.parse(fs.readFileSync(p, "utf8"));
+  return {
+    api: process.env.SOMA_WIDGET_API || "https://soma.gkos.dev",
+    token: process.env.SOMA_WIDGET_TOKEN || "",
+  };
+}
+
+// Copy the Kotlin sources + res files into the freshly-generated android project,
+// and generate WidgetSecrets.kt from the gitignored secrets.json (or env vars).
+const withSource = (config) =>
+  withDangerousMod(config, [
+    "android",
+    async (cfg) => {
+      const projectRoot = cfg.modRequest.projectRoot;
+      const androidRoot = cfg.modRequest.platformProjectRoot;
+      const pluginAndroid = path.join(
+        projectRoot,
+        "plugins/soma-widget/android"
+      );
+
+      const javaDest = path.join(
+        androidRoot,
+        "app/src/main/java",
+        WIDGET_PKG_DIR
+      );
+      copyDir(path.join(pluginAndroid, "kotlin"), javaDest);
+
+      const s = readSecrets(projectRoot);
+      const secretsKt =
+        `package ${PKG}.widget\n\n` +
+        `object WidgetSecrets {\n` +
+        `    const val API = ${JSON.stringify(s.api)}\n` +
+        `    const val TOKEN = ${JSON.stringify(s.token)}\n` +
+        `}\n`;
+      fs.writeFileSync(path.join(javaDest, "WidgetSecrets.kt"), secretsKt);
+
+      const resSrc = path.join(pluginAndroid, "res");
+      const resDest = path.join(androidRoot, "app/src/main/res");
+      for (const sub of ["layout", "xml", "drawable"]) {
+        const from = path.join(resSrc, sub);
+        if (fs.existsSync(from)) copyDir(from, path.join(resDest, sub));
+      }
+      return cfg;
+    },
+  ]);
+
+// Register the two AppWidget receivers in AndroidManifest.
+const withReceivers = (config) =>
+  withAndroidManifest(config, (cfg) => {
+    const app = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      cfg.modResults
+    );
+    app.receiver = app.receiver || [];
+    const mk = (name, info, label) => ({
+      $: {
+        "android:name": `.widget.${name}`,
+        "android:exported": "true",
+        "android:label": label,
+      },
+      "intent-filter": [
+        {
+          action: [
+            {
+              $: {
+                "android:name": "android.appwidget.action.APPWIDGET_UPDATE",
+              },
+            },
+          ],
+        },
+      ],
+      "meta-data": [
+        {
+          $: {
+            "android:name": "android.appwidget.provider",
+            "android:resource": `@xml/${info}`,
+          },
+        },
+      ],
+    });
+    const existing = app.receiver.map((r) => r.$ && r.$["android:name"]);
+    if (!existing.includes(".widget.SomaTodayWidget")) {
+      app.receiver.push(mk("SomaTodayWidget", "soma_today_info", "Soma Today"));
+    }
+    if (!existing.includes(".widget.SomaNutritionWidget")) {
+      app.receiver.push(
+        mk("SomaNutritionWidget", "soma_nutrition_info", "Soma Nutrition")
+      );
+    }
+    return cfg;
+  });
+
+module.exports = (config) => withReceivers(withSource(config));


### PR DESCRIPTION
## What
Two native Android home-screen widgets, matching the iOS WidgetKit widgets:
- **Soma Today**: steps, active kcal, resting HR, avg stress, training readiness.
- **Soma Nutrition**: kcal left/eaten + one-tap quick-log of preset meals.

## How
An Expo config plugin (`plugins/soma-widget/`) injects two `AppWidgetProvider`s (RemoteViews + Kotlin background fetch) on `prebuild`, mirroring the iOS approach: each widget self-fetches its own data with a read-scoped bearer token (gitignored `secrets.json` to generated `WidgetSecrets.kt`), so it works even when the app is killed. The Nutrition preset rows `POST /api/nutrition/log-meal` on tap (parity with the iOS `LogPresetIntent`).

## Verified
- Kotlin compiles clean; release APK builds; installed on a physical device.
- Both providers register (`dumpsys appwidget` shows `SomaTodayWidget` + `SomaNutritionWidget`).

## Pending (draft — do not merge yet)
On-device render verification. The ColorOS launcher's add-widget flow is a finger gesture that did not automate reliably. Holding the merge until a widget is placed and screenshotted rendering with live data.

Closes #397
