### PR TITLE
App parity — Nutrition: Trajectory charts + drink management (#419)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl, TextInput } from "react-native";
 import { Text, Card, Badge, SegmentedControl, ProgressBar, Button, Modal, Pill, PillGroup, Sparkline } from "soma-style";
 import {
-  useSomaPlan, usePresets, logPresetMeal, deleteMeal, quickAddMeal, skipSlot, useDrinks, logDrink, closeDay,
+  useSomaPlan, usePresets, logPresetMeal, deleteMeal, quickAddMeal, skipSlot, useDrinks, logDrink, deleteDrink, closeDay,
   reopenDay, copyDay, setManualOverride,
   fetchJson, usePullRefresh, todayLocal, type Preset, type SomaMeal,
 } from "../../lib/api";
+import { BodyCompChart } from "../../components/body-comp-chart";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -79,6 +80,7 @@ export default function NutritionScreen() {
   const [reopenBusy, setReopenBusy] = useState(false);
   const [copyBusy, setCopyBusy] = useState(false);
   const [unlockBusy, setUnlockBusy] = useState(false);
+  const [delDrinkId, setDelDrinkId] = useState<number | null>(null);
 
   const plan = data?.plan;
   const consumed = data?.consumed;
@@ -89,6 +91,7 @@ export default function NutritionScreen() {
   const bd = data?.breakdown;
   const meals = data?.meals ?? [];
   const skippedSlots = data?.skippedSlots ?? [];
+  const loggedDrinks = data?.drinks ?? [];
   const dayClosed = closeStatus === "closed" || plan?.status === "closed";
   const manualOverride = (bd?.manualOverride ?? false) && !dayClosed;
   const caloriesTrend = useCaloriesTrend();
@@ -156,6 +159,12 @@ export default function NutritionScreen() {
     setDrinkBusy(key);
     const ok = await logDrink(DATE, key);
     setDrinkBusy(null);
+    if (ok) refetch();
+  }
+  async function onDeleteDrink(id: number) {
+    setDelDrinkId(id);
+    const ok = await deleteDrink(id);
+    setDelDrinkId(null);
     if (ok) refetch();
   }
   async function onCloseDay() {
@@ -351,7 +360,8 @@ export default function NutritionScreen() {
           </>
         ) : (
           <>
-            {/* Trend tab — adherence + 7-day table */}
+            {/* Trend tab — body-composition trajectory, then adherence + 7-day table */}
+            <BodyCompChart visible={tab === "Trend"} />
             {adherence ? (
               <Card className="gap-2">
                 <Text variant="eyebrow">Weekly adherence</Text>
@@ -447,6 +457,24 @@ export default function NutritionScreen() {
 
       {/* Log-drink modal */}
       <Modal visible={drinkOpen} onClose={() => setDrinkOpen(false)} title="Log a drink">
+        {loggedDrinks.length ? (
+          <View className="mb-3 gap-1">
+            <Text variant="eyebrow" className="text-text-muted">Logged today</Text>
+            {loggedDrinks.map((d) => (
+              <View key={d.id} className="flex-row items-center gap-2 border-b border-border-subtle py-1.5">
+                <View className="flex-1">
+                  <Text variant="caption" className="text-text" numberOfLines={1}>
+                    {d.quantity > 1 ? `${d.quantity}× ` : ""}{d.name}
+                  </Text>
+                  <Text variant="micro" className="text-text-muted tabular-nums">
+                    {Math.round(d.calories)} kcal{d.fat_oxidation_pause_hours ? ` · fat-ox paused ${d.fat_oxidation_pause_hours}h` : ""}
+                  </Text>
+                </View>
+                <Button label={delDrinkId === d.id ? "…" : "✕"} variant="ghost" size="sm" disabled={delDrinkId != null} onPress={() => onDeleteDrink(d.id)} />
+              </View>
+            ))}
+          </View>
+        ) : null}
         <Text variant="caption" className="mb-2 text-text-secondary">One default serving is logged per tap.</Text>
         <ScrollView className="max-h-80">
           {drinks.map((d) => (

--- a/universal/src/components/body-comp-chart.tsx
+++ b/universal/src/components/body-comp-chart.tsx
@@ -1,0 +1,193 @@
+import { View } from "react-native";
+import { Text, Card, Badge } from "soma-style";
+import { useBodyComp, type BodyComp } from "../lib/api";
+import { LineChart, ChartLegend } from "./line-chart";
+
+const C = {
+  actual: "#a9e4ec", // light teal — raw weigh-ins (dots)
+  smooth: "#77c8d1", // teal — smoothed line
+  trend: "#77c8d1", // teal dashed — projection
+  goal: "#e0a458", // warm — goal line
+  deficit: "#6ad4a0", // green — cumulative deficit
+};
+
+const dayMs = 86400000;
+function toDate(iso: string): number {
+  const [y, m, d] = iso.split("-").map(Number);
+  return Date.UTC(y, (m ?? 1) - 1, d ?? 1);
+}
+function shortLabel(iso: string): string {
+  const [, m, d] = iso.split("-").map(Number);
+  return `${["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][(m ?? 1) - 1]} ${d}`;
+}
+
+/** Sorted unique union of every date across the given arrays. */
+function axisOf(...arrs: { date: string }[][]): string[] {
+  const set = new Set<string>();
+  for (const a of arrs) for (const p of a) set.add(p.date);
+  return [...set].sort();
+}
+/** Map a keyed series onto the axis; null where the axis date is absent. */
+function alignBy(axis: string[], pts: { date: string }[], key: string): (number | null)[] {
+  const m = new Map(pts.map((p) => [p.date, (p as Record<string, unknown>)[key] as number]));
+  return axis.map((d) => (m.has(d) ? (m.get(d) as number) : null));
+}
+/** A straight line between the first and last of `pts`, sampled on the axis
+ *  (null outside their date span). Used for the 2-point goal line. */
+function interpLine(axis: string[], pts: { date: string }[], key: string): (number | null)[] {
+  if (pts.length < 2) return axis.map(() => null);
+  const a = pts[0], b = pts[pts.length - 1];
+  const t0 = toDate(a.date), t1 = toDate(b.date);
+  const y0 = (a as Record<string, unknown>)[key] as number;
+  const y1 = (b as Record<string, unknown>)[key] as number;
+  const span = t1 - t0 || 1;
+  return axis.map((d) => {
+    const t = toDate(d);
+    if (t < t0 || t > t1) return null;
+    return y0 + (y1 - y0) * ((t - t0) / span);
+  });
+}
+
+function kg(v: number | null | undefined): string {
+  return v == null ? "–" : `${v.toFixed(1)} kg`;
+}
+
+function StatusCard({ p }: { p: BodyComp["profile"] }) {
+  const slope = p.trendSlope ?? 0;
+  const losing = slope < 0;
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Body composition</Text>
+        {p.onTrack != null ? (
+          <Badge label={p.onTrack ? "On track" : "Behind pace"} tone={p.onTrack ? "success" : "warm"} />
+        ) : null}
+      </View>
+      <View className="flex-row items-end gap-2">
+        <Text variant="display" className="tabular-nums">{kg(p.latestActualWeight ?? p.currentWeight)}</Text>
+        <Text variant="body" className="text-text-muted mb-1">→ {kg(p.targetWeight)}</Text>
+      </View>
+      <View className="flex-row flex-wrap gap-x-5 gap-y-1">
+        <View>
+          <Text variant="micro" className="text-text-muted">Body fat</Text>
+          <Text variant="caption" className="tabular-nums">
+            {(p.latestActualBf ?? p.currentBf)?.toFixed?.(1) ?? "–"}% → {p.targetBf?.toFixed?.(1) ?? "–"}%
+          </Text>
+        </View>
+        <View>
+          <Text variant="micro" className="text-text-muted">Trend</Text>
+          <Text variant="caption" className={`tabular-nums ${losing ? "text-success" : "text-warm"}`}>
+            {slope > 0 ? "+" : ""}{slope.toFixed(2)} kg/wk
+          </Text>
+        </View>
+        {p.totalActualDeficit != null ? (
+          <View>
+            <Text variant="micro" className="text-text-muted">Total deficit</Text>
+            <Text variant="caption" className="tabular-nums">{Math.round(p.totalActualDeficit).toLocaleString()} kcal</Text>
+          </View>
+        ) : null}
+        {p.daysRemaining != null ? (
+          <View>
+            <Text variant="micro" className="text-text-muted">Days left</Text>
+            <Text variant="caption" className="tabular-nums">{p.daysRemaining}</Text>
+          </View>
+        ) : null}
+      </View>
+    </Card>
+  );
+}
+
+/** Full body-composition trajectory for the nutrition Trend tab: a status
+ *  card + Weight, Body-Fat%, and Cumulative-Deficit charts. */
+export function BodyCompChart({ visible }: { visible: boolean }) {
+  const { data, loading } = useBodyComp(visible);
+  if (!visible) return null;
+  if (loading && !data) return <Card><Text variant="body" className="text-text-secondary">Loading trajectory…</Text></Card>;
+  if (!data) return null;
+
+  const { profile, weights, goalLine, trendPrediction, dailyDeficits, goalDeficit } = data;
+
+  // Weight + BF% share one date axis (weigh-ins + goal + projection).
+  const wAxis = axisOf(weights, goalLine, trendPrediction);
+  const wLabels = wAxis.map(shortLabel);
+  const actual = alignBy(wAxis, weights, "weight");
+  const smoothed = alignBy(wAxis, weights, "smoothed");
+  const wTrend = alignBy(wAxis, trendPrediction, "weight");
+  const wGoal = interpLine(wAxis, goalLine, "weight");
+  const bfActual = alignBy(wAxis, weights, "bf");
+  const bfSmooth = alignBy(wAxis, weights, "smoothedBf");
+  const bfTrend = alignBy(wAxis, trendPrediction, "bf");
+  const bfGoal = interpLine(wAxis, goalLine, "bf");
+
+  const dAxis = dailyDeficits.map((d) => d.date);
+  const dLabels = dAxis.map(shortLabel);
+  const cumulative = dailyDeficits.map((d) => d.cumulative);
+  const goalPace = dailyDeficits.map((d) => d.goalPace);
+
+  const legend = [
+    { color: C.actual, label: "Weigh-in" },
+    { color: C.smooth, label: "Smoothed" },
+    { color: C.trend, label: "Projected", dashed: true },
+    { color: C.goal, label: "Goal", dashed: true },
+  ];
+
+  return (
+    <View className="gap-4">
+      <StatusCard p={profile} />
+
+      <Card className="gap-2">
+        <Text variant="eyebrow">Weight</Text>
+        <LineChart
+          height={140}
+          labels={wLabels}
+          yFormat={(v) => `${v.toFixed(1)}`}
+          series={[
+            { values: wGoal, color: C.goal, dashed: true, width: 1.5 },
+            { values: wTrend, color: C.trend, dashed: true, width: 1.5 },
+            { values: smoothed, color: C.smooth, width: 2.2 },
+            { values: actual, color: C.actual, mode: "dots" },
+          ]}
+        />
+        <ChartLegend items={legend} />
+      </Card>
+
+      <Card className="gap-2">
+        <Text variant="eyebrow">Body fat %</Text>
+        <LineChart
+          height={140}
+          labels={wLabels}
+          yFormat={(v) => `${v.toFixed(1)}%`}
+          series={[
+            { values: bfGoal, color: C.goal, dashed: true, width: 1.5 },
+            { values: bfTrend, color: C.trend, dashed: true, width: 1.5 },
+            { values: bfSmooth, color: C.smooth, width: 2.2 },
+            { values: bfActual, color: C.actual, mode: "dots" },
+          ]}
+        />
+        <ChartLegend items={legend} />
+      </Card>
+
+      {dailyDeficits.length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Cumulative deficit</Text>
+            <Text variant="micro" className="text-text-muted tabular-nums">goal {Math.round(goalDeficit)}/day</Text>
+          </View>
+          <LineChart
+            height={130}
+            labels={dLabels}
+            yFormat={(v) => `${Math.round(v / 1000)}k`}
+            series={[
+              { values: goalPace, color: "#3a5563", dashed: true, width: 1.5 },
+              { values: cumulative, color: C.deficit, width: 2.2 },
+            ]}
+          />
+          <ChartLegend items={[
+            { color: C.deficit, label: "Actual" },
+            { color: "#3a5563", label: "Goal pace", dashed: true },
+          ]} />
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -1,0 +1,124 @@
+import { View } from "react-native";
+import Svg, { Polyline, Line, Circle } from "react-native-svg";
+import { Text } from "soma-style";
+
+/**
+ * One data series on a LineChart. Values are aligned to a shared x-index
+ * (index i of every series maps to the same x position); `null` marks a gap.
+ * - mode "line": connected polyline (dense series — smoothed, trend, goal)
+ * - mode "dots": a dot per non-null point (sparse series — actual weigh-ins)
+ */
+export interface ChartSeries {
+  values: (number | null)[];
+  color: string;
+  width?: number;
+  dashed?: boolean;
+  mode?: "line" | "dots";
+  label?: string;
+}
+
+export interface LineChartProps {
+  series: ChartSeries[];
+  /** x labels aligned to the value index; only first + last are drawn. */
+  labels?: string[];
+  height?: number;
+  /** Format a y value for the axis labels (min/max) and the reference line. */
+  yFormat?: (v: number) => string;
+  /** Optional horizontal reference line (e.g. a goal pace at y=0). */
+  refLine?: { y: number; color?: string };
+  yMin?: number;
+  yMax?: number;
+}
+
+const VBW = 320; // viewBox width; scales uniformly to the container
+
+/** A compact, dependency-free line chart (react-native-svg) with y-axis
+ *  min/max labels and first/last x labels. Reused across every app chart. */
+export function LineChart({ series, labels, height = 120, yFormat, refLine, yMin, yMax }: LineChartProps) {
+  const fmt = yFormat ?? ((v: number) => String(Math.round(v)));
+  const all: number[] = [];
+  for (const s of series) for (const v of s.values) if (v != null && isFinite(v)) all.push(v);
+  if (refLine && isFinite(refLine.y)) all.push(refLine.y);
+  if (all.length < 2) {
+    return <View style={{ height }} className="items-center justify-center"><Text variant="micro" className="text-text-muted">Not enough data yet.</Text></View>;
+  }
+  const lo = yMin != null ? yMin : Math.min(...all);
+  const hi = yMax != null ? yMax : Math.max(...all);
+  const range = hi - lo || 1;
+  const padTop = 6;
+  const padBottom = 6;
+  const plotH = height - padTop - padBottom;
+  const n = Math.max(...series.map((s) => s.values.length));
+  const xAt = (i: number) => (n <= 1 ? 0 : (i / (n - 1)) * VBW);
+  const yAt = (v: number) => padTop + (1 - (v - lo) / range) * plotH;
+
+  return (
+    <View>
+      <View className="flex-row">
+        <View className="w-9 justify-between" style={{ height, paddingVertical: padTop }}>
+          <Text variant="micro" className="text-text-muted tabular-nums">{fmt(hi)}</Text>
+          <Text variant="micro" className="text-text-muted tabular-nums">{fmt(lo)}</Text>
+        </View>
+        <View className="flex-1">
+          <Svg width="100%" height={height} viewBox={`0 0 ${VBW} ${height}`}>
+            {/* baseline + top gridline */}
+            <Line x1={0} y1={yAt(hi)} x2={VBW} y2={yAt(hi)} stroke="#1e2f38" strokeWidth={1} />
+            <Line x1={0} y1={yAt(lo)} x2={VBW} y2={yAt(lo)} stroke="#1e2f38" strokeWidth={1} />
+            {refLine && refLine.y >= lo && refLine.y <= hi ? (
+              <Line x1={0} y1={yAt(refLine.y)} x2={VBW} y2={yAt(refLine.y)} stroke={refLine.color ?? "#3a5563"} strokeWidth={1} strokeDasharray="4 4" />
+            ) : null}
+            {series.map((s, si) => {
+              if (s.mode === "dots") {
+                return s.values.map((v, i) =>
+                  v == null || !isFinite(v) ? null : (
+                    <Circle key={`${si}-${i}`} cx={xAt(i)} cy={yAt(v)} r={2.6} fill={s.color} />
+                  ),
+                );
+              }
+              // line mode: split into segments on null gaps
+              const segs: string[] = [];
+              let cur: string[] = [];
+              s.values.forEach((v, i) => {
+                if (v == null || !isFinite(v)) { if (cur.length) { segs.push(cur.join(" ")); cur = []; } }
+                else cur.push(`${xAt(i)},${yAt(v)}`);
+              });
+              if (cur.length) segs.push(cur.join(" "));
+              return segs.map((pts, gi) => (
+                <Polyline
+                  key={`${si}-${gi}`}
+                  points={pts}
+                  fill="none"
+                  stroke={s.color}
+                  strokeWidth={s.width ?? 2}
+                  strokeDasharray={s.dashed ? "5 4" : undefined}
+                  strokeLinejoin="round"
+                  strokeLinecap="round"
+                />
+              ));
+            })}
+          </Svg>
+          {labels && labels.length >= 2 ? (
+            <View className="flex-row justify-between">
+              <Text variant="micro" className="text-text-muted">{labels[0]}</Text>
+              <Text variant="micro" className="text-text-muted">{labels[labels.length - 1]}</Text>
+            </View>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+/** A small colored-line + label legend row for a chart. */
+export function ChartLegend({ items }: { items: { color: string; label: string; dashed?: boolean }[] }) {
+  return (
+    <View className="flex-row flex-wrap gap-x-3 gap-y-1">
+      {items.map((it) => (
+        <View key={it.label} className="flex-row items-center gap-1.5">
+          <View style={{ width: 12, height: 0, borderTopWidth: 2, borderColor: it.color, borderStyle: it.dashed ? "dashed" : "solid" }} />
+          <Text variant="micro" className="text-text-muted">{it.label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -53,6 +53,10 @@ export interface SomaBreakdown {
   drinkCalories?: number; deficit?: number; manualOverride?: boolean;
 }
 export interface TrendDay { date: string; ate: number; burn: number; deficit: number; closed: boolean; isToday: boolean }
+export interface LoggedDrink {
+  id: number; name: string; drink_type: string; quantity: number;
+  calories: number; carbs?: number; alcohol_grams?: number; fat_oxidation_pause_hours?: number;
+}
 export interface SomaPlan {
   plan: { target_calories: number; target_protein: number; target_carbs: number; target_fat: number; target_fiber: number; status?: string } | null;
   consumed: MacroSet;
@@ -60,6 +64,7 @@ export interface SomaPlan {
   slotBudgets: Record<string, { calories: number; protein?: number; carbs?: number; fat?: number; fiber?: number }> | null;
   skippedSlots?: string[];
   meals?: SomaMeal[];
+  drinks?: LoggedDrink[];
   breakdown?: SomaBreakdown | null;
   adaptive: { effectiveTdee: number; reportedTdee: number; driftFlag: boolean; deficitDurationDays: number; dietBreakLevel: string } | null;
   trend7d?: {
@@ -678,6 +683,49 @@ export async function logDrink(date: string, drinkType: string, quantity = 1): P
     body: JSON.stringify({ date, drink_type: drinkType, quantity }),
   });
   return res.ok;
+}
+
+/** Delete a previously-logged drink by its row id. */
+export async function deleteDrink(id: number): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/nutrition/log-drink?id=${id}`, {
+    method: "DELETE",
+    headers: { ...AUTH_HEADERS },
+  });
+  return res.ok;
+}
+
+/** Body-composition trajectory: weigh-ins, smoothed + trend + goal projections,
+ *  and cumulative-deficit pacing. Feeds the nutrition Trend tab charts. */
+export interface BodyCompProfile {
+  currentWeight: number; currentBf: number;
+  latestActualWeight?: number | null; latestActualBf?: number | null;
+  targetWeight: number; targetBf: number; targetDate?: string | null;
+  deficit: number; onTrack?: boolean;
+  trendSlope?: number; daysRemaining?: number; weeklyRate?: number;
+  totalActualDeficit?: number; realisticDate?: string | null;
+}
+export interface BodyComp {
+  profile: BodyCompProfile;
+  weights: { date: string; weight: number; smoothed: number; bf: number; smoothedBf: number }[];
+  goalLine: { date: string; weight: number; bf: number }[];
+  trendPrediction: { date: string; weight: number; bf: number }[];
+  dailyDeficits: { date: string; deficit: number; cumulative: number; goalPace: number; closed: boolean; isToday: boolean }[];
+  goalDeficit: number;
+}
+export function useBodyComp(enabled: boolean) {
+  const [data, setData] = useState<BodyComp | null>(null);
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    if (!enabled || data) return;
+    let alive = true;
+    setLoading(true);
+    fetchJson<BodyComp>("/api/nutrition/body-comp")
+      .then((d) => alive && setData(d))
+      .catch(() => {})
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [enabled, data]);
+  return { data, loading };
 }
 
 /** Close (finalize) a day. Returns the resulting status ("closed" | "already_closed"). */


### PR DESCRIPTION
## App parity — Nutrition: Trajectory tab charts + drink management

Part of the app↔web parity build (umbrella #238). The app's nutrition **Trend** tab was a lighter substitute (weekly-adherence bar + a 7-day table). This brings the web's body-composition trajectory and drink management to the app.

### What changed
- **Reusable `LineChart`** (`components/line-chart.tsx`, react-native-svg) — multi-series with null-gap handling, `line`/`dots` modes, y-axis min/max labels, first/last x labels, an optional dashed reference line, and a `ChartLegend` helper. This is the charting foundation for the rest of the app's chart-fidelity work (Training/Workouts/Sleep/Running/Activities).
- **`BodyCompChart`** on the Trend tab (fetches `/api/nutrition/body-comp`):
  - **Status card** — latest weight → target, body-fat → target, trend (kg/week, green when losing), on-track badge, total deficit, days left.
  - **Weight** chart — weigh-ins (dots) + smoothed (line) + projection (dashed) + goal (dashed).
  - **Body-Fat %** chart — same series in BF%.
  - **Cumulative deficit** chart — actual vs goal-pace.
  - The existing adherence + 7-day table stay below.
- **Drink management** — the Log-a-drink modal now lists the day's logged drinks (name, quantity, kcal, fat-oxidation-pause) each with a delete, on top of the existing catalog logging.

### Files
- `universal/src/components/line-chart.tsx` (new), `universal/src/components/body-comp-chart.tsx` (new)
- `universal/src/lib/api.ts` — `useBodyComp` + `BodyComp` types, `deleteDrink`, `SomaPlan.drinks`, `LoggedDrink`.
- `universal/src/app/(main)/nutrition.tsx` — render `BodyCompChart` on the Trend tab; logged-drinks list + delete in the drink modal.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Android release APK built + installed; screenshots of the Trend tab charts + drink list in the PR thread.

Closes #419
