### PR TITLE
App parity — Overview: This Week training-summary card

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
+import { ThisWeekCard, type WeeklyTraining } from "../../components/this-week-card";
 import {
   useToday,
   useTraining,
@@ -69,6 +70,19 @@ function useSleepGlance() {
   return s;
 }
 
+/** This-week vs last-week training totals + streak for the This Week card. */
+function useWeeklyTraining() {
+  const [w, setW] = useState<WeeklyTraining | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<WeeklyTraining>("/api/overview/weekly-training")
+      .then((d) => alive && setW(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+  return w;
+}
+
 const TL_TONE: Record<string, "success" | "warm" | "danger" | "teal"> = {
   green: "success",
   amber: "warm",
@@ -96,6 +110,7 @@ export default function OverviewScreen() {
   const weight = useWeightTrend();
   const sleep = useSleepGlance();
   const trends = useOverviewTrends();
+  const weekly = useWeeklyTraining();
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
     refetchTraining();
@@ -175,6 +190,9 @@ export default function OverviewScreen() {
             </View>
           </Card>
         ) : null}
+
+        {/* This Week training summary */}
+        <ThisWeekCard data={weekly} />
 
         {/* Cross-domain glance row */}
         <View className="flex-row flex-wrap gap-3">

--- a/universal/src/components/this-week-card.tsx
+++ b/universal/src/components/this-week-card.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { View, Pressable } from "react-native";
+import { Text, Card, Badge, Modal } from "soma-style";
+
+interface WeekTotals { sessions: number; total_hours: number; total_km: number; total_cal: number }
+export interface WeeklyTraining { this_week: WeekTotals | null; last_week: WeekTotals | null; streak: number }
+
+type MetricKey = "sessions" | "total_hours" | "total_km" | "total_cal";
+const METRICS: { key: MetricKey; label: string; unit: string; fmt: (v: number) => string }[] = [
+  { key: "sessions", label: "Sessions", unit: "", fmt: (v) => String(Math.round(v)) },
+  { key: "total_hours", label: "Duration", unit: "h", fmt: (v) => v.toFixed(1) },
+  { key: "total_km", label: "Distance", unit: "km", fmt: (v) => String(Math.round(v)) },
+  { key: "total_cal", label: "Calories", unit: "kcal", fmt: (v) => Math.round(v).toLocaleString() },
+];
+
+const num = (t: WeekTotals) => ({
+  sessions: Number(t.sessions) || 0, total_hours: Number(t.total_hours) || 0,
+  total_km: Number(t.total_km) || 0, total_cal: Number(t.total_cal) || 0,
+});
+function pctChange(cur: number, prev: number | null): number | null {
+  if (prev == null || prev === 0) return null;
+  return Math.round(((cur - prev) / prev) * 100);
+}
+
+/** Overview "This Week" training summary: Sessions / Duration / Distance /
+ *  Calories with vs-last-week deltas + a streak badge; taps into a this-vs-last
+ *  comparison dialog. Mobile-adapted from the web InteractiveThisWeek. */
+export function ThisWeekCard({ data }: { data: WeeklyTraining | null }) {
+  const [open, setOpen] = useState(false);
+  if (!data || !data.this_week) return null;
+  const tw = num(data.this_week);
+  const lw = data.last_week ? num(data.last_week) : null;
+
+  return (
+    <>
+      <Pressable onPress={() => setOpen(true)}>
+        <Card className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">This week</Text>
+            {data.streak > 0 ? <Badge label={`${data.streak}-day streak`} tone="teal" /> : <Text variant="micro" className="text-text-muted">›</Text>}
+          </View>
+          <View className="flex-row flex-wrap gap-y-3">
+            {METRICS.map((m) => {
+              const cur = tw[m.key];
+              const pc = pctChange(cur, lw ? lw[m.key] : null);
+              return (
+                <View key={m.key} className="w-1/2 gap-0.5 pr-2">
+                  <Text variant="micro" className="text-text-muted">{m.label}</Text>
+                  <Text variant="headline" className="tabular-nums">{m.fmt(cur)}{m.unit ? ` ${m.unit}` : ""}</Text>
+                  {pc != null ? (
+                    <Text variant="micro" className={pc >= 0 ? "text-success" : "text-text-muted"}>{pc >= 0 ? "+" : ""}{pc}% vs last week</Text>
+                  ) : null}
+                </View>
+              );
+            })}
+          </View>
+        </Card>
+      </Pressable>
+
+      <Modal visible={open} onClose={() => setOpen(false)} title="This week vs last">
+        <View className="gap-1">
+          <View className="flex-row border-b border-border-subtle pb-1.5">
+            <Text variant="micro" className="flex-1 text-text-muted">Metric</Text>
+            <Text variant="micro" className="w-24 text-right text-text-muted">This week</Text>
+            <Text variant="micro" className="w-24 text-right text-text-muted">Last week</Text>
+          </View>
+          {METRICS.map((m) => {
+            const cur = tw[m.key];
+            const prev = lw ? lw[m.key] : null;
+            const pc = pctChange(cur, prev);
+            return (
+              <View key={m.key} className="flex-row items-center border-b border-border-subtle py-2">
+                <View className="flex-1">
+                  <Text variant="caption" className="text-text">{m.label}</Text>
+                  {pc != null ? <Text variant="micro" className={pc >= 0 ? "text-success" : "text-text-muted"}>{pc >= 0 ? "+" : ""}{pc}%</Text> : null}
+                </View>
+                <Text variant="caption" className="w-24 text-right tabular-nums">{m.fmt(cur)}{m.unit ? ` ${m.unit}` : ""}</Text>
+                <Text variant="caption" className="w-24 text-right tabular-nums text-text-muted">{prev != null ? `${m.fmt(prev)}${m.unit ? ` ${m.unit}` : ""}` : "–"}</Text>
+              </View>
+            );
+          })}
+          {data.streak > 0 ? (
+            <View className="mt-2 flex-row justify-center">
+              <Badge label={`${data.streak}-day training streak 🔥`} tone="teal" />
+            </View>
+          ) : null}
+        </View>
+      </Modal>
+    </>
+  );
+}

--- a/web/app/api/overview/weekly-training/route.ts
+++ b/web/app/api/overview/weekly-training/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * This-week vs last-week training summary + current training streak, for the
+ * overview "This Week" card (mobile app + anything else that needs the totals).
+ * Mirrors the server-side aggregation the web overview page computes inline.
+ */
+export async function GET() {
+  const sql = getDb();
+
+  const weekRows = await sql`
+    WITH week_data AS (
+      SELECT
+        CASE
+          WHEN (raw_json->>'startTimeLocal')::timestamp >= DATE_TRUNC('week', CURRENT_DATE)
+          THEN 'this_week'
+          ELSE 'last_week'
+        END as period,
+        (raw_json->>'duration')::float / 3600.0 as hours,
+        (raw_json->>'distance')::float / 1000.0 as km,
+        (raw_json->>'calories')::float as cal
+      FROM garmin_activity_raw
+      WHERE endpoint_name = 'summary'
+        AND (raw_json->>'startTimeLocal')::timestamp >= DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '7 days'
+    )
+    SELECT
+      period,
+      COUNT(*) as sessions,
+      ROUND(SUM(hours)::numeric, 1) as total_hours,
+      ROUND(SUM(km)::numeric, 0) as total_km,
+      ROUND(SUM(cal)::numeric, 0) as total_cal
+    FROM week_data
+    GROUP BY period
+  `;
+  const byPeriod: Record<string, unknown> = {};
+  for (const r of weekRows as Record<string, unknown>[]) byPeriod[String(r.period)] = r;
+
+  const dayRows = (await sql`
+    SELECT DISTINCT day FROM (
+      SELECT LEFT((raw_json->>'startTimeLocal')::text, 10) as day
+      FROM garmin_activity_raw WHERE endpoint_name = 'summary'
+      UNION
+      SELECT LEFT((raw_json->>'start_time')::text, 10) as day
+      FROM hevy_raw_data WHERE endpoint_name = 'workout'
+    ) combined
+    ORDER BY day DESC
+    LIMIT 90
+  `) as { day: string }[];
+
+  let streak = 0;
+  if (dayRows.length) {
+    const days = new Set(dayRows.map((r) => r.day));
+    const d = new Date();
+    const todayStr = d.toISOString().slice(0, 10);
+    if (!days.has(todayStr)) d.setDate(d.getDate() - 1);
+    while (days.has(d.toISOString().slice(0, 10))) {
+      streak++;
+      d.setDate(d.getDate() - 1);
+    }
+  }
+
+  return NextResponse.json({
+    this_week: byPeriod.this_week ?? null,
+    last_week: byPeriod.last_week ?? null,
+    streak,
+  });
+}


### PR DESCRIPTION
## App parity — Overview: This Week training-summary card

Part of the app↔web parity build (umbrella #238), Overview screen (#409). Adds the "This Week" training summary the app was missing.

### What changed
- **web**: `GET /api/overview/weekly-training` — returns this-week vs last-week `{sessions, total_hours, total_km, total_cal}` + the current training `streak`. This is the aggregation the web overview page (`page.tsx`) computed inline server-side; the app needs it as an endpoint. Read-only, `runtime = "edge"`, matches the existing nutrition/overview route patterns.
- **app**: **`ThisWeekCard`** (new) — Sessions / Duration / Distance / Calories with **"+X% vs last week"** deltas and a **streak badge**; tapping it opens a this-vs-last comparison dialog (per-metric table + streak). `useWeeklyTraining` hook feeds it.

### Mobile trim (web-only for now)
The day-by-day bar chart inside the web dialog (needs per-day data) — the this-vs-last table covers the comparison on mobile.

### Files
- `web/app/api/overview/weekly-training/route.ts` (new)
- `universal/src/components/this-week-card.tsx` (new)
- `universal/src/app/(main)/overview.tsx` — `useWeeklyTraining` hook + render the card.

### Verification
- App `tsc --noEmit` clean; **web `tsc --noEmit` clean** (Vercel CI gate); `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (device locked): confirmed the card (6-DAY STREAK badge; Sessions 5 +25%, Duration 6.4h +25%, Distance 42km +20%, Calories 3,820 +23% — deltas correct) and the comparison dialog (this-vs-last table + streak).

Closes #411
