### PR TITLE
App parity — Workouts: exercise + workout detail modals (part of #429)

### DIFF
--- a/universal/src/components/exercise-detail-modal.tsx
+++ b/universal/src/components/exercise-detail-modal.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { View } from "react-native";
+import { Text, Card, Modal, Badge } from "soma-style";
+import { LineChart } from "./line-chart";
+import { fetchJson } from "../lib/api";
+
+interface Rec { value: number; date: string; reps?: number; weight?: number }
+interface ProgPoint {
+  date: string; workoutId: string; program: string | null;
+  maxWeight: number; totalVolume: number; maxReps: number; estimated1RM: number;
+  avgHr: number | null; sets: { weight: number; reps: number; type: string }[];
+}
+interface ExerciseDetail {
+  name: string;
+  muscles: { primary: string[]; secondary: string[] };
+  totalSessions: number; totalSets: number; totalReps: number;
+  records: { maxWeight: Rec; maxReps: Rec; maxVolume: Rec; estimated1RM: Rec };
+  progression: ProgPoint[];
+}
+
+const KG_TO_LB = 2.20462;
+function shortDate(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "2-digit" });
+}
+
+/**
+ * Per-exercise detail (web parity, #429): muscles, PRs (max weight / est 1RM /
+ * max reps), a weight-progression LineChart, and the most-recent sets. Fetches
+ * /api/workouts/exercise?name= on open. Weight unit follows the screen toggle.
+ */
+export function ExerciseDetailModal({ name, unit, onClose }: { name: string | null; unit: "kg" | "lb"; onClose: () => void }) {
+  const [data, setData] = useState<ExerciseDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    if (!name) { setData(null); return; }
+    let alive = true;
+    setLoading(true);
+    fetchJson<ExerciseDetail>(`/api/workouts/exercise?name=${encodeURIComponent(name)}`)
+      .then((d) => alive && setData(d))
+      .catch(() => alive && setData(null))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [name]);
+
+  if (!name) return null;
+  const w = (kg: number | null | undefined) => (kg == null ? "—" : `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10} ${unit}`);
+  const prog = data?.progression ?? [];
+  const wSeries = prog.map((p) => (unit === "lb" ? p.maxWeight * KG_TO_LB : p.maxWeight));
+  const last = prog.length ? prog[prog.length - 1] : null;
+  const muscles = [...(data?.muscles.primary ?? [])];
+
+  return (
+    <Modal visible={!!name} onClose={onClose} title={name}>
+      <View className="gap-3">
+        {loading && !data ? (
+          <Text variant="body" className="text-text-muted">Loading…</Text>
+        ) : !data ? (
+          <Text variant="body" className="text-text-muted">No data for this exercise.</Text>
+        ) : (
+          <>
+            {muscles.length ? (
+              <View className="flex-row flex-wrap gap-1.5">
+                {muscles.map((m) => <Badge key={m} label={m} tone="teal" />)}
+                {(data.muscles.secondary ?? []).map((m) => <Badge key={m} label={m} tone="neutral" />)}
+              </View>
+            ) : null}
+
+            <View className="flex-row flex-wrap gap-3">
+              <View className="min-w-[46%] flex-1">
+                <Text variant="eyebrow" className="text-text-muted">Max weight</Text>
+                <Text variant="title" className="text-lime">{w(data.records.maxWeight?.value)}</Text>
+                <Text variant="micro" className="text-text-muted">{data.records.maxWeight?.reps ?? "—"} reps · {shortDate(data.records.maxWeight?.date)}</Text>
+              </View>
+              <View className="min-w-[46%] flex-1">
+                <Text variant="eyebrow" className="text-text-muted">Est. 1RM</Text>
+                <Text variant="title" className="text-teal">{w(data.records.estimated1RM?.value)}</Text>
+                <Text variant="micro" className="text-text-muted">{shortDate(data.records.estimated1RM?.date)}</Text>
+              </View>
+              <View className="min-w-[46%] flex-1">
+                <Text variant="eyebrow" className="text-text-muted">Max reps</Text>
+                <Text variant="title" className="text-text">{data.records.maxReps?.value ?? "—"}</Text>
+                <Text variant="micro" className="text-text-muted">@ {w(data.records.maxReps?.weight)}</Text>
+              </View>
+              <View className="min-w-[46%] flex-1">
+                <Text variant="eyebrow" className="text-text-muted">Sessions</Text>
+                <Text variant="title" className="text-text">{data.totalSessions}</Text>
+                <Text variant="micro" className="text-text-muted">{data.totalSets} sets · {data.totalReps} reps</Text>
+              </View>
+            </View>
+
+            {wSeries.length >= 2 ? (
+              <View className="gap-1">
+                <Text variant="eyebrow" className="text-text-muted">Max weight · {wSeries.length} sessions</Text>
+                <LineChart height={140} series={[{ values: wSeries, color: "#cbe896", width: 2.2 }]} yFormat={(v) => `${Math.round(v)}`} />
+              </View>
+            ) : null}
+
+            {last?.sets?.length ? (
+              <View className="gap-1">
+                <Text variant="eyebrow" className="text-text-muted">Last session · {shortDate(last.date)}</Text>
+                <View className="flex-row flex-wrap gap-1.5">
+                  {last.sets.map((s, i) => (
+                    <View key={i} className="rounded-md bg-surface-subtle px-2 py-1">
+                      <Text variant="micro" className="tabular-nums text-text">{w(s.weight)} × {s.reps}</Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ) : null}
+          </>
+        )}
+      </View>
+    </Modal>
+  );
+}

--- a/universal/src/components/workout-detail-modal.tsx
+++ b/universal/src/components/workout-detail-modal.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import { View } from "react-native";
+import { Text, Card, Modal, Badge } from "soma-style";
+import { fetchJson } from "../lib/api";
+
+interface WSet { weight_kg: number | null; reps: number | null; type?: string; avg_hr?: number }
+interface WExercise { title: string; sets: WSet[] }
+interface WorkoutDetail {
+  id: string; title?: string; start_time?: string; end_time?: string;
+  exercises: WExercise[];
+  garmin: { avg_hr: number | null; max_hr: number | null; calories: number | null } | null;
+}
+
+const KG_TO_LB = 2.20462;
+function longDate(iso: string | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+}
+function durationMin(w: WorkoutDetail): number | null {
+  if (!w.start_time || !w.end_time) return null;
+  const a = new Date(w.start_time).getTime(), b = new Date(w.end_time).getTime();
+  return isFinite(a) && isFinite(b) && b > a ? Math.round((b - a) / 60000) : null;
+}
+
+/**
+ * Single-workout detail (web parity, #429): per-exercise sets (weight × reps),
+ * total volume + set count, and the Garmin HR / calories overlay. Fetches
+ * /api/workout/[id] on open. Weight unit follows the screen toggle.
+ */
+export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | null; title?: string; unit: "kg" | "lb"; onClose: () => void }) {
+  const [data, setData] = useState<WorkoutDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    if (!id) { setData(null); return; }
+    let alive = true;
+    setLoading(true);
+    fetchJson<WorkoutDetail>(`/api/workout/${encodeURIComponent(id)}`)
+      .then((d) => alive && setData(d))
+      .catch(() => alive && setData(null))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [id]);
+
+  if (!id) return null;
+  const w = (kg: number | null | undefined) => (kg == null ? "—" : `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10}`);
+  const exercises = data?.exercises ?? [];
+  let volumeKg = 0, setCount = 0;
+  for (const ex of exercises) for (const s of ex.sets) {
+    if (s.weight_kg != null && s.reps != null) volumeKg += s.weight_kg * s.reps;
+    setCount++;
+  }
+  const vol = unit === "lb" ? volumeKg * KG_TO_LB : volumeKg;
+  const dur = data ? durationMin(data) : null;
+
+  return (
+    <Modal visible={!!id} onClose={onClose} title={data?.title || title || "Workout"}>
+      <View className="gap-3">
+        {loading && !data ? (
+          <Text variant="body" className="text-text-muted">Loading…</Text>
+        ) : !data ? (
+          <Text variant="body" className="text-text-muted">No detail for this workout.</Text>
+        ) : (
+          <>
+            <Text variant="micro" className="text-text-muted">{longDate(data.start_time)}</Text>
+            <View className="flex-row flex-wrap gap-3">
+              <View className="min-w-[30%] flex-1">
+                <Text variant="eyebrow" className="text-text-muted">Volume</Text>
+                <Text variant="title" className="text-teal">{vol >= 1000 ? `${(vol / 1000).toFixed(1)}k` : Math.round(vol)}</Text>
+                <Text variant="micro" className="text-text-muted">{unit} · {setCount} sets</Text>
+              </View>
+              {dur != null ? (
+                <View className="min-w-[30%] flex-1">
+                  <Text variant="eyebrow" className="text-text-muted">Duration</Text>
+                  <Text variant="title" className="text-lime">{dur}</Text>
+                  <Text variant="micro" className="text-text-muted">min</Text>
+                </View>
+              ) : null}
+              {data.garmin?.calories != null ? (
+                <View className="min-w-[30%] flex-1">
+                  <Text variant="eyebrow" className="text-text-muted">Calories</Text>
+                  <Text variant="title" className="text-warm">{Math.round(data.garmin.calories)}</Text>
+                  <Text variant="micro" className="text-text-muted">kcal · Garmin</Text>
+                </View>
+              ) : null}
+              {data.garmin?.avg_hr != null ? (
+                <View className="min-w-[30%] flex-1">
+                  <Text variant="eyebrow" className="text-text-muted">Avg HR</Text>
+                  <Text variant="title" className="text-danger">{Math.round(data.garmin.avg_hr)}</Text>
+                  <Text variant="micro" className="text-text-muted">{data.garmin.max_hr != null ? `max ${Math.round(data.garmin.max_hr)}` : "bpm"}</Text>
+                </View>
+              ) : null}
+            </View>
+
+            <View className="gap-2">
+              {exercises.map((ex, ei) => (
+                <View key={ei} className="gap-1 border-t border-border-subtle pt-2">
+                  <Text variant="body" className="text-text" numberOfLines={1}>{ex.title || "Exercise"}</Text>
+                  <View className="flex-row flex-wrap gap-1.5">
+                    {ex.sets.map((s, si) => (
+                      <View key={si} className="rounded-md bg-surface-subtle px-2 py-1">
+                        <Text variant="micro" className="tabular-nums text-text-secondary">
+                          {s.weight_kg != null ? `${w(s.weight_kg)} × ` : ""}{s.reps ?? "—"}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                </View>
+              ))}
+            </View>
+          </>
+        )}
+      </View>
+    </Modal>
+  );
+}

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -1,7 +1,10 @@
-import { View } from "react-native";
-import { Text, Card } from "soma-style";
+import { useState } from "react";
+import { View, Pressable } from "react-native";
+import { Text, Card, SegmentedControl } from "soma-style";
 import type { WorkoutSummary } from "../lib/api";
 import { LineChart } from "./line-chart";
+import { ExerciseDetailModal } from "./exercise-detail-modal";
+import { WorkoutDetailModal } from "./workout-detail-modal";
 
 const num = (v: unknown): number => {
   const n = Number(v);
@@ -19,13 +22,16 @@ function kvol(v: number): string {
 function VolumeChart({ weeks }: { weeks: WorkoutSummary["weeklyVolume"] }) {
   const recent = weeks.slice(-16);
   const vals = recent.map((w) => num(w.total_volume));
-  if (vals.filter((v) => v > 0).length < 2) return null;
+  const nonZero = vals.filter((v) => v > 0);
+  if (nonZero.length < 2) return null;
   const labels = recent.map((w) => shortDate(String(w.week)));
+  const avg = nonZero.reduce((a, b) => a + b, 0) / nonZero.length;
   return (
     <LineChart
       height={130}
       labels={labels}
       yFormat={(v) => kvol(v)}
+      refLine={{ y: avg, color: "#5a7a8a" }}
       series={[{ values: vals.map((v) => (v > 0 ? v : null)), color: "#77c8d1", width: 2.4 }]}
     />
   );
@@ -34,6 +40,9 @@ function VolumeChart({ weeks }: { weeks: WorkoutSummary["weeklyVolume"] }) {
 /** Workouts dashboard: summary stats + weekly volume + top exercises (+ optional
     recent list — hidden on the workouts screen, which has its own sync-status list). */
 export function WorkoutsDashboard({ summary, showRecent = true }: { summary: WorkoutSummary | null | undefined; showRecent?: boolean }) {
+  const [unit, setUnit] = useState<"kg" | "lb">("kg");
+  const [exName, setExName] = useState<string | null>(null);
+  const [wkId, setWkId] = useState<{ id: string; title: string } | null>(null);
   if (!summary) return null;
   const s = summary.stats;
   const stats: { label: string; value: string; sub: string }[] = s
@@ -59,6 +68,14 @@ export function WorkoutsDashboard({ summary, showRecent = true }: { summary: Wor
         </View>
       ) : null}
 
+      {/* Weight-unit toggle (kg ↔ lb) — drives the detail modals */}
+      <View className="flex-row items-center justify-between">
+        <Text variant="micro" className="text-text-muted">Tap an exercise or workout for detail</Text>
+        <View className="w-24">
+          <SegmentedControl options={["kg", "lb"] as const} value={unit} onChange={(v) => setUnit(v as "kg" | "lb")} />
+        </View>
+      </View>
+
       {summary.weeklyVolume.length >= 2 ? (
         <Card className="gap-2">
           <View className="flex-row items-center justify-between">
@@ -73,11 +90,17 @@ export function WorkoutsDashboard({ summary, showRecent = true }: { summary: Wor
       {summary.topExercises.length ? (
         <Card className="gap-2">
           <Text variant="eyebrow">Top exercises</Text>
-          {summary.topExercises.map((e) => (
-            <View key={e.name} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
-              <Text variant="body" className="text-text-secondary flex-1" numberOfLines={1}>{e.name}</Text>
-              <Text variant="caption" className="tabular-nums text-text-muted ml-2">{e.sessions}×</Text>
-            </View>
+          {summary.topExercises.map((e, i) => (
+            <Pressable key={e.name} onPress={() => setExName(e.name)} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+              <View className="flex-row items-center gap-2 flex-1">
+                <Text variant="micro" className="tabular-nums text-text-muted w-5">{i + 1}</Text>
+                <Text variant="body" className="text-text-secondary flex-1" numberOfLines={1}>{e.name}</Text>
+              </View>
+              <View className="flex-row items-center gap-1.5 ml-2">
+                <Text variant="caption" className="tabular-nums text-text-muted">{e.sessions}×</Text>
+                <Text variant="micro" className="text-text-muted">›</Text>
+              </View>
+            </Pressable>
           ))}
         </Card>
       ) : null}
@@ -86,18 +109,24 @@ export function WorkoutsDashboard({ summary, showRecent = true }: { summary: Wor
         <Card className="gap-2">
           <Text variant="eyebrow">Recent workouts</Text>
           {summary.recent.slice(0, 10).map((w) => (
-            <View key={w.id} className="border-b border-border-subtle py-2">
+            <Pressable key={w.id} onPress={() => setWkId({ id: w.id, title: w.title || "Workout" })} className="border-b border-border-subtle py-2">
               <View className="flex-row items-center justify-between">
                 <Text variant="body" className="text-text flex-1" numberOfLines={1}>{w.title || "Workout"}</Text>
-                <Text variant="micro" className="text-text-muted ml-2">{shortDate(w.start_time)}</Text>
+                <View className="flex-row items-center gap-1.5 ml-2">
+                  <Text variant="micro" className="text-text-muted">{shortDate(w.start_time)}</Text>
+                  <Text variant="micro" className="text-text-muted">›</Text>
+                </View>
               </View>
               <Text variant="micro" className="text-text-muted">
                 {w.exercise_count} exercises{w.duration_min ? ` · ${w.duration_min} min` : ""}{w.volume > 0 ? ` · ${kvol(w.volume)} kg` : ""}
               </Text>
-            </View>
+            </Pressable>
           ))}
         </Card>
       ) : null}
+
+      <ExerciseDetailModal name={exName} unit={unit} onClose={() => setExName(null)} />
+      <WorkoutDetailModal id={wkId?.id ?? null} title={wkId?.title} unit={unit} onClose={() => setWkId(null)} />
     </View>
   );
 }


### PR DESCRIPTION
## App parity — Workouts: exercise + workout detail modals (part of #429)

Adds the workout/exercise drill-in layer the app was missing, using the **two existing HTTP endpoints** (no new endpoint). Part of the Workouts screen (#425).

### What changed
- **Tap a Top Exercise → `ExerciseDetailModal`** — muscle badges, PR grid (max weight / est 1RM / max reps / sessions), a max-weight **progression LineChart**, and the last session's sets. Fetches `/api/workouts/exercise?name=`.
- **Tap a Recent Workout → `WorkoutDetailModal`** — total volume + set count, duration, Garmin **calories + avg/max HR**, and every exercise's sets. Fetches `/api/workout/[id]`.
- **kg ↔ lb toggle** drives both modals; Top Exercises rows gain a rank number; the Weekly Volume chart gains a dashed **average reference line**.

### Deferred (to the Workouts insights endpoint, PR-B)
The web page's Top-Exercise best-weight / recency / sparkline, the **Training Span** stat, and a **Show-all** workouts dialog all rely on page-only SQL (`getTopExercises`, `getWorkoutSummaryStats.first/last`). PR-B adds a `/api/workouts/insights` endpoint and completes these, closing #429 alongside #426/#427/#428. Documented mobile trim: chart hover tooltips.

### Files
- New: `exercise-detail-modal.tsx`, `workout-detail-modal.tsx`.
- Modified: `workouts-dashboard.tsx` (unit toggle, tappable rows, volume avg line).

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (mobile 390×844): numbered Top Exercises; ExerciseDetailModal (Bench Press — CHEST/TRICEPS/FRONT DELTS, max 100 kg / est 1RM 116.7 kg / 64 sessions, rising progression chart, 97×8/97×6/87×10 last sets); WorkoutDetailModal (Push Day — 3.7k kg · 9 sets, 67 min, 432 kcal Garmin, avg HR 121, per-exercise sets); and the kg→lb toggle converting correctly (80 kg → 176.4 lb, volume 3.7k kg → 8.2k lb).

Part of #429
