### PR TITLE
App parity — Activities: per-sport sections + kite wind + sortable table (#438)

### DIFF
--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -3,6 +3,7 @@ import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
 import { fetchJson, usePullRefresh, useActivitiesDeep } from "../../lib/api";
 import { ActivitiesMonthly, KiteDeepDive, ActivitiesList } from "../../components/activities-deep";
+import { ActivitySports } from "../../components/activity-sports";
 
 /** Daily activity-count series (per-day sessions) for the Sessions trend. */
 function useSessionsTrend() {
@@ -286,6 +287,9 @@ export default function ActivitiesScreen() {
             ))}
           </Card>
         ) : null}
+
+        {/* Per-sport sections (Walking/Cycling/Swimming) + Activity-by-Year (web parity) */}
+        {deep ? <ActivitySports all={deep.all} /> : null}
 
         {/* Monthly distribution — stacked columns by sport (web parity) */}
         {deep ? <ActivitiesMonthly monthly={deep.monthly} /> : null}

--- a/universal/src/components/activities-deep.tsx
+++ b/universal/src/components/activities-deep.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
-import { View, Pressable } from "react-native";
+import { View, Pressable, TextInput } from "react-native";
 import Svg, { Circle, Polyline } from "react-native-svg";
 import { Text, Card } from "soma-style";
 import type { ActivitiesDeep, ActivityRow, KiteSession } from "../lib/api";
+import { ActivityDetailModal } from "./activity-detail-modal";
 
 /* Sport → colour, mirroring the web activities palette. */
 const SPORT_COLOR: Record<string, string> = {
@@ -144,24 +145,92 @@ export function KiteDeepDive({ sessions }: { sessions: KiteSession[] }) {
           ))}
         </View>
       ) : null}
+
+      <KiteWind sessions={sessions} />
     </Card>
   );
 }
 
