### PR TITLE
App parity — Workouts: chart fidelity + stat detail (part of #429)

### DIFF
--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,7 +1,8 @@
-import { ScrollView, View, RefreshControl } from "react-native";
+import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
 import { fetchJson, usePullRefresh, useWorkoutsSummary } from "../../lib/api";
+import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { WorkoutsDashboard } from "../../components/workouts-dashboard";
 
 interface RecentWorkout {
@@ -60,6 +61,7 @@ export default function WorkoutsScreen() {
   const [range, setRange] = useState<"30d" | "90d" | "1y">("90d");
   const { data: wkSum } = useWorkoutsSummary(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
+  const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
 
   const recent = data?.recent ?? [];
   const totalSynced = data?.totalSynced ?? 0;
@@ -136,20 +138,33 @@ export default function WorkoutsScreen() {
 
         {/* Summary stats */}
         <View className="flex-row flex-wrap gap-3">
-          {stats.map((s) => (
-            <Card key={s.label} className="min-w-[46%] flex-1 gap-1">
-              <Text variant="eyebrow">{s.label}</Text>
-              <Text variant="headline" className={s.cls}>
-                {s.value}
-              </Text>
-              <Text variant="micro">{s.sub}</Text>
-              {s.spark && s.spark.data.length >= 2 ? (
-                <View className="mt-1">
-                  <Sparkline data={s.spark.data} color={s.spark.color} height={24} baseline />
-                </View>
-              ) : null}
-            </Card>
-          ))}
+          {stats.map((s) => {
+            const tappable = !!(s.spark && s.spark.data.length >= 2);
+            return (
+              <Pressable
+                key={s.label}
+                className="min-w-[46%] flex-1"
+                disabled={!tappable}
+                onPress={() => s.spark && setStatDetail({ label: s.label, value: s.value, sub: s.sub, spark: s.spark.data, color: s.spark.color, unit: s.label === "Avg Calories" ? "kcal" : undefined })}
+              >
+                <Card className="gap-1">
+                  <View className="flex-row items-center justify-between">
+                    <Text variant="eyebrow">{s.label}</Text>
+                    {tappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+                  </View>
+                  <Text variant="headline" className={s.cls}>
+                    {s.value}
+                  </Text>
+                  <Text variant="micro">{s.sub}</Text>
+                  {tappable && s.spark ? (
+                    <View className="mt-1">
+                      <Sparkline data={s.spark.data} color={s.spark.color} height={24} baseline />
+                    </View>
+                  ) : null}
+                </Card>
+              </Pressable>
+            );
+          })}
         </View>
 
         {/* Workout data — volume, stats, top exercises, recent (new /api/workouts/summary) */}
@@ -179,6 +194,8 @@ export default function WorkoutsScreen() {
         ) : null}
 
       </View>
+
+      <StatDetailModal stat={statDetail} onClose={() => setStatDetail(null)} />
     </ScrollView>
   );
 }

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -1,6 +1,7 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
 import type { WorkoutSummary } from "../lib/api";
+import { LineChart } from "./line-chart";
 
 const num = (v: unknown): number => {
   const n = Number(v);
@@ -14,20 +15,19 @@ function kvol(v: number): string {
   return v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${v}`;
 }
 
-/** Weekly training-volume bars, peak highlighted. */
+/** Weekly training-volume as a full trend chart (axes + dated x-labels). */
 function VolumeChart({ weeks }: { weeks: WorkoutSummary["weeklyVolume"] }) {
-  const data = weeks.map((w) => num(w.total_volume)).filter((v) => v > 0).slice(-16);
-  if (data.length < 2) return null;
-  const max = Math.max(...data) || 1;
-  const maxIdx = data.indexOf(max);
+  const recent = weeks.slice(-16);
+  const vals = recent.map((w) => num(w.total_volume));
+  if (vals.filter((v) => v > 0).length < 2) return null;
+  const labels = recent.map((w) => shortDate(String(w.week)));
   return (
-    <View className="h-24 flex-row items-end gap-1">
-      {data.map((v, i) => (
-        <View key={i} className="flex-1 items-center justify-end self-stretch">
-          <View className="w-full rounded-t-sm" style={{ height: `${Math.max(3, (v / max) * 100)}%`, backgroundColor: i === maxIdx ? "#77c8d1" : "#2f4a58" }} />
-        </View>
-      ))}
-    </View>
+    <LineChart
+      height={130}
+      labels={labels}
+      yFormat={(v) => kvol(v)}
+      series={[{ values: vals.map((v) => (v > 0 ? v : null)), color: "#77c8d1", width: 2.4 }]}
+    />
   );
 }
 


### PR DESCRIPTION
## App parity — Workouts: chart fidelity + stat detail (part of #429)

Part of the app↔web parity build (umbrella #238), Workouts screen (#425) — first contribution. **Partial progress on #429.** Reuses existing data (no new endpoint).

### What changed
- **Weekly Volume** — upgraded from plain bars to a full **`LineChart`** (y-axis labels + dated x-axis + peak marker) in `workouts-dashboard.tsx`.
- **Avg Calories** stat card is now **Pressable** (with a `›` affordance) into the reused **`StatDetailModal`** (full trend LineChart + min/avg/max).

### Deferred (remaining Workouts subs)
Muscle Activation Map + Monthly Volume by Muscle (#426), Strength Progression + PRs + Program Split (#427), Training Calendar + Weekly Frequency + Avg-HR chart (#428), and per-workout/exercise detail modals + drill-ins (#429).

### Files
- `universal/src/app/(main)/workouts.tsx` — tappable stat cards + `StatDetailModal`.
- `universal/src/components/workouts-dashboard.tsx` — VolumeChart → LineChart.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright: the Weekly Volume LineChart (y 29.2k→19.7k, dated axis) and tapping Avg Calories → the dialog (419 kcal, 12-day trend, min 380·avg 419·max 457).

Part of #429
