### PR TITLE
App parity — Sleep: schedule chart + expandable charts + stats/qualifiers (#430)

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
-import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
+import { Text, Card, Badge, SegmentedControl, Sparkline } from "soma-style";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { LineChart, ChartLegend } from "../../components/line-chart";
 import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule, useWeekdayWeekend } from "../../lib/api";
@@ -9,6 +9,7 @@ import { RecoveryVitals } from "../../components/recovery-vitals";
 import { SleepRespiratory } from "../../components/sleep-respiratory";
 import { SleepRegularity } from "../../components/sleep-regularity";
 import { SleepWeekdayWeekend } from "../../components/sleep-weekday-weekend";
+import { SleepScheduleChart } from "../../components/sleep-schedule-chart";
 
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
@@ -137,10 +138,6 @@ export default function SleepScreen() {
   const sleepDelta = delta(sleep);
   const rhrDelta = delta(rhr);
 
-  // Sparse bar visualisation of the sleep-hours series (approximates the web chart).
-  const sleepBars = (sleep?.current ?? []).slice(-14);
-  const maxHours = Math.max(9, ...sleepBars.map((p) => p.value ?? 0));
-
   const summaryCards: {
     label: string;
     value: string;
@@ -184,6 +181,48 @@ export default function SleepScreen() {
     },
   ];
 
+  // Range-average headline stats sourced from /api/sleep/summary (parity with
+  // the web stat row: Avg Score / Avg Deep % / Avg Sleep HR).
+  const st = sleepSum?.stats;
+  const scoreSeries = (sleepSum?.trend ?? []).map((n) => n.score).filter((v): v is number => v != null);
+  const deepPctSeries = (sleepSum?.trend ?? [])
+    .map((n) => (n.total && n.total > 0 && n.deep != null ? (n.deep / n.total) * 100 : null))
+    .filter((v): v is number => v != null);
+  const sleepHrSeries = (sleepSum?.trend ?? []).map((n) => n.hr).filter((v): v is number => v != null);
+  const extraCards: typeof summaryCards = st
+    ? [
+        {
+          label: "Avg Score",
+          value: fmt0(st.avg_score),
+          sub: "out of 100",
+          cls: "text-indigo",
+          spark: scoreSeries.length >= 2 ? { data: scoreSeries, color: "#a5b4fc" } : undefined,
+        },
+        {
+          label: "Avg Deep",
+          value: fmt0(st.avg_deep_pct, "%"),
+          sub: st.avg_rem_pct != null ? `REM ${Math.round(st.avg_rem_pct)}%` : "of sleep",
+          cls: "text-teal",
+          spark: deepPctSeries.length >= 2 ? { data: deepPctSeries, color: "#c084fc" } : undefined,
+          unit: "%",
+        },
+        {
+          label: "Avg Sleep HR",
+          value: fmt0(st.avg_sleep_hr, " bpm"),
+          sub: st.avg_spo2 != null ? `SpO₂ ${Math.round(st.avg_spo2)}%` : "during sleep",
+          cls: "text-danger",
+          spark: sleepHrSeries.length >= 2 ? { data: sleepHrSeries, color: "#e06060" } : undefined,
+          unit: "bpm",
+        },
+      ]
+    : [];
+  const allCards = [...summaryCards, ...extraCards];
+
+  // Sleep-duration-per-night series for the full-chart upgrade (was a bar list).
+  const durSeries = (sleep?.current ?? []).map((p) => finiteOrNull(p.value));
+  const durLabels = (sleep?.current ?? []).map((p) => chartLabel(p.date));
+  const durVals = durSeries.filter((v): v is number => v != null);
+
   return (
     <ScrollView
       className="flex-1 bg-base"
@@ -222,7 +261,7 @@ export default function SleepScreen() {
 
         {/* Summary stat cards */}
         <View className="flex-row flex-wrap gap-3">
-          {summaryCards.map((s) => {
+          {allCards.map((s) => {
             const tappable = !!(s.spark && s.spark.data.length >= 2);
             return (
               <Pressable
@@ -303,13 +342,16 @@ export default function SleepScreen() {
         ) : null}
 
         {/* Sleep dashboard — last night + stages + score (new /api/sleep/summary) */}
-        <SleepDashboard summary={sleepSum} />
+        <SleepDashboard summary={sleepSum} onExpand={setStatDetail} />
 
         {/* Recovery vitals — HRV + training readiness (new /api/recovery/summary) */}
-        <RecoveryVitals summary={recoveryVitals} />
+        <RecoveryVitals summary={recoveryVitals} onExpand={setStatDetail} />
 
         {/* Blood oxygen + respiration (new /api/sleep/respiratory) */}
-        <SleepRespiratory data={respiratory} />
+        <SleepRespiratory data={respiratory} onExpand={setStatDetail} />
+
+        {/* Sleep schedule — per-night bedtime → wake band (new /api/sleep/schedule) */}
+        <SleepScheduleChart schedule={schedule?.schedule} />
 
         {/* Sleep regularity — bedtime/wake consistency (new /api/sleep/schedule) */}
         <SleepRegularity data={schedule} />
@@ -317,45 +359,53 @@ export default function SleepScreen() {
         {/* Weekday vs weekend comparison (new /api/sleep/weekday-weekend) */}
         <SleepWeekdayWeekend data={weekdayWeekend} />
 
-        {/* Sleep duration trend (bar approximation) */}
-        <Card className="gap-3">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Sleep duration</Text>
-            {sleepDelta != null ? (
-              <Text
-                variant="caption"
-                className={`tabular-nums ${sleepDelta >= 0 ? "text-success" : "text-warning"}`}
-              >
-                {sleepDelta >= 0 ? "+" : ""}
-                {sleepDelta.toFixed(1)}h vs prev
-              </Text>
-            ) : null}
-          </View>
-          {sleepBars.length ? (
-            sleepBars.map((p) => (
-              <View key={p.date} className="gap-1">
-                <View className="flex-row justify-between">
-                  <Text variant="micro" className="text-text-muted">
-                    {p.date.slice(5)}
-                  </Text>
-                  <Text variant="micro" className="tabular-nums text-text">
-                    {fmt1(p.value, "h")}
-                  </Text>
-                </View>
-                <ProgressBar
-                  pct={(p.value ?? 0) / maxHours}
-                  color={(p.value ?? 0) >= 7 ? "#6ad4a0" : "#e0a458"}
-                />
+        {/* Sleep duration trend — full chart with 7h target line, tap to expand */}
+        <Pressable
+          disabled={durVals.length < 2}
+          onPress={() =>
+            durVals.length >= 2 &&
+            setStatDetail({
+              label: "Sleep duration",
+              value: fmt1(sleep?.summary.current_avg, "h"),
+              sub: `avg · last ${durVals.length} nights`,
+              spark: durVals,
+              color: "#6ad4a0",
+              unit: "h",
+            })
+          }
+        >
+          <Card className="gap-3">
+            <View className="flex-row items-center justify-between">
+              <View className="flex-row items-center gap-1.5">
+                <Text variant="eyebrow">Sleep duration</Text>
+                {durVals.length >= 2 ? <Text variant="micro" className="text-text-muted">›</Text> : null}
               </View>
-            ))
-          ) : (
-            <Text variant="micro">No sleep data in this range.</Text>
-          )}
-          <Text variant="micro">
-            Green ≥ 7h · amber below target. Showing last{" "}
-            {sleepBars.length} nights.
-          </Text>
-        </Card>
+              {sleepDelta != null ? (
+                <Text
+                  variant="caption"
+                  className={`tabular-nums ${sleepDelta >= 0 ? "text-success" : "text-warning"}`}
+                >
+                  {sleepDelta >= 0 ? "+" : ""}
+                  {sleepDelta.toFixed(1)}h vs prev
+                </Text>
+              ) : null}
+            </View>
+            {durVals.length >= 2 ? (
+              <LineChart
+                height={140}
+                labels={durLabels}
+                yFormat={(v) => `${v.toFixed(1)}h`}
+                refLine={{ y: 7, color: "#6ad4a0" }}
+                series={[{ values: durSeries, color: "#8b9df0", width: 2.2 }]}
+              />
+            ) : (
+              <Text variant="micro">No sleep data in this range.</Text>
+            )}
+            <Text variant="micro">
+              Dashed line = 7h target. Showing last {durVals.length} nights.
+            </Text>
+          </Card>
+        </Pressable>
 
         {/* Recovery signals */}
         <Card className="gap-2">

--- a/universal/src/components/recovery-vitals.tsx
+++ b/universal/src/components/recovery-vitals.tsx
@@ -1,6 +1,7 @@
-import { View } from "react-native";
+import { View, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
 import type { RecoverySummary } from "../lib/api";
+import type { StatDetail } from "./stat-detail-modal";
 
 const HRV_TONE: Record<string, "success" | "warm" | "danger" | "teal"> = {
   BALANCED: "success",
@@ -15,11 +16,18 @@ const RDY_TONE = (level: string | null): "success" | "warm" | "danger" | "teal" 
 };
 
 /** HRV + training-readiness cards (recovery vitals), fed by /api/recovery/summary. */
-export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | undefined }) {
+export function RecoveryVitals({
+  summary,
+  onExpand,
+}: {
+  summary: RecoverySummary | null | undefined;
+  onExpand?: (s: StatDetail) => void;
+}) {
   if (!summary) return null;
   const hrv = summary.hrv.latest;
   const rdy = summary.readiness.latest;
   const hrvSeries = summary.hrv.trend.map((p) => p.weekly_avg).filter((v): v is number => v != null);
+  const hrvTappable = !!(onExpand && hrvSeries.length >= 2);
 
   const factors: { label: string; v: number | null; color: string }[] = rdy
     ? [
@@ -36,20 +44,37 @@ export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | 
   return (
     <View className="gap-4">
       {hrv ? (
-        <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Heart rate variability</Text>
-            {hrv.status ? <Badge label={hrv.status} tone={HRV_TONE[hrv.status] ?? "teal"} /> : null}
-          </View>
-          <View className="flex-row items-end gap-2">
-            <Text variant="display" className="text-teal">{hrv.weekly_avg ?? "—"}</Text>
-            <Text variant="caption" className="text-text-muted mb-1">ms weekly avg</Text>
-            {hrv.last_night_avg != null ? (
-              <Text variant="micro" className="text-text-muted mb-1">· last night {hrv.last_night_avg}</Text>
-            ) : null}
-          </View>
-          {hrvSeries.length >= 2 ? <Sparkline data={hrvSeries} color="#77c8d1" height={36} baseline /> : null}
-        </Card>
+        <Pressable
+          disabled={!hrvTappable}
+          onPress={() =>
+            onExpand?.({
+              label: "Heart rate variability",
+              value: hrv.weekly_avg != null ? `${hrv.weekly_avg} ms` : "—",
+              sub: hrv.last_night_avg != null ? `last night ${hrv.last_night_avg} ms` : "weekly avg",
+              spark: hrvSeries,
+              color: "#77c8d1",
+              unit: "ms",
+            })
+          }
+        >
+          <Card className="gap-2">
+            <View className="flex-row items-center justify-between">
+              <Text variant="eyebrow">Heart rate variability</Text>
+              <View className="flex-row items-center gap-1.5">
+                {hrv.status ? <Badge label={hrv.status} tone={HRV_TONE[hrv.status] ?? "teal"} /> : null}
+                {hrvTappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+              </View>
+            </View>
+            <View className="flex-row items-end gap-2">
+              <Text variant="display" className="text-teal">{hrv.weekly_avg ?? "—"}</Text>
+              <Text variant="caption" className="text-text-muted mb-1">ms weekly avg</Text>
+              {hrv.last_night_avg != null ? (
+                <Text variant="micro" className="text-text-muted mb-1">· last night {hrv.last_night_avg}</Text>
+              ) : null}
+            </View>
+            {hrvSeries.length >= 2 ? <Sparkline data={hrvSeries} color="#77c8d1" height={36} baseline /> : null}
+          </Card>
+        </Pressable>
       ) : null}
 
       {rdy ? (

--- a/universal/src/components/sleep-dashboard.tsx
+++ b/universal/src/components/sleep-dashboard.tsx
@@ -1,11 +1,20 @@
-import { View } from "react-native";
-import { Text, Card, Sparkline } from "soma-style";
+import { View, Pressable } from "react-native";
+import { Text, Card, Sparkline, Badge } from "soma-style";
 import type { SleepSummary, SleepNight } from "../lib/api";
+import type { StatDetail } from "./stat-detail-modal";
 
 const DEEP = "#4f46e5";
 const LIGHT = "#a5b4fc";
 const REM = "#c084fc";
 const AWAKE = "#f87171";
+
+/** Garmin-style sleep-score qualifier band, derived from the 0-100 score. */
+function scoreQualifier(score: number): { label: string; tone: "success" | "warm" | "danger" } {
+  if (score >= 80) return { label: "Excellent", tone: "success" };
+  if (score >= 60) return { label: "Good", tone: "success" };
+  if (score >= 40) return { label: "Fair", tone: "warm" };
+  return { label: "Poor", tone: "danger" };
+}
 
 function hm(sec: number | null | undefined): string {
   if (sec == null) return "—";
@@ -77,17 +86,28 @@ function Legend() {
 }
 
 /** Sleep dashboard: last-night detail + stages trend + score trend. Fed by /api/sleep/summary. */
-export function SleepDashboard({ summary }: { summary: SleepSummary | null | undefined }) {
+export function SleepDashboard({
+  summary,
+  onExpand,
+}: {
+  summary: SleepSummary | null | undefined;
+  onExpand?: (s: StatDetail) => void;
+}) {
   if (!summary) return null;
   const ln = summary.lastNight;
   const scores = summary.trend.map((n) => n.score).filter((v): v is number => v != null);
+  const lnQual = ln?.score != null ? scoreQualifier(ln.score) : null;
+  const scoreTappable = !!(onExpand && scores.length >= 2);
 
   return (
     <View className="gap-4">
       {ln ? (
         <Card className="gap-3">
           <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Last night</Text>
+            <View className="flex-row items-center gap-2">
+              <Text variant="eyebrow">Last night</Text>
+              {lnQual ? <Badge label={lnQual.label} tone={lnQual.tone} /> : null}
+            </View>
             <Text variant="micro" className="text-text-muted">{shortDate(ln.date)}</Text>
           </View>
           <View className="flex-row items-end gap-2">
@@ -115,15 +135,31 @@ export function SleepDashboard({ summary }: { summary: SleepSummary | null | und
       </Card>
 
       {scores.length >= 2 ? (
-        <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Sleep score</Text>
-            <Text variant="micro" className="tabular-nums text-text-muted">
-              avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"}
-            </Text>
-          </View>
-          <Sparkline data={scores} color="#a5b4fc" height={40} baseline />
-        </Card>
+        <Pressable
+          disabled={!scoreTappable}
+          onPress={() =>
+            onExpand?.({
+              label: "Sleep score",
+              value: summary.stats.avg_score != null ? String(Math.round(summary.stats.avg_score)) : "—",
+              sub: `avg · last ${scores.length} nights`,
+              spark: scores,
+              color: "#a5b4fc",
+            })
+          }
+        >
+          <Card className="gap-2">
+            <View className="flex-row items-center justify-between">
+              <Text variant="eyebrow">Sleep score</Text>
+              <View className="flex-row items-center gap-1.5">
+                <Text variant="micro" className="tabular-nums text-text-muted">
+                  avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"}
+                </Text>
+                {scoreTappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+              </View>
+            </View>
+            <Sparkline data={scores} color="#a5b4fc" height={40} baseline />
+          </Card>
+        </Pressable>
       ) : null}
     </View>
   );

--- a/universal/src/components/sleep-respiratory.tsx
+++ b/universal/src/components/sleep-respiratory.tsx
@@ -1,6 +1,7 @@
-import { View } from "react-native";
+import { View, Pressable } from "react-native";
 import { Text, Card, Sparkline } from "soma-style";
 import type { Respiratory } from "../lib/api";
+import type { StatDetail } from "./stat-detail-modal";
 
 function avg(vals: (number | null)[]): number | null {
   const nn = vals.filter((v): v is number => v != null && isFinite(v));
@@ -8,49 +9,96 @@ function avg(vals: (number | null)[]): number | null {
 }
 
 /** SpO2 + respiration cards for the sleep screen, fed by /api/sleep/respiratory. */
-export function SleepRespiratory({ data }: { data: Respiratory | null | undefined }) {
+export function SleepRespiratory({
+  data,
+  onExpand,
+}: {
+  data: Respiratory | null | undefined;
+  onExpand?: (s: StatDetail) => void;
+}) {
   if (!data) return null;
   const spo2 = data.spo2.latest;
   const resp = data.respiration.latest;
   const spo2Series = data.spo2.trend.map((p) => p.avg_spo2).filter((v): v is number => v != null);
   const respSeries = data.respiration.trend.map((p) => p.sleep_resp ?? p.awake_resp).filter((v): v is number => v != null);
   const spo2Avg = avg(data.spo2.trend.slice(-7).map((p) => p.avg_spo2));
+  const spo2Tappable = !!(onExpand && spo2Series.length >= 2);
+  const respTappable = !!(onExpand && respSeries.length >= 2);
 
   if (!spo2 && !resp) return null;
 
   return (
     <View className="gap-4">
       {spo2 ? (
-        <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Blood oxygen (SpO₂)</Text>
-            {spo2.low_spo2 != null ? <Text variant="micro" className="text-text-muted">low {spo2.low_spo2}%</Text> : null}
-          </View>
-          <View className="flex-row items-end gap-2">
-            <Text variant="display" className="text-teal">{spo2.avg_spo2 != null ? Math.round(spo2.avg_spo2) : "—"}</Text>
-            <Text variant="caption" className="text-text-muted mb-1">% avg</Text>
-            {spo2Avg != null ? <Text variant="micro" className="text-text-muted mb-1">· 7d avg {Math.round(spo2Avg)}%</Text> : null}
-          </View>
-          {spo2Series.length >= 2 ? <Sparkline data={spo2Series} color="#6aa0e0" height={34} baseline /> : null}
-        </Card>
+        <Pressable
+          disabled={!spo2Tappable}
+          onPress={() =>
+            onExpand?.({
+              label: "Blood oxygen (SpO₂)",
+              value: spo2.avg_spo2 != null ? `${Math.round(spo2.avg_spo2)}%` : "—",
+              sub: spo2.low_spo2 != null ? `low ${spo2.low_spo2}%` : "avg",
+              spark: spo2Series,
+              color: "#6aa0e0",
+              unit: "%",
+            })
+          }
+        >
+          <Card className="gap-2">
+            <View className="flex-row items-center justify-between">
+              <Text variant="eyebrow">Blood oxygen (SpO₂)</Text>
+              <View className="flex-row items-center gap-1.5">
+                {spo2.low_spo2 != null ? <Text variant="micro" className="text-text-muted">low {spo2.low_spo2}%</Text> : null}
+                {spo2Tappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+              </View>
+            </View>
+            <View className="flex-row items-end gap-2">
+              <Text variant="display" className="text-teal">{spo2.avg_spo2 != null ? Math.round(spo2.avg_spo2) : "—"}</Text>
+              <Text variant="caption" className="text-text-muted mb-1">% avg</Text>
+              {spo2Avg != null ? <Text variant="micro" className="text-text-muted mb-1">· 7d avg {Math.round(spo2Avg)}%</Text> : null}
+            </View>
+            {spo2Series.length >= 2 ? <Sparkline data={spo2Series} color="#6aa0e0" height={34} baseline /> : null}
+          </Card>
+        </Pressable>
       ) : null}
 
       {resp ? (
-        <Card className="gap-2">
-          <Text variant="eyebrow">Respiration rate</Text>
-          <View className="flex-row items-end gap-2">
-            <Text variant="display" className="text-indigo">
-              {resp.sleep_resp != null ? Math.round(resp.sleep_resp) : resp.awake_resp != null ? Math.round(resp.awake_resp) : "—"}
-            </Text>
-            <Text variant="caption" className="text-text-muted mb-1">br/min {resp.sleep_resp != null ? "sleeping" : "awake"}</Text>
-          </View>
-          <View className="flex-row flex-wrap gap-x-5 gap-y-1">
-            {resp.awake_resp != null ? <Text variant="micro" className="text-text-secondary">Awake {Math.round(resp.awake_resp)}</Text> : null}
-            {resp.low_resp != null ? <Text variant="micro" className="text-text-secondary">Low {Math.round(resp.low_resp)}</Text> : null}
-            {resp.high_resp != null ? <Text variant="micro" className="text-text-secondary">High {Math.round(resp.high_resp)}</Text> : null}
-          </View>
-          {respSeries.length >= 2 ? <Sparkline data={respSeries} color="#a5b4fc" height={34} baseline /> : null}
-        </Card>
+        <Pressable
+          disabled={!respTappable}
+          onPress={() =>
+            onExpand?.({
+              label: "Respiration rate",
+              value:
+                resp.sleep_resp != null
+                  ? `${Math.round(resp.sleep_resp)}`
+                  : resp.awake_resp != null
+                    ? `${Math.round(resp.awake_resp)}`
+                    : "—",
+              sub: `br/min ${resp.sleep_resp != null ? "sleeping" : "awake"}`,
+              spark: respSeries,
+              color: "#a5b4fc",
+              unit: "br/min",
+            })
+          }
+        >
+          <Card className="gap-2">
+            <View className="flex-row items-center justify-between">
+              <Text variant="eyebrow">Respiration rate</Text>
+              {respTappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+            </View>
+            <View className="flex-row items-end gap-2">
+              <Text variant="display" className="text-indigo">
+                {resp.sleep_resp != null ? Math.round(resp.sleep_resp) : resp.awake_resp != null ? Math.round(resp.awake_resp) : "—"}
+              </Text>
+              <Text variant="caption" className="text-text-muted mb-1">br/min {resp.sleep_resp != null ? "sleeping" : "awake"}</Text>
+            </View>
+            <View className="flex-row flex-wrap gap-x-5 gap-y-1">
+              {resp.awake_resp != null ? <Text variant="micro" className="text-text-secondary">Awake {Math.round(resp.awake_resp)}</Text> : null}
+              {resp.low_resp != null ? <Text variant="micro" className="text-text-secondary">Low {Math.round(resp.low_resp)}</Text> : null}
+              {resp.high_resp != null ? <Text variant="micro" className="text-text-secondary">High {Math.round(resp.high_resp)}</Text> : null}
+            </View>
+            {respSeries.length >= 2 ? <Sparkline data={respSeries} color="#a5b4fc" height={34} baseline /> : null}
+          </Card>
+        </Pressable>
       ) : null}
     </View>
   );

--- a/universal/src/components/sleep-schedule-chart.tsx
+++ b/universal/src/components/sleep-schedule-chart.tsx
@@ -1,0 +1,67 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import { LineChart, ChartLegend } from "./line-chart";
+import type { SchedulePoint } from "../lib/api";
+
+const BED = "#8b7fe0"; // bedtime line (indigo)
+const WAKE = "#e0a458"; // wake line (amber)
+
+/** Decimal hour (may be ≥24 for after-midnight values) → "H:MM AM/PM". */
+function fmtHour(h: number): string {
+  const actual = h >= 24 ? h - 24 : h;
+  const whole = Math.floor(actual);
+  const mins = Math.round((actual - whole) * 60);
+  const ampm = whole >= 12 ? "PM" : "AM";
+  const h12 = whole % 12 === 0 ? 12 : whole % 12;
+  return `${h12}:${String(mins).padStart(2, "0")} ${ampm}`;
+}
+
+const chartLabel = (iso: string) => {
+  const [, m, d] = iso.slice(0, 10).split("-").map(Number);
+  return `${["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][(m ?? 1) - 1]} ${d}`;
+};
+
+/**
+ * Per-night sleep-schedule chart: bedtime + wake time across the range, on a
+ * continuous clock axis. Bedtimes before 6 PM are wrapped to the next day
+ * (+24) so an overnight window reads as a single band between the two lines.
+ * Mirrors the web SleepScheduleChart; fed by /api/sleep/schedule `schedule[]`.
+ */
+export function SleepScheduleChart({ schedule }: { schedule: SchedulePoint[] | undefined }) {
+  const pts = (schedule ?? []).filter(
+    (p) => isFinite(p.bedtimeHour) && isFinite(p.wakeHour),
+  );
+  if (pts.length < 2) return null;
+  const recent = pts.slice(-30);
+
+  const norm = (h: number) => (h < 18 ? h + 24 : h); // wrap early-morning bedtimes
+  const bedtimes = recent.map((p) => norm(p.bedtimeHour));
+  const wakes = recent.map((p) => p.wakeHour);
+  const labels = recent.map((p) => chartLabel(p.date));
+
+  // Last-7-night average bedtime → wake, shown in the header (matches web).
+  const last7 = recent.slice(-7);
+  const avgBed = last7.reduce((s, p) => s + norm(p.bedtimeHour), 0) / last7.length;
+  const avgWake = last7.reduce((s, p) => s + p.wakeHour, 0) / last7.length;
+
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Sleep schedule</Text>
+        <Text variant="micro" className="text-text-muted tabular-nums">
+          {fmtHour(avgBed)} → {fmtHour(avgWake)}
+        </Text>
+      </View>
+      <LineChart
+        height={150}
+        labels={labels}
+        yFormat={(v) => fmtHour(v)}
+        series={[
+          { values: bedtimes, color: BED, width: 2.2 },
+          { values: wakes, color: WAKE, width: 2.2 },
+        ]}
+      />
+      <ChartLegend items={[{ color: BED, label: "Bedtime" }, { color: WAKE, label: "Wake" }]} />
+    </Card>
+  );
+}


### PR DESCRIPTION
## App parity — Sleep screen

Brings the app Sleep screen (#430) to full parity with the web page. All three open subs, from data the existing sleep/recovery endpoints already serve (no new API route).

### What changed
- **Sleep schedule chart (#431)** — new `SleepScheduleChart`: per-night bedtime → wake on a continuous clock axis (early-morning bedtimes wrap +24 so the overnight window reads as a band between the two lines), with a last-7-night `bedtime → wake` header + legend. Mirrors the web `SleepScheduleChart`.
- **Sparklines → full charts + expand (#432)** — the Sleep score, HRV, SpO₂ and respiration cards are now tappable into the shared `StatDetailModal` (full `LineChart` + min/avg/max). The sleep-duration bar list is replaced by a full `LineChart` with a 7h dashed target line, also tap-to-expand.
- **Missing stats + qualifiers (#433)** — three headline stat cards added from `/api/sleep/summary` stats (**Avg Score**, **Avg Deep %** with REM sub, **Avg Sleep HR** with SpO₂ sub), and a Garmin-style **quality qualifier badge** (Excellent / Good / Fair / Poor) on the Last Night card, derived from the 0–100 score.

### Files
- `universal/src/components/sleep-schedule-chart.tsx` — new schedule chart.
- `universal/src/components/sleep-dashboard.tsx` — quality badge + tappable score card.
- `universal/src/components/sleep-respiratory.tsx` — tappable SpO₂ + respiration.
- `universal/src/components/recovery-vitals.tsx` — tappable HRV.
- `universal/src/app/(main)/sleep.tsx` — new stat cards, schedule chart, duration LineChart, wired expand.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (mobile 390×844): 7 summary cards incl. the 3 new (Avg Score 72, Avg Deep 20%/REM 20%, Avg Sleep HR 51/SpO₂ 95%); the Sleep Schedule band chart ("10:58 PM → 7:00 AM"); the Last Night "Excellent" qualifier badge; the Sleep Duration LineChart with 7h target line; and tapping it opens the detail modal (6.7h avg · min 6h/avg 7h/max 8h).

Closes #431
Closes #432
Closes #433
Closes #430
