### PR TITLE
perf(sync): stop re-reading all activity blobs every sync (Neon egress fix)

### DIFF
--- a/web/lib/pmc-stream.ts
+++ b/web/lib/pmc-stream.ts
@@ -105,10 +105,21 @@ function addDaysUtc(dateStr: string, days: number): string {
  * (ON CONFLICT DO NOTHING). Returns the count inserted. DB-only.
  */
 export async function backfillLoadFromHistory(sql: QueryFn): Promise<number> {
+  // Only read blobs for activities not already in training_load. Existing rows
+  // are ON CONFLICT DO NOTHING no-ops below, so the computed result is identical
+  // to reading everything — but this avoids re-downloading every 'summary' blob
+  // from Neon on every sync run (that full re-read was the dominant network-
+  // transfer cost and paused the Free-tier project). If training_load is ever
+  // empty, NOT EXISTS matches nothing and the full history is rebuilt as before.
+  // ::text on both sides keeps the join type-safe regardless of column types.
   const rows = await sql`
-    SELECT activity_id, raw_json
-    FROM garmin_activity_raw
-    WHERE endpoint_name = 'summary'`;
+    SELECT g.activity_id, g.raw_json
+    FROM garmin_activity_raw g
+    WHERE g.endpoint_name = 'summary'
+      AND NOT EXISTS (
+        SELECT 1 FROM training_load tl
+        WHERE tl.activity_id::text = g.activity_id::text
+      )`;
   // Build all candidate rows in JS, then batch-insert (a per-row loop is one
   // Neon round-trip per activity — hundreds of them). ON CONFLICT DO NOTHING +
   // RETURNING counts only the genuinely new activities.


### PR DESCRIPTION
## Problem
The Neon `soma` project hit the Free-plan **5 GB/month network-transfer** cap (6.05 GB by day 9) and was paused, taking the personal app down. Root cause: `backfillLoadFromHistory` (`web/lib/pmc-stream.ts`) runs on **every** sync (~36×/day) and `SELECT`s **every** activity's `summary` blob out of Neon each run, then only *inserts* new rows (`ON CONFLICT DO NOTHING`). ≈ **0.58 GB/day (~87% of egress)**, all of it re-reading data already in `training_load`.

## Fix
Filter the read with `NOT EXISTS` against `training_load` so only genuinely new activities' blobs are pulled (`::text` on both sides for type safety).

## Why it's safe (no backlog or upload regressions)
- **Byte-identical output.** Activities already in `training_load` were `ON CONFLICT DO NOTHING` no-ops before; now they're skipped at read instead of at insert. Same rows land in `training_load`.
- **Backlog still fills.** New activities are always read + inserted. If `training_load` is ever empty/cleared, `NOT EXISTS` matches nothing and the full history rebuilds exactly as before.
- **Uploads unaffected.** This touches only the training-load computation. The upload path (`garmin-ingest` / `hevy-upload` / `garmin-enrich`) and the sync cadence are unchanged, so activity upload frequency is identical.
- Edge case: activities missing `startTimeLocal` were never inserted and are still re-read each run (unchanged, negligible).

## Verification
- `tsc --noEmit`: 0 errors. `vitest lib/pmc-stream.test.ts`: 4/4 pass.
- **Post-upgrade live check (pending DB un-pause):** run the sync once, confirm `training_load` row count is unchanged and Neon network-transfer per run is negligible.

Projected transfer: ~20 GB/mo → ~2–3 GB/mo.

Closes #399
