### PR TITLE
App parity — Running: charts + sortable run table + split/intensity/shoe detail (#434)

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -2,13 +2,16 @@ import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
-import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits, useHrPace, useRecentRoutes } from "../../lib/api";
+import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits, useHrPace, useRecentRoutes, useRunHeatmap } from "../../lib/api";
 import { RunningMileage } from "../../components/running-mileage";
 import { RunningDeepTrends } from "../../components/running-deep-trends";
 import { RunningFitnessScores } from "../../components/running-fitness-scores";
 import { RunningSplits } from "../../components/running-splits";
 import { RunningHrPace } from "../../components/running-hr-pace";
 import { RunningRoutes } from "../../components/running-routes";
+import { RunningPaceVo2Charts } from "../../components/running-pace-vo2-charts";
+import { RunHeatmap } from "../../components/run-heatmap";
+import { RunTable } from "../../components/run-table";
 
 /* ------------------------------------------------------------------ */
 /* Types — mirror the fields the web /running page renders             */
@@ -169,6 +172,7 @@ export default function RunningScreen() {
   const { data: splits } = useRunningSplits(range);
   const { data: hrPace } = useHrPace(range);
   const { data: routes } = useRecentRoutes();
+  const { routes: heatRoutes } = useRunHeatmap();
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const stats = data?.stats;
@@ -350,8 +354,14 @@ export default function RunningScreen() {
         {/* Monthly mileage bar chart (web parity) */}
         <RunningMileage mileage={trends?.mileage} />
 
+        {/* Dedicated Pace Progression + VO2max Trend charts (web parity) */}
+        <RunningPaceVo2Charts pace={trends?.pace} vo2max={trends?.vo2max} />
+
         {/* Recent route thumbnails (SVG shapes from /api/running/recent-routes) */}
         <RunningRoutes routes={routes} />
+
+        {/* Route heatmap — all recent GPS paths overlaid (new /api/running/heatmap) */}
+        <RunHeatmap routes={heatRoutes} />
 
         {/* Range governs the trend charts below (stats above are all-time). */}
         <View className="gap-1">
@@ -379,6 +389,26 @@ export default function RunningScreen() {
         {zones.length > 0 ? (
           <Card className="gap-3">
             <Text variant="eyebrow">Training Intensity Distribution</Text>
+            {/* Single stacked 5-zone bar (web parity) */}
+            {zoneTotal > 0 ? (
+              <View className="gap-1">
+                <View className="flex-row h-4 rounded-full overflow-hidden">
+                  {zones.map((z, i) =>
+                    num(z.count) > 0 ? (
+                      <View key={`seg-${z.zone}`} style={{ width: `${(num(z.count) / zoneTotal) * 100}%`, backgroundColor: ZONE_HEX[i] ?? ZONE_HEX[0] }} />
+                    ) : null,
+                  )}
+                </View>
+                <View className="flex-row flex-wrap gap-x-3 gap-y-0.5">
+                  {zones.map((z, i) => (
+                    <View key={`lg-${z.zone}`} className="flex-row items-center gap-1">
+                      <View className="h-2 w-2 rounded-full" style={{ backgroundColor: ZONE_HEX[i] ?? ZONE_HEX[0] }} />
+                      <Text variant="micro" className="text-text-muted">{z.zone} {Math.round((num(z.count) / zoneTotal) * 100)}%</Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ) : null}
             {zones.map((z, i) => {
               const pct = zoneTotal > 0 ? num(z.count) / zoneTotal : 0;
               return (
@@ -538,48 +568,28 @@ export default function RunningScreen() {
                     </Text>
                   </View>
                   {maxKm ? <ProgressBar pct={Math.min(worn, 1)} color={barColor} /> : null}
-                  <Text variant="micro">
-                    {maxKm
-                      ? `${totalKm.toFixed(0)} / ${maxKm.toFixed(0)} km (${Math.round(worn * 100)}%)`
-                      : `${totalKm.toFixed(0)} km total`}
-                  </Text>
+                  <View className="flex-row items-center justify-between">
+                    <Text variant="micro">
+                      {maxKm
+                        ? `${totalKm.toFixed(0)} / ${maxKm.toFixed(0)} km (${Math.round(worn * 100)}%)`
+                        : `${totalKm.toFixed(0)} km total`}
+                    </Text>
+                    {maxKm ? (
+                      <Text variant="micro" className={worn >= 1 ? "text-danger" : "text-text-muted"}>
+                        {worn >= 1
+                          ? `${(totalKm - maxKm).toFixed(0)} km over`
+                          : `${(maxKm - totalKm).toFixed(0)} km remaining`}
+                      </Text>
+                    ) : null}
+                  </View>
                 </View>
               );
             })}
           </Card>
         ) : null}
 
-        {/* Recent Runs */}
-        {recent.length > 0 ? (
-          <Card className="gap-2">
-            <Text variant="eyebrow">Recent Runs</Text>
-            {recent.map((r) => (
-              <View
-                key={r.activity_id}
-                className="flex-row items-center justify-between border-b border-border-subtle py-2"
-              >
-                <View className="flex-1 gap-0.5 pr-2">
-                  <Text variant="body" className="text-text" numberOfLines={1}>
-                    {r.name ?? "Run"}
-                  </Text>
-                  <Text variant="micro">
-                    {shortDate(r.date)} ·{" "}
-                    {r.distance != null ? `${num(r.distance).toFixed(1)} km` : "—"}
-                  </Text>
-                </View>
-                <View className="items-end gap-0.5">
-                  <Text variant="caption" className="tabular-nums text-teal">
-                    {r.pace != null ? `${formatPace(r.pace)}/km` : "—"}
-                  </Text>
-                  <Text variant="micro" className="tabular-nums">
-                    {r.avg_hr != null ? `${Math.round(num(r.avg_hr))} bpm` : "—"} ·{" "}
-                    {r.duration_min != null ? `${Math.round(num(r.duration_min))} min` : "—"}
-                  </Text>
-                </View>
-              </View>
-            ))}
-          </Card>
-        ) : null}
+        {/* Recent Runs — sortable, tap-to-detail table (web parity) */}
+        <RunTable runs={recent} />
       </View>
 
       <StatDetailModal stat={statDetail} onClose={() => setStatDetail(null)} />

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -26,6 +26,8 @@ export interface LineChartProps {
   yFormat?: (v: number) => string;
   /** Optional horizontal reference line (e.g. a goal pace at y=0). */
   refLine?: { y: number; color?: string };
+  /** Additional horizontal reference lines (e.g. ACWR 0.8/1.3/1.5 guides). */
+  refLines?: { y: number; color?: string; dashed?: boolean }[];
   yMin?: number;
   yMax?: number;
 }
@@ -34,11 +36,12 @@ const VBW = 320; // viewBox width; scales uniformly to the container
 
 /** A compact, dependency-free line chart (react-native-svg) with y-axis
  *  min/max labels and first/last x labels. Reused across every app chart. */
-export function LineChart({ series, labels, height = 120, yFormat, refLine, yMin, yMax }: LineChartProps) {
+export function LineChart({ series, labels, height = 120, yFormat, refLine, refLines, yMin, yMax }: LineChartProps) {
   const fmt = yFormat ?? ((v: number) => String(Math.round(v)));
   const all: number[] = [];
   for (const s of series) for (const v of s.values) if (v != null && isFinite(v)) all.push(v);
   if (refLine && isFinite(refLine.y)) all.push(refLine.y);
+  if (refLines) for (const r of refLines) if (isFinite(r.y)) all.push(r.y);
   if (all.length < 2) {
     return <View style={{ height }} className="items-center justify-center"><Text variant="micro" className="text-text-muted">Not enough data yet.</Text></View>;
   }
@@ -67,6 +70,11 @@ export function LineChart({ series, labels, height = 120, yFormat, refLine, yMin
             {refLine && refLine.y >= lo && refLine.y <= hi ? (
               <Line x1={0} y1={yAt(refLine.y)} x2={VBW} y2={yAt(refLine.y)} stroke={refLine.color ?? "#3a5563"} strokeWidth={1} strokeDasharray="4 4" />
             ) : null}
+            {refLines?.map((r, ri) =>
+              r.y >= lo && r.y <= hi ? (
+                <Line key={`rl-${ri}`} x1={0} y1={yAt(r.y)} x2={VBW} y2={yAt(r.y)} stroke={r.color ?? "#3a5563"} strokeWidth={1} strokeDasharray={r.dashed === false ? undefined : "4 4"} />
+              ) : null,
+            )}
             {series.map((s, si) => {
               if (s.mode === "dots") {
                 return s.values.map((v, i) =>

--- a/universal/src/components/run-heatmap.tsx
+++ b/universal/src/components/run-heatmap.tsx
@@ -1,0 +1,74 @@
+import { View } from "react-native";
+import Svg, { Polyline } from "react-native-svg";
+import { Text, Card } from "soma-style";
+import type { HeatRoute } from "../lib/api";
+
+/**
+ * Route heatmap (web parity, #435): all recent run GPS paths overlaid on one
+ * shared, aspect-corrected canvas. The web uses a Leaflet map; on mobile we
+ * draw every route as a semi-transparent polyline so overlapping segments
+ * (the roads you run most) accumulate into brighter lines — a dependency-free
+ * density map. Fed by /api/running/heatmap.
+ */
+export function RunHeatmap({ routes }: { routes: HeatRoute[] }) {
+  const valid = (routes ?? []).filter((r) => Array.isArray(r) && r.length >= 2);
+  if (valid.length < 1) return null;
+
+  // Shared bounding box across every route.
+  let minLo = Infinity, maxLo = -Infinity, minLa = Infinity, maxLa = -Infinity;
+  for (const r of valid) for (const [lng, lat] of r) {
+    if (!isFinite(lng) || !isFinite(lat)) continue;
+    if (lng < minLo) minLo = lng; if (lng > maxLo) maxLo = lng;
+    if (lat < minLa) minLa = lat; if (lat > maxLa) maxLa = lat;
+  }
+  if (!isFinite(minLo) || !isFinite(minLa)) return null;
+  const rLo = maxLo - minLo || 1e-6;
+  const rLa = maxLa - minLa || 1e-6;
+  // Correct longitude for latitude compression so shapes aren't stretched.
+  const midLa = (minLa + maxLa) / 2;
+  const cos = Math.max(0.2, Math.cos((midLa * Math.PI) / 180));
+  const spanLo = rLo * cos;
+  const span = Math.max(spanLo, rLa) || 1e-6;
+  // center each axis within a 100x100 box
+  const offX = (100 - (spanLo / span) * 92) / 2;
+  const offY = (100 - (rLa / span) * 92) / 2;
+
+  const project = (r: HeatRoute) => {
+    const step = Math.max(1, Math.floor(r.length / 120));
+    const out: string[] = [];
+    for (let i = 0; i < r.length; i += step) {
+      const [lng, lat] = r[i];
+      if (!isFinite(lng) || !isFinite(lat)) continue;
+      const x = offX + ((lng - minLo) * cos / span) * 92;
+      const y = offY + (1 - (lat - minLa) / span) * 92;
+      out.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+    }
+    return out.join(" ");
+  };
+
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Route heatmap</Text>
+        <Text variant="micro" className="text-text-muted">{valid.length} routes · last 12 mo</Text>
+      </View>
+      <View className="rounded-lg bg-surface-subtle overflow-hidden" style={{ aspectRatio: 1 }}>
+        <Svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
+          {valid.map((r, i) => (
+            <Polyline
+              key={i}
+              points={project(r)}
+              fill="none"
+              stroke="#77c8d1"
+              strokeWidth={0.7}
+              strokeOpacity={0.35}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+          ))}
+        </Svg>
+      </View>
+      <Text variant="micro" className="text-text-muted">Brighter lines = roads you run most.</Text>
+    </Card>
+  );
+}

--- a/universal/src/components/run-table.tsx
+++ b/universal/src/components/run-table.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from "react";
+import { View, Pressable } from "react-native";
+import { Text, Card, Modal, Badge } from "soma-style";
+
+/** One run row — structurally matches the screen's RecentRun. */
+export interface RunRow {
+  activity_id: string;
+  date: string | null;
+  name: string | null;
+  distance: number | null; // km
+  duration_min: number | null;
+  pace: number | null; // min/km
+  avg_hr: number | null;
+  calories: number | null;
+}
+
+type SortKey = "date" | "distance" | "pace" | "avg_hr";
+const COLS: { key: SortKey; label: string }[] = [
+  { key: "date", label: "Date" },
+  { key: "distance", label: "Dist" },
+  { key: "pace", label: "Pace" },
+  { key: "avg_hr", label: "HR" },
+];
+
+const num = (v: number | null | undefined): number => (v == null ? 0 : Number(v));
+function paceLabel(mins: number | null | undefined): string {
+  if (mins == null || !isFinite(mins)) return "—";
+  const t = Math.round(mins * 60);
+  return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`;
+}
+function shortDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "—" : d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+function longDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+}
+
+/** Detail dialog for one run (the drill-in behind a table row). */
+function RunDetailModal({ run, onClose }: { run: RunRow | null; onClose: () => void }) {
+  if (!run) return null;
+  const rows: [string, string][] = [
+    ["Distance", run.distance != null ? `${num(run.distance).toFixed(2)} km` : "—"],
+    ["Duration", run.duration_min != null ? `${Math.round(num(run.duration_min))} min` : "—"],
+    ["Avg pace", run.pace != null ? `${paceLabel(run.pace)} /km` : "—"],
+    ["Avg HR", run.avg_hr != null ? `${Math.round(num(run.avg_hr))} bpm` : "—"],
+    ["Calories", run.calories != null ? `${Math.round(num(run.calories))} kcal` : "—"],
+  ];
+  return (
+    <Modal visible={!!run} onClose={onClose} title={run.name ?? "Run"}>
+      <View className="gap-3">
+        <View className="flex-row items-end gap-2">
+          <Text variant="display" className="text-teal">{run.distance != null ? num(run.distance).toFixed(1) : "—"}</Text>
+          <Text variant="body" className="mb-1 text-text-muted">km · {longDate(run.date)}</Text>
+        </View>
+        <View className="gap-2">
+          {rows.map(([label, value]) => (
+            <View key={label} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+              <Text variant="body" className="text-text-secondary">{label}</Text>
+              <Text variant="body" className="tabular-nums text-text">{value}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+/**
+ * Sortable, tap-to-detail run table (web parity, #436). Replaces the plain
+ * "Recent Runs" list: tap a column header to sort (tap again to reverse),
+ * tap a row to open its detail modal. Fed by the screen's recentRuns.
+ */
+export function RunTable({ runs }: { runs: RunRow[] }) {
+  const [sortKey, setSortKey] = useState<SortKey>("date");
+  const [asc, setAsc] = useState(false);
+  const [selected, setSelected] = useState<RunRow | null>(null);
+
+  const sorted = useMemo(() => {
+    const arr = [...(runs ?? [])];
+    arr.sort((a, b) => {
+      let av: number, bv: number;
+      if (sortKey === "date") { av = a.date ? new Date(a.date).getTime() : 0; bv = b.date ? new Date(b.date).getTime() : 0; }
+      else { av = num(a[sortKey]); bv = num(b[sortKey]); }
+      return asc ? av - bv : bv - av;
+    });
+    return arr;
+  }, [runs, sortKey, asc]);
+
+  if (!runs || runs.length === 0) return null;
+
+  const onHeader = (k: SortKey) => {
+    if (k === sortKey) setAsc((v) => !v);
+    else { setSortKey(k); setAsc(k === "pace"); } // pace defaults ascending (fastest first)
+  };
+
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Runs</Text>
+        <Text variant="micro" className="text-text-muted">{runs.length} · tap to sort / open</Text>
+      </View>
+
+      {/* Sortable header row */}
+      <View className="flex-row items-center border-b border-border-subtle pb-1.5">
+        <Pressable className="flex-1" onPress={() => onHeader("date")}>
+          <Text variant="micro" className={sortKey === "date" ? "text-teal" : "text-text-muted"}>
+            {COLS[0].label}{sortKey === "date" ? (asc ? " ↑" : " ↓") : ""}
+          </Text>
+        </Pressable>
+        {COLS.slice(1).map((c) => (
+          <Pressable key={c.key} className="w-16 items-end" onPress={() => onHeader(c.key)}>
+            <Text variant="micro" className={sortKey === c.key ? "text-teal" : "text-text-muted"}>
+              {c.label}{sortKey === c.key ? (asc ? " ↑" : " ↓") : ""}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {/* Rows */}
+      {sorted.map((r) => (
+        <Pressable key={r.activity_id} onPress={() => setSelected(r)} className="flex-row items-center border-b border-border-subtle py-2">
+          <View className="flex-1 pr-2">
+            <Text variant="caption" className="text-text" numberOfLines={1}>{r.name ?? "Run"}</Text>
+            <Text variant="micro" className="text-text-muted">{shortDate(r.date)}</Text>
+          </View>
+          <Text variant="caption" className="w-16 text-right tabular-nums text-text">
+            {r.distance != null ? `${num(r.distance).toFixed(1)}` : "—"}
+          </Text>
+          <Text variant="caption" className="w-16 text-right tabular-nums text-lime">
+            {r.pace != null ? paceLabel(r.pace) : "—"}
+          </Text>
+          <Text variant="caption" className="w-16 text-right tabular-nums text-danger">
+            {r.avg_hr != null ? Math.round(num(r.avg_hr)) : "—"}
+          </Text>
+        </Pressable>
+      ))}
+
+      <RunDetailModal run={selected} onClose={() => setSelected(null)} />
+    </Card>
+  );
+}

--- a/universal/src/components/running-deep-trends.tsx
+++ b/universal/src/components/running-deep-trends.tsx
@@ -1,7 +1,8 @@
 import { View } from "react-native";
-import Svg, { Polyline, Line } from "react-native-svg";
-import { Text, Card, Badge, Sparkline } from "soma-style";
+import Svg, { Polyline } from "react-native-svg";
+import { Text, Card, Badge } from "soma-style";
 import type { RunningTrends } from "../lib/api";
+import { LineChart, ChartLegend } from "./line-chart";
 
 /** Two lines on a shared y-scale (acute vs chronic load). */
 function DualLine({ a, b, colorA, colorB, height = 44 }: { a: number[]; b: number[]; colorA: string; colorB: string; height?: number }) {
@@ -32,6 +33,12 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
   const loadLast = load.length ? load[load.length - 1] : null;
   const acute = load.map((p) => Number(p.acute)).filter(isFinite);
   const chronic = load.map((p) => Number(p.chronic)).filter(isFinite);
+
+  // Per-point ACWR (acute / chronic) for the guide-banded ratio line.
+  const acwrSeries = load.map((p) =>
+    p.acute != null && p.chronic != null && Number(p.chronic) > 0 ? Number(p.acute) / Number(p.chronic) : null,
+  );
+  const hasAcwr = acwrSeries.filter((v): v is number => v != null).length >= 2;
 
   const cad = trends.cadenceStride.filter((p) => p.cadence != null);
   const cadLast = cad.length ? cad[cad.length - 1] : null;
@@ -64,6 +71,23 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
             <View className="flex-row items-center gap-1"><View className="h-2 w-2 rounded-full bg-teal" /><Text variant="micro" className="text-text-muted">acute (7d)</Text></View>
             <View className="flex-row items-center gap-1"><View className="h-2 w-2 rounded-full" style={{ backgroundColor: "#5a7a8a" }} /><Text variant="micro" className="text-text-muted">chronic (28d)</Text></View>
           </View>
+
+          {hasAcwr ? (
+            <View className="gap-1 border-t border-border-subtle pt-2">
+              <Text variant="micro" className="text-text-muted">ACWR ratio · sweet spot 0.8–1.3</Text>
+              <LineChart
+                height={110}
+                yFormat={(v) => v.toFixed(2)}
+                series={[{ values: acwrSeries, color: "#77c8d1", width: 2 }]}
+                refLines={[
+                  { y: 0.8, color: "#6ad4a0" },
+                  { y: 1.3, color: "#e0c458" },
+                  { y: 1.5, color: "#e06060" },
+                ]}
+              />
+              <ChartLegend items={[{ color: "#6ad4a0", label: "0.8", dashed: true }, { color: "#e0c458", label: "1.3", dashed: true }, { color: "#e06060", label: "1.5 high", dashed: true }]} />
+            </View>
+          ) : null}
         </Card>
       ) : null}
 
@@ -77,7 +101,13 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
             <Text variant="display" className="text-lime">{cadLast.cadence}</Text>
             <Text variant="caption" className="text-text-muted mb-1">spm</Text>
           </View>
-          <Sparkline data={cadSeries} color="#cbe896" height={36} baseline />
+          <LineChart
+            height={110}
+            yFormat={(v) => String(Math.round(v))}
+            series={[{ values: cadSeries, color: "#cbe896", width: 2.2 }]}
+            refLine={{ y: 180, color: "#77c8d1" }}
+          />
+          <Text variant="micro" className="text-text-muted">Dashed line = 180 spm target.</Text>
         </Card>
       ) : null}
     </View>

--- a/universal/src/components/running-pace-vo2-charts.tsx
+++ b/universal/src/components/running-pace-vo2-charts.tsx
@@ -1,0 +1,61 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import { LineChart } from "./line-chart";
+
+/** Decimal minutes → "M:SS" pace label. */
+function paceLabel(mins: number): string {
+  const t = Math.round(mins * 60);
+  const m = Math.floor(t / 60);
+  const s = t % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/**
+ * Dedicated Pace Progression + VO2max Trend charts (web parity, #435).
+ * Both series come from /api/running/stats `trends` (already fetched by the
+ * screen) — the summary cards show these as sparklines; these render them as
+ * full LineCharts with axis labels, matching the web's ExpandableChartCards.
+ */
+export function RunningPaceVo2Charts({
+  pace,
+  vo2max,
+}: {
+  pace: number[] | null | undefined;
+  vo2max: number[] | null | undefined;
+}) {
+  const paceVals = (pace ?? []).filter((v) => isFinite(v));
+  const vo2Vals = (vo2max ?? []).filter((v) => isFinite(v));
+  if (paceVals.length < 2 && vo2Vals.length < 2) return null;
+
+  return (
+    <View className="gap-4">
+      {paceVals.length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Pace progression</Text>
+            <Text variant="micro" className="text-text-muted">min/km · lower is faster</Text>
+          </View>
+          <LineChart
+            height={140}
+            yFormat={(v) => paceLabel(v)}
+            series={[{ values: paceVals, color: "#cbe896", width: 2.2 }]}
+          />
+        </Card>
+      ) : null}
+
+      {vo2Vals.length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">VO₂max trend</Text>
+            <Text variant="micro" className="text-text-muted">ml/kg/min</Text>
+          </View>
+          <LineChart
+            height={140}
+            yFormat={(v) => v.toFixed(1)}
+            series={[{ values: vo2Vals, color: "#e0a458", width: 2.2 }]}
+          />
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/components/running-routes.tsx
+++ b/universal/src/components/running-routes.tsx
@@ -1,17 +1,22 @@
-import { View } from "react-native";
+import { useState } from "react";
+import { View, Pressable } from "react-native";
 import Svg, { Polyline } from "react-native-svg";
-import { Text, Card } from "soma-style";
+import { Text, Card, Modal } from "soma-style";
 import type { RouteItem, RoutePoint } from "../lib/api";
 
 function shortDate(iso: string): string {
   const d = new Date(iso);
   return isNaN(d.getTime()) ? "" : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
+function paceLabel(mins: number | null): string {
+  if (mins == null || !isFinite(mins)) return "—";
+  const t = Math.round(mins * 60);
+  return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`;
+}
 
 /** One route's GPS path as a normalized SVG polyline (north up), no map tiles. */
-function RouteThumb({ points }: { points: RoutePoint[] }) {
+function RouteThumb({ points, stroke = 2 }: { points: RoutePoint[]; stroke?: number }) {
   const pts = points.filter((p) => isFinite(p.lat) && isFinite(p.lng));
-  // sample down to ~80 points for perf
   const step = Math.max(1, Math.floor(pts.length / 80));
   const s = pts.filter((_, i) => i % step === 0);
   if (s.length < 2) return <View className="h-24 rounded-lg bg-surface-subtle" />;
@@ -19,38 +24,80 @@ function RouteThumb({ points }: { points: RoutePoint[] }) {
   const minLa = Math.min(...lats), maxLa = Math.max(...lats);
   const minLo = Math.min(...lngs), maxLo = Math.max(...lngs);
   const rLa = maxLa - minLa || 1e-6, rLo = maxLo - minLo || 1e-6;
-  // keep aspect roughly square, pad to 4..96
   const poly = s
     .map((p) => `${((p.lng - minLo) / rLo) * 92 + 4},${(1 - (p.lat - minLa) / rLa) * 92 + 4}`)
     .join(" ");
   return (
     <View className="h-24 rounded-lg bg-surface-subtle overflow-hidden">
       <Svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
-        <Polyline points={poly} fill="none" stroke="#77c8d1" strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
+        <Polyline points={poly} fill="none" stroke="#77c8d1" strokeWidth={stroke} strokeLinejoin="round" strokeLinecap="round" />
       </Svg>
     </View>
   );
 }
 
+/** Enlarged route + stats (drill-in behind a thumbnail). */
+function RouteDetailModal({ route, onClose }: { route: RouteItem | null; onClose: () => void }) {
+  if (!route) return null;
+  const km = route.distance_km;
+  const durMin = route.duration_s != null ? route.duration_s / 60 : null;
+  const pace = km && durMin ? durMin / km : null;
+  const rows: [string, string][] = [
+    ["Distance", km != null ? `${km.toFixed(2)} km` : "—"],
+    ["Duration", durMin != null ? `${Math.round(durMin)} min` : "—"],
+    ["Avg pace", pace != null ? `${paceLabel(pace)} /km` : "—"],
+  ];
+  return (
+    <Modal visible={!!route} onClose={onClose} title={route.name ?? "Run"}>
+      <View className="gap-3">
+        <View className="rounded-lg bg-surface-subtle overflow-hidden" style={{ aspectRatio: 1 }}>
+          <RouteThumb points={route.gps_points} stroke={2.4} />
+        </View>
+        <Text variant="micro" className="text-text-muted">{shortDate(route.date)}</Text>
+        <View className="gap-2">
+          {rows.map(([label, value]) => (
+            <View key={label} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+              <Text variant="body" className="text-text-secondary">{label}</Text>
+              <Text variant="body" className="tabular-nums text-text">{value}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
 /** Recent-runs route gallery (SVG route shapes), fed by /api/running/recent-routes. */
 export function RunningRoutes({ routes }: { routes: RouteItem[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const [selected, setSelected] = useState<RouteItem | null>(null);
   const withGps = (routes ?? []).filter((r) => (r.gps_points?.length ?? 0) >= 2);
   if (!withGps.length) return null;
+  const shown = showAll ? withGps : withGps.slice(0, 6);
 
   return (
     <Card className="gap-3">
-      <Text variant="eyebrow">Recent routes</Text>
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Recent routes</Text>
+        <Text variant="micro" className="text-text-muted">{withGps.length} routes · tap to open</Text>
+      </View>
       <View className="flex-row flex-wrap gap-3">
-        {withGps.slice(0, 6).map((r) => (
-          <View key={r.activity_id} className="min-w-[46%] flex-1 gap-1">
+        {shown.map((r) => (
+          <Pressable key={r.activity_id} className="min-w-[46%] flex-1 gap-1" onPress={() => setSelected(r)}>
             <RouteThumb points={r.gps_points} />
             <Text variant="micro" className="text-text-secondary" numberOfLines={1}>{r.name || "Run"}</Text>
             <Text variant="micro" className="text-text-muted">
               {shortDate(r.date)}{r.distance_km != null ? ` · ${r.distance_km.toFixed(1)} km` : ""}
             </Text>
-          </View>
+          </Pressable>
         ))}
       </View>
+      {withGps.length > 6 ? (
+        <Pressable onPress={() => setShowAll((v) => !v)} className="self-start">
+          <Text variant="caption" className="text-teal">{showAll ? "Show fewer" : `Show all ${withGps.length}`}</Text>
+        </Pressable>
+      ) : null}
+      <RouteDetailModal route={selected} onClose={() => setSelected(null)} />
     </Card>
   );
 }

--- a/universal/src/components/running-splits.tsx
+++ b/universal/src/components/running-splits.tsx
@@ -34,17 +34,27 @@ export function RunningSplits({ data }: { data: RunningSplits | null | undefined
             const p = Number(k.avg_pace);
             const t = (p - minP) / rangeP; // 0 fastest → 1 slowest
             const color = t < 0.4 ? "#6ad4a0" : t < 0.7 ? "#e0c458" : "#e0a458";
+            const detail: string[] = [];
+            if (k.fast_pace != null && k.slow_pace != null) detail.push(`${pace(k.fast_pace)}–${pace(k.slow_pace)}`);
+            if (k.avg_hr != null) detail.push(`${Math.round(Number(k.avg_hr))} bpm`);
+            if (k.avg_cadence != null) detail.push(`${Math.round(Number(k.avg_cadence))} spm`);
+            if (k.runs != null) detail.push(`${k.runs} runs`);
             return (
-              <View key={k.km} className="flex-row items-center gap-2 py-1">
-                <Text variant="micro" className="tabular-nums text-text-muted w-8">km{k.km}</Text>
-                <View className="flex-1 h-3 rounded-full bg-surface-subtle overflow-hidden">
-                  <View className="h-full rounded-full" style={{ width: `${Math.max(6, (1 - t) * 100)}%`, backgroundColor: color }} />
+              <View key={k.km} className="gap-0.5 py-1">
+                <View className="flex-row items-center gap-2">
+                  <Text variant="micro" className="tabular-nums text-text-muted w-8">km{k.km}</Text>
+                  <View className="flex-1 h-3 rounded-full bg-surface-subtle overflow-hidden">
+                    <View className="h-full rounded-full" style={{ width: `${Math.max(6, (1 - t) * 100)}%`, backgroundColor: color }} />
+                  </View>
+                  <Text variant="caption" className="tabular-nums text-text w-16 text-right">{pace(p)}/km</Text>
                 </View>
-                <Text variant="caption" className="tabular-nums text-text w-16 text-right">{pace(p)}/km</Text>
+                {detail.length ? (
+                  <Text variant="micro" className="tabular-nums text-text-muted pl-10">{detail.join(" · ")}</Text>
+                ) : null}
               </View>
             );
           })}
-          <Text variant="micro" className="text-text-muted">avg over ≥10 runs per km</Text>
+          <Text variant="micro" className="text-text-muted">range · avg HR · cadence · runs, per km</Text>
         </Card>
       ) : null}
 

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -405,6 +405,25 @@ export function useRecentRoutes() {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Route heatmap: many run GPS paths overlaid (12mo) ----
+/** Each route is an array of [lng, lat] points (GeoJSON order). */
+export type HeatRoute = [number, number][];
+
+/** Recent run routes (up to ~40 over 12 months) from /api/running/heatmap,
+ *  overlaid as a dependency-free multi-polyline "heatmap" on mobile. */
+export function useRunHeatmap() {
+  const [routes, setRoutes] = useState<HeatRoute[]>([]);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<{ routes: HeatRoute[] }>("/api/running/heatmap")
+      .then((d) => alive && setRoutes(Array.isArray(d?.routes) ? d.routes : []))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [reload]);
+  return { routes, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- HR-vs-pace scatter points ----
 export interface HrPacePoint { date: string; name: string | null; pace: number | null; hr: number | null; distance: number | null }
 


### PR DESCRIPTION
## App parity — Running screen

Brings the app Running screen (#434) to parity with the web page across all three open subs. Data comes from endpoints the screen already uses; the only new fetch is a client hook for the existing `/api/running/heatmap`.

### What changed
**Missing charts + fidelity (#435)**
- Dedicated **Pace Progression** + **VO₂max Trend** LineCharts (`running-pace-vo2-charts.tsx`) from the already-fetched `trends`.
- **Route Heatmap** (`run-heatmap.tsx` + new `useRunHeatmap`) — overlays every recent GPS path on one aspect-corrected canvas so the roads you run most accumulate into brighter lines (dependency-free mobile take on the web Leaflet map).
- **Training Load** gains an **ACWR ratio line** with 0.8 / 1.3 / 1.5 guide bands; **Cadence** gains a **180 spm** target line. `LineChart` extended with a backward-compatible `refLines[]` prop.

**Sortable clickable run table + routes (#436)**
- Recent Runs → **`RunTable`**: tap-to-sort columns (Date / Dist / Pace / HR) + tap-to-open **RunDetailModal** (distance / duration / pace / HR / calories).
- Recent Routes gains an **"{N} routes"** count, **Show all**, and **tap-to-open** route detail modal.

**Split / intensity / shoe detail (#437)**
- Per-km splits show **fast–slow range + avg HR + cadence + "{n} runs"**.
- Training Intensity gains the **single stacked 5-zone bar** + percentage legend.
- Shoe Mileage shows **"{remaining} km remaining / {over} km over"**.

### Documented mobile trims
HR-vs-Pace year-toggle + hover tooltip, Fitness Scores dual-axis, fullscreen chart-expand on the dedicated charts, and the splits "power" metric (not present in the splits payload).

### Files
- New: `run-heatmap.tsx`, `run-table.tsx`, `running-pace-vo2-charts.tsx`.
- Modified: `running.tsx`, `line-chart.tsx` (refLines[]), `running-deep-trends.tsx`, `running-routes.tsx`, `running-splits.tsx`, `lib/api.ts` (useRunHeatmap).

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (mobile 390×844): Pace/VO₂max charts, the 8-route heatmap overlay, ACWR ratio line with 0.8/1.3/1.5 guides, cadence 180 spm line, per-km split detail (`5:22–6:16 · 157 bpm · 180 spm · 18 runs`), the stacked intensity bar, shoe "260 km remaining / 40 km over", and the sortable run table — sorting by Pace re-ordered fastest-first and tapping a row opened the detail modal (Morning Run: 10 km · 54 min · 5:24/km · 150 bpm · 650 kcal).

Closes #435
Closes #436
Closes #437
Closes #434
