### PR TITLE
App parity — Nutrition: ActivitySelector + macro goalposts

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -7,6 +7,7 @@ import {
   fetchJson, usePullRefresh, todayLocal, type Preset, type SomaMeal,
 } from "../../lib/api";
 import { BodyCompChart } from "../../components/body-comp-chart";
+import { ActivitySelector } from "../../components/activity-selector";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -21,11 +22,11 @@ function useCaloriesTrend() {
   return series;
 }
 
-const MACROS = [
+const MACROS: { key: string; label: string; color: string; tKey: string; ceiling?: number }[] = [
   { key: "protein", label: "Protein", color: "#b17850", tKey: "target_protein" },
   { key: "carbs", label: "Carbs", color: "#6366b0", tKey: "target_carbs" },
   { key: "fat", label: "Fat", color: "#cbe896", tKey: "target_fat" },
-  { key: "fiber", label: "Fiber", color: "#82d0c8", tKey: "target_fiber" },
+  { key: "fiber", label: "Fiber", color: "#82d0c8", tKey: "target_fiber", ceiling: 60 },
 ] as const;
 
 const SLOT_ORDER = ["breakfast", "lunch", "during_workout", "dinner", "pre_sleep"];
@@ -48,6 +49,23 @@ function shiftDate(iso: string, days: number): string {
   const dt = new Date(y, (mo ?? 1) - 1, (d ?? 1) + days);
   const p = (n: number) => String(n).padStart(2, "0");
   return `${dt.getFullYear()}-${p(dt.getMonth() + 1)}-${p(dt.getDate())}`;
+}
+
+/** A macro progress bar with goalposts: a teal floor marker at the target
+ *  ("eat at least here") and, where a research ceiling applies (fiber 60 g),
+ *  a warm ceiling marker — the fill turns amber when the ceiling is crossed. */
+function MacroGoalBar({ eaten, target, ceiling, color }: { eaten: number; target: number; ceiling?: number; color: string }) {
+  const max = ceiling ?? (target > 0 ? target * 1.3 : Math.max(eaten, 1));
+  const pct = Math.max(0, Math.min(eaten / max, 1));
+  const floorPct = target > 0 ? Math.min(target / max, 1) : 0;
+  const over = ceiling != null && eaten > ceiling;
+  return (
+    <View className="relative h-2 overflow-hidden rounded-full" style={{ backgroundColor: "#16242c" }}>
+      <View className="absolute left-0 top-0 h-full rounded-full" style={{ width: `${pct * 100}%`, backgroundColor: over ? "#e0a458" : color }} />
+      {target > 0 ? <View className="absolute top-0 h-full" style={{ left: `${floorPct * 100}%`, width: 2, backgroundColor: "#77c8d1" }} /> : null}
+      {ceiling != null ? <View className="absolute top-0 h-full" style={{ left: `${Math.min(ceiling / max, 1) * 100}%`, width: 2, backgroundColor: "#e0a458" }} /> : null}
+    </View>
+  );
 }
 
 export default function NutritionScreen() {
@@ -248,13 +266,16 @@ export default function NutritionScreen() {
             {MACROS.map((m) => {
               const target = (plan as Record<string, number> | null | undefined)?.[m.tKey] ?? 0;
               const eaten = (consumed as Record<string, number> | undefined)?.[m.key] ?? 0;
+              const over = m.ceiling != null && eaten > m.ceiling;
               return (
                 <View key={m.key} className="gap-1">
                   <View className="flex-row justify-between">
                     <Text variant="caption" className="text-text-secondary">{m.label}</Text>
-                    <Text variant="caption" className="tabular-nums text-text-muted">{Math.round(eaten)}{target > 0 ? ` / ${Math.round(target)}` : ""}g</Text>
+                    <Text variant="caption" className={`tabular-nums ${over ? "text-warm" : "text-text-muted"}`}>
+                      {Math.round(eaten)}{target > 0 ? ` / ${Math.round(target)}` : ""}g{m.ceiling != null ? ` · max ${m.ceiling}` : ""}
+                    </Text>
                   </View>
-                  <ProgressBar pct={target > 0 ? eaten / target : 0} color={m.color} />
+                  <MacroGoalBar eaten={eaten} target={target} ceiling={m.ceiling} color={m.color} />
                 </View>
               );
             })}
@@ -263,6 +284,19 @@ export default function NutritionScreen() {
 
         {tab === "Day" ? (
           <>
+            {/* Today's activity — the inputs that drive the day's burn (locked once closed) */}
+            {plan && !dayClosed ? (
+              <ActivitySelector
+                date={DATE}
+                runEnabled={data?.runEnabled ?? true}
+                plannedRunKm={Number(plan?.planned_run_km) || 0}
+                expectedSteps={bd?.expectedSteps ?? (Number(plan?.expected_steps) || 8000)}
+                selectedWorkouts={data?.selectedWorkouts ?? []}
+                runDistanceKm={bd?.runDistanceKm ?? 0}
+                onChanged={refetch}
+              />
+            ) : null}
+
             {/* Burn breakdown — why today's target is what it is */}
             {bd ? (
               <Card className="gap-0.5">

--- a/universal/src/components/activity-selector.tsx
+++ b/universal/src/components/activity-selector.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from "react";
+import { View } from "react-native";
+import { Text, Card, Button } from "soma-style";
+import { setActivity, useWorkoutCalories } from "../lib/api";
+
+function Stepper({
+  label, value, onChange, min, max, step, format,
+}: {
+  label: string; value: number; onChange: (v: number) => void;
+  min: number; max: number; step: number; format?: (v: number) => string;
+}) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text variant="caption" className="text-text-secondary">{label}</Text>
+      <View className="flex-row items-center gap-1">
+        <Button label="−" variant="ghost" size="sm" disabled={value <= min} onPress={() => onChange(Math.max(min, Math.round((value - step) * 100) / 100))} />
+        <Text variant="body" className="w-20 text-center tabular-nums">{format ? format(value) : value}</Text>
+        <Button label="+" variant="ghost" size="sm" disabled={value >= max} onPress={() => onChange(Math.min(max, Math.round((value + step) * 100) / 100))} />
+      </View>
+    </View>
+  );
+}
+
+export interface ActivitySelectorProps {
+  date: string;
+  runEnabled: boolean;
+  plannedRunKm: number;
+  expectedSteps: number;
+  selectedWorkouts: string[];
+  /** A coach-planned or actual run exists for the day when > 0. */
+  runDistanceKm: number;
+  disabled?: boolean;
+  onChanged: () => void;
+}
+
+/** "Today's Activity" — the card that drives the day's burn: run on/off (or
+ *  ad-hoc planned km), expected steps, and which gym workouts count. Mirrors
+ *  the web ActivitySelector, mobile-adapted with steppers + chips. */
+export function ActivitySelector({
+  date, runEnabled, plannedRunKm, expectedSteps, selectedWorkouts, runDistanceKm, disabled, onChanged,
+}: ActivitySelectorProps) {
+  const routines = useWorkoutCalories();
+  const [run, setRun] = useState(runEnabled);
+  const [km, setKm] = useState(plannedRunKm);
+  const [steps, setSteps] = useState(expectedSteps);
+  const [selected, setSelected] = useState<string[]>(selectedWorkouts);
+  const [saving, setSaving] = useState(false);
+
+  // Re-sync from the plan whenever it reloads (after a save/refetch).
+  useEffect(() => { setRun(runEnabled); }, [runEnabled]);
+  useEffect(() => { setKm(plannedRunKm); }, [plannedRunKm]);
+  useEffect(() => { setSteps(expectedSteps); }, [expectedSteps]);
+  const selKey = selectedWorkouts.join(",");
+  useEffect(() => { setSelected(selectedWorkouts); }, [selKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function save(opts: { run_enabled?: boolean; selected_workouts?: string[]; expected_steps?: number; planned_run_km?: number | null }) {
+    setSaving(true);
+    const ok = await setActivity(date, opts);
+    setSaving(false);
+    if (ok) onChanged();
+  }
+
+  const hasRun = runDistanceKm > 0;
+
+  return (
+    <Card className={`gap-3 ${disabled ? "opacity-50" : ""}`}>
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Today&apos;s activity</Text>
+        {saving ? <Text variant="micro" className="text-text-muted">saving…</Text> : null}
+      </View>
+
+      {hasRun ? (
+        <View className="flex-row items-center justify-between">
+          <View>
+            <Text variant="caption" className="text-text-secondary">Planned run</Text>
+            <Text variant="micro" className="text-text-muted tabular-nums">{runDistanceKm.toFixed(1)} km</Text>
+          </View>
+          <Button
+            label={run ? "Counts · ON" : "OFF"}
+            variant={run ? "secondary" : "ghost"}
+            size="sm"
+            disabled={disabled}
+            onPress={() => { const next = !run; setRun(next); save({ run_enabled: next, selected_workouts: selected, expected_steps: steps }); }}
+          />
+        </View>
+      ) : (
+        <View className="gap-0.5">
+          <Stepper
+            label="Ad-hoc run"
+            value={km}
+            min={0}
+            max={50}
+            step={0.5}
+            format={(v) => `${v.toFixed(1)} km`}
+            onChange={(v) => { setKm(v); save({ planned_run_km: v > 0 ? v : null }); }}
+          />
+          {km > 0 ? <Text variant="micro" className="text-text-muted self-end">≈ {Math.round(km * 70)} kcal pre-allocated</Text> : null}
+        </View>
+      )}
+
+      <Stepper
+        label="Expected steps"
+        value={steps}
+        min={1000}
+        max={30000}
+        step={250}
+        format={(v) => v.toLocaleString()}
+        onChange={(v) => { setSteps(v); save({ run_enabled: run, selected_workouts: selected, expected_steps: v }); }}
+      />
+
+      {routines.length > 0 ? (
+        <View className="gap-1.5">
+          <Text variant="micro" className="text-text-muted">Gym workouts</Text>
+          <View className="flex-row flex-wrap gap-1.5">
+            {routines.map((r) => {
+              const on = selected.includes(r.hevy_title);
+              return (
+                <Button
+                  key={r.hevy_title}
+                  label={`${r.hevy_title} · ${r.avg_calories}`}
+                  variant={on ? "secondary" : "ghost"}
+                  size="sm"
+                  disabled={disabled}
+                  onPress={() => {
+                    const next = on ? selected.filter((w) => w !== r.hevy_title) : [...selected, r.hevy_title];
+                    setSelected(next);
+                    save({ run_enabled: run, selected_workouts: next, expected_steps: steps });
+                  }}
+                />
+              );
+            })}
+          </View>
+        </View>
+      ) : null}
+
+      {!hasRun && routines.length === 0 ? (
+        <Text variant="micro" className="text-text-muted">No gym or planned-run data for today.</Text>
+      ) : null}
+    </Card>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -58,7 +58,9 @@ export interface LoggedDrink {
   calories: number; carbs?: number; alcohol_grams?: number; fat_oxidation_pause_hours?: number;
 }
 export interface SomaPlan {
-  plan: { target_calories: number; target_protein: number; target_carbs: number; target_fat: number; target_fiber: number; status?: string } | null;
+  plan: { target_calories: number; target_protein: number; target_carbs: number; target_fat: number; target_fiber: number; status?: string; planned_run_km?: number | null; expected_steps?: number | null } | null;
+  runEnabled?: boolean;
+  selectedWorkouts?: string[];
   consumed: MacroSet;
   remaining: MacroSet | null;
   slotBudgets: Record<string, { calories: number; protein?: number; carbs?: number; fat?: number; fiber?: number }> | null;
@@ -768,6 +770,38 @@ export async function setManualOverride(date: string, on: boolean): Promise<bool
     body: JSON.stringify({ date, manual_override: on }),
   });
   return res.ok;
+}
+
+/** Update the day's activity plan (drives the burn calc): run on/off + which
+ *  gym workouts count + expected steps + ad-hoc planned-run km. */
+export async function setActivity(
+  date: string,
+  opts: { run_enabled?: boolean; selected_workouts?: string[]; expected_steps?: number; planned_run_km?: number | null },
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/nutrition/activity-select`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({ date, ...opts }),
+    });
+    return res.ok;
+  } catch {
+    return false; // network error — keep the optimistic local state, drop the "saving…"
+  }
+}
+
+/** Gym routines with their average burned calories (for the activity chips). */
+export interface WorkoutCalorie { hevy_title: string; avg_calories: number }
+export function useWorkoutCalories() {
+  const [routines, setRoutines] = useState<WorkoutCalorie[]>([]);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<{ routines: WorkoutCalorie[] }>("/api/nutrition/workout-calories")
+      .then((d) => alive && setRoutines(d.routines ?? []))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+  return routines;
 }
 
 /** Log a preset meal into a slot. Returns true on success. */


### PR DESCRIPTION
## App parity — Nutrition: ActivitySelector + macro goalposts

Part of the app↔web parity build (umbrella #238). Brings the web's "Today's Activity" card (the inputs that drive the day's burn) and its goalpost macro bars to the app nutrition screen.

### What changed
- **`ActivitySelector`** (`components/activity-selector.tsx`) — a "Today's Activity" card:
  - Run: an on/off toggle when a coach-planned or actual run exists (`runDistanceKm > 0`), otherwise an **ad-hoc planned-km stepper** (0–50, 0.5) with an estimated-kcal hint.
  - **Expected-steps stepper** (1,000–30,000, 250).
  - **Gym-workout chips** from `/api/nutrition/workout-calories`, tap to toggle which workouts count.
  - Saves via `setActivity` (`POST /api/nutrition/activity-select`) and refetches; hidden while the day is closed.
- **Macro goalposts** — the Protein/Carbs/Fat/Fiber bars gain a teal **floor marker** at the target ("eat at least here") and, for fiber, a warm **ceiling marker** at 60 g; the fill and count turn amber when the ceiling is crossed.

### Files
- `universal/src/components/activity-selector.tsx` (new)
- `universal/src/lib/api.ts` — `setActivity` (network-error-safe) + `useWorkoutCalories`; `SomaPlan.runEnabled`/`selectedWorkouts` + `plan.planned_run_km`/`expected_steps`.
- `universal/src/app/(main)/nutrition.tsx` — render the card on the Day tab; `MacroGoalBar` goalpost bars.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (device locked): confirmed the card (run stepper, expected-steps 9,500, Push/Pull/Leg chips with selection state), the goalposts (fiber over-60 g amber), and the chip-toggle interaction.
- **Caught + fixed mid-verify:** `setActivity` fires on every stepper tap / chip toggle, so a failed fetch must not throw (it would strand "saving…" and raise an unhandled rejection). It now returns `false` on network error — verified the error overlay no longer appears on a failed save.

Closes #418
