### PR TITLE
App parity — Training: Fitness Trajectory chart (part of #421)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -17,6 +17,7 @@ import { TrainingSchedule } from "../../components/training-schedule";
 import { TrainingPaces } from "../../components/training-paces";
 import { RaceProtocol } from "../../components/race-protocol";
 import { TrainingTrends } from "../../components/training-trends";
+import { TrajectoryChart } from "../../components/trajectory-chart";
 import { PaceComputation } from "../../components/pace-computation";
 
 /** VO2max trend (last year, chronological) from the shared stats endpoint. */
@@ -179,6 +180,10 @@ export default function TrainingScreen() {
 
         {/* Pace computation breakdown — mobile replacement for the web DAG */}
         <PaceComputation nodes={graphNodes} />
+
+        {/* Fitness trajectory — the centerpiece: model vs Garmin across
+            Fitness (VDOT) / Readiness / Load. Replaces the flat VO2 sparkline. */}
+        <TrajectoryChart comparison={sim?.comparison ?? null} />
 
         {vo2Trend.length >= 2 ? (
           <Card className="gap-2">

--- a/universal/src/components/trajectory-chart.tsx
+++ b/universal/src/components/trajectory-chart.tsx
@@ -1,0 +1,74 @@
+import { useState, useMemo } from "react";
+import { View } from "react-native";
+import { Text, Card, SegmentedControl } from "soma-style";
+import { LineChart, ChartLegend } from "./line-chart";
+import type { ForwardSim } from "../lib/api";
+
+type Dim = "Fitness" | "Readiness" | "Load";
+const DIMS = ["Fitness", "Readiness", "Load"] as const;
+const CFG: Record<Dim, { keyA: string; keyB: string; labelA: string; labelB: string; colorA: string; colorB: string; unit: string; fmt: (v: number) => string }> = {
+  Fitness: { keyA: "ourVdot", keyB: "garminVo", labelA: "Model VDOT", labelB: "Garmin VO₂max", colorA: "#77c8d1", colorB: "#a9e4ec", unit: "", fmt: (v) => v.toFixed(1) },
+  Readiness: { keyA: "ourScore", keyB: "garminScore", labelA: "Our readiness", labelB: "Garmin", colorA: "#6ad4a0", colorB: "#cbe896", unit: "", fmt: (v) => String(Math.round(v)) },
+  Load: { keyA: "ctl", keyB: "atl", labelA: "Fitness (CTL)", labelB: "Fatigue (ATL)", colorA: "#77c8d1", colorB: "#e0a458", unit: "", fmt: (v) => String(Math.round(v)) },
+};
+
+function shortLabel(iso: string): string {
+  const [, m, d] = iso.slice(0, 10).split("-").map(Number);
+  return `${["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][(m ?? 1) - 1]} ${d}`;
+}
+
+/** Fitness trajectory: our-model line vs Garmin's, across Fitness (VDOT),
+ *  Readiness, and Load dimensions. Mobile-adapted from the web trajectory
+ *  chart — the goal-zone bands, taper band, and what-if line stay web-only
+ *  for now (the what-if belongs with #422). */
+export function TrajectoryChart({ comparison }: { comparison: ForwardSim["comparison"] }) {
+  const [dim, setDim] = useState<Dim>("Fitness");
+  const cfg = CFG[dim];
+  const src = useMemo(() => {
+    if (!comparison) return [];
+    return dim === "Fitness" ? comparison.fitness : dim === "Readiness" ? comparison.readiness : comparison.load;
+  }, [comparison, dim]);
+
+  const { labels, a, b, cur } = useMemo(() => {
+    const num = (p: Record<string, unknown>, k: string) => {
+      const v = Number(p[k]);
+      return isFinite(v) && v > 0 ? v : null;
+    };
+    const lbls = src.map((p) => shortLabel(String(p.date)));
+    const av = src.map((p) => num(p as Record<string, unknown>, cfg.keyA));
+    const bv = src.map((p) => num(p as Record<string, unknown>, cfg.keyB));
+    const last = [...av].reverse().find((v) => v != null) ?? null;
+    return { labels: lbls, a: av, b: bv, cur: last };
+  }, [src, cfg]);
+
+  if (!comparison) return null;
+
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Fitness trajectory</Text>
+        {cur != null ? <Text variant="body" className="text-teal tabular-nums">{cfg.fmt(cur)}{dim === "Fitness" ? " VDOT" : ""}</Text> : null}
+      </View>
+      <SegmentedControl options={DIMS} value={dim} onChange={(v) => setDim(v as Dim)} />
+      {a.some((v) => v != null) || b.some((v) => v != null) ? (
+        <>
+          <LineChart
+            height={170}
+            labels={labels}
+            yFormat={(v) => cfg.fmt(v)}
+            series={[
+              { values: b, color: cfg.colorB, width: 1.6, dashed: dim !== "Load" },
+              { values: a, color: cfg.colorA, width: 2.4 },
+            ]}
+          />
+          <ChartLegend items={[
+            { color: cfg.colorA, label: cfg.labelA },
+            { color: cfg.colorB, label: cfg.labelB, dashed: dim !== "Load" },
+          ]} />
+        </>
+      ) : (
+        <Text variant="caption" className="text-text-muted">Not enough {dim.toLowerCase()} history yet.</Text>
+      )}
+    </Card>
+  );
+}


### PR DESCRIPTION
## App parity — Training: Fitness Trajectory chart (part of #421)

Part of the app↔web parity build (umbrella #238), Training screen (#420). The app training screen had only a flat VO₂max sparkline; this adds the real fitness-trajectory chart (the screen's centerpiece). **Partial progress on #421** — it delivers the multi-dimension trajectory but not the full web feature set (see "Deferred").

### What changed
- **`TrajectoryChart`** (new): a multi-line `LineChart` of the **model line vs Garmin** across three dimensions, switched with a `SegmentedControl`:
  - **Fitness** — model VDOT vs Garmin VO₂max
  - **Readiness** — our percentile vs Garmin
  - **Load** — Fitness (CTL) vs Fatigue (ATL)
  - with a current-value header and a legend.
- Replaces the flat VO₂max sparkline on the training screen. Built on the existing `useForwardSim` comparison data — **no new endpoint**.

### Deferred (web-only for now, per the parity-audit triage)
Goal-zone A/B/C bands with HM times, taper band, race markers, S-curve inflection, the rich hover tooltip, and the 7-line visibility dropdown. The **what-if line** belongs with **#422**.

### Files
- `universal/src/components/trajectory-chart.tsx` (new)
- `universal/src/app/(main)/training.tsx` — render it as the centerpiece.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (device locked; against real production forward-sim data): the **Fitness** view (58.2 VDOT header, Model VDOT + Garmin VO₂max lines, dated axis, legend) and the **Load** view (CTL vs ATL, header 34) — the dimension toggle switches chart + value + legend correctly.

Part of #421
