### PR TITLE
Bump hevy2garmin to 0.2.0 + pass timezone to uploads

### DIFF
--- a/web/lib/hevy-upload.ts
+++ b/web/lib/hevy-upload.ts
@@ -96,7 +96,11 @@ export interface UploadOutcome { hevyId: string; status: "uploaded" | "error"; a
 /** Generate a FIT for one workout and upload it to Garmin, then rename. Side-effectful. */
 export async function processWorkout(client: GarminClient, c: UploadCandidate): Promise<UploadOutcome> {
   try {
-    const { fit } = generateFit(c.workout, c.hrSamples.length ? c.hrSamples : null, {});
+    // HEVY2GARMIN_TIMEZONE (IANA, e.g. Europe/Athens) stamps local_timestamp into
+    // the FIT so Garmin forwards the correct local time to Strava. Empty = raw UTC.
+    const { fit } = generateFit(c.workout, c.hrSamples.length ? c.hrSamples : null, {
+      profile: { timezone: process.env.HEVY2GARMIN_TIMEZONE ?? "" },
+    });
     const start = c.workout?.start_time;
     const { activityId } = await uploadFit(client, fit, start);
     if (c.hevyTitle && activityId) {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,7 @@
         "date-fns": "^4.1.0",
         "fflate": "^0.8.3",
         "garmin-auth": "^0.4.1",
-        "hevy2garmin": "^0.1.3",
+        "hevy2garmin": "^0.2.0",
         "lucide-react": "^0.575.0",
         "macro-engine-core": "^0.1.1",
         "maplibre-gl": "^5.19.0",
@@ -10879,9 +10879,9 @@
       }
     },
     "node_modules/hevy2garmin": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.1.3.tgz",
-      "integrity": "sha512-uwnifBFjyV/g6gyx2DI5r/+OdLdCmTgdUITJz6TeG6u0J7bL42+c5ZCSUNDaZdgeXUykw7Z9kbrw3rxQ/H0CvA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.2.0.tgz",
+      "integrity": "sha512-QZe8eeSd4Ilw8+2SVPItYz7VkHA4LJcyZYJH0aDOqexQRwr/rDxX/E35DvhPy8KNWKJf2ZwOaUskd4uyyyW51g==",
       "license": "MIT",
       "dependencies": {
         "@garmin/fitsdk": "^21.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "date-fns": "^4.1.0",
     "fflate": "^0.8.3",
     "garmin-auth": "^0.4.1",
-    "hevy2garmin": "^0.1.3",
+    "hevy2garmin": "^0.2.0",
     "lucide-react": "^0.575.0",
     "macro-engine-core": "^0.1.1",
     "maplibre-gl": "^5.19.0",


### PR DESCRIPTION
Wires soma's upload pipeline to hevy2garmin 0.2.0.

- Bumps `web/package.json` to `hevy2garmin@^0.2.0` (from ^0.1.3). Every Hevy→Garmin upload now uses the synced exercise map: +25 mappings and 44 corrected category/subcategory values.
- Passes `HEVY2GARMIN_TIMEZONE` (IANA, e.g. `Europe/Athens`) through `generateFit`, defaulting to empty. When set, the uploaded FIT carries `local_timestamp` so Garmin forwards the correct local time to Strava instead of raw UTC. Empty keeps current behaviour, so this is a no-op until the env var is set.

Verified: `tsc --noEmit` clean, hevy-upload tests green.

To activate the Strava-time fix on the live pipeline, set `HEVY2GARMIN_TIMEZONE` in the soma sync GitHub Actions env (and Vercel, if the manual route is used).

Closes #401
