### PR TITLE
App parity — Nutrition: compose custom meal + ingredient picker

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../lib/api";
 import { BodyCompChart } from "../../components/body-comp-chart";
 import { ActivitySelector } from "../../components/activity-selector";
+import { ComposeMealView } from "../../components/compose-meal-view";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -73,9 +74,9 @@ export default function NutritionScreen() {
   const isToday = DATE === todayLocal();
   const { data, loading, error, refetch } = useSomaPlan(DATE);
   // Reset per-day transient UI when the viewed day changes.
-  useEffect(() => { setCloseStatus(null); setQOpen(false); setLogOpen(false); }, [DATE]);
+  useEffect(() => { setCloseStatus(null); setLogMode("preset"); setLogOpen(false); }, [DATE]);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
-  const { presets } = usePresets();
+  const { presets, ingredients } = usePresets();
   const { drinks } = useDrinks();
   const [tab, setTab] = useState<"Day" | "Trend">("Day");
   const [logOpen, setLogOpen] = useState(false);
@@ -87,7 +88,7 @@ export default function NutritionScreen() {
   const [closeOpen, setCloseOpen] = useState(false);
   const [closing, setClosing] = useState(false);
   const [closeStatus, setCloseStatus] = useState<string | null>(null);
-  const [qOpen, setQOpen] = useState(false);
+  const [logMode, setLogMode] = useState<"preset" | "quick" | "compose">("preset");
   const [qName, setQName] = useState("");
   const [qCal, setQCal] = useState("");
   const [qP, setQP] = useState("");
@@ -144,7 +145,7 @@ export default function NutritionScreen() {
     });
     setQBusy(false);
     if (ok) {
-      setQOpen(false);
+      setLogMode("preset");
       setQName(""); setQCal(""); setQP(""); setQC(""); setQF("");
       refetch();
     }
@@ -445,11 +446,19 @@ export default function NutritionScreen() {
             <Pill key={s} label={slotLabel(s)} active={slot === s} onPress={() => setSlot(s)} />
           ))}
         </PillGroup>
-        <View className="mb-2 flex-row items-center justify-between">
-          <Text variant="eyebrow" className="text-text-muted">{qOpen ? "Quick add" : "Presets"}</Text>
-          <Button label={qOpen ? "Use a preset" : "＋ Quick add"} variant="ghost" size="sm" onPress={() => setQOpen(!qOpen)} />
+        <View className="mb-3 flex-row gap-1.5">
+          <Button label="Presets" variant={logMode === "preset" ? "secondary" : "ghost"} size="sm" onPress={() => setLogMode("preset")} />
+          <Button label="Quick add" variant={logMode === "quick" ? "secondary" : "ghost"} size="sm" onPress={() => setLogMode("quick")} />
+          <Button label="Compose" variant={logMode === "compose" ? "secondary" : "ghost"} size="sm" onPress={() => setLogMode("compose")} />
         </View>
