### PR TITLE
App parity — Sleep: summary cards to full-chart (part of #432)

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View, RefreshControl } from "react-native";
+import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
+import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule, useWeekdayWeekend } from "../../lib/api";
 import { SleepDashboard } from "../../components/sleep-dashboard";
 import { RecoveryVitals } from "../../components/recovery-vitals";
@@ -101,6 +102,7 @@ function delta(series: StatSeries | null): number | null {
 
 export default function SleepScreen() {
   const [range, setRange] = useState<Range>("30d");
+  const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
   const { sleep, rhr, stress, battery, recovery, loading, error, refetch } =
     useSleepRecovery(range);
   const { data: sleepSum } = useSleepSummary(range);
@@ -139,6 +141,7 @@ export default function SleepScreen() {
     sub: string;
     cls: string;
     spark?: { data: number[]; color: string };
+    unit?: string;
   }[] = [
     {
       label: "Avg Sleep",
@@ -146,6 +149,7 @@ export default function SleepScreen() {
       sub: `${fmt1(sleep?.summary.current_min, "h")}–${fmt1(sleep?.summary.current_max, "h")}`,
       cls: "text-indigo",
       spark: { data: seriesVals(sleep?.current), color: "#6366b0" },
+      unit: "h",
     },
     {
       label: "Last Night",
@@ -162,6 +166,7 @@ export default function SleepScreen() {
           : `${rhrDelta >= 0 ? "+" : ""}${rhrDelta.toFixed(1)} vs prev`,
       cls: "text-danger",
       spark: { data: seriesVals(rhr?.current), color: "#e06060" },
+      unit: "bpm",
     },
     {
       label: "HRV (weekly)",
@@ -169,6 +174,7 @@ export default function SleepScreen() {
       sub: hrvLatest?.last_night_avg != null ? `last night ${hrvLatest.last_night_avg} ms` : "weekly avg",
       cls: "text-lime",
       spark: { data: hrvTrend, color: "#cbe896" },
+      unit: "ms",
     },
   ];
 
@@ -210,20 +216,33 @@ export default function SleepScreen() {
 
         {/* Summary stat cards */}
         <View className="flex-row flex-wrap gap-3">
-          {summaryCards.map((s) => (
-            <Card key={s.label} className="min-w-[46%] flex-1 gap-1">
-              <Text variant="eyebrow">{s.label}</Text>
-              <Text variant="headline" className={s.cls}>
-                {s.value}
-              </Text>
-              <Text variant="micro">{s.sub}</Text>
-              {s.spark && s.spark.data.length >= 2 ? (
-                <View className="mt-1">
-                  <Sparkline data={s.spark.data} color={s.spark.color} height={26} baseline />
-                </View>
-              ) : null}
-            </Card>
-          ))}
+          {summaryCards.map((s) => {
+            const tappable = !!(s.spark && s.spark.data.length >= 2);
+            return (
+              <Pressable
+                key={s.label}
+                className="min-w-[46%] flex-1"
+                disabled={!tappable}
+                onPress={() => s.spark && setStatDetail({ label: s.label, value: s.value, sub: s.sub, spark: s.spark.data, color: s.spark.color, unit: s.unit })}
+              >
+                <Card className="gap-1">
+                  <View className="flex-row items-center justify-between">
+                    <Text variant="eyebrow">{s.label}</Text>
+                    {tappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+                  </View>
+                  <Text variant="headline" className={s.cls}>
+                    {s.value}
+                  </Text>
+                  <Text variant="micro">{s.sub}</Text>
+                  {tappable && s.spark ? (
+                    <View className="mt-1">
+                      <Sparkline data={s.spark.data} color={s.spark.color} height={26} baseline />
+                    </View>
+                  ) : null}
+                </Card>
+              </Pressable>
+            );
+          })}
         </View>
 
         {/* Sleep dashboard — last night + stages + score (new /api/sleep/summary) */}
@@ -357,6 +376,8 @@ export default function SleepScreen() {
           </Card>
         </View>
       </View>
+
+      <StatDetailModal stat={statDetail} onClose={() => setStatDetail(null)} />
     </ScrollView>
   );
 }


### PR DESCRIPTION
## App parity — Sleep: summary cards → tap-to-full-chart (part of #432)

Part of the app↔web parity build (umbrella #238), Sleep screen (#430). Upgrades the sleep summary stat cards from bare sparklines to tappable full-trend dialogs — the "upgrade sparklines to full charts + expand" for those cards. **Partial progress on #432.**

### What changed
- The sleep summary cards (**Avg Sleep**, **Resting HR**, **HRV**) are now **Pressable** (with a `›` affordance) and open a **`StatDetailModal`** — the full `LineChart` trend + min/avg/max — reusing the component from Overview #410. This is the mobile "expand to full chart".

### Already covered / deferred
- HRV / SpO₂ / Respiration already render as fuller charts via their own components (`RecoveryVitals` / `SleepRespiratory`).
- The dedicated **Sleep Stages** full chart and an explicit expand control on those cards remain a follow-up.

### Files
- `universal/src/app/(main)/sleep.tsx` — tappable summary cards + a `unit` per card; render `StatDetailModal`.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright: tapping **Avg Sleep** opens the dialog with a full 30-day `LineChart` (y 72→54) + min 54 · avg 63 · max 72 h.

Part of #432
