### PR TITLE
fix(app): 3 shipped mobile-parity bugs (405 Connect, fake push prefs, wrong readiness metric)

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -325,18 +325,18 @@ export default function SleepScreen() {
           </Card>
         ) : null}
 
-        {(recovery?.current?.length ?? 0) >= 2 ? (
+        {(recoveryVitals?.readiness?.trend?.length ?? 0) >= 2 ? (
           <Card className="gap-2">
             <View className="flex-row items-center justify-between">
               <Text variant="eyebrow">Training readiness</Text>
-              <Text variant="micro" className="text-text-muted">30 days</Text>
+              <Text variant="micro" className="text-text-muted">score · 30 days</Text>
             </View>
             <LineChart
               height={130}
-              labels={recovery!.current.map((p) => chartLabel(p.date))}
+              labels={recoveryVitals!.readiness.trend.map((p) => chartLabel(p.date))}
               yFormat={(v) => String(Math.round(v))}
               refLine={{ y: 50, color: "#3a5563" }}
-              series={[{ values: recovery!.current.map((p) => finiteOrNull(p.value)), color: "#6ad4a0", width: 2.2 }]}
+              series={[{ values: recoveryVitals!.readiness.trend.map((p) => finiteOrNull(p.score)), color: "#6ad4a0", width: 2.2 }]}
             />
           </Card>
         ) : null}

--- a/universal/src/components/push-notifications-card.tsx
+++ b/universal/src/components/push-notifications-card.tsx
@@ -1,32 +1,51 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { View, Switch } from "react-native";
 import { Text, Card, Badge } from "soma-style";
+import { getNotificationPrefs, setNotificationPrefs, type NotificationPrefs } from "../lib/api";
 
-const PREFS: { key: string; label: string }[] = [
-  { key: "workout_synced", label: "Workout synced to Garmin" },
-  { key: "daily_summary", label: "Daily training summary" },
-  { key: "new_pr", label: "New personal record" },
-  { key: "kite_session", label: "Kite session processed" },
-  { key: "sync_error", label: "Sync errors" },
+const PREFS: { key: keyof NotificationPrefs; label: string }[] = [
+  { key: "on_sync_workout", label: "Workout synced to Garmin" },
+  { key: "on_sync_run", label: "Run synced" },
+  { key: "on_sync_error", label: "Sync errors" },
+  { key: "on_milestone", label: "Milestones & personal records" },
+  { key: "on_playlist_ready", label: "Playlist ready" },
 ];
+
+const DEFAULTS: NotificationPrefs = {
+  enabled: false, on_sync_workout: true, on_sync_run: true, on_sync_error: true, on_milestone: true, on_playlist_ready: false,
+};
 
 /**
  * Push notification preferences (web parity, #446): a master enable toggle +
- * per-event preference switches. The actual device registration (Expo push
- * token) is a documented native trim; this manages the preference set.
+ * per-event preference switches, persisted to /api/notifications/preferences
+ * (GET on mount, PUT on change) with the server's real keys. The device push
+ * token registration itself is a documented native trim.
  */
 export function PushNotificationsCard() {
-  const [enabled, setEnabled] = useState(false);
-  const [prefs, setPrefs] = useState<Record<string, boolean>>(
-    Object.fromEntries(PREFS.map((p) => [p.key, true])),
-  );
-  const toggle = (k: string) => setPrefs((m) => ({ ...m, [k]: !m[k] }));
+  const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULTS);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    getNotificationPrefs().then((p) => { if (alive && p) setPrefs({ ...DEFAULTS, ...p }); });
+    return () => { alive = false; };
+  }, []);
+
+  async function update(next: NotificationPrefs) {
+    setPrefs(next);
+    setSaving(true);
+    const ok = await setNotificationPrefs(next);
+    setSaving(false);
+    if (!ok) getNotificationPrefs().then((p) => p && setPrefs({ ...DEFAULTS, ...p })); // revert to server truth
+  }
+  const setEnabled = (v: boolean) => update({ ...prefs, enabled: v });
+  const toggle = (k: keyof NotificationPrefs) => update({ ...prefs, [k]: !prefs[k] });
 
   return (
     <Card className="gap-3">
       <View className="flex-row items-center justify-between">
         <Text variant="eyebrow">Push notifications</Text>
-        <Badge label={enabled ? "On" : "Off"} tone={enabled ? "success" : "neutral"} />
+        <Badge label={saving ? "Saving…" : prefs.enabled ? "On" : "Off"} tone={prefs.enabled ? "success" : "neutral"} />
       </View>
 
       <View className="flex-row items-center justify-between">
@@ -35,23 +54,23 @@ export function PushNotificationsCard() {
           <Text variant="micro" className="text-text-muted">Get alerts on this device</Text>
         </View>
         <Switch
-          value={enabled}
+          value={prefs.enabled}
           onValueChange={setEnabled}
           trackColor={{ false: "#2a3843", true: "#2f6d5b" }}
-          thumbColor={enabled ? "#77c8d1" : "#8aa0ac"}
+          thumbColor={prefs.enabled ? "#77c8d1" : "#8aa0ac"}
         />
       </View>
 
       <View className="gap-2 border-t border-border-subtle pt-2">
         {PREFS.map((p) => (
           <View key={p.key} className="flex-row items-center justify-between">
-            <Text variant="body" className={enabled ? "text-text-secondary" : "text-text-muted"}>{p.label}</Text>
+            <Text variant="body" className={prefs.enabled ? "text-text-secondary" : "text-text-muted"}>{p.label}</Text>
             <Switch
-              value={enabled && prefs[p.key]}
+              value={prefs.enabled && prefs[p.key]}
               onValueChange={() => toggle(p.key)}
-              disabled={!enabled}
+              disabled={!prefs.enabled}
               trackColor={{ false: "#2a3843", true: "#2f6d5b" }}
-              thumbColor={enabled && prefs[p.key] ? "#6ad4a0" : "#8aa0ac"}
+              thumbColor={prefs.enabled && prefs[p.key] ? "#6ad4a0" : "#8aa0ac"}
             />
           </View>
         ))}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -343,6 +343,30 @@ export async function deleteSyncRule(id: number): Promise<boolean> {
   return res.ok;
 }
 
+// ---- Notification preferences (server-persisted singleton) ----
+export interface NotificationPrefs {
+  enabled: boolean;
+  on_sync_workout: boolean;
+  on_sync_run: boolean;
+  on_sync_error: boolean;
+  on_milestone: boolean;
+  on_playlist_ready: boolean;
+}
+/** Read the persisted notification preferences (GET /api/notifications/preferences). */
+export async function getNotificationPrefs(): Promise<NotificationPrefs | null> {
+  try { return await fetchJson<NotificationPrefs>("/api/notifications/preferences"); }
+  catch { return null; }
+}
+/** Persist notification preferences (PUT /api/notifications/preferences). */
+export async function setNotificationPrefs(prefs: NotificationPrefs): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/notifications/preferences`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify(prefs),
+  });
+  return res.ok;
+}
+
 /** Apply a what-if intensity factor to upcoming plan days (POST /api/training/intensity).
  *  Best-effort — the server owns the re-sim + persist; returns true on success. */
 export async function applyIntensity(factor: number, dayIds: number[]): Promise<boolean> {
@@ -357,7 +381,7 @@ export async function applyIntensity(factor: number, dayIds: number[]): Promise<
 /** Submit platform credentials to connect it (POST /api/connections/[platform]). */
 export async function connectPlatform(platform: string, credentials: Record<string, string>): Promise<boolean> {
   const res = await fetch(`${API_BASE}/api/connections/${platform}`, {
-    method: "POST",
+    method: "PUT",
     headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
     body: JSON.stringify(credentials),
   });


### PR DESCRIPTION
## Fix 3 shipped mobile-parity bugs (post-audit)

A fresh field-level re-audit of every mobile screen vs web (tracked in #473) surfaced three defects in already-merged parity code:

- **Connections — Connect was a no-op:** `connectPlatform` did a `POST` to `/api/connections/[platform]`, which only defines `GET/PUT/DELETE` → **405**. Hevy/Telegram credential save silently failed. → use **PUT**.
- **Connections — push prefs were fake:** the Push Notifications card was **local-only** `useState` with keys that don't match the API, and never fetched or persisted. → now **GET + PUT `/api/notifications/preferences`** with the server's real keys, reflects server state on mount, reverts on save failure.
- **Sleep — readiness chart wrong metric:** the "Training readiness" trend plotted `/api/stats/recovery.value` (= **body_battery_max**), mislabeled. → now plots `recoveryVitals.readiness.trend[].score`.

### Verification
`tsc` 0, `vitest` 5/5. Playwright (390×844): the push card renders the **fetched** server prefs (Run synced OFF, Milestones OFF, Playlist ready ON — differing from local defaults); the Sleep readiness chart plots the rising score (60→92) matching the 92/100 readiness card, instead of the flat battery-max series.

Part of #473
