### PR TITLE
App parity — Overview: Fitness Age + Total Activities (closes #413)

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -74,6 +74,20 @@ function useSleepGlance() {
   return s;
 }
 
+interface FitnessResp { fitness_age: number | null; chrono_age: number | null; achievable_age: number | null; total_activities: number }
+/** Garmin Fitness Age + lifetime activity count, from /api/overview/fitness. */
+function useOverviewFitness() {
+  const [f, setF] = useState<FitnessResp | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<FitnessResp>("/api/overview/fitness")
+      .then((d) => alive && setF(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+  return f;
+}
+
 interface Vo2maxResp { stats: { vo2max: number | null } | null; trends: { vo2max: number[] } }
 /** Current VO2max + its trend, from /api/running/stats. */
 function useVo2max() {
@@ -132,6 +146,7 @@ export default function OverviewScreen() {
   const vo2 = useVo2max();
   const recovery = useRecoverySummary("30d");
   const { data: activitiesDeep } = useActivitiesDeep("180d");
+  const fitness = useOverviewFitness();
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
     refetchTraining();
@@ -168,6 +183,7 @@ export default function OverviewScreen() {
     { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0", unit: "min" },
     { label: "VO₂max", value: vo2.current != null ? String(vo2.current) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1" },
     { label: "HRV", value: hrvLatest?.weekly_avg != null ? String(hrvLatest.weekly_avg) : "—", sub: hrvLatest?.status ? String(hrvLatest.status) : "7-night avg", cls: "text-lime", spark: hrvSpark, color: "#cbe896", unit: "ms" },
+    { label: "Total activities", value: fitness?.total_activities != null && fitness.total_activities > 0 ? fitness.total_activities.toLocaleString() : "—", sub: "all time", cls: "text-teal", color: "#77c8d1" },
   ];
 
   return (
@@ -220,6 +236,31 @@ export default function OverviewScreen() {
 
         {/* This Week training summary */}
         <ThisWeekCard data={weekly} />
+
+        {/* Fitness age */}
+        {fitness?.fitness_age != null ? (
+          <Card className="gap-2">
+            <Text variant="eyebrow">Fitness age</Text>
+            <View className="flex-row items-end gap-2">
+              <Text variant="display" className="text-teal tabular-nums">{Math.round(fitness.fitness_age)}</Text>
+              {fitness.chrono_age != null ? (
+                <Text variant="body" className={`mb-1 ${fitness.chrono_age - fitness.fitness_age >= 0 ? "text-success" : "text-warm"}`}>
+                  {Math.abs(Math.round(fitness.chrono_age - fitness.fitness_age))} yrs {fitness.chrono_age - fitness.fitness_age >= 0 ? "younger" : "older"}
+                </Text>
+              ) : null}
+            </View>
+            {fitness.chrono_age != null ? (
+              <>
+                <View className="h-2 overflow-hidden rounded-full" style={{ backgroundColor: "#16242c" }}>
+                  <View className="h-full rounded-full" style={{ width: `${Math.min((fitness.fitness_age / fitness.chrono_age) * 100, 100)}%`, backgroundColor: "#6ad4a0" }} />
+                </View>
+                <Text variant="micro" className="text-text-muted">
+                  chronological age {fitness.chrono_age}{fitness.achievable_age != null ? ` · achievable ${Math.round(fitness.achievable_age)}` : ""}
+                </Text>
+              </>
+            ) : null}
+          </Card>
+        ) : null}
 
         {/* Cross-domain glance row */}
         <View className="flex-row flex-wrap gap-3">

--- a/web/app/api/overview/fitness/route.ts
+++ b/web/app/api/overview/fitness/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "edge";
+
+/**
+ * Overview extras that the mobile app needs but were server-only on the web
+ * page: the latest Garmin Fitness Age (+ chronological/achievable) and the
+ * lifetime activity count (Garmin activities minus strength, plus Hevy).
+ */
+export async function GET() {
+  const sql = getDb();
+
+  const fitnessRows = await sql`
+    SELECT
+      (raw_json->>'fitnessAge')::float          as fitness_age,
+      (raw_json->>'chronologicalAge')::int      as chrono_age,
+      (raw_json->>'achievableFitnessAge')::float as achievable_age
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'fitnessage_data'
+      AND raw_json->>'fitnessAge' IS NOT NULL
+    ORDER BY date DESC
+    LIMIT 1
+  `;
+
+  const countRows = await sql`
+    SELECT
+      (SELECT COUNT(*) FROM garmin_activity_raw
+        WHERE endpoint_name = 'summary'
+          AND COALESCE(raw_json->'activityType'->>'typeKey', '') NOT IN ('strength_training', 'gym'))
+      +
+      (SELECT COUNT(*) FROM hevy_raw_data WHERE endpoint_name = 'workout') AS total
+  `;
+
+  const fitness = (fitnessRows as Record<string, unknown>[])[0] ?? null;
+  return NextResponse.json({
+    fitness_age: fitness ? (fitness.fitness_age ?? null) : null,
+    chrono_age: fitness ? (fitness.chrono_age ?? null) : null,
+    achievable_age: fitness ? (fitness.achievable_age ?? null) : null,
+    total_activities: Number((countRows as Record<string, unknown>[])[0]?.total ?? 0),
+  });
+}


### PR DESCRIPTION
## App parity — Overview: Fitness Age + Total Activities (closes #413)

Completes #413 (VO₂max + HRV shipped in #457) — the two remaining stats needed server data the app couldn't reach, so this adds one small read-only endpoint. With this, the whole **Overview** screen (#409) is at parity.

### What changed
- **web**: `GET /api/overview/fitness` — the latest Garmin **Fitness Age** (+ chronological + achievable, from `garmin_raw_data` `fitnessage_data`) and the **lifetime activity count** (Garmin activities minus strength, plus Hevy). `runtime = "edge"`, matches the `weekly-training` route.
- **app**:
  - **Fitness Age card** — age + "N yrs younger/older" + a progress bar + chronological/achievable, via a new `useOverviewFitness` hook.
  - **Total activities** stat in the Today's-metrics grid (all-time count).

### Files
- `web/app/api/overview/fitness/route.ts` (new)
- `universal/src/app/(main)/overview.tsx` — `useOverviewFitness` + the card + the stat.

### Verification
- App `tsc` clean, **web `tsc` clean** (Vercel gate), `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (device locked): the Fitness Age card (**32**, 5 yrs younger, progress bar, "chronological age 37 · achievable 29") and the **Total activities** stat (1,284, all time).

Closes #413
