### PR TITLE
App parity — Overview: clickable stat cards + detail dialogs

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View, RefreshControl } from "react-native";
+import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
+import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import {
   useToday,
   useTraining,
@@ -101,6 +102,7 @@ export default function OverviewScreen() {
     refetchPlan();
   });
 
+  const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
   const readiness = training?.readiness;
   const tsb = training?.pmc?.tsb ?? null;
 
@@ -117,13 +119,13 @@ export default function OverviewScreen() {
   const sleepLatest = sleepSeries.length ? sleepSeries[sleepSeries.length - 1] : null;
   const sleepAvg = sleep?.summary?.current_avg ?? null;
 
-  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string }[] = [
+  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string }[] = [
     { label: "Steps", value: (data?.total_steps ?? 0).toLocaleString(), sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1" },
-    { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850" },
-    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060" },
+    { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850", unit: "kcal" },
+    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060", unit: "bpm" },
     { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458" },
     { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${Math.abs(data?.body_battery_drained ?? 0)} drained`, cls: "text-lime", spark: trends?.bodyBattery, color: "#cbe896" },
-    { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0" },
+    { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0", unit: "min" },
   ];
 
   return (
@@ -206,19 +208,26 @@ export default function OverviewScreen() {
         <Text variant="eyebrow" className="text-text-muted mt-1">Today's metrics</Text>
         <View className="flex-row flex-wrap gap-3">
           {stats.map((s) => (
-            <Card key={s.label} className="min-w-[46%] flex-1 gap-1">
-              <Text variant="eyebrow">{s.label}</Text>
-              <Text variant="headline" className={s.cls}>{s.value}</Text>
-              <Text variant="micro">{s.sub}</Text>
-              {s.spark && s.spark.length >= 2 ? (
-                <View className="mt-1">
-                  <Sparkline data={s.spark} color={s.color} height={26} baseline />
+            <Pressable key={s.label} className="min-w-[46%] flex-1" onPress={() => setStatDetail(s)}>
+              <Card className="gap-1">
+                <View className="flex-row items-center justify-between">
+                  <Text variant="eyebrow">{s.label}</Text>
+                  <Text variant="micro" className="text-text-muted">›</Text>
                 </View>
-              ) : null}
-            </Card>
+                <Text variant="headline" className={s.cls}>{s.value}</Text>
+                <Text variant="micro">{s.sub}</Text>
+                {s.spark && s.spark.length >= 2 ? (
+                  <View className="mt-1">
+                    <Sparkline data={s.spark} color={s.color} height={26} baseline />
+                  </View>
+                ) : null}
+              </Card>
+            </Pressable>
           ))}
         </View>
       </View>
+
+      <StatDetailModal stat={statDetail} onClose={() => setStatDetail(null)} />
     </ScrollView>
   );
 }

--- a/universal/src/components/stat-detail-modal.tsx
+++ b/universal/src/components/stat-detail-modal.tsx
@@ -1,0 +1,51 @@
+import { View } from "react-native";
+import { Text, Modal } from "soma-style";
+import { LineChart } from "./line-chart";
+
+export interface StatDetail {
+  label: string;
+  value: string;
+  sub: string;
+  spark?: number[];
+  color: string;
+  /** Optional unit suffix for the axis labels (e.g. "bpm", "kcal"). */
+  unit?: string;
+}
+
+/** Detail dialog for an overview stat card: the current value + a full trend
+ *  chart (upgraded from the card's sparkline) with min / avg / max. */
+export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; onClose: () => void }) {
+  if (!stat) return null;
+  const s = (stat.spark ?? []).filter((v) => isFinite(v));
+  const min = s.length ? Math.min(...s) : null;
+  const max = s.length ? Math.max(...s) : null;
+  const avg = s.length ? s.reduce((a, b) => a + b, 0) / s.length : null;
+  const fmt = (v: number | null) => (v == null ? "–" : `${Math.round(v).toLocaleString()}${stat.unit ? ` ${stat.unit}` : ""}`);
+  return (
+    <Modal visible={!!stat} onClose={onClose} title={stat.label}>
+      <View className="gap-3">
+        <View className="flex-row items-end gap-2">
+          <Text variant="display" className="tabular-nums" style={{ color: stat.color }}>{stat.value}</Text>
+          <Text variant="body" className="mb-1 text-text-muted">{stat.sub}</Text>
+        </View>
+        {s.length >= 2 ? (
+          <View className="gap-1">
+            <Text variant="eyebrow" className="text-text-muted">Trend · last {s.length} days</Text>
+            <LineChart
+              height={160}
+              series={[{ values: s, color: stat.color, width: 2.2 }]}
+              yFormat={(v) => `${Math.round(v).toLocaleString()}`}
+            />
+            <View className="mt-1 flex-row justify-between">
+              <Text variant="micro" className="text-text-muted tabular-nums">min {fmt(min)}</Text>
+              <Text variant="micro" className="text-text-muted tabular-nums">avg {fmt(avg)}</Text>
+              <Text variant="micro" className="text-text-muted tabular-nums">max {fmt(max)}</Text>
+            </View>
+          </View>
+        ) : (
+          <Text variant="caption" className="text-text-muted">No trend data yet.</Text>
+        )}
+      </View>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## App parity — Overview: clickable stat cards + detail dialogs

Part of the app↔web parity build (umbrella #238), first sub of the Overview screen (#409). Addresses the parity-audit's systemic gap #1 — "nothing is clickable-to-detail" — for the overview's "Today's metrics" cards.

### What changed
- **`StatDetailModal`** (new): tapping a metric card opens a dialog with the current value (in the metric's color), its sub-label, a **full `LineChart` trend** (y-axis min/max labels — a real upgrade from the card's bare sparkline), and a **min / avg / max** summary with units.
- Each "Today's metrics" card (Steps, Active Calories, Resting HR, Avg Stress, Body Battery, Intensity) is now **Pressable** with a `›` affordance.

### Reuse
Uses the `LineChart` foundation (#419) inside the dialog and the tap-to-detail modal pattern established for meals (#415). No new endpoint — the trend series already come from `useOverviewTrends` (`/api/overview/trends`).

### Files
- `universal/src/components/stat-detail-modal.tsx` (new)
- `universal/src/app/(main)/overview.tsx` — tappable stat cards + a `unit` per stat; render the modal.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (device locked): confirmed the cards' `›` affordance and, on tapping **Resting HR**, the dialog with **50** + 48–159 bpm, a full 14-day LineChart (y-axis 57→48, red trend line), and **min 48 · avg 53 · max 57 bpm**.

Closes #410
