### PR TITLE
Set HEVY2GARMIN_TIMEZONE=Europe/Athens in the sync pipeline

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -108,4 +108,7 @@ jobs:
           VAPID_PRIVATE_KEY: ${{ secrets.VAPID_PRIVATE_KEY }}
           VAPID_SUBJECT: ${{ secrets.VAPID_SUBJECT }}
           MERGE_MODE: ${{ secrets.MERGE_MODE }}
+          # IANA zone stamped into the uploaded FIT's local_timestamp so Garmin
+          # forwards the correct local time to Strava (not raw UTC).
+          HEVY2GARMIN_TIMEZONE: Europe/Athens
         run: npx tsx scripts/sync-pipeline.mts


### PR DESCRIPTION
One-line follow-up to #401: sets `HEVY2GARMIN_TIMEZONE: Europe/Athens` in the sync.yml pipeline env so uploaded FITs carry `local_timestamp` and Garmin forwards the correct local time to Strava (fixes the 6am→3am UTC display for the user's own syncs).

Closes #403