-        {qOpen ? (
+        {logMode === "compose" ? (
+          <ComposeMealView
+            ingredients={ingredients}
+            date={DATE}
+            slot={slot}
+            onLogged={() => { setLogOpen(false); refetch(); }}
+          />
+        ) : logMode === "quick" ? (
           <View className="gap-2 rounded-lg border border-border-subtle p-3">
             <TextInput
               placeholder="Name (e.g. Restaurant burger)"
@@ -465,7 +474,7 @@ export default function NutritionScreen() {
               <TextInput placeholder="F" placeholderTextColor="#5a7a8a" keyboardType="numeric" value={qF} onChangeText={setQF} className="flex-1 rounded-md border border-border-subtle px-2 py-2 text-text tabular-nums" />
             </View>
             <View className="flex-row justify-end gap-2">
-              <Button label="Cancel" variant="ghost" size="sm" onPress={() => setQOpen(false)} />
+              <Button label="Cancel" variant="ghost" size="sm" onPress={() => setLogMode("preset")} />
               <Button label={qBusy ? "…" : "Add"} variant="primary" size="sm" disabled={qBusy || !qCal} onPress={onQuickAdd} />
             </View>
           </View>

--- a/universal/src/components/compose-meal-view.tsx
+++ b/universal/src/components/compose-meal-view.tsx
@@ -1,0 +1,130 @@
+import { useState, useMemo } from "react";
+import { View, ScrollView, TextInput, Pressable } from "react-native";
+import { Text, Button } from "soma-style";
+import { ingredientMacros, logComposedMeal, type Ingredient } from "../lib/api";
+
+const CATEGORY_LABELS: Record<string, string> = {
+  protein: "Protein", carbs: "Carbs", grain: "Grain", vegetable: "Vegetable", fat: "Fat",
+  dairy: "Dairy", fruit: "Fruit", sauce: "Sauce", supplement: "Supplement",
+};
+const CATEGORY_ORDER = ["protein", "carbs", "grain", "vegetable", "fat", "dairy", "fruit", "sauce", "supplement"];
+
+/** Compose a meal from raw ingredients: search + category-grouped picker,
+ *  per-ingredient gram editors with live macros, running totals, and log.
+ *  Mobile-adapted from the web ComposeMealView (grams-based; the raw/cooked
+ *  and count editors + save-as-preset stay a web-only power feature for now). */
+export function ComposeMealView({
+  ingredients, date, slot, onLogged,
+}: {
+  ingredients: Ingredient[]; date: string; slot: string; onLogged: () => void;
+}) {
+  const [search, setSearch] = useState("");
+  const [grams, setGrams] = useState<Record<string, number>>({});
+  const [busy, setBusy] = useState(false);
+
+  const byId = useMemo(() => new Map(ingredients.map((i) => [i.id, i])), [ingredients]);
+  const selectedIds = Object.keys(grams).filter((id) => (grams[id] ?? 0) > 0 && byId.has(id));
+
+  const filtered = search.trim()
+    ? ingredients.filter((i) => i.name.toLowerCase().includes(search.trim().toLowerCase()))
+    : ingredients;
+  const groups = useMemo(() => {
+    const m = new Map<string, Ingredient[]>();
+    for (const ing of filtered) {
+      const c = ing.category || "other";
+      if (!m.has(c)) m.set(c, []);
+      m.get(c)!.push(ing);
+    }
+    const order = [...CATEGORY_ORDER, ...[...m.keys()].filter((c) => !CATEGORY_ORDER.includes(c))];
+    return order.filter((c) => m.has(c)).map((c) => [c, m.get(c)!] as const);
+  }, [filtered]);
+
+  const totals = selectedIds.reduce(
+    (a, id) => {
+      const mm = ingredientMacros(byId.get(id)!, grams[id]);
+      return { calories: a.calories + mm.calories, protein: a.protein + mm.protein, carbs: a.carbs + mm.carbs, fat: a.fat + mm.fat, fiber: a.fiber + mm.fiber };
+    },
+    { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
+  );
+
+  const add = (id: string) => setGrams((g) => ({ ...g, [id]: g[id] && g[id] > 0 ? g[id] : 100 }));
+  const setG = (id: string, v: number) => setGrams((g) => ({ ...g, [id]: Math.max(0, Math.round(v)) }));
+  const remove = (id: string) => setGrams((g) => { const n = { ...g }; delete n[id]; return n; });
+
+  async function onLog() {
+    setBusy(true);
+    const items = selectedIds.map((id) => {
+      const ing = byId.get(id)!;
+      const m = ingredientMacros(ing, grams[id]);
+      return { ingredient_id: id, name: ing.name, grams: grams[id], calories: m.calories, protein: m.protein, carbs: m.carbs, fat: m.fat, fiber: m.fiber };
+    });
+    const ok = await logComposedMeal(date, slot, items);
+    setBusy(false);
+    if (ok) { setGrams({}); onLogged(); }
+  }
+
+  return (
+    <View className="gap-3">
+      {/* Selected ingredients — gram editors + live macros */}
+      {selectedIds.length ? (
+        <View className="gap-2 rounded-lg border border-border-subtle p-3">
+          <Text variant="eyebrow" className="text-text-muted">In this meal</Text>
+          {selectedIds.map((id) => {
+            const ing = byId.get(id)!;
+            const g = grams[id];
+            const m = ingredientMacros(ing, g);
+            return (
+              <View key={id} className="flex-row items-center gap-2 border-b border-border-subtle pb-1.5">
+                <View className="flex-1">
+                  <Text variant="caption" className="text-text" numberOfLines={1}>{ing.name}</Text>
+                  <Text variant="micro" className="text-text-muted tabular-nums">
+                    {Math.round(m.calories)} kcal · P{Math.round(m.protein)} C{Math.round(m.carbs)} F{Math.round(m.fat)}
+                  </Text>
+                </View>
+                <View className="flex-row items-center gap-1">
+                  <Button label="−" variant="ghost" size="sm" onPress={() => setG(id, g - 10)} />
+                  <Text variant="caption" className="w-14 text-center tabular-nums">{g} g</Text>
+                  <Button label="+" variant="ghost" size="sm" onPress={() => setG(id, g + 10)} />
+                  <Button label="✕" variant="ghost" size="sm" onPress={() => remove(id)} />
+                </View>
+              </View>
+            );
+          })}
+          <View className="flex-row items-center justify-between pt-1">
+            <Text variant="caption" className="font-semibold tabular-nums">
+              {Math.round(totals.calories)} kcal · P{Math.round(totals.protein)} C{Math.round(totals.carbs)} F{Math.round(totals.fat)}
+            </Text>
+            <Button label={busy ? "…" : "Log meal"} variant="primary" size="sm" disabled={busy || selectedIds.length === 0} onPress={onLog} />
+          </View>
+        </View>
+      ) : null}
+
+      {/* Search + category-grouped ingredient picker */}
+      <TextInput
+        placeholder="Search ingredients…"
+        placeholderTextColor="#5a7a8a"
+        value={search}
+        onChangeText={setSearch}
+        className="rounded-md border border-border-subtle px-3 py-2 text-text"
+      />
+      <ScrollView className="max-h-72" keyboardShouldPersistTaps="handled">
+        {groups.length === 0 ? (
+          <Text variant="caption" className="text-text-muted">No ingredients match.</Text>
+        ) : groups.map(([cat, list]) => (
+          <View key={cat} className="mb-2">
+            <Text variant="micro" className="mb-1 text-text-muted">{CATEGORY_LABELS[cat] ?? cat}</Text>
+            {list.map((ing) => {
+              const on = (grams[ing.id] ?? 0) > 0;
+              return (
+                <Pressable key={ing.id} onPress={() => (on ? remove(ing.id) : add(ing.id))} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+                  <Text variant="caption" className={on ? "text-teal" : "text-text"} numberOfLines={1}>{ing.name}</Text>
+                  <Text variant="micro" className="text-text-muted tabular-nums">{on ? "✓ " : ""}{Math.round(ing.calories_per_100g)}/100g</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -642,17 +642,51 @@ export interface Preset {
 }
 
 /** soma's saved preset meals (log-meal is preset-based, not free-food search). */
+/** A raw ingredient from the catalog (per-100g macros). */
+export interface Ingredient {
+  id: string; name: string; category: string;
+  calories_per_100g: number; protein_per_100g: number; carbs_per_100g: number; fat_per_100g: number; fiber_per_100g: number;
+  unit?: string | null; grams_per_unit?: number | null;
+}
+/** Macros for `grams` of an ingredient (linear per-100g scaling). */
+export function ingredientMacros(ing: Ingredient, grams: number) {
+  const f = (Number(grams) || 0) / 100;
+  return {
+    calories: (Number(ing.calories_per_100g) || 0) * f,
+    protein: (Number(ing.protein_per_100g) || 0) * f,
+    carbs: (Number(ing.carbs_per_100g) || 0) * f,
+    fat: (Number(ing.fat_per_100g) || 0) * f,
+    fiber: (Number(ing.fiber_per_100g) || 0) * f,
+  };
+}
+
+export interface ComposeItem { ingredient_id: string; name: string; grams: number; calories: number; protein: number; carbs: number; fat: number; fiber: number }
+/** Log a meal composed from raw ingredients into a slot. */
+export async function logComposedMeal(date: string, slot: string, items: ComposeItem[]): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/nutrition/log-meal`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({ date, meal_slot: slot, source: "compose", items }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 export function usePresets() {
   const [presets, setPresets] = useState<Preset[]>([]);
+  const [ingredients, setIngredients] = useState<Ingredient[]>([]);
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
-    fetchJson<{ presets: Preset[] }>("/api/nutrition/presets")
-      .then((d) => alive && (setPresets(d.presets ?? []), setError(null)))
+    fetchJson<{ presets: Preset[]; ingredients: Ingredient[] }>("/api/nutrition/presets")
+      .then((d) => alive && (setPresets(d.presets ?? []), setIngredients(d.ingredients ?? []), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => { alive = false; };
   }, []);
-  return { presets, error };
+  return { presets, ingredients, error };
 }
 
 export interface Drink {


### PR DESCRIPTION
## App parity — Nutrition: compose custom meal + ingredient picker

Part of the app↔web parity build (umbrella #238). Brings the web's compose-from-ingredients flow to the app, so a meal can be built from raw ingredients — not just logged from a preset (#415-era) or entered as raw macros (quick-add).

### What changed
- **`ComposeMealView`** (`components/compose-meal-view.tsx`):
  - Searchable, category-grouped ingredient picker (Protein / Carbs / Grain / Vegetable / Fat / Dairy / Fruit / Sauce / Supplement).
  - Tap an ingredient to add it (✓), tap again to remove.
  - Per-ingredient **gram steppers** with live per-item macros, and a **running total** (kcal · P/C/F).
  - **Log meal** → `logComposedMeal` (`POST /api/nutrition/log-meal`, `source: "compose"`).
- The log modal's Presets ↔ Quick-add toggle is now a **3-way selector**: Presets / Quick add / Compose.

### Why no new endpoint or dependency
`/api/nutrition/presets` already returns the full `ingredients` catalog — the app was fetching it via `usePresets` and discarding it. Grams-based macros are a linear per-100g scale (`ingredientMacros`), so no `macro-engine-core` dependency is needed.

### Files
- `universal/src/components/compose-meal-view.tsx` (new)
- `universal/src/lib/api.ts` — `Ingredient` + `ingredientMacros`; `usePresets` now returns `ingredients`; `logComposedMeal` (network-error-safe).
- `universal/src/app/(main)/nutrition.tsx` — 3-way mode selector + the Compose branch.

### Mobile trim (web-only for now, per the parity-audit triage)
raw/cooked + count editors, max-yolks, volume score, the 5-goalpost compose bars, and save-as-preset.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (device locked; browser network interception feeds a realistic ingredient catalog): confirmed the picker, tap-to-add, gram steppers, correct live totals (Chicken 165 + Oats 389 = **554 kcal · P48 C66 F11**), and Log meal closing the modal.

Closes #416
