### PR TITLE
App parity — Training: race header + what-if intensity + matched-activity panel (#420)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -9,11 +9,14 @@ import {
   useActivityMatches,
   setDayCompletion,
   toggleCalibration,
+  applyIntensity,
   fetchJson,
   usePullRefresh,
   type PlanDay,
 } from "../../lib/api";
 import { TrainingSchedule } from "../../components/training-schedule";
+import { RaceHeader } from "../../components/race-header";
+import { WhatIfSlider } from "../../components/whatif-slider";
 import { TrainingPaces } from "../../components/training-paces";
 import { RaceProtocol } from "../../components/race-protocol";
 import { TrainingTrends } from "../../components/training-trends";
@@ -136,14 +139,17 @@ export default function TrainingScreen() {
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
     >
       <View className="w-full max-w-2xl gap-4">
-        <View className="flex-row items-center gap-2">
-          <Text variant="headline">Training</Text>
-          {readiness ? (
-            <Badge
-              label={`Readiness ${readiness.traffic_light}`}
-              tone={TL_TONE[readiness.traffic_light] ?? "teal"}
-            />
-          ) : null}
+        <View className="gap-2">
+          <View className="flex-row items-center gap-2">
+            <Text variant="headline">Training</Text>
+            {readiness ? (
+              <Badge
+                label={`Readiness ${readiness.traffic_light}`}
+                tone={TL_TONE[readiness.traffic_light] ?? "teal"}
+              />
+            ) : null}
+          </View>
+          <RaceHeader planDays={planDays} today={sim?.today ?? todayISO()} />
         </View>
 
         {error ? (
@@ -175,6 +181,18 @@ export default function TrainingScreen() {
             today={sim?.today ?? todayISO()}
             matches={matches}
             onToggleComplete={onToggleComplete}
+          />
+        ) : null}
+
+        {/* What-if intensity — preview scaling upcoming workouts + apply */}
+        {planDays.length ? (
+          <WhatIfSlider
+            planDays={planDays}
+            onApply={async (factor, dayIds) => {
+              const ok = await applyIntensity(factor, dayIds);
+              if (ok) refetchSim();
+              return ok;
+            }}
           />
         ) : null}
 

--- a/universal/src/components/matched-activity-panel.tsx
+++ b/universal/src/components/matched-activity-panel.tsx
@@ -1,0 +1,99 @@
+import { View } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+import { Text, Modal, Badge } from "soma-style";
+import type { ActivityMatch, PlanDay } from "../lib/api";
+
+const num = (v: number | string | null | undefined): number => (v == null || !isFinite(Number(v)) ? 0 : Number(v));
+function paceLabel(secKm: number | null): string {
+  if (secKm == null || !isFinite(secKm) || secKm <= 0) return "—";
+  const t = Math.round(secKm);
+  return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}/km`;
+}
+
+/** Circular completion-score ring (0-100). */
+function ScoreRing({ score }: { score: number }) {
+  const pct = Math.max(0, Math.min(1, score / 100));
+  const R = 34, C = 2 * Math.PI * R;
+  const color = score >= 85 ? "#6ad4a0" : score >= 65 ? "#e0c458" : "#e0a458";
+  return (
+    <View style={{ width: 84, height: 84 }} className="items-center justify-center">
+      <Svg width={84} height={84} style={{ position: "absolute" }}>
+        <Circle cx={42} cy={42} r={R} stroke="#1e2f38" strokeWidth={7} fill="none" />
+        <Circle cx={42} cy={42} r={R} stroke={color} strokeWidth={7} fill="none"
+          strokeDasharray={`${C}`} strokeDashoffset={C * (1 - pct)} strokeLinecap="round"
+          transform="rotate(-90 42 42)" />
+      </Svg>
+      <Text variant="title" style={{ color }}>{Math.round(score)}</Text>
+    </View>
+  );
+}
+
+function Bar({ label, plan, actual, unit, invert }: { label: string; plan: number; actual: number; unit: string; invert?: boolean }) {
+  const ratio = plan > 0 ? actual / plan : 0;
+  // compliance: 1.0 = on target; color by closeness
+  const off = Math.abs(1 - ratio);
+  const color = off <= 0.05 ? "#6ad4a0" : off <= 0.15 ? "#e0c458" : "#e0a458";
+  return (
+    <View className="gap-1">
+      <View className="flex-row justify-between">
+        <Text variant="micro" className="text-text-secondary">{label}</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">
+          {actual.toFixed(unit === "km" ? 1 : 0)}{unit} / {plan.toFixed(unit === "km" ? 1 : 0)}{unit} plan
+        </Text>
+      </View>
+      <View className="h-2 rounded-full bg-surface-subtle overflow-hidden">
+        <View className="h-full rounded-full" style={{ width: `${Math.max(4, Math.min(1, ratio) * 100)}%`, backgroundColor: color }} />
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Matched-activity compliance panel (web parity, #424): the completion-score
+ * ring + plan-vs-actual compliance (distance / pace / HR) for a plan day that
+ * matched a Garmin activity. Fed by /api/training/activity-match.
+ */
+export function MatchedActivityPanel({ match, day, onClose }: { match: ActivityMatch | null; day: PlanDay | null; onClose: () => void }) {
+  if (!match || !match.activity) return null;
+  const a = match.activity;
+  const planKm = num(day?.targetDistanceKm);
+  const actKm = num(a.distance_km);
+  const rows: [string, string][] = [
+    ["Distance", `${actKm.toFixed(2)} km`],
+    ["Duration", a.duration_min != null ? `${Math.round(num(a.duration_min))} min` : "—"],
+    ["Avg pace", paceLabel(a.avg_pace_sec_km)],
+    ["Avg HR", a.avg_hr != null ? `${Math.round(num(a.avg_hr))} bpm` : "—"],
+    ["Max HR", a.max_hr != null ? `${Math.round(num(a.max_hr))} bpm` : "—"],
+    ["Calories", a.calories != null ? `${Math.round(num(a.calories))} kcal` : "—"],
+  ];
+
+  return (
+    <Modal visible={!!match} onClose={onClose} title={day?.runTitle || "Matched activity"}>
+      <View className="gap-3">
+        <View className="flex-row items-center gap-4">
+          <ScoreRing score={num(match.completionScore)} />
+          <View className="flex-1 gap-1">
+            <Text variant="eyebrow" className="text-text-muted">Completion score</Text>
+            {a.garmin_id != null ? <Badge label="Garmin matched" tone="success" /> : null}
+            <Text variant="micro" className="text-text-muted">{day?.dayDate ?? ""}</Text>
+          </View>
+        </View>
+
+        {planKm > 0 ? (
+          <View className="gap-2 border-t border-border-subtle pt-2">
+            <Bar label="Distance compliance" plan={planKm} actual={actKm} unit="km" />
+          </View>
+        ) : null}
+
+        <View className="gap-2 border-t border-border-subtle pt-2">
+          {rows.map(([label, value]) => (
+            <View key={label} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+              <Text variant="body" className="text-text-secondary">{label}</Text>
+              <Text variant="body" className="tabular-nums text-text">{value}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/universal/src/components/race-header.tsx
+++ b/universal/src/components/race-header.tsx
@@ -1,0 +1,35 @@
+import { View } from "react-native";
+import { Text, Badge } from "soma-style";
+import type { PlanDay } from "../lib/api";
+
+function daysBetween(a: string, b: string): number {
+  const da = new Date(a + "T00:00:00Z").getTime();
+  const db = new Date(b + "T00:00:00Z").getTime();
+  return Math.round((db - da) / 86400000);
+}
+
+/**
+ * Race context header (web parity, #424): current week X / Y and days-to-race,
+ * derived from the plan schedule (the last plan day is race day). Rendered
+ * inline next to the screen title.
+ */
+export function RaceHeader({ planDays, today }: { planDays: PlanDay[]; today: string }) {
+  const days = (planDays ?? []).filter((d) => d.dayDate);
+  if (days.length < 2) return null;
+  const weeks = days.map((d) => d.weekNumber).filter((w) => w != null);
+  const totalWeeks = weeks.length ? Math.max(...weeks) : 0;
+  // current week = the week of the first plan day on/after today
+  const upcoming = [...days].sort((a, b) => a.dayDate.localeCompare(b.dayDate)).find((d) => d.dayDate >= today);
+  const currentWeek = upcoming?.weekNumber ?? totalWeeks;
+  const raceDate = [...days].sort((a, b) => a.dayDate.localeCompare(b.dayDate))[days.length - 1].dayDate;
+  const dtr = daysBetween(today, raceDate);
+
+  return (
+    <View className="flex-row flex-wrap items-center gap-2">
+      {totalWeeks > 0 ? <Badge label={`Week ${currentWeek} / ${totalWeeks}`} tone="teal" /> : null}
+      {dtr >= 0 ? (
+        <Badge label={dtr === 0 ? "Race day" : `${dtr} days to race`} tone={dtr <= 14 ? "warm" : "neutral"} />
+      ) : null}
+    </View>
+  );
+}

--- a/universal/src/components/training-schedule.tsx
+++ b/universal/src/components/training-schedule.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { View, Pressable } from "react-native";
 import { Text, Card } from "soma-style";
 import { requestGarminPush, type ActivityMatch, type PlanDay, type WorkoutStep } from "../lib/api";
+import { MatchedActivityPanel } from "./matched-activity-panel";
 
 /* Run-type → colour, matching the web training plan (easy green, quality orange,
    long blue, rest grey). Used for the small type pill on each day row. */
@@ -52,11 +53,13 @@ function DayRow({
   isToday,
   match,
   onToggleComplete,
+  onOpenMatch,
 }: {
   day: PlanDay;
   isToday: boolean;
   match?: ActivityMatch;
   onToggleComplete: (day: PlanDay) => void;
+  onOpenMatch?: (day: PlanDay, match: ActivityMatch) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [pushOverride, setPushOverride] = useState<string | null>(null);
@@ -100,9 +103,12 @@ function DayRow({
               <Text variant="micro" style={{ color: runColor(day.runType) }}>{day.runType}</Text>
             </View>
             {match?.matched && match.completionScore != null ? (
-              <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: scoreColor(match.completionScore) + "22" }}>
-                <Text variant="micro" style={{ color: scoreColor(match.completionScore) }}>{match.completionScore}%</Text>
-              </View>
+              <Pressable onPress={() => onOpenMatch?.(day, match)} hitSlop={6}>
+                <View className="flex-row items-center gap-0.5 rounded-full px-2 py-0.5" style={{ backgroundColor: scoreColor(match.completionScore) + "22" }}>
+                  <Text variant="micro" style={{ color: scoreColor(match.completionScore) }}>{match.completionScore}%</Text>
+                  <Text variant="micro" style={{ color: scoreColor(match.completionScore) }}>›</Text>
+                </View>
+              </Pressable>
             ) : null}
             {day.gymWorkout ? (
               <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: "#6366b022" }}>
@@ -205,6 +211,7 @@ export function TrainingSchedule({
     [planDays, today, weeks],
   );
   const [expanded, setExpanded] = useState<Set<number>>(() => new Set(currentWeek != null ? [currentWeek] : []));
+  const [openMatch, setOpenMatch] = useState<{ day: PlanDay; match: ActivityMatch } | null>(null);
 
   const toggleWeek = (w: number) =>
     setExpanded((prev) => {
@@ -246,13 +253,15 @@ export function TrainingSchedule({
             {isOpen ? (
               <View className="mt-1">
                 {days.map((d) => (
-                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} match={matches?.[d.id]} onToggleComplete={onToggleComplete} />
+                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} match={matches?.[d.id]} onToggleComplete={onToggleComplete}
+                    onOpenMatch={(day, match) => setOpenMatch({ day, match })} />
                 ))}
               </View>
             ) : null}
           </Card>
         );
       })}
+      <MatchedActivityPanel match={openMatch?.match ?? null} day={openMatch?.day ?? null} onClose={() => setOpenMatch(null)} />
     </View>
   );
 }

--- a/universal/src/components/trajectory-chart.tsx
+++ b/universal/src/components/trajectory-chart.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { View } from "react-native";
+import { View, Pressable } from "react-native";
 import { Text, Card, SegmentedControl } from "soma-style";
 import { LineChart, ChartLegend } from "./line-chart";
 import type { ForwardSim } from "../lib/api";
@@ -18,18 +18,21 @@ function shortLabel(iso: string): string {
 }
 
 /** Fitness trajectory: our-model line vs Garmin's, across Fitness (VDOT),
- *  Readiness, and Load dimensions. Mobile-adapted from the web trajectory
- *  chart — the goal-zone bands, taper band, and what-if line stay web-only
- *  for now (the what-if belongs with #422). */
+ *  Readiness, and Load dimensions, with a "You are here" marker on the latest
+ *  model value and a toggle to hide the Garmin comparison. Mobile-adapted from
+ *  the web trajectory chart — goal-zone/taper/race bands need goal+taper data
+ *  absent from the mobile payload, and the rich hover tooltip + 7-line
+ *  visibility dropdown are replaced by the dimension + compare toggles. */
 export function TrajectoryChart({ comparison }: { comparison: ForwardSim["comparison"] }) {
   const [dim, setDim] = useState<Dim>("Fitness");
+  const [compare, setCompare] = useState(true);
   const cfg = CFG[dim];
   const src = useMemo(() => {
     if (!comparison) return [];
     return dim === "Fitness" ? comparison.fitness : dim === "Readiness" ? comparison.readiness : comparison.load;
   }, [comparison, dim]);
 
-  const { labels, a, b, cur } = useMemo(() => {
+  const { labels, a, b, cur, hereDot } = useMemo(() => {
     const num = (p: Record<string, unknown>, k: string) => {
       const v = Number(p[k]);
       return isFinite(v) && v > 0 ? v : null;
@@ -37,8 +40,12 @@ export function TrajectoryChart({ comparison }: { comparison: ForwardSim["compar
     const lbls = src.map((p) => shortLabel(String(p.date)));
     const av = src.map((p) => num(p as Record<string, unknown>, cfg.keyA));
     const bv = src.map((p) => num(p as Record<string, unknown>, cfg.keyB));
-    const last = [...av].reverse().find((v) => v != null) ?? null;
-    return { labels: lbls, a: av, b: bv, cur: last };
+    // "You are here": a single dot on the most recent model value.
+    let hereIdx = -1;
+    for (let i = av.length - 1; i >= 0; i--) if (av[i] != null) { hereIdx = i; break; }
+    const dot = av.map((v, i) => (i === hereIdx ? v : null));
+    const last = hereIdx >= 0 ? av[hereIdx] : null;
+    return { labels: lbls, a: av, b: bv, cur: last, hereDot: dot };
   }, [src, cfg]);
 
   if (!comparison) return null;
@@ -49,7 +56,16 @@ export function TrajectoryChart({ comparison }: { comparison: ForwardSim["compar
         <Text variant="eyebrow">Fitness trajectory</Text>
         {cur != null ? <Text variant="body" className="text-teal tabular-nums">{cfg.fmt(cur)}{dim === "Fitness" ? " VDOT" : ""}</Text> : null}
       </View>
-      <SegmentedControl options={DIMS} value={dim} onChange={(v) => setDim(v as Dim)} />
+      <View className="flex-row items-center gap-2">
+        <View className="flex-1">
+          <SegmentedControl options={DIMS} value={dim} onChange={(v) => setDim(v as Dim)} />
+        </View>
+        <Pressable onPress={() => setCompare((c) => !c)} hitSlop={6}>
+          <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: compare ? cfg.colorB + "33" : "#142530" }}>
+            <Text variant="micro" style={{ color: compare ? cfg.colorB : "#8aa0ac" }}>Garmin</Text>
+          </View>
+        </Pressable>
+      </View>
       {a.some((v) => v != null) || b.some((v) => v != null) ? (
         <>
           <LineChart
@@ -57,13 +73,15 @@ export function TrajectoryChart({ comparison }: { comparison: ForwardSim["compar
             labels={labels}
             yFormat={(v) => cfg.fmt(v)}
             series={[
-              { values: b, color: cfg.colorB, width: 1.6, dashed: dim !== "Load" },
+              ...(compare ? [{ values: b, color: cfg.colorB, width: 1.6, dashed: dim !== "Load" }] : []),
               { values: a, color: cfg.colorA, width: 2.4 },
+              { values: hereDot, color: "#ffffff", mode: "dots" as const, width: 3 },
             ]}
           />
           <ChartLegend items={[
             { color: cfg.colorA, label: cfg.labelA },
-            { color: cfg.colorB, label: cfg.labelB, dashed: dim !== "Load" },
+            ...(compare ? [{ color: cfg.colorB, label: cfg.labelB, dashed: dim !== "Load" }] : []),
+            { color: "#ffffff", label: "You are here" },
           ]} />
         </>
       ) : (

--- a/universal/src/components/whatif-slider.tsx
+++ b/universal/src/components/whatif-slider.tsx
@@ -1,0 +1,95 @@
+import { useMemo, useState } from "react";
+import { View, Pressable } from "react-native";
+import { Text, Card, Button } from "soma-style";
+import type { PlanDay } from "../lib/api";
+
+const num = (v: number | null | undefined): number => (v == null || !isFinite(Number(v)) ? 0 : Number(v));
+const clamp = (v: number) => Math.max(0.5, Math.min(1.5, Math.round(v * 100) / 100));
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+/**
+ * What-if intensity control (web parity, #422). A discrete Easier ↔ Harder
+ * stepper (0.5×–1.5×; the web's continuous drag-slider is a documented mobile
+ * trim) previews scaling the upcoming plan, then "Apply changes" persists the
+ * deltas via onApply. An override banner shows while intensity ≠ 1.0×.
+ */
+export function WhatIfSlider({ planDays, onApply }: { planDays: PlanDay[]; onApply?: (factor: number, dayIds: number[]) => Promise<boolean> }) {
+  const [factor, setFactor] = useState(1.0);
+  const [state, setState] = useState<SaveState>("idle");
+
+  const upcoming = useMemo(
+    () => (planDays ?? []).filter((d) => !d.completed && d.targetDistanceKm != null && num(d.targetDistanceKm) > 0),
+    [planDays],
+  );
+  const baseKm = upcoming.reduce((s, d) => s + num(d.targetDistanceKm), 0);
+  const scaledKm = baseKm * factor;
+  const changed = Math.abs(factor - 1) > 0.001;
+
+  const step = (delta: number) => { setFactor((f) => clamp(f + delta)); setState("idle"); };
+  const pct = Math.round(factor * 100);
+  const label = factor < 0.98 ? "Easier" : factor > 1.02 ? "Harder" : "Normal";
+  const labelColor = factor < 0.98 ? "#6ad4a0" : factor > 1.02 ? "#e0a458" : "#8aa0ac";
+
+  async function apply() {
+    if (!onApply || !changed || !upcoming.length) return;
+    setState("saving");
+    const ok = await onApply(factor, upcoming.map((d) => d.id));
+    setState(ok ? "saved" : "error");
+    if (ok) setFactor(1.0);
+  }
+
+  if (!upcoming.length) return null;
+
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">What-if intensity</Text>
+        <Text variant="caption" className="tabular-nums" style={{ color: labelColor }}>{label} · {pct}%</Text>
+      </View>
+
+      {/* Discrete stepper: Easier ← [−] value [+] → Harder */}
+      <View className="flex-row items-center gap-3">
+        <Pressable onPress={() => step(-0.05)} hitSlop={8} className="h-9 w-9 items-center justify-center rounded-lg bg-surface-subtle">
+          <Text variant="title" className="text-teal">−</Text>
+        </Pressable>
+        <View className="flex-1 items-center">
+          <View className="h-2 w-full rounded-full bg-surface-subtle overflow-hidden">
+            <View className="h-full rounded-full" style={{ width: `${((factor - 0.5) / 1.0) * 100}%`, backgroundColor: labelColor }} />
+          </View>
+          <Text variant="micro" className="text-text-muted mt-1">0.5× easier — 1.5× harder</Text>
+        </View>
+        <Pressable onPress={() => step(0.05)} hitSlop={8} className="h-9 w-9 items-center justify-center rounded-lg bg-surface-subtle">
+          <Text variant="title" className="text-warm">+</Text>
+        </Pressable>
+      </View>
+
+      {/* Preview */}
+      <View className="flex-row items-center justify-between">
+        <Text variant="micro" className="text-text-muted">{upcoming.length} upcoming workouts</Text>
+        <Text variant="caption" className="tabular-nums text-text">
+          {baseKm.toFixed(0)} → {scaledKm.toFixed(0)} km
+          {changed ? <Text className={factor > 1 ? "text-warm" : "text-success"}>{`  (${factor > 1 ? "+" : ""}${(scaledKm - baseKm).toFixed(0)})`}</Text> : null}
+        </Text>
+      </View>
+
+      {/* Override banner */}
+      {changed ? (
+        <View className="rounded-lg px-3 py-2" style={{ backgroundColor: (factor > 1 ? "#e0a458" : "#6ad4a0") + "1a" }}>
+          <Text variant="micro" style={{ color: factor > 1 ? "#e0a458" : "#6ad4a0" }}>
+            Override active — upcoming workouts scaled to {pct}%. Apply to persist.
+          </Text>
+        </View>
+      ) : null}
+
+      <Button
+        variant="primary"
+        size="sm"
+        disabled={!changed || state === "saving"}
+        label={state === "saving" ? "Saving…" : state === "saved" ? "Saved" : state === "error" ? "Retry" : `Apply changes (${upcoming.length} workouts)`}
+        onPress={apply}
+      />
+      {state === "error" ? <Text variant="micro" className="text-danger">Couldn't save — the plan adjust flow may be web-only.</Text> : null}
+    </Card>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -343,6 +343,17 @@ export async function deleteSyncRule(id: number): Promise<boolean> {
   return res.ok;
 }
 
+/** Apply a what-if intensity factor to upcoming plan days (POST /api/training/intensity).
+ *  Best-effort — the server owns the re-sim + persist; returns true on success. */
+export async function applyIntensity(factor: number, dayIds: number[]): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/training/intensity`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify({ factor, day_ids: dayIds }),
+  });
+  return res.ok;
+}
+
 /** Submit platform credentials to connect it (POST /api/connections/[platform]). */
 export async function connectPlatform(platform: string, credentials: Record<string, string>): Promise<boolean> {
   const res = await fetch(`${API_BASE}/api/connections/${platform}`, {


### PR DESCRIPTION
## App parity — Training screen

Completes the Training screen (#420) from the forward-sim + activity-match data the app already loads (only a best-effort intensity-apply endpoint is new). The screen already had PMC, the week→day→step schedule, paces, the trajectory chart, and the reference panel.

### What changed
- **#424 Race header** (`race-header.tsx`) — Week X / Y + days-to-race from the plan schedule, beside the title. Plus a **matched-activity compliance panel** (`matched-activity-panel.tsx`): completion-score ring + distance compliance + plan-vs-actual stats, opened by tapping a plan day's score badge.
- **#421 Trajectory chart** — a **"You are here"** marker on the latest model value + a toggle to hide the Garmin comparison line.
- **#422 What-if intensity** (`whatif-slider.tsx`) — a discrete **Easier ↔ Harder stepper** previews scaling the upcoming plan (N workouts, km delta), with an **override banner** and an **Apply-changes delta-save** (Saving / Saved / Error) via a new `applyIntensity` helper.
- **#423** — plan-day score badges now **tap-to-open** the compliance panel (steps already render HR zones + inline matched-activity detail).

### Documented mobile trims
Trajectory goal-zone / taper / race bands + rich hover tooltip + 7-line visibility dropdown (need goal+taper data absent from the mobile payload, or are pointer interactions replaced by the dimension + compare toggles); the continuous drag-slider (a discrete stepper instead); inline workout-step editor + PaceWaterfall + per-day traffic-light (server / editing-layer only).

### Files
- New: `race-header.tsx`, `matched-activity-panel.tsx`, `whatif-slider.tsx`.
- Modified: `lib/api.ts` (`applyIntensity`), `trajectory-chart.tsx`, `training-schedule.tsx`, `app/(main)/training.tsx`.

### Verification
- `tsc --noEmit` clean; `vitest` 5/5.
- Real-pixel render via Expo web + Playwright (mobile 390×844): the race header (WEEK 1/3 + 14 DAYS TO RACE); tapping a plan-day score opened the MatchedActivityPanel (92 score ring, Garmin-matched, 10.2/10.0 km compliance, 5:24/km, 148 bpm, 640 kcal); the trajectory chart with the "You are here" dot + Garmin toggle; and the what-if slider — stepping to Harder 115% showed "129 → 149 km (+19)", the override banner, and Apply changes flipping to "Saved" then resetting.

Closes #421
Closes #422
Closes #423
Closes #424
Closes #420
