### PR TITLE
App parity — Nutrition: meal detail + edit (finishes #415)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View, RefreshControl, TextInput } from "react-native";
+import { ScrollView, View, RefreshControl, TextInput, Pressable } from "react-native";
 import { Text, Card, Badge, SegmentedControl, ProgressBar, Button, Modal, Pill, PillGroup, Sparkline } from "soma-style";
 import {
   useSomaPlan, usePresets, logPresetMeal, deleteMeal, quickAddMeal, skipSlot, useDrinks, logDrink, deleteDrink, closeDay,
@@ -9,6 +9,7 @@ import {
 import { BodyCompChart } from "../../components/body-comp-chart";
 import { ActivitySelector } from "../../components/activity-selector";
 import { ComposeMealView } from "../../components/compose-meal-view";
+import { MealDetailModal } from "../../components/meal-detail-modal";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -74,7 +75,7 @@ export default function NutritionScreen() {
   const isToday = DATE === todayLocal();
   const { data, loading, error, refetch } = useSomaPlan(DATE);
   // Reset per-day transient UI when the viewed day changes.
-  useEffect(() => { setCloseStatus(null); setLogMode("preset"); setLogOpen(false); }, [DATE]);
+  useEffect(() => { setCloseStatus(null); setLogMode("preset"); setLogOpen(false); setEditMeal(null); setDetailMeal(null); }, [DATE]);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
   const { presets, ingredients } = usePresets();
   const { drinks } = useDrinks();
@@ -100,6 +101,8 @@ export default function NutritionScreen() {
   const [copyBusy, setCopyBusy] = useState(false);
   const [unlockBusy, setUnlockBusy] = useState(false);
   const [delDrinkId, setDelDrinkId] = useState<number | null>(null);
+  const [detailMeal, setDetailMeal] = useState<SomaMeal | null>(null);
+  const [editMeal, setEditMeal] = useState<{ id: number; grams: Record<string, number> } | null>(null);
 
   const plan = data?.plan;
   const consumed = data?.consumed;
@@ -128,11 +131,23 @@ export default function NutritionScreen() {
     setBusyId(null);
     if (ok) refetch();
   }
-  async function onDelete(id: number) {
-    setDelId(id);
-    const ok = await deleteMeal(id);
+  async function onDetailDelete() {
+    if (!detailMeal) return;
+    setDelId(detailMeal.id);
+    const ok = await deleteMeal(detailMeal.id);
     setDelId(null);
-    if (ok) refetch();
+    if (ok) { setDetailMeal(null); refetch(); }
+  }
+  function onEditMeal(m: SomaMeal) {
+    const g: Record<string, number> = {};
+    for (const it of m.items ?? []) {
+      if (it.ingredient_id && it.grams) g[it.ingredient_id] = Math.round(it.grams);
+    }
+    setEditMeal({ id: m.id, grams: g });
+    setSlot(m.meal_slot);
+    setLogMode("compose");
+    setDetailMeal(null);
+    setLogOpen(true);
   }
   async function onQuickAdd() {
     setQBusy(true);
@@ -353,15 +368,15 @@ export default function NutritionScreen() {
                     <>
                       {budget > 0 ? <ProgressBar pct={Math.min(eatenInSlot / budget, 1)} color={eatenInSlot > budget ? "#e0a458" : "#77c8d1"} /> : null}
                       {slotMeals.map((m) => (
-                        <View key={m.id} className="flex-row items-center gap-2 border-b border-border-subtle py-1.5">
+                        <Pressable key={m.id} onPress={() => setDetailMeal(m)} className="flex-row items-center gap-2 border-b border-border-subtle py-1.5">
                           <View className="flex-1">
                             <Text variant="body" className="text-text" numberOfLines={1}>{mealName(m)}</Text>
                             <Text variant="micro" className="tabular-nums">
                               {Math.round(m.calories)} kcal · P{Math.round(m.protein)} C{Math.round(m.carbs)} F{Math.round(m.fat)}
                             </Text>
                           </View>
-                          <Button label={delId === m.id ? "…" : "Remove"} variant="ghost" size="sm" disabled={delId != null} onPress={() => onDelete(m.id)} />
-                        </View>
+                          <Text variant="body" className="text-text-muted">›</Text>
+                        </Pressable>
                       ))}
                       {!dayClosed ? (
                         <View className="flex-row gap-2 self-start">
@@ -440,23 +455,25 @@ export default function NutritionScreen() {
       </View>
 
       {/* Log-meal modal — preset picker, prefilled to the tapped slot */}
-      <Modal visible={logOpen} onClose={() => setLogOpen(false)} title={`Log ${slotLabel(slot)}`}>
+      <Modal visible={logOpen} onClose={() => { setLogOpen(false); setEditMeal(null); }} title={editMeal ? `Edit ${slotLabel(slot)}` : `Log ${slotLabel(slot)}`}>
         <PillGroup className="mb-3">
           {slots.map((s) => (
             <Pill key={s} label={slotLabel(s)} active={slot === s} onPress={() => setSlot(s)} />
           ))}
         </PillGroup>
         <View className="mb-3 flex-row gap-1.5">
-          <Button label="Presets" variant={logMode === "preset" ? "secondary" : "ghost"} size="sm" onPress={() => setLogMode("preset")} />
-          <Button label="Quick add" variant={logMode === "quick" ? "secondary" : "ghost"} size="sm" onPress={() => setLogMode("quick")} />
-          <Button label="Compose" variant={logMode === "compose" ? "secondary" : "ghost"} size="sm" onPress={() => setLogMode("compose")} />
+          <Button label="Presets" variant={logMode === "preset" ? "secondary" : "ghost"} size="sm" onPress={() => { setLogMode("preset"); setEditMeal(null); }} />
+          <Button label="Quick add" variant={logMode === "quick" ? "secondary" : "ghost"} size="sm" onPress={() => { setLogMode("quick"); setEditMeal(null); }} />
+          <Button label={editMeal ? "Editing" : "Compose"} variant={logMode === "compose" ? "secondary" : "ghost"} size="sm" onPress={() => { setLogMode("compose"); setEditMeal(null); }} />
         </View>
         {logMode === "compose" ? (
           <ComposeMealView
             ingredients={ingredients}
             date={DATE}
             slot={slot}
-            onLogged={() => { setLogOpen(false); refetch(); }}
+            initialGrams={editMeal?.grams}
+            editMealId={editMeal?.id ?? null}
+            onLogged={() => { setLogOpen(false); setEditMeal(null); refetch(); }}
           />
         ) : logMode === "quick" ? (
           <View className="gap-2 rounded-lg border border-border-subtle p-3">
@@ -494,9 +511,20 @@ export default function NutritionScreen() {
           </ScrollView>
         )}
         <View className="mt-4 flex-row justify-end">
-          <Button label="Done" variant="primary" onPress={() => setLogOpen(false)} />
+          <Button label={logMode === "compose" ? "Cancel" : "Done"} variant={logMode === "compose" ? "ghost" : "primary"} onPress={() => { setLogOpen(false); setEditMeal(null); }} />
         </View>
       </Modal>
+
+      {/* Logged-meal detail — tap a meal to see macros + ingredients, edit or delete */}
+      <MealDetailModal
+        meal={detailMeal}
+        name={detailMeal ? mealName(detailMeal) : ""}
+        slotLabel={slotLabel}
+        deleting={delId != null}
+        onClose={() => setDetailMeal(null)}
+        onDelete={onDetailDelete}
+        onEdit={detailMeal ? () => onEditMeal(detailMeal) : undefined}
+      />
 
       {/* Log-drink modal */}
       <Modal visible={drinkOpen} onClose={() => setDrinkOpen(false)} title="Log a drink">

--- a/universal/src/components/compose-meal-view.tsx
+++ b/universal/src/components/compose-meal-view.tsx
@@ -1,7 +1,7 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { View, ScrollView, TextInput, Pressable } from "react-native";
 import { Text, Button } from "soma-style";
-import { ingredientMacros, logComposedMeal, type Ingredient } from "../lib/api";
+import { ingredientMacros, logComposedMeal, deleteMeal, type Ingredient } from "../lib/api";
 
 const CATEGORY_LABELS: Record<string, string> = {
   protein: "Protein", carbs: "Carbs", grain: "Grain", vegetable: "Vegetable", fat: "Fat",
@@ -14,13 +14,19 @@ const CATEGORY_ORDER = ["protein", "carbs", "grain", "vegetable", "fat", "dairy"
  *  Mobile-adapted from the web ComposeMealView (grams-based; the raw/cooked
  *  and count editors + save-as-preset stay a web-only power feature for now). */
 export function ComposeMealView({
-  ingredients, date, slot, onLogged,
+  ingredients, date, slot, onLogged, initialGrams, editMealId,
 }: {
   ingredients: Ingredient[]; date: string; slot: string; onLogged: () => void;
+  /** Pre-select ingredients (id -> grams) — used when editing a logged meal. */
+  initialGrams?: Record<string, number>;
+  /** When set, saving deletes this meal after re-logging (edit = replace). */
+  editMealId?: number | null;
 }) {
   const [search, setSearch] = useState("");
-  const [grams, setGrams] = useState<Record<string, number>>({});
+  const [grams, setGrams] = useState<Record<string, number>>(initialGrams ?? {});
   const [busy, setBusy] = useState(false);
+  const initKey = initialGrams ? Object.entries(initialGrams).map(([k, v]) => `${k}:${v}`).join(",") : "";
+  useEffect(() => { if (initialGrams) setGrams(initialGrams); }, [initKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const byId = useMemo(() => new Map(ingredients.map((i) => [i.id, i])), [ingredients]);
   const selectedIds = Object.keys(grams).filter((id) => (grams[id] ?? 0) > 0 && byId.has(id));
@@ -59,6 +65,8 @@ export function ComposeMealView({
       return { ingredient_id: id, name: ing.name, grams: grams[id], calories: m.calories, protein: m.protein, carbs: m.carbs, fat: m.fat, fiber: m.fiber };
     });
     const ok = await logComposedMeal(date, slot, items);
+    // Edit = replace: only remove the original after the new one is logged.
+    if (ok && editMealId != null) await deleteMeal(editMealId);
     setBusy(false);
     if (ok) { setGrams({}); onLogged(); }
   }
@@ -94,7 +102,7 @@ export function ComposeMealView({
             <Text variant="caption" className="font-semibold tabular-nums">
               {Math.round(totals.calories)} kcal · P{Math.round(totals.protein)} C{Math.round(totals.carbs)} F{Math.round(totals.fat)}
             </Text>
-            <Button label={busy ? "…" : "Log meal"} variant="primary" size="sm" disabled={busy || selectedIds.length === 0} onPress={onLog} />
+            <Button label={busy ? "…" : editMealId != null ? "Save changes" : "Log meal"} variant="primary" size="sm" disabled={busy || selectedIds.length === 0} onPress={onLog} />
           </View>
         </View>
       ) : null}

--- a/universal/src/components/meal-detail-modal.tsx
+++ b/universal/src/components/meal-detail-modal.tsx
@@ -1,0 +1,65 @@
+import { View } from "react-native";
+import { Text, Modal, Button, Badge } from "soma-style";
+import type { SomaMeal } from "../lib/api";
+
+const MACRO_ROWS: { key: "protein" | "carbs" | "fat" | "fiber"; label: string }[] = [
+  { key: "protein", label: "Protein" }, { key: "carbs", label: "Carbs" },
+  { key: "fat", label: "Fat" }, { key: "fiber", label: "Fiber" },
+];
+
+/** Detail view for a logged meal: macros + ingredient breakdown, with Delete
+ *  and (for composed meals) Edit. Tapping a meal row opens this. */
+export function MealDetailModal({
+  meal, name, slotLabel, onClose, onDelete, onEdit, deleting,
+}: {
+  meal: SomaMeal | null;
+  name: string;
+  slotLabel: (s: string) => string;
+  onClose: () => void;
+  onDelete: () => void;
+  onEdit?: () => void;
+  deleting?: boolean;
+}) {
+  if (!meal) return null;
+  const canEdit = meal.source === "compose" && (meal.items?.some((i) => i.ingredient_id) ?? false);
+  return (
+    <Modal visible={!!meal} onClose={onClose} title="Meal details">
+      <View className="gap-3">
+        <View className="flex-row items-center gap-2">
+          <Badge label={slotLabel(meal.meal_slot)} tone="teal" />
+          {meal.source ? <Badge label={meal.source} tone="neutral" /> : null}
+        </View>
+        <Text variant="title" numberOfLines={2}>{name}</Text>
+        <Text variant="display" className="tabular-nums">{Math.round(meal.calories)} kcal</Text>
+        <View className="flex-row flex-wrap gap-x-6 gap-y-1">
+          {MACRO_ROWS.map((m) => (
+            <View key={m.key}>
+              <Text variant="micro" className="text-text-muted">{m.label}</Text>
+              <Text variant="caption" className="tabular-nums">{Math.round(meal[m.key])}g</Text>
+            </View>
+          ))}
+        </View>
+
+        {meal.items?.length ? (
+          <View className="gap-1 rounded-lg border border-border-subtle p-3">
+            <Text variant="eyebrow" className="text-text-muted">Ingredients</Text>
+            {meal.items.map((it, i) => (
+              <View key={i} className="flex-row items-center justify-between border-b border-border-subtle py-1">
+                <Text variant="caption" className="flex-1 text-text" numberOfLines={1}>{it.name ?? "Item"}</Text>
+                <Text variant="micro" className="text-text-muted tabular-nums">
+                  {it.grams ? `${Math.round(it.grams)} g` : ""}{it.calories ? ` · ${Math.round(it.calories)} kcal` : ""}
+                </Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        <View className="mt-1 flex-row items-center justify-end gap-2">
+          <Button label="Close" variant="ghost" onPress={onClose} />
+          {canEdit && onEdit ? <Button label="Edit" variant="secondary" onPress={onEdit} /> : null}
+          <Button label={deleting ? "…" : "Delete"} variant="ghost" className="text-danger" disabled={deleting} onPress={onDelete} />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -35,7 +35,7 @@ export interface MacroSet {
   fiber: number;
 }
 
-export interface SomaMealItem { name?: string; grams?: number }
+export interface SomaMealItem { name?: string; grams?: number; ingredient_id?: string; calories?: number; protein?: number; carbs?: number; fat?: number; fiber?: number }
 export interface SomaMeal {
   id: number;
   meal_slot: string;


### PR DESCRIPTION
## App parity — Nutrition: meal detail + edit (finishes #415)

Completes the **edit** half of #415 (add / quick-add / skip shipped earlier in #448). This also addresses the parity audit's systemic gap #1 — "nothing is clickable-to-detail" — for logged meals, and closes out the Nutrition cluster (#414).

### What changed
- **`MealDetailModal`** (new): tapping a logged meal opens a detail view — slot + source badges, name, full macros (kcal · P/C/F/Fiber), and a per-ingredient breakdown (name · grams · kcal) — with **Delete** and, for composed meals, **Edit**.
- Meal rows are now **Pressable** (tap → detail, with a `›` affordance); the inline "Remove" button moves into the detail modal.
- **Edit reuses the compose view** (#416): it re-opens `ComposeMealView` pre-filled with the meal's ingredients (`initialGrams`), and on **Save changes** re-logs then deletes the original (`editMealId`) — edit-as-replace, since there is no meal-update endpoint (only POST + DELETE).

### Files
- `universal/src/components/meal-detail-modal.tsx` (new)
- `universal/src/components/compose-meal-view.tsx` — `initialGrams` + `editMealId` props (prefill + delete-old-on-save; "Save changes" label).
- `universal/src/lib/api.ts` — `SomaMealItem` gains `ingredient_id` + per-item macros.
- `universal/src/app/(main)/nutrition.tsx` — tappable meal rows, detail/edit state + handlers, render the modal.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (device locked; a composed meal fed via network interception): confirmed the detail modal (BREAKFAST + COMPOSE badges, 554 kcal, P48 C66 F11, ingredient list), Edit opening the composer **pre-filled** at the right grams with a "Save changes" button, and Save closing the modal (re-log + delete-old).

Closes #415
