### PR TITLE
App parity — Training: external-signals reference panel (part of #424)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
 import {
@@ -18,6 +18,7 @@ import { TrainingPaces } from "../../components/training-paces";
 import { RaceProtocol } from "../../components/race-protocol";
 import { TrainingTrends } from "../../components/training-trends";
 import { TrajectoryChart } from "../../components/trajectory-chart";
+import { ReferencePanel, type RefMetric } from "../../components/reference-panel";
 import { PaceComputation } from "../../components/pace-computation";
 
 /** VO2max trend (last year, chronological) from the shared stats endpoint. */
@@ -85,6 +86,26 @@ export default function TrainingScreen() {
   const readiness = data?.readiness;
   const vdot = fit?.vdot_adjusted ?? sim?.fitness?.vdotAdjusted ?? null;
   const vo2Trend = useVo2Trend();
+
+  // External comparison signals (Garmin-side + PMC) with trend sparklines.
+  const refMetrics: RefMetric[] = useMemo(() => {
+    const c = sim?.comparison;
+    const nums = (arr: { [k: string]: number | string }[] | undefined, key: string) =>
+      (arr ?? []).map((p) => Number(p[key])).filter((v) => isFinite(v) && v > 0);
+    const last = (a: number[]) => (a.length ? a[a.length - 1] : 0);
+    const m: RefMetric[] = [];
+    const gv = nums(c?.fitness, "garminVo");
+    if (gv.length) m.push({ label: "Garmin VO₂max", value: last(gv).toFixed(1), spark: gv, color: "#a9e4ec" });
+    const gs = nums(c?.readiness, "garminScore");
+    if (gs.length) m.push({ label: "Garmin readiness", value: String(Math.round(last(gs))), spark: gs, color: "#cbe896" });
+    const ctl = nums(c?.load, "ctl");
+    if (ctl.length) m.push({ label: "Fitness (CTL)", value: String(Math.round(last(ctl))), spark: ctl, color: "#77c8d1" });
+    const atl = nums(c?.load, "atl");
+    if (atl.length) m.push({ label: "Fatigue (ATL)", value: String(Math.round(last(atl))), spark: atl, color: "#e0a458" });
+    const dec = (fit as { decoupling_pct?: number | null } | undefined)?.decoupling_pct;
+    if (dec != null) m.push({ label: "Decoupling", value: `${Number(dec).toFixed(1)}%`, spark: [], color: "#6366b0", note: "aerobic drift" });
+    return m;
+  }, [sim, fit]);
 
   async function onToggleWeighting(mode: "Adaptive" | "Equal") {
     const ok = await toggleCalibration(mode === "Equal");
@@ -197,6 +218,9 @@ export default function TrainingScreen() {
 
         {/* Compact model-vs-Garmin comparison trends (Tier 2/3 adapted) */}
         <TrainingTrends comparison={sim?.comparison} />
+
+        {/* External comparison signals (reference, with trend sparklines) */}
+        <ReferencePanel metrics={refMetrics} />
 
         {readiness ? (
           <Card className="gap-2">

--- a/universal/src/components/reference-panel.tsx
+++ b/universal/src/components/reference-panel.tsx
@@ -1,0 +1,37 @@
+import { View } from "react-native";
+import { Text, Card, Sparkline } from "soma-style";
+
+export interface RefMetric {
+  label: string;
+  value: string;
+  spark: number[];
+  color: string;
+  note?: string;
+}
+
+/** "External comparison signals" — Garmin-side + PMC metrics shown for
+ *  reference (not part of the model), each with a trend sparkline.
+ *  Mobile-adapted from the web ReferencePanel. */
+export function ReferencePanel({ metrics }: { metrics: RefMetric[] }) {
+  if (!metrics.length) return null;
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">External signals</Text>
+        <Text variant="micro" className="text-text-muted">reference · not the model</Text>
+      </View>
+      <View className="flex-row flex-wrap gap-3">
+        {metrics.map((m) => (
+          <View key={m.label} className="min-w-[46%] flex-1 gap-1 rounded-lg border border-border-subtle p-2.5">
+            <Text variant="micro" className="text-text-muted">{m.label}</Text>
+            <View className="flex-row items-center justify-between gap-2">
+              <Text variant="body" className="tabular-nums" style={{ color: m.color }}>{m.value}</Text>
+              {m.spark.length >= 2 ? <Sparkline data={m.spark} color={m.color} height={20} baseline /> : null}
+            </View>
+            {m.note ? <Text variant="micro" className="text-text-muted">{m.note}</Text> : null}
+          </View>
+        ))}
+      </View>
+    </Card>
+  );
+}


### PR DESCRIPTION
## App parity — Training: external-signals reference panel (part of #424)

Part of the app↔web parity build (umbrella #238), Training screen (#420). Adds the "External signals" reference panel. **Partial progress on #424** — the race header and matched-activity side panel are deferred (see below).

### What changed
- **`ReferencePanel`** (new): a grid of reference metric cards — Garmin VO₂max, Garmin readiness, Fitness (CTL), Fatigue (ATL), Decoupling — each with the current value + a trend sparkline. Framed as "reference · not the model", mirroring the web's "External Comparison Signals". Built on the existing `useForwardSim` comparison data — **no new endpoint**.

### Deferred (follow-up, per the parity-audit triage)
- **Race header** (plan name / days-to-race / week X/Y) — the app doesn't expose race-plan data yet (would need a small endpoint).
- **Matched-activity side panel** (score ring, pace/distance/HR compliance bars, plan-vs-actual table, Garmin link) — a larger, separate piece.

### Files
- `universal/src/components/reference-panel.tsx` (new)
- `universal/src/app/(main)/training.tsx` — compute the metrics from `sim.comparison` + `fit`; render the panel.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright: the "External signals" panel with 4 cards + trend sparklines (Garmin VO₂max 52.1, Garmin readiness 53, Fitness CTL 55, Fatigue ATL 45); the Decoupling card is data-dependent (renders when `decoupling_pct` is present). (The OPPO re-locked during the build — its Face-recognition auto-locks — so I verified on web; the APK is installed for a native look.)

Part of #424
