### PR TITLE
App parity — Workouts: insights endpoint + muscle/strength/calendar (#425)

### DIFF
--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,9 +1,12 @@
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useWorkoutsSummary } from "../../lib/api";
+import { fetchJson, usePullRefresh, useWorkoutsSummary, useWorkoutInsights } from "../../lib/api";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { WorkoutsDashboard } from "../../components/workouts-dashboard";
+import { WorkoutActivity } from "../../components/workout-activity";
+import { WorkoutMuscle } from "../../components/workout-muscle";
+import { WorkoutStrength } from "../../components/workout-strength";
 
 interface RecentWorkout {
   title: string;
@@ -59,9 +62,22 @@ function formatDate(dateStr: string): string {
 export default function WorkoutsScreen() {
   const { data, error, refetch } = useWorkouts();
   const [range, setRange] = useState<"30d" | "90d" | "1y">("90d");
+  const [unit, setUnit] = useState<"kg" | "lb">("kg");
   const { data: wkSum } = useWorkoutsSummary(range);
+  const { data: insights } = useWorkoutInsights(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
   const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
+
+  // Training span (first → last workout) from the all-time calendar.
+  const trainingSpan = (() => {
+    const cal = insights?.calendar ?? [];
+    if (cal.length < 2) return null;
+    const first = new Date(String(cal[0].day).slice(0, 10));
+    const last = new Date(String(cal[cal.length - 1].day).slice(0, 10));
+    const days = Math.round((last.getTime() - first.getTime()) / 86400000);
+    const months = Math.max(1, Math.round(days / 30.4));
+    return { count: cal.length, years: days / 365, months, first: cal[0].day, last: cal[cal.length - 1].day };
+  })();
 
   const recent = data?.recent ?? [];
   const totalSynced = data?.totalSynced ?? 0;
@@ -106,6 +122,14 @@ export default function WorkoutsScreen() {
       cls: "text-warm",
       spark: { data: kcalTrend, color: "#b17850" },
     },
+    ...(trainingSpan
+      ? [{
+          label: "Training Span",
+          value: trainingSpan.years >= 1 ? `${trainingSpan.years.toFixed(1)}y` : `${trainingSpan.months}mo`,
+          sub: `${trainingSpan.count} workouts logged`,
+          cls: "text-indigo",
+        }]
+      : []),
   ];
 
   return (
@@ -168,12 +192,28 @@ export default function WorkoutsScreen() {
         </View>
 
         {/* Workout data — volume, stats, top exercises, recent (new /api/workouts/summary) */}
-        <SegmentedControl
-          options={["30d", "90d", "1y"] as const}
-          value={range}
-          onChange={(v) => setRange(v as "30d" | "90d" | "1y")}
-        />
-        <WorkoutsDashboard summary={wkSum} />
+        <View className="flex-row items-center gap-3">
+          <View className="flex-1">
+            <SegmentedControl
+              options={["30d", "90d", "1y"] as const}
+              value={range}
+              onChange={(v) => setRange(v as "30d" | "90d" | "1y")}
+            />
+          </View>
+          <View className="w-24">
+            <SegmentedControl options={["kg", "lb"] as const} value={unit} onChange={(v) => setUnit(v as "kg" | "lb")} />
+          </View>
+        </View>
+        <WorkoutsDashboard summary={wkSum} unit={unit} topRich={insights?.topExercises} />
+
+        {/* Muscle-group distribution + monthly-by-muscle (new /api/workouts/insights) */}
+        <WorkoutMuscle insights={insights} />
+
+        {/* Configurable strength progression + PRs + program split */}
+        <WorkoutStrength insights={insights} unit={unit} />
+
+        {/* Training calendar + weekly frequency + avg-HR per workout */}
+        <WorkoutActivity insights={insights} />
 
         {/* Sync coverage bar */}
         {recent.length > 0 ? (

--- a/universal/src/components/workout-activity.tsx
+++ b/universal/src/components/workout-activity.tsx
@@ -1,0 +1,127 @@
+import { useMemo } from "react";
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import { LineChart, ChartLegend } from "./line-chart";
+import type { WorkoutInsights } from "../lib/api";
+
+const num = (v: unknown): number => { const n = Number(v); return isFinite(n) ? n : 0; };
+const EMPTY = "#16242b";
+const LVL = ["#1e3a44", "#2f6d5b", "#4fa07a", "#77c8a0"]; // workout-day intensity
+
+function isoDay(d: Date): string { return d.toISOString().slice(0, 10); }
+function mondayIndex(d: Date): number { return (d.getUTCDay() + 6) % 7; } // Mon=0..Sun=6
+
+/** 26-week workout calendar heatmap (day cells colored by that day's session count). */
+function CalendarHeatmap({ calendar }: { calendar: WorkoutInsights["calendar"] }) {
+  const { weeks } = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const c of calendar) {
+      const key = String(c.day).slice(0, 10);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    // anchor to today (UTC); 26 columns ending this week
+    const today = new Date(isoDay(new Date()) + "T00:00:00Z");
+    const end = new Date(today); end.setUTCDate(end.getUTCDate() - mondayIndex(today) + 6); // Sunday of this week
+    const cols: { c: string; n: number }[][] = [];
+    for (let w = 25; w >= 0; w--) {
+      const col: { c: string; n: number }[] = [];
+      for (let d = 0; d < 7; d++) {
+        const day = new Date(end);
+        day.setUTCDate(end.getUTCDate() - w * 7 - (6 - d));
+        const n = counts.get(isoDay(day)) ?? 0;
+        col.push({ c: n === 0 ? EMPTY : LVL[Math.min(LVL.length - 1, n - 1)], n });
+      }
+      cols.push(col);
+    }
+    return { weeks: cols };
+  }, [calendar]);
+
+  return (
+    <View className="gap-1.5">
+      <View className="flex-row gap-0.5">
+        {weeks.map((col, wi) => (
+          <View key={wi} className="flex-1 gap-0.5">
+            {col.map((cell, di) => (
+              <View key={di} className="rounded-[2px]" style={{ aspectRatio: 1, backgroundColor: cell.c }} />
+            ))}
+          </View>
+        ))}
+      </View>
+      <View className="flex-row items-center justify-end gap-1">
+        <Text variant="micro" className="text-text-muted">less</Text>
+        {[EMPTY, ...LVL].map((c) => <View key={c} className="h-2.5 w-2.5 rounded-[2px]" style={{ backgroundColor: c }} />)}
+        <Text variant="micro" className="text-text-muted">more</Text>
+      </View>
+    </View>
+  );
+}
+
+/** Weekly workout frequency (sessions/week), derived from the calendar. */
+function frequencyFromCalendar(calendar: WorkoutInsights["calendar"]): { labels: string[]; counts: number[] } {
+  const wk = new Map<string, number>();
+  for (const c of calendar) {
+    const d = new Date(String(c.day).slice(0, 10) + "T00:00:00Z");
+    d.setUTCDate(d.getUTCDate() - mondayIndex(d)); // Monday of that week
+    const key = isoDay(d);
+    wk.set(key, (wk.get(key) ?? 0) + 1);
+  }
+  const sorted = [...wk.entries()].sort((a, b) => a[0].localeCompare(b[0])).slice(-16);
+  return {
+    labels: sorted.map(([k]) => { const [, m, d] = k.split("-").map(Number); return `${["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][(m ?? 1) - 1]} ${d}`; }),
+    counts: sorted.map(([, v]) => v),
+  };
+}
+
+/** Calendar heatmap + weekly frequency + per-workout avg-HR (web parity, #428). */
+export function WorkoutActivity({ insights }: { insights: WorkoutInsights | null | undefined }) {
+  if (!insights) return null;
+  const cal = insights.calendar ?? [];
+  const freq = frequencyFromCalendar(cal);
+  const hr = insights.hrTrend ?? [];
+  const hrAvg = hr.map((h) => (h.avg_hr == null ? null : num(h.avg_hr)));
+  const hrMax = hr.map((h) => (h.max_hr == null ? null : num(h.max_hr)));
+  const hrLabels = hr.map((h) => { const [, m, d] = String(h.date).slice(0, 10).split("-").map(Number); return `${["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][(m ?? 1) - 1]} ${d}`; });
+
+  return (
+    <View className="gap-4">
+      {cal.length ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Training calendar</Text>
+            <Text variant="micro" className="text-text-muted">last 26 weeks</Text>
+          </View>
+          <CalendarHeatmap calendar={cal} />
+        </Card>
+      ) : null}
+
+      {freq.counts.length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Weekly frequency</Text>
+            <Text variant="micro" className="text-text-muted">sessions / week</Text>
+          </View>
+          <LineChart height={120} labels={freq.labels} yFormat={(v) => String(Math.round(v))} series={[{ values: freq.counts, color: "#6ad4a0", width: 2.2 }]} />
+        </Card>
+      ) : null}
+
+      {hrAvg.filter((v) => v != null).length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Avg HR per workout</Text>
+            <Text variant="micro" className="text-text-muted">bpm</Text>
+          </View>
+          <LineChart
+            height={130}
+            labels={hrLabels}
+            yFormat={(v) => String(Math.round(v))}
+            series={[
+              { values: hrMax, color: "#e06060", dashed: true, width: 1.5 },
+              { values: hrAvg, color: "#e0a458", width: 2.2 },
+            ]}
+          />
+          <ChartLegend items={[{ color: "#e0a458", label: "avg" }, { color: "#e06060", label: "max", dashed: true }]} />
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/components/workout-muscle.tsx
+++ b/universal/src/components/workout-muscle.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import type { WorkoutInsights } from "../lib/api";
+
+const num = (v: unknown): number => { const n = Number(v); return isFinite(n) ? n : 0; };
+const GROUPS = ["Chest", "Back", "Shoulders", "Arms", "Legs", "Core"] as const;
+const COLOR: Record<string, string> = {
+  Chest: "#e06060", Back: "#77c8d1", Shoulders: "#e0a458",
+  Arms: "#c084fc", Legs: "#6ad4a0", Core: "#cbe896",
+};
+function kvol(v: number): string { return v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${Math.round(v)}`; }
+function monthLabel(m: string): string { const [, mm] = m.split("-").map(Number); return ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][(mm ?? 1) - 1]; }
+
+/**
+ * Muscle-group training distribution (web parity, #426): a per-muscle volume
+ * bar breakdown (mobile take on the anatomical body map) plus a stacked
+ * monthly-volume-by-muscle chart. Fed by /api/workouts/insights.monthlyMuscle.
+ */
+export function WorkoutMuscle({ insights }: { insights: WorkoutInsights | null | undefined }) {
+  const rows = insights?.monthlyMuscle ?? [];
+  const { totals, grandTotal, months } = useMemo(() => {
+    const t: Record<string, number> = {};
+    const monthMap = new Map<string, Record<string, number>>();
+    for (const r of rows) {
+      const g = r.muscle_group; const v = num(r.volume);
+      t[g] = (t[g] ?? 0) + v;
+      if (!monthMap.has(r.month)) monthMap.set(r.month, {});
+      const mm = monthMap.get(r.month)!; mm[g] = (mm[g] ?? 0) + v;
+    }
+    const gt = Object.values(t).reduce((a, b) => a + b, 0);
+    const ms = [...monthMap.entries()].sort((a, b) => a[0].localeCompare(b[0])).slice(-8);
+    return { totals: t, grandTotal: gt, months: ms };
+  }, [rows]);
+
+  if (!rows.length || grandTotal <= 0) return null;
+  const maxGroup = Math.max(...GROUPS.map((g) => totals[g] ?? 0)) || 1;
+  const maxMonth = Math.max(...months.map(([, mm]) => Object.values(mm).reduce((a, b) => a + b, 0))) || 1;
+
+  return (
+    <View className="gap-4">
+      <Card className="gap-2">
+        <Text variant="eyebrow">Muscle volume</Text>
+        {GROUPS.map((g) => {
+          const v = totals[g] ?? 0;
+          const pct = grandTotal > 0 ? Math.round((v / grandTotal) * 100) : 0;
+          return (
+            <View key={g} className="flex-row items-center gap-2 py-0.5">
+              <Text variant="micro" className="text-text-secondary w-16">{g}</Text>
+              <View className="flex-1 h-3 rounded-full bg-surface-subtle overflow-hidden">
+                <View className="h-full rounded-full" style={{ width: `${Math.max(3, (v / maxGroup) * 100)}%`, backgroundColor: COLOR[g] }} />
+              </View>
+              <Text variant="micro" className="tabular-nums text-text-muted w-20 text-right">{kvol(v)} · {pct}%</Text>
+            </View>
+          );
+        })}
+        <Text variant="micro" className="text-text-muted">total volume by muscle group (kg × reps)</Text>
+      </Card>
+
+      {months.length >= 2 ? (
+        <Card className="gap-2">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Monthly volume by muscle</Text>
+            <Text variant="micro" className="text-text-muted">last {months.length} mo</Text>
+          </View>
+          <View className="h-32 flex-row items-end gap-1.5">
+            {months.map(([month, mm]) => {
+              const monthTotal = Object.values(mm).reduce((a, b) => a + b, 0);
+              const colH = monthTotal > 0 ? (monthTotal / maxMonth) * 100 : 0;
+              return (
+                <View key={month} className="flex-1 justify-end self-stretch">
+                  <View className="w-full overflow-hidden rounded-t-sm" style={{ height: `${Math.max(3, colH)}%` }}>
+                    {GROUPS.filter((g) => (mm[g] ?? 0) > 0).map((g) => (
+                      <View key={g} style={{ height: `${((mm[g] ?? 0) / monthTotal) * 100}%`, backgroundColor: COLOR[g] }} />
+                    ))}
+                  </View>
+                </View>
+              );
+            })}
+          </View>
+          <View className="flex-row gap-1.5">
+            {months.map(([month]) => (
+              <Text key={month} variant="micro" className="flex-1 text-center text-text-muted">{monthLabel(month)}</Text>
+            ))}
+          </View>
+          <View className="flex-row flex-wrap gap-x-3 gap-y-1">
+            {GROUPS.map((g) => (
+              <View key={g} className="flex-row items-center gap-1">
+                <View className="h-2 w-2 rounded-full" style={{ backgroundColor: COLOR[g] }} />
+                <Text variant="micro" className="text-text-muted">{g}</Text>
+              </View>
+            ))}
+          </View>
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/components/workout-strength.tsx
+++ b/universal/src/components/workout-strength.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { View, Pressable, ScrollView } from "react-native";
+import { Text, Card } from "soma-style";
+import { LineChart } from "./line-chart";
+import { fetchJson } from "../lib/api";
+import type { WorkoutInsights } from "../lib/api";
+
+const KG_TO_LB = 2.20462;
+const num = (v: unknown): number => { const n = Number(v); return isFinite(n) ? n : 0; };
+
+interface ProgResp { progression: { date: string; maxWeight: number; estimated1RM: number }[] }
+
+/** Configurable per-exercise strength progression: pick an exercise pill, load
+ *  its max-weight-over-time line from /api/workouts/exercise. */
+function StrengthProgression({ names, unit }: { names: string[]; unit: "kg" | "lb" }) {
+  const [sel, setSel] = useState<string | null>(names[0] ?? null);
+  const [prog, setProg] = useState<ProgResp["progression"]>([]);
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    if (!sel) return;
+    let alive = true; setLoading(true);
+    fetchJson<ProgResp>(`/api/workouts/exercise?name=${encodeURIComponent(sel)}`)
+      .then((d) => alive && setProg(d.progression ?? []))
+      .catch(() => alive && setProg([]))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [sel]);
+  if (!names.length) return null;
+  const vals = prog.map((p) => (unit === "lb" ? p.maxWeight * KG_TO_LB : p.maxWeight));
+
+  return (
+    <Card className="gap-2">
+      <Text variant="eyebrow">Strength progression</Text>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-2 pr-2">
+        {names.map((n) => (
+          <Pressable key={n} onPress={() => setSel(n)} className={`rounded-full px-3 py-1 ${sel === n ? "bg-teal" : "bg-surface-subtle"}`}>
+            <Text variant="micro" className={sel === n ? "text-base" : "text-text-secondary"}>{n}</Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+      {loading && !vals.length ? (
+        <Text variant="micro" className="text-text-muted">Loading…</Text>
+      ) : vals.length >= 2 ? (
+        <LineChart height={140} series={[{ values: vals, color: "#cbe896", width: 2.2 }]} yFormat={(v) => `${Math.round(v)} ${unit}`} />
+      ) : (
+        <Text variant="micro" className="text-text-muted">Not enough sessions for {sel}.</Text>
+      )}
+    </Card>
+  );
+}
+
+/** Strength progression + PR grid + program split (web parity, #427). */
+export function WorkoutStrength({ insights, unit }: { insights: WorkoutInsights | null | undefined; unit: "kg" | "lb" }) {
+  if (!insights) return null;
+  const w = (kg: number) => `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10} ${unit}`;
+  const names = (insights.topExercises ?? []).map((e) => e.exercise).slice(0, 8);
+  const prs = insights.prs ?? [];
+  const split = insights.programSplit ?? [];
+  const maxSessions = Math.max(1, ...split.map((p) => num(p.sessions)));
+
+  return (
+    <View className="gap-4">
+      <StrengthProgression names={names} unit={unit} />
+
+      {prs.length ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Personal records</Text>
+          <View className="flex-row flex-wrap gap-3">
+            {prs.slice(0, 8).map((p) => (
+              <View key={p.exercise} className="min-w-[46%] flex-1 gap-0.5">
+                <Text variant="micro" className="text-text-secondary" numberOfLines={1}>{p.exercise}</Text>
+                <Text variant="title" className="text-lime">{w(num(p.pr_weight))}</Text>
+                {p.reps_at_pr != null ? <Text variant="micro" className="text-text-muted">{num(p.reps_at_pr)} reps</Text> : null}
+              </View>
+            ))}
+          </View>
+        </Card>
+      ) : null}
+
+      {split.length ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Program split</Text>
+          {split.map((p) => (
+            <View key={p.program} className="flex-row items-center gap-2 py-0.5">
+              <Text variant="micro" className="text-text-secondary flex-1" numberOfLines={1}>{p.program || "Untitled"}</Text>
+              <View className="w-24 h-3 rounded-full bg-surface-subtle overflow-hidden">
+                <View className="h-full rounded-full bg-teal" style={{ width: `${Math.max(6, (num(p.sessions) / maxSessions) * 100)}%` }} />
+              </View>
+              <Text variant="micro" className="tabular-nums text-text-muted w-20 text-right">
+                {num(p.sessions)}× · {p.avg_duration != null ? `${num(p.avg_duration)}m` : "—"}
+              </Text>
+            </View>
+          ))}
+        </Card>
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import { View, Pressable } from "react-native";
-import { Text, Card, SegmentedControl } from "soma-style";
-import type { WorkoutSummary } from "../lib/api";
+import { Text, Card, Sparkline } from "soma-style";
+import type { WorkoutSummary, TopExerciseRich } from "../lib/api";
 import { LineChart } from "./line-chart";
 import { ExerciseDetailModal } from "./exercise-detail-modal";
 import { WorkoutDetailModal } from "./workout-detail-modal";
+
+const KG_TO_LB = 2.20462;
 
 const num = (v: unknown): number => {
   const n = Number(v);
@@ -39,11 +41,12 @@ function VolumeChart({ weeks }: { weeks: WorkoutSummary["weeklyVolume"] }) {
 
 /** Workouts dashboard: summary stats + weekly volume + top exercises (+ optional
     recent list — hidden on the workouts screen, which has its own sync-status list). */
-export function WorkoutsDashboard({ summary, showRecent = true }: { summary: WorkoutSummary | null | undefined; showRecent?: boolean }) {
-  const [unit, setUnit] = useState<"kg" | "lb">("kg");
+export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", topRich }: { summary: WorkoutSummary | null | undefined; showRecent?: boolean; unit?: "kg" | "lb"; topRich?: TopExerciseRich[] }) {
   const [exName, setExName] = useState<string | null>(null);
   const [wkId, setWkId] = useState<{ id: string; title: string } | null>(null);
   if (!summary) return null;
+  const richByName = new Map((topRich ?? []).map((t) => [t.exercise, t]));
+  const bestW = (kg: number | null) => (kg == null ? null : `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10} ${unit}`);
   const s = summary.stats;
   const stats: { label: string; value: string; sub: string }[] = s
     ? [
@@ -68,13 +71,7 @@ export function WorkoutsDashboard({ summary, showRecent = true }: { summary: Wor
         </View>
       ) : null}
 
-      {/* Weight-unit toggle (kg ↔ lb) — drives the detail modals */}
-      <View className="flex-row items-center justify-between">
-        <Text variant="micro" className="text-text-muted">Tap an exercise or workout for detail</Text>
-        <View className="w-24">
-          <SegmentedControl options={["kg", "lb"] as const} value={unit} onChange={(v) => setUnit(v as "kg" | "lb")} />
-        </View>
-      </View>
+      <Text variant="micro" className="text-text-muted">Tap an exercise or workout for detail</Text>
 
       {summary.weeklyVolume.length >= 2 ? (
         <Card className="gap-2">
@@ -90,18 +87,31 @@ export function WorkoutsDashboard({ summary, showRecent = true }: { summary: Wor
       {summary.topExercises.length ? (
         <Card className="gap-2">
           <Text variant="eyebrow">Top exercises</Text>
-          {summary.topExercises.map((e, i) => (
-            <Pressable key={e.name} onPress={() => setExName(e.name)} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
-              <View className="flex-row items-center gap-2 flex-1">
-                <Text variant="micro" className="tabular-nums text-text-muted w-5">{i + 1}</Text>
-                <Text variant="body" className="text-text-secondary flex-1" numberOfLines={1}>{e.name}</Text>
-              </View>
-              <View className="flex-row items-center gap-1.5 ml-2">
-                <Text variant="caption" className="tabular-nums text-text-muted">{e.sessions}×</Text>
-                <Text variant="micro" className="text-text-muted">›</Text>
-              </View>
-            </Pressable>
-          ))}
+          {summary.topExercises.map((e, i) => {
+            const r = richByName.get(e.name);
+            const spark = (r?.recent_weights ?? []).map((x) => Number(x)).filter((x) => isFinite(x));
+            const best = r?.best_weight != null ? bestW(Number(r.best_weight)) : null;
+            return (
+              <Pressable key={e.name} onPress={() => setExName(e.name)} className="border-b border-border-subtle py-1.5">
+                <View className="flex-row items-center justify-between">
+                  <View className="flex-row items-center gap-2 flex-1">
+                    <Text variant="micro" className="tabular-nums text-text-muted w-5">{i + 1}</Text>
+                    <Text variant="body" className="text-text-secondary flex-1" numberOfLines={1}>{e.name}</Text>
+                  </View>
+                  <View className="flex-row items-center gap-1.5 ml-2">
+                    {best ? <Text variant="micro" className="tabular-nums text-lime">{best}</Text> : null}
+                    <Text variant="caption" className="tabular-nums text-text-muted">{e.sessions}×</Text>
+                    <Text variant="micro" className="text-text-muted">›</Text>
+                  </View>
+                </View>
+                {spark.length >= 2 ? (
+                  <View className="mt-1 pl-7">
+                    <Sparkline data={spark} color="#77c8d1" height={18} baseline />
+                  </View>
+                ) : null}
+              </Pressable>
+            );
+          })}
         </Card>
       ) : null}
 

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -487,6 +487,35 @@ export function useWorkoutsSummary(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Workout insights (muscle / PRs / calendar / frequency / HR / program) ----
+export interface TopExerciseRich {
+  exercise: string; workout_count: number | string;
+  best_weight: number | string | null; avg_weight: number | string | null;
+  last_performed: string | null; recent_weights: number[];
+}
+export interface WorkoutInsights {
+  topExercises: TopExerciseRich[];
+  programSplit: { program: string; sessions: number | string; avg_duration: number | string | null }[];
+  prs: { exercise: string; pr_weight: number | string; reps_at_pr: number | string | null }[];
+  hrTrend: { date: string; avg_hr: number | string | null; max_hr: number | string | null; title: string; duration_min: number | string | null }[];
+  monthlyMuscle: { month: string; muscle_group: string; volume: number | string }[];
+  calendar: { day: string; program: string | null }[];
+}
+
+/** Page-only workout SQL exposed as JSON from /api/workouts/insights. */
+export function useWorkoutInsights(range: string) {
+  const [data, setData] = useState<WorkoutInsights | null>(null);
+  const [reload, setReload] = useState(0);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<WorkoutInsights>(`/api/workouts/insights?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range, reload]);
+  return { data, refetch: () => setReload((n) => n + 1) };
+}
+
 // ---- Per-night sleep data (stages, score, sleep HR, SpO2) for the sleep dashboard ----
 export interface SleepNight {
   date: string;

--- a/web/app/api/workouts/insights/route.ts
+++ b/web/app/api/workouts/insights/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Workout "insights" as JSON for the native app: the panels the web /workouts
+ * page renders directly from SQL (no HTTP endpoint existed). Ports the page's
+ * getTopExercises / getProgramSplit / getExercisePRs / getWorkoutHrTrend /
+ * getMonthlyMuscleVolume / getTrainingCalendar queries. Weekly frequency and
+ * training span are derived client-side from `calendar` to keep this lean.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "90d";
+  const days = range === "30d" ? 30 : range === "1y" ? 365 : range === "6m" ? 182 : 90;
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+
+  const sql = getDb();
+
+  const [topExercises, programSplit, prs, hrTrend, monthlyMuscle, calendar] = await Promise.all([
+    // Top exercises (rich): count, best/avg weight, last performed, last-8 max weights
+    sql`
+      WITH base AS (
+        SELECT e->>'title' as exercise,
+          COUNT(DISTINCT raw_json->>'id') as workout_count,
+          MAX((s->>'weight_kg')::float) as best_weight,
+          ROUND(AVG((s->>'weight_kg')::float)::numeric, 1) as avg_weight,
+          MAX((raw_json->>'start_time')::date) as last_performed
+        FROM hevy_raw_data,
+          jsonb_array_elements(raw_json->'exercises') as e,
+          jsonb_array_elements(e->'sets') as s
+        WHERE endpoint_name = 'workout'
+          AND (raw_json->>'start_time')::timestamp >= ${cutoff}::date
+          AND s->>'type' = 'normal' AND (s->>'weight_kg')::float > 0
+        GROUP BY e->>'title' ORDER BY workout_count DESC LIMIT 10
+      ),
+      recent_w AS (
+        SELECT e->>'title' as exercise, (raw_json->>'start_time')::date as wdate,
+          MAX((s->>'weight_kg')::float) as max_weight
+        FROM hevy_raw_data,
+          jsonb_array_elements(raw_json->'exercises') as e,
+          jsonb_array_elements(e->'sets') as s
+        WHERE endpoint_name = 'workout'
+          AND (raw_json->>'start_time')::timestamp >= ${cutoff}::date
+          AND s->>'type' = 'normal' AND (s->>'weight_kg')::float > 0
+          AND e->>'title' IN (SELECT exercise FROM base)
+        GROUP BY e->>'title', wdate
+      ),
+      ranked AS (
+        SELECT exercise, max_weight,
+          ROW_NUMBER() OVER (PARTITION BY exercise ORDER BY wdate DESC) as rn
+        FROM recent_w
+      ),
+      agg AS (
+        SELECT exercise, array_agg(max_weight ORDER BY rn DESC) as recent_weights
+        FROM ranked WHERE rn <= 8 GROUP BY exercise
+      )
+      SELECT b.*, COALESCE(a.recent_weights, ARRAY[]::float[]) as recent_weights
+      FROM base b LEFT JOIN agg a ON a.exercise = b.exercise
+      ORDER BY b.workout_count DESC
+    `,
+    // Program split
+    sql`
+      SELECT raw_json->>'title' as program, COUNT(*) as sessions,
+        ROUND(AVG(EXTRACT(EPOCH FROM ((raw_json->>'end_time')::timestamp - (raw_json->>'start_time')::timestamp)) / 60)::numeric) as avg_duration
+      FROM hevy_raw_data
+      WHERE endpoint_name = 'workout'
+        AND (raw_json->>'start_time')::timestamp >= ${cutoff}::date
+      GROUP BY raw_json->>'title' ORDER BY sessions DESC LIMIT 6
+    `,
+    // Personal records (all-time, top 20 by max weight)
+    sql`
+      WITH all_sets AS (
+        SELECT e->>'title' as exercise, (s->>'weight_kg')::float as weight, (s->>'reps')::int as reps
+        FROM hevy_raw_data,
+          jsonb_array_elements(raw_json->'exercises') as e,
+          jsonb_array_elements(e->'sets') as s
+        WHERE endpoint_name = 'workout' AND s->>'type' = 'normal' AND (s->>'weight_kg')::float > 0
+      ),
+      maxes AS (SELECT exercise, MAX(weight) as pr_weight FROM all_sets GROUP BY exercise HAVING MAX(weight) > 0)
+      SELECT m.exercise, m.pr_weight, MAX(a.reps) as reps_at_pr
+      FROM maxes m JOIN all_sets a ON a.exercise = m.exercise AND a.weight = m.pr_weight
+      GROUP BY m.exercise, m.pr_weight ORDER BY m.pr_weight DESC LIMIT 20
+    `,
+    // Per-workout avg/max HR (enrichment)
+    sql`
+      SELECT (h.raw_json->>'start_time')::date as date, we.avg_hr, we.max_hr,
+        h.raw_json->>'title' as title,
+        ROUND(EXTRACT(EPOCH FROM ((h.raw_json->>'end_time')::timestamp - (h.raw_json->>'start_time')::timestamp)) / 60)::int as duration_min
+      FROM hevy_raw_data h JOIN workout_enrichment we ON we.hevy_id = h.raw_json->>'id'
+      WHERE h.endpoint_name = 'workout'
+        AND (h.raw_json->>'start_time')::timestamp >= ${cutoff}::date
+        AND we.avg_hr IS NOT NULL
+      ORDER BY date ASC
+    `,
+    // Monthly volume by muscle group (6 groups via ILIKE CASE)
+    sql`
+      WITH exercise_muscles AS (
+        SELECT TO_CHAR((raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York', 'YYYY-MM') as month,
+          CASE
+            WHEN e->>'title' ILIKE '%bench%' OR e->>'title' ILIKE '%chest%' OR e->>'title' ILIKE '%dip%' THEN 'Chest'
+            WHEN e->>'title' ILIKE '%row%' OR e->>'title' ILIKE '%pull up%' OR e->>'title' ILIKE '%lat %' OR e->>'title' ILIKE '%deadlift%' OR e->>'title' ILIKE '%back extension%' THEN 'Back'
+            WHEN e->>'title' ILIKE '%shoulder%' OR e->>'title' ILIKE '%overhead press%' OR e->>'title' ILIKE '%lateral raise%' OR e->>'title' ILIKE '%face pull%' OR e->>'title' ILIKE '%rear delt%' OR e->>'title' ILIKE '%reverse fly%' THEN 'Shoulders'
+            WHEN e->>'title' ILIKE '%curl%' OR e->>'title' ILIKE '%hammer%' OR e->>'title' ILIKE '%preacher%' THEN 'Arms'
+            WHEN e->>'title' ILIKE '%tricep%' OR e->>'title' ILIKE '%pushdown%' THEN 'Arms'
+            WHEN e->>'title' ILIKE '%leg press%' OR e->>'title' ILIKE '%leg extension%' OR e->>'title' ILIKE '%squat%' OR e->>'title' ILIKE '%leg curl%' OR e->>'title' ILIKE '%romanian%' OR e->>'title' ILIKE '%hip%' THEN 'Legs'
+            WHEN e->>'title' ILIKE '%calf%' THEN 'Legs'
+            WHEN e->>'title' ILIKE '%crunch%' OR e->>'title' ILIKE '%plank%' OR e->>'title' ILIKE '%leg raise%' OR e->>'title' ILIKE '%side bend%' OR e->>'title' ILIKE '%russian twist%' OR e->>'title' ILIKE '%superman%' OR e->>'title' ILIKE '%torso%' THEN 'Core'
+            ELSE NULL
+          END as muscle_group,
+          (s->>'weight_kg')::float * (s->>'reps')::int as volume
+        FROM hevy_raw_data,
+          jsonb_array_elements(raw_json->'exercises') as e,
+          jsonb_array_elements(e->'sets') as s
+        WHERE endpoint_name = 'workout'
+          AND (raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York' >= ${cutoff}::date
+          AND s->>'type' = 'normal' AND (s->>'weight_kg')::float > 0 AND (s->>'reps')::int > 0
+      )
+      SELECT month, muscle_group, ROUND(SUM(volume)::numeric) as volume
+      FROM exercise_muscles WHERE muscle_group IS NOT NULL
+      GROUP BY month, muscle_group ORDER BY month ASC, muscle_group
+    `,
+    // Training calendar — all workout days (all-time; drives heatmap + frequency + span)
+    sql`
+      SELECT ((raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York')::date as day,
+        raw_json->>'title' as program
+      FROM hevy_raw_data WHERE endpoint_name = 'workout' ORDER BY day ASC
+    `,
+  ]);
+
+  return NextResponse.json({ topExercises, programSplit, prs, hrTrend, monthlyMuscle, calendar });
+}


### PR DESCRIPTION
## App parity — Workouts screen (insights)

Completes the Workouts screen (#425). The web `/workouts` page renders ~8 panels from **server-only SQL with no HTTP endpoint**, so this adds one JSON endpoint that ports those queries, then builds the mobile panels on top.

### New endpoint
`web/app/api/workouts/insights/route.ts` — ports the page's `getTopExercises` (rich), `getProgramSplit`, `getExercisePRs`, `getWorkoutHrTrend`, `getMonthlyMuscleVolume`, `getTrainingCalendar`. Weekly frequency and training span are derived client-side from the calendar.

### App panels
- **#426 Muscle** — per-muscle-group volume bars + a stacked **monthly-volume-by-muscle** chart (`workout-muscle.tsx`). Mobile take on the web anatomical body-map SVG (trimmed).
- **#427 Strength** — a **configurable per-exercise progression** chart (pills → `/api/workouts/exercise`), a **Personal Records** grid, and a **Program Split** card (`workout-strength.tsx`).
- **#428 Activity** — a **26-week training-calendar heatmap**, a **weekly-frequency** chart, and an **avg/max-HR-per-workout** chart (`workout-activity.tsx`).
- **#429 finish** — Top Exercises now show **best weight + a recent-weights sparkline**, and a **Training Span** summary stat is added. (PR #468 shipped the detail modals + kg/lb toggle + volume avg line.)

The kg/lb toggle is lifted to the screen so one switch drives the dashboard, its modals, and the strength panels.

### Documented mobile trims
Anatomical body-map SVG (replaced by muscle-volume bars), chart hover tooltips, multi-line strength overlay.

### Files
- New: `web/app/api/workouts/insights/route.ts`, `workout-muscle.tsx`, `workout-strength.tsx`, `workout-activity.tsx`.
- Modified: `lib/api.ts` (`useWorkoutInsights`), `workouts-dashboard.tsx` (unit prop + top-ex enrichment), `app/(main)/workouts.tsx`.

### Verification
- `universal tsc --noEmit` clean; `web tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (mobile 390×844): Training Span 6mo stat; enriched Top Exercises (best weight + sparkline per row); Muscle Volume bars (6 groups) + the stacked Monthly-by-muscle chart; Strength progression (Bench Press pill → rising max-weight chart) + PR grid (Deadlift 170 kg …) + Program Split bars; Training Calendar heatmap + Weekly Frequency chart + Avg/Max HR chart. Caught + fixed a flexbox percentage-height bug that left the monthly-muscle bars blank (re-verified after restart).

Closes #426
Closes #427
Closes #428
Closes #429
Closes #425