-const PAGE = 15;
+/** Kite wind conditions: avg wind, max gust, sessions-with-wind + a per-session list. */
+function KiteWind({ sessions }: { sessions: KiteSession[] }) {
+  const withWind = (sessions ?? []).filter((s) => (s.windKts ?? 0) > 0);
+  if (withWind.length < 1) return null;
+  const winds = withWind.map((s) => s.windKts as number);
+  const avgWind = winds.reduce((a, b) => a + b, 0) / winds.length;
+  const gusts = withWind.map((s) => s.gustKts ?? 0).filter((g) => g > 0);
+  const maxGust = gusts.length ? Math.max(...gusts) : null;
+  const windy = [...withWind].sort((a, b) => (b.windKts ?? 0) - (a.windKts ?? 0)).slice(0, 4);
 
-/** Full activity list: sport-filter pills + load-more paging. */
+  return (
+    <View className="gap-2 border-t border-border-subtle pt-2.5">
+      <Text variant="micro" className="text-text-muted">WIND CONDITIONS</Text>
+      <View className="flex-row flex-wrap gap-x-6 gap-y-1">
+        {[
+          ["Avg wind", `${avgWind.toFixed(0)} kts`],
+          ["Max gust", maxGust != null ? `${maxGust.toFixed(0)} kts` : "—"],
+          ["With wind", `${withWind.length}`],
+        ].map(([label, value]) => (
+          <View key={label} className="gap-0.5">
+            <Text variant="micro" className="text-text-muted">{label}</Text>
+            <Text variant="title" className="text-teal">{value}</Text>
+          </View>
+        ))}
+      </View>
+      {windy.map((s, i) => (
+        <View key={`${s.date}-${i}`} className="flex-row items-center justify-between">
+          <Text variant="micro" className="text-text-secondary flex-1" numberOfLines={1}>{s.spot ?? "Session"} · {shortDate(s.date)}</Text>
+          <Text variant="micro" className="tabular-nums text-text-muted ml-2">
+            {(s.windKts as number).toFixed(0)} kts{s.gustKts != null && s.gustKts > 0 ? ` · gust ${s.gustKts.toFixed(0)}` : ""}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const PAGE = 12;
+type SortKey = "date" | "distance_km" | "duration_min" | "avg_hr" | "calories" | "elev_gain";
+const SORTS: { key: SortKey; label: string }[] = [
+  { key: "date", label: "Date" }, { key: "distance_km", label: "Dist" }, { key: "duration_min", label: "Time" },
+  { key: "avg_hr", label: "HR" }, { key: "calories", label: "Cal" }, { key: "elev_gain", label: "Elev" },
+];
+const numf = (v: number | null | undefined): number => (v == null || !isFinite(Number(v)) ? 0 : Number(v));
+
+/** Full activity table: search + sport pills + sortable columns + numbered
+ *  pagination + tap-to-detail. Web parity (#441). */
 export function ActivitiesList({ all }: { all: ActivityRow[] }) {
   const [filter, setFilter] = useState<string | null>(null);
-  const [shown, setShown] = useState(PAGE);
+  const [q, setQ] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("date");
+  const [asc, setAsc] = useState(false);
+  const [page, setPage] = useState(0);
+  const [selected, setSelected] = useState<ActivityRow | null>(null);
+
   const sports = useMemo(() => {
     const m = new Map<string, number>();
     for (const a of all ?? []) m.set(a.sport, (m.get(a.sport) ?? 0) + 1);
     return [...m.entries()].sort((a, b) => b[1] - a[1]);
   }, [all]);
-  const filtered = (all ?? []).filter((a) => !filter || a.sport === filter);
-  const page = filtered.slice(0, shown);
+
+  const filtered = useMemo(() => {
+    const ql = q.trim().toLowerCase();
+    const arr = (all ?? []).filter((a) =>
+      (!filter || a.sport === filter) &&
+      (!ql || (a.name ?? "").toLowerCase().includes(ql) || a.sport.toLowerCase().includes(ql)),
+    );
+    arr.sort((a, b) => {
+      const av = sortKey === "date" ? new Date(a.date).getTime() : numf(a[sortKey]);
+      const bv = sortKey === "date" ? new Date(b.date).getTime() : numf(b[sortKey]);
+      return asc ? av - bv : bv - av;
+    });
+    return arr;
+  }, [all, filter, q, sortKey, asc]);
+
   if (!all?.length) return null;
+  const pages = Math.max(1, Math.ceil(filtered.length / PAGE));
+  const cur = Math.min(page, pages - 1);
+  const rows = filtered.slice(cur * PAGE, cur * PAGE + PAGE);
+  const onSort = (k: SortKey) => { if (k === sortKey) setAsc((v) => !v); else { setSortKey(k); setAsc(false); } setPage(0); };
 
   return (
     <Card className="gap-2">
@@ -169,15 +238,25 @@ export function ActivitiesList({ all }: { all: ActivityRow[] }) {
         <Text variant="eyebrow">All activities</Text>
         <Text variant="micro" className="tabular-nums text-text-muted">{filtered.length} total</Text>
       </View>
+
+      <TextInput
+        value={q}
+        onChangeText={(t) => { setQ(t); setPage(0); }}
+        placeholder="Search activities…"
+        placeholderTextColor="#5a7a8a"
+        className="rounded-lg bg-surface-subtle px-3 py-2 text-text"
+        style={{ color: "#e6edf0" }}
+      />
+
       {sports.length > 1 ? (
         <View className="flex-row flex-wrap gap-2">
-          <Pressable onPress={() => { setFilter(null); setShown(PAGE); }} hitSlop={6}>
+          <Pressable onPress={() => { setFilter(null); setPage(0); }} hitSlop={6}>
             <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: filter == null ? "#77c8d122" : "#142530" }}>
               <Text variant="micro" style={{ color: filter == null ? "#77c8d1" : "#8aa0ac" }}>All</Text>
             </View>
           </Pressable>
           {sports.map(([s, c]) => (
-            <Pressable key={s} onPress={() => { setFilter(filter === s ? null : s); setShown(PAGE); }} hitSlop={6}>
+            <Pressable key={s} onPress={() => { setFilter(filter === s ? null : s); setPage(0); }} hitSlop={6}>
               <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: filter === s ? sportColor(s) + "33" : "#142530" }}>
                 <Text variant="micro" style={{ color: filter === s ? sportColor(s) : "#8aa0ac" }}>{s} {c}</Text>
               </View>
@@ -185,29 +264,52 @@ export function ActivitiesList({ all }: { all: ActivityRow[] }) {
           ))}
         </View>
       ) : null}
-      {page.map((a) => (
-        <View key={a.activity_id} className="border-b border-border-subtle py-2">
+
+      {/* Sortable column chips */}
+      <View className="flex-row flex-wrap gap-1.5 border-b border-border-subtle pb-1.5">
+        {SORTS.map((c) => (
+          <Pressable key={c.key} onPress={() => onSort(c.key)} hitSlop={4}>
+            <Text variant="micro" className={sortKey === c.key ? "text-teal" : "text-text-muted"}>
+              {c.label}{sortKey === c.key ? (asc ? " ↑" : " ↓") : ""}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {rows.map((a) => (
+        <Pressable key={a.activity_id} onPress={() => setSelected(a)} className="border-b border-border-subtle py-2">
           <View className="flex-row items-center justify-between">
             <View className="flex-row items-center gap-2 flex-1 pr-2">
               <View className="h-2 w-2 rounded-full" style={{ backgroundColor: sportColor(a.sport) }} />
               <Text variant="body" className="text-text" numberOfLines={1} style={{ flex: 1 }}>{a.name || a.sport}</Text>
             </View>
-            <Text variant="micro" className="text-text-muted">{shortDate(a.date)}</Text>
+            <View className="flex-row items-center gap-1.5">
+              <Text variant="micro" className="text-text-muted">{shortDate(a.date)}</Text>
+              <Text variant="micro" className="text-text-muted">›</Text>
+            </View>
           </View>
           <Text variant="micro" className="text-text-muted ml-4">
             {a.distance_km != null && a.distance_km > 0 ? `${a.distance_km.toFixed(1)} km · ` : ""}{hm(a.duration_min)}
             {a.avg_hr != null ? ` · ${Math.round(a.avg_hr)} bpm` : ""}
+            {a.calories != null && a.calories > 0 ? ` · ${Math.round(a.calories)} kcal` : ""}
             {a.elev_gain > 0 ? ` · ↑${Math.round(a.elev_gain)}m` : ""}
           </Text>
-        </View>
-      ))}
-      {filtered.length > shown ? (
-        <Pressable onPress={() => setShown((n) => n + PAGE)} hitSlop={6}>
-          <View className="items-center rounded-lg bg-surface-subtle py-2">
-            <Text variant="caption" className="text-teal">Show {Math.min(PAGE, filtered.length - shown)} more</Text>
-          </View>
         </Pressable>
+      ))}
+
+      {pages > 1 ? (
+        <View className="flex-row items-center justify-between pt-1">
+          <Pressable disabled={cur === 0} onPress={() => setPage((p) => Math.max(0, p - 1))} hitSlop={6}>
+            <Text variant="caption" className={cur === 0 ? "text-text-muted" : "text-teal"}>‹ Prev</Text>
+          </Pressable>
+          <Text variant="micro" className="tabular-nums text-text-muted">Page {cur + 1} of {pages}</Text>
+          <Pressable disabled={cur >= pages - 1} onPress={() => setPage((p) => Math.min(pages - 1, p + 1))} hitSlop={6}>
+            <Text variant="caption" className={cur >= pages - 1 ? "text-text-muted" : "text-teal"}>Next ›</Text>
+          </Pressable>
+        </View>
       ) : null}
+
+      <ActivityDetailModal activity={selected} onClose={() => setSelected(null)} />
     </Card>
   );
 }

--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -1,0 +1,51 @@
+import { View } from "react-native";
+import { Text, Card, Modal, Badge } from "soma-style";
+import type { ActivityRow } from "../lib/api";
+
+const num = (v: number | null | undefined): number => (v == null ? 0 : Number(v));
+function longDate(iso: string): string {
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+}
+function hm(mins: number | null | undefined): string {
+  if (mins == null || !isFinite(mins)) return "—";
+  const h = Math.floor(mins / 60), m = Math.round(mins % 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+/**
+ * Activity detail dialog (web parity, #441): the full stat line for one
+ * activity (the drill-in behind a table row). The web modal also offers a
+ * Strava photo upload + FIT download — those are native/file features left as
+ * a documented mobile trim.
+ */
+export function ActivityDetailModal({ activity, onClose }: { activity: ActivityRow | null; onClose: () => void }) {
+  if (!activity) return null;
+  const a = activity;
+  const rows: [string, string][] = [
+    ["Sport", a.sport],
+    ["Distance", a.distance_km != null && a.distance_km > 0 ? `${num(a.distance_km).toFixed(2)} km` : "—"],
+    ["Duration", hm(a.duration_min)],
+    ["Avg HR", a.avg_hr != null ? `${Math.round(num(a.avg_hr))} bpm` : "—"],
+    ["Calories", a.calories != null && a.calories > 0 ? `${Math.round(num(a.calories))} kcal` : "—"],
+    ["Elevation", a.elev_gain > 0 ? `↑ ${Math.round(a.elev_gain)} m` : "—"],
+  ];
+  return (
+    <Modal visible={!!activity} onClose={onClose} title={a.name || a.sport}>
+      <View className="gap-3">
+        <View className="flex-row items-center gap-2">
+          <Badge label={a.sport} tone="teal" />
+          <Text variant="micro" className="text-text-muted">{longDate(a.date)}</Text>
+        </View>
+        <View className="gap-2">
+          {rows.map(([label, value]) => (
+            <View key={label} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+              <Text variant="body" className="text-text-secondary">{label}</Text>
+              <Text variant="body" className="tabular-nums text-text">{value}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/universal/src/components/activity-sports.tsx
+++ b/universal/src/components/activity-sports.tsx
@@ -1,0 +1,117 @@
+import { useMemo } from "react";
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import type { ActivityRow } from "../lib/api";
+
+const num = (v: number | null | undefined): number => (v == null || !isFinite(Number(v)) ? 0 : Number(v));
+function shortDate(iso: string): string {
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+const SPORT_COLOR: Record<string, string> = {
+  Kiteboarding: "#22d3ee", Snowboarding: "#93c5fd", Hiking: "#6ad4a0", "E-Bike": "#c084fc",
+  Swimming: "#6aa0e0", Walking: "#cbe896", Cycling: "#e0a458", Cardio: "#e06060", Running: "#6ad4a0",
+  Gym: "#e0a458", SUP: "#f0abfc", Other: "#5a7a8a",
+};
+const sportColor = (s: string) => SPORT_COLOR[s] ?? "#5a7a8a";
+
+/** One sport section: heading + 4 stat cards + a short recent list. Data from all[]. */
+function SportSection({ sport, rows }: { sport: string; rows: ActivityRow[] }) {
+  const mine = useMemo(
+    () => rows.filter((a) => a.sport.toLowerCase().includes(sport.toLowerCase())).sort((a, b) => b.date.localeCompare(a.date)),
+    [rows, sport],
+  );
+  if (mine.length < 1) return null;
+  const km = mine.reduce((s, a) => s + num(a.distance_km), 0);
+  const hours = mine.reduce((s, a) => s + num(a.duration_min), 0) / 60;
+  const hrVals = mine.map((a) => num(a.avg_hr)).filter((v) => v > 0);
+  const avgHr = hrVals.length ? Math.round(hrVals.reduce((a, b) => a + b, 0) / hrVals.length) : null;
+  const stats: [string, string][] = [
+    ["Sessions", `${mine.length}`],
+    ["Distance", km > 0 ? `${km.toFixed(0)} km` : "—"],
+    ["Time", `${hours.toFixed(0)}h`],
+    ["Avg HR", avgHr != null ? `${avgHr} bpm` : "—"],
+  ];
+
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center gap-2">
+        <View className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: sportColor(sport) }} />
+        <Text variant="eyebrow">{sport}</Text>
+      </View>
+      <View className="flex-row flex-wrap gap-3">
+        {stats.map(([label, value]) => (
+          <View key={label} className="min-w-[22%] flex-1 gap-0.5">
+            <Text variant="micro" className="text-text-muted">{label}</Text>
+            <Text variant="title" style={{ color: sportColor(sport) }}>{value}</Text>
+          </View>
+        ))}
+      </View>
+      <View className="gap-1">
+        {mine.slice(0, 3).map((a) => (
+          <View key={a.activity_id} className="flex-row items-center justify-between border-t border-border-subtle pt-1.5">
+            <Text variant="micro" className="text-text-secondary flex-1" numberOfLines={1}>{a.name || sport}</Text>
+            <Text variant="micro" className="tabular-nums text-text-muted ml-2">
+              {num(a.distance_km) > 0 ? `${num(a.distance_km).toFixed(1)} km · ` : ""}{shortDate(a.date)}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </Card>
+  );
+}
+
+/** Activity-by-Year: per-year sessions / km / hours + a stacked sport bar. */
+function ActivityByYear({ rows }: { rows: ActivityRow[] }) {
+  const years = useMemo(() => {
+    const m = new Map<string, { count: number; km: number; min: number; sports: Record<string, number> }>();
+    for (const a of rows) {
+      const y = String(a.date).slice(0, 4);
+      if (!m.has(y)) m.set(y, { count: 0, km: 0, min: 0, sports: {} });
+      const e = m.get(y)!;
+      e.count++; e.km += num(a.distance_km); e.min += num(a.duration_min);
+      e.sports[a.sport] = (e.sports[a.sport] ?? 0) + 1;
+    }
+    return [...m.entries()].sort((a, b) => b[0].localeCompare(a[0]));
+  }, [rows]);
+  if (years.length < 1) return null;
+
+  return (
+    <Card className="gap-3">
+      <Text variant="eyebrow">Activity by year</Text>
+      {years.map(([year, e]) => {
+        const sports = Object.entries(e.sports).sort((a, b) => b[1] - a[1]);
+        return (
+          <View key={year} className="gap-1.5 border-b border-border-subtle pb-2">
+            <View className="flex-row items-center justify-between">
+              <Text variant="body" className="text-text">{year}</Text>
+              <Text variant="micro" className="tabular-nums text-text-muted">
+                {e.count} · {e.km > 0 ? `${e.km.toFixed(0)} km · ` : ""}{(e.min / 60).toFixed(0)}h
+              </Text>
+            </View>
+            <View className="h-2.5 flex-row overflow-hidden rounded-full">
+              {sports.map(([s, c]) => (
+                <View key={s} style={{ flex: c, backgroundColor: sportColor(s) }} />
+              ))}
+            </View>
+          </View>
+        );
+      })}
+    </Card>
+  );
+}
+
+/** Per-sport sections (Walking / Cycling / Swimming) + Activity-by-Year (web parity, #439). */
+export function ActivitySports({ all }: { all: ActivityRow[] | undefined }) {
+  const rows = all ?? [];
+  if (rows.length < 1) return null;
+  return (
+    <View className="gap-4">
+      {["Walking", "Cycling", "Swimming"].map((sp) => (
+        <SportSection key={sp} sport={sp} rows={rows} />
+      ))}
+      <ActivityByYear rows={rows} />
+    </View>
+  );
+}


### PR DESCRIPTION
## App parity — Activities screen

Completes the Activities screen (#438) from data the existing `/api/activities/deep` already serves (no new endpoint).

### What changed
- **#439 Per-sport sections** — Walking / Cycling / Swimming each get a heading + 4 stat cards (sessions / distance / time / avg HR) + a short recent list, plus an **Activity-by-Year** breakdown (per-year sessions / km / hours + a stacked sport bar). New `activity-sports.tsx`, aggregated from `all[]`.
- **#440 Kite Wind Conditions** — added to the kite deep-dive: avg wind, max gust, sessions-with-wind + a per-session list, from `kite.sessions` wind/gust.
- **#441 Activity table** — the flat list becomes a full table: a **search box**, **sortable columns** (Date / Dist / Time / HR / Cal / Elev), **numbered pagination** (Prev / Page X of Y / Next), and **row tap → `ActivityDetailModal`** (sport / distance / duration / HR / calories / elevation). New `activity-detail-modal.tsx`.

### Documented mobile trims
Snow Resorts breakdown (resort names aren't in the activity rows), the web chart expand-to-fullscreen, and the detail modal's Strava photo upload + FIT download (native/file features). The existing Snowboarding summary card is retained.

### Files
- New: `activity-sports.tsx`, `activity-detail-modal.tsx`.
- Modified: `activities-deep.tsx` (kite wind + upgraded table), `app/(main)/activities.tsx` (per-sport wiring).

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (mobile 390×844): per-sport sections (Cycling 7 · 72 km · 7h · 136 bpm; Swimming with null HR) + Activity-by-Year stacked bars (2026/2025/2024); Kite Wind Conditions (avg 23 kts, max gust 40 kts, 16 with wind + session list); the activity table with search box, sport pills, sortable chips — tapping **Dist** re-sorted 15.0 km → 14.2 km, and tapping a row opened the detail modal (Running session 4 — 15 km · 1h 20m · 150 bpm · 600 kcal · ↑320 m).

Closes #439
Closes #440
Closes #441
Closes #438
