### PR TITLE
feat(app): LineChart foundation (tap-read/dual-axis/expand) + Running chart fidelity

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -216,8 +216,12 @@ export default function RunningScreen() {
     },
     {
       label: "VO2max",
-      value: stats?.peak_vo2max != null ? num(stats.peak_vo2max).toFixed(1) : "—",
-      sub: "ml/kg/min",
+      value: (() => {
+        const t = trends?.vo2max;
+        const latest = t && t.length ? t[t.length - 1] : stats?.peak_vo2max;
+        return latest != null ? num(latest).toFixed(1) : "—";
+      })(),
+      sub: stats?.peak_vo2max != null ? `peak ${num(stats.peak_vo2max).toFixed(1)}` : "ml/kg/min",
       cls: "text-warning",
       spark: trends?.vo2max?.length ? { data: trends.vo2max, color: "#e0a458" } : undefined,
       unit: "ml/kg/min",

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -1,12 +1,13 @@
-import { View } from "react-native";
+import { useState, type ReactNode } from "react";
+import { View, type LayoutChangeEvent, type GestureResponderEvent } from "react-native";
 import Svg, { Polyline, Line, Circle } from "react-native-svg";
-import { Text } from "soma-style";
+import { Text, Modal } from "soma-style";
 
 /**
- * One data series on a LineChart. Values are aligned to a shared x-index
- * (index i of every series maps to the same x position); `null` marks a gap.
- * - mode "line": connected polyline (dense series — smoothed, trend, goal)
- * - mode "dots": a dot per non-null point (sparse series — actual weigh-ins)
+ * One data series on a LineChart. Values align to a shared x-index; `null` is a gap.
+ * - mode "line": connected polyline · mode "dots": a dot per non-null point
+ * - axis "right": scaled to a secondary right-hand y-axis (dual-axis charts)
+ * - sizes: per-point radius for dots mode (scatter with variable dot size)
  */
 export interface ChartSeries {
   values: (number | null)[];
@@ -15,109 +16,218 @@ export interface ChartSeries {
   dashed?: boolean;
   mode?: "line" | "dots";
   label?: string;
+  axis?: "left" | "right";
+  sizes?: (number | null)[];
 }
 
 export interface LineChartProps {
   series: ChartSeries[];
-  /** x labels aligned to the value index; only first + last are drawn. */
+  /** x labels aligned to the value index. */
   labels?: string[];
   height?: number;
-  /** Format a y value for the axis labels (min/max) and the reference line. */
+  /** Format a left-axis y value (also the reference-line labels). */
   yFormat?: (v: number) => string;
-  /** Optional horizontal reference line (e.g. a goal pace at y=0). */
+  /** Format a right-axis y value (dual-axis). */
+  yFormatRight?: (v: number) => string;
   refLine?: { y: number; color?: string };
-  /** Additional horizontal reference lines (e.g. ACWR 0.8/1.3/1.5 guides). */
   refLines?: { y: number; color?: string; dashed?: boolean }[];
   yMin?: number;
   yMax?: number;
+  /** Number of evenly-spaced x labels to draw (default 2 = first + last). */
+  xTicks?: number;
+  /** Enable tap/drag to read the exact value(s) at a point. */
+  interactive?: boolean;
 }
 
-const VBW = 320; // viewBox width; scales uniformly to the container
+const VBW = 320;
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+/** ISO date → "Mon D" (used by the interactive callout when labels look like dates). */
+export function chartDateLabel(iso: string): string {
+  const [, m, d] = iso.slice(0, 10).split("-").map(Number);
+  return m && d ? `${MONTHS[m - 1]} ${d}` : iso;
+}
 
-/** A compact, dependency-free line chart (react-native-svg) with y-axis
- *  min/max labels and first/last x labels. Reused across every app chart. */
-export function LineChart({ series, labels, height = 120, yFormat, refLine, refLines, yMin, yMax }: LineChartProps) {
-  const fmt = yFormat ?? ((v: number) => String(Math.round(v)));
-  const all: number[] = [];
-  for (const s of series) for (const v of s.values) if (v != null && isFinite(v)) all.push(v);
-  if (refLine && isFinite(refLine.y)) all.push(refLine.y);
-  if (refLines) for (const r of refLines) if (isFinite(r.y)) all.push(r.y);
-  if (all.length < 2) {
-    return <View style={{ height }} className="items-center justify-center"><Text variant="micro" className="text-text-muted">Not enough data yet.</Text></View>;
+/** A compact react-native-svg line/scatter chart with y-axis labels, dated x
+ *  ticks, an optional right axis, and optional tap-to-read cursor + callout. */
+export function LineChart(props: LineChartProps) {
+  const { series, labels, height = 120, yFormat, yFormatRight, refLine, refLines, yMin, yMax, xTicks, interactive } = props;
+  const fmtL = yFormat ?? ((v: number) => String(Math.round(v)));
+  const fmtR = yFormatRight ?? fmtL;
+  const [active, setActive] = useState<number | null>(null);
+  const [plotW, setPlotW] = useState(0);
+
+  const leftS = series.filter((s) => s.axis !== "right");
+  const rightS = series.filter((s) => s.axis === "right");
+  const gather = (ss: ChartSeries[], extra: number[] = []) => {
+    const all = [...extra];
+    for (const s of ss) for (const v of s.values) if (v != null && isFinite(v)) all.push(v);
+    return all;
+  };
+  const lExtra: number[] = [];
+  if (refLine && isFinite(refLine.y)) lExtra.push(refLine.y);
+  if (refLines) for (const r of refLines) if (isFinite(r.y)) lExtra.push(r.y);
+  const lAll = gather(leftS, lExtra);
+  const rAll = gather(rightS);
+
+  if (lAll.length + rAll.length < 2) {
+    return (
+      <View style={{ height }} className="items-center justify-center">
+        <Text variant="micro" className="text-text-muted">Not enough data yet.</Text>
+      </View>
+    );
   }
-  const lo = yMin != null ? yMin : Math.min(...all);
-  const hi = yMax != null ? yMax : Math.max(...all);
-  const range = hi - lo || 1;
+
+  const loL = yMin != null ? yMin : Math.min(...lAll);
+  const hiL = yMax != null ? yMax : Math.max(...lAll);
+  const rangeL = hiL - loL || 1;
+  const loR = rAll.length ? Math.min(...rAll) : 0;
+  const hiR = rAll.length ? Math.max(...rAll) : 1;
+  const rangeR = hiR - loR || 1;
   const padTop = 6;
   const padBottom = 6;
   const plotH = height - padTop - padBottom;
   const n = Math.max(...series.map((s) => s.values.length));
   const xAt = (i: number) => (n <= 1 ? 0 : (i / (n - 1)) * VBW);
-  const yAt = (v: number) => padTop + (1 - (v - lo) / range) * plotH;
+  const yAtL = (v: number) => padTop + (1 - (v - loL) / rangeL) * plotH;
+  const yAtR = (v: number) => padTop + (1 - (v - loR) / rangeR) * plotH;
+  const yOf = (s: ChartSeries, v: number) => (s.axis === "right" ? yAtR(v) : yAtL(v));
+
+  // x tick indices
+  const tickCount = xTicks && xTicks > 2 ? Math.min(xTicks, n) : 2;
+  const tickIdx = labels && labels.length >= 2
+    ? (tickCount <= 2 ? [0, n - 1] : Array.from({ length: tickCount }, (_, k) => Math.round((k / (tickCount - 1)) * (n - 1))))
+    : [];
+
+  const onTouch = (e: GestureResponderEvent) => {
+    if (!interactive || plotW <= 0 || n <= 1) return;
+    const x = e.nativeEvent.locationX;
+    const i = Math.max(0, Math.min(n - 1, Math.round((x / plotW) * (n - 1))));
+    setActive(i);
+  };
+  const onLayout = (e: LayoutChangeEvent) => setPlotW(e.nativeEvent.layout.width);
+
+  // Active-point callout data
+  const callout = active != null
+    ? {
+        i: active,
+        label: labels?.[active] ? (String(labels[active]).match(/^\d{4}-\d{2}-\d{2}/) ? chartDateLabel(String(labels[active])) : String(labels[active])) : "",
+        rows: series
+          .map((s) => ({ color: s.color, v: s.values[active], fmt: s.axis === "right" ? fmtR : fmtL, label: s.label }))
+          .filter((r) => r.v != null && isFinite(Number(r.v))),
+        leftPct: n <= 1 ? 0 : (active / (n - 1)) * 100,
+      }
+    : null;
 
   return (
     <View>
       <View className="flex-row">
+        {/* left axis labels */}
         <View className="w-9 justify-between" style={{ height, paddingVertical: padTop }}>
-          <Text variant="micro" className="text-text-muted tabular-nums">{fmt(hi)}</Text>
-          <Text variant="micro" className="text-text-muted tabular-nums">{fmt(lo)}</Text>
+          <Text variant="micro" className="text-text-muted tabular-nums">{fmtL(hiL)}</Text>
+          <Text variant="micro" className="text-text-muted tabular-nums">{fmtL(loL)}</Text>
         </View>
-        <View className="flex-1">
+
+        <View
+          className="flex-1"
+          onLayout={onLayout}
+          onStartShouldSetResponder={() => !!interactive}
+          onMoveShouldSetResponder={() => !!interactive}
+          onResponderGrant={onTouch}
+          onResponderMove={onTouch}
+          onResponderRelease={() => interactive && setActive(null)}
+        >
           <Svg width="100%" height={height} viewBox={`0 0 ${VBW} ${height}`}>
-            {/* baseline + top gridline */}
-            <Line x1={0} y1={yAt(hi)} x2={VBW} y2={yAt(hi)} stroke="#1e2f38" strokeWidth={1} />
-            <Line x1={0} y1={yAt(lo)} x2={VBW} y2={yAt(lo)} stroke="#1e2f38" strokeWidth={1} />
-            {refLine && refLine.y >= lo && refLine.y <= hi ? (
-              <Line x1={0} y1={yAt(refLine.y)} x2={VBW} y2={yAt(refLine.y)} stroke={refLine.color ?? "#3a5563"} strokeWidth={1} strokeDasharray="4 4" />
+            <Line x1={0} y1={yAtL(hiL)} x2={VBW} y2={yAtL(hiL)} stroke="#1e2f38" strokeWidth={1} />
+            <Line x1={0} y1={yAtL(loL)} x2={VBW} y2={yAtL(loL)} stroke="#1e2f38" strokeWidth={1} />
+            {refLine && refLine.y >= loL && refLine.y <= hiL ? (
+              <Line x1={0} y1={yAtL(refLine.y)} x2={VBW} y2={yAtL(refLine.y)} stroke={refLine.color ?? "#3a5563"} strokeWidth={1} strokeDasharray="4 4" />
             ) : null}
             {refLines?.map((r, ri) =>
-              r.y >= lo && r.y <= hi ? (
-                <Line key={`rl-${ri}`} x1={0} y1={yAt(r.y)} x2={VBW} y2={yAt(r.y)} stroke={r.color ?? "#3a5563"} strokeWidth={1} strokeDasharray={r.dashed === false ? undefined : "4 4"} />
+              r.y >= loL && r.y <= hiL ? (
+                <Line key={`rl-${ri}`} x1={0} y1={yAtL(r.y)} x2={VBW} y2={yAtL(r.y)} stroke={r.color ?? "#3a5563"} strokeWidth={1} strokeDasharray={r.dashed === false ? undefined : "4 4"} />
               ) : null,
             )}
             {series.map((s, si) => {
               if (s.mode === "dots") {
                 return s.values.map((v, i) =>
                   v == null || !isFinite(v) ? null : (
-                    <Circle key={`${si}-${i}`} cx={xAt(i)} cy={yAt(v)} r={2.6} fill={s.color} />
+                    <Circle key={`${si}-${i}`} cx={xAt(i)} cy={yOf(s, v)} r={s.sizes?.[i] != null ? Math.max(1.4, Number(s.sizes[i])) : 2.6} fill={s.color} fillOpacity={s.sizes ? 0.55 : 1} />
                   ),
                 );
               }
-              // line mode: split into segments on null gaps
               const segs: string[] = [];
               let cur: string[] = [];
               s.values.forEach((v, i) => {
                 if (v == null || !isFinite(v)) { if (cur.length) { segs.push(cur.join(" ")); cur = []; } }
-                else cur.push(`${xAt(i)},${yAt(v)}`);
+                else cur.push(`${xAt(i)},${yOf(s, v)}`);
               });
               if (cur.length) segs.push(cur.join(" "));
               return segs.map((pts, gi) => (
-                <Polyline
-                  key={`${si}-${gi}`}
-                  points={pts}
-                  fill="none"
-                  stroke={s.color}
-                  strokeWidth={s.width ?? 2}
-                  strokeDasharray={s.dashed ? "5 4" : undefined}
-                  strokeLinejoin="round"
-                  strokeLinecap="round"
-                />
+                <Polyline key={`${si}-${gi}`} points={pts} fill="none" stroke={s.color} strokeWidth={s.width ?? 2} strokeDasharray={s.dashed ? "5 4" : undefined} strokeLinejoin="round" strokeLinecap="round" />
               ));
             })}
+            {/* interactive cursor */}
+            {callout != null ? (
+              <>
+                <Line x1={xAt(callout.i)} y1={0} x2={xAt(callout.i)} y2={height} stroke="#77c8d1" strokeWidth={1} strokeDasharray="2 3" />
+                {series.map((s, si) => {
+                  const v = s.values[callout.i];
+                  return v == null || !isFinite(Number(v)) ? null : (
+                    <Circle key={`ac-${si}`} cx={xAt(callout.i)} cy={yOf(s, Number(v))} r={3.2} fill={s.color} stroke="#0c1519" strokeWidth={1} />
+                  );
+                })}
+              </>
+            ) : null}
           </Svg>
-          {labels && labels.length >= 2 ? (
-            <View className="flex-row justify-between">
-              <Text variant="micro" className="text-text-muted">{labels[0]}</Text>
-              <Text variant="micro" className="text-text-muted">{labels[labels.length - 1]}</Text>
+
+          {/* right axis labels */}
+          {rightS.length ? (
+            <View className="absolute right-0 top-0 items-end justify-between" style={{ height, paddingVertical: padTop }} pointerEvents="none">
+              <Text variant="micro" className="text-text-muted tabular-nums">{fmtR(hiR)}</Text>
+              <Text variant="micro" className="text-text-muted tabular-nums">{fmtR(loR)}</Text>
             </View>
+          ) : null}
+
+          {/* interactive callout box */}
+          {callout != null ? (
+            <View pointerEvents="none" className="absolute top-0 rounded-md px-2 py-1" style={{ left: `${Math.max(0, Math.min(70, callout.leftPct - 15))}%`, backgroundColor: "#152028", borderWidth: 1, borderColor: "#2a3a48" }}>
+              {callout.label ? <Text variant="micro" className="text-text-muted">{callout.label}</Text> : null}
+              {callout.rows.map((r, ri) => (
+                <View key={ri} className="flex-row items-center gap-1">
+                  <View className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: r.color }} />
+                  <Text variant="micro" className="tabular-nums text-text">{r.fmt(Number(r.v))}</Text>
+                </View>
+              ))}
+            </View>
+          ) : null}
+
+          {/* x tick labels */}
+          {tickIdx.length ? (
+            tickCount <= 2 ? (
+              <View className="flex-row justify-between">
+                <Text variant="micro" className="text-text-muted">{labels![0]}</Text>
+                <Text variant="micro" className="text-text-muted">{labels![labels!.length - 1]}</Text>
+              </View>
+            ) : (
+              <View style={{ height: 14 }}>
+                {tickIdx.map((idx, k) => (
+                  <Text key={k} variant="micro" className="text-text-muted absolute" style={{ left: `${Math.max(0, Math.min(92, (idx / (n - 1)) * 100 - 3))}%` }}>
+                    {labels![idx] ? (String(labels![idx]).match(/^\d{4}-\d{2}-\d{2}/) ? chartDateLabel(String(labels![idx])) : String(labels![idx])) : ""}
+                  </Text>
+                ))}
+              </View>
+            )
           ) : null}
         </View>
       </View>
+      {interactive && active == null ? (
+        <Text variant="micro" className="text-text-muted mt-0.5 text-center" style={{ opacity: 0.6 }}>tap the chart to read values</Text>
+      ) : null}
     </View>
   );
 }
 
-/** A small colored-line + label legend row for a chart. */
+/** A colored-line + label legend row for a chart. */
 export function ChartLegend({ items }: { items: { color: string; label: string; dashed?: boolean }[] }) {
   return (
     <View className="flex-row flex-wrap gap-x-3 gap-y-1">
@@ -127,6 +237,33 @@ export function ChartLegend({ items }: { items: { color: string; label: string; 
           <Text variant="micro" className="text-text-muted">{it.label}</Text>
         </View>
       ))}
+    </View>
+  );
+}
+
+/** Wraps a chart card with a maximize affordance that opens the same chart,
+ *  taller + interactive, in a Modal. Pass the inline chart as children and the
+ *  LineChart props to render big in the modal. */
+export function ExpandableChart({
+  title,
+  children,
+  chart,
+}: {
+  title: string;
+  children: ReactNode;
+  chart: LineChartProps;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <View>
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">{title}</Text>
+        <Text variant="micro" className="text-teal" onPress={() => setOpen(true)}>⤢ expand</Text>
+      </View>
+      {children}
+      <Modal visible={open} onClose={() => setOpen(false)} title={title}>
+        <LineChart {...chart} height={300} interactive xTicks={chart.xTicks ?? 4} />
+      </Modal>
     </View>
   );
 }

--- a/universal/src/components/run-table.tsx
+++ b/universal/src/components/run-table.tsx
@@ -14,12 +14,14 @@ export interface RunRow {
   calories: number | null;
 }
 
-type SortKey = "date" | "distance" | "pace" | "avg_hr";
+type SortKey = "date" | "distance" | "duration_min" | "pace" | "avg_hr" | "calories";
 const COLS: { key: SortKey; label: string }[] = [
   { key: "date", label: "Date" },
   { key: "distance", label: "Dist" },
+  { key: "duration_min", label: "Time" },
   { key: "pace", label: "Pace" },
   { key: "avg_hr", label: "HR" },
+  { key: "calories", label: "Cal" },
 ];
 
 const num = (v: number | null | undefined): number => (v == null ? 0 : Number(v));
@@ -104,15 +106,10 @@ export function RunTable({ runs }: { runs: RunRow[] }) {
         <Text variant="micro" className="text-text-muted">{runs.length} · tap to sort / open</Text>
       </View>
 
-      {/* Sortable header row */}
-      <View className="flex-row items-center border-b border-border-subtle pb-1.5">
-        <Pressable className="flex-1" onPress={() => onHeader("date")}>
-          <Text variant="micro" className={sortKey === "date" ? "text-teal" : "text-text-muted"}>
-            {COLS[0].label}{sortKey === "date" ? (asc ? " ↑" : " ↓") : ""}
-          </Text>
-        </Pressable>
-        {COLS.slice(1).map((c) => (
-          <Pressable key={c.key} className="w-16 items-end" onPress={() => onHeader(c.key)}>
+      {/* Sortable column chips (all 6 sortable; 3 are shown as aligned columns) */}
+      <View className="flex-row flex-wrap gap-x-3 gap-y-1 border-b border-border-subtle pb-1.5">
+        {COLS.map((c) => (
+          <Pressable key={c.key} onPress={() => onHeader(c.key)} hitSlop={4}>
             <Text variant="micro" className={sortKey === c.key ? "text-teal" : "text-text-muted"}>
               {c.label}{sortKey === c.key ? (asc ? " ↑" : " ↓") : ""}
             </Text>
@@ -125,15 +122,19 @@ export function RunTable({ runs }: { runs: RunRow[] }) {
         <Pressable key={r.activity_id} onPress={() => setSelected(r)} className="flex-row items-center border-b border-border-subtle py-2">
           <View className="flex-1 pr-2">
             <Text variant="caption" className="text-text" numberOfLines={1}>{r.name ?? "Run"}</Text>
-            <Text variant="micro" className="text-text-muted">{shortDate(r.date)}</Text>
+            <Text variant="micro" className="text-text-muted">
+              {shortDate(r.date)}
+              {r.duration_min != null ? ` · ${Math.round(num(r.duration_min))} min` : ""}
+              {r.calories != null && r.calories > 0 ? ` · ${Math.round(num(r.calories))} kcal` : ""}
+            </Text>
           </View>
-          <Text variant="caption" className="w-16 text-right tabular-nums text-text">
+          <Text variant="caption" className="w-14 text-right tabular-nums text-text">
             {r.distance != null ? `${num(r.distance).toFixed(1)}` : "—"}
           </Text>
-          <Text variant="caption" className="w-16 text-right tabular-nums text-lime">
+          <Text variant="caption" className="w-14 text-right tabular-nums text-lime">
             {r.pace != null ? paceLabel(r.pace) : "—"}
           </Text>
-          <Text variant="caption" className="w-16 text-right tabular-nums text-danger">
+          <Text variant="caption" className="w-12 text-right tabular-nums text-danger">
             {r.avg_hr != null ? Math.round(num(r.avg_hr)) : "—"}
           </Text>
         </Pressable>

--- a/universal/src/components/running-deep-trends.tsx
+++ b/universal/src/components/running-deep-trends.tsx
@@ -42,7 +42,9 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
 
   const cad = trends.cadenceStride.filter((p) => p.cadence != null);
   const cadLast = cad.length ? cad[cad.length - 1] : null;
-  const cadSeries = cad.map((p) => Number(p.cadence)).filter(isFinite);
+  const cadSeries = cad.map((p) => (p.cadence != null && isFinite(Number(p.cadence)) ? Number(p.cadence) : null));
+  const strideSeries = cad.map((p) => (p.stride != null && isFinite(Number(p.stride)) ? Number(p.stride) : null));
+  const hasStride = strideSeries.filter((v) => v != null).length >= 2;
 
   return (
     <View className="gap-4">
@@ -94,7 +96,7 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
       {cadLast && cadSeries.length >= 2 ? (
         <Card className="gap-2">
           <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Cadence</Text>
+            <Text variant="eyebrow">Cadence &amp; stride</Text>
             <Text variant="micro" className="tabular-nums text-text-muted">{cadLast.stride != null ? `stride ${cadLast.stride} cm` : ""}</Text>
           </View>
           <View className="flex-row items-end gap-2">
@@ -102,12 +104,21 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
             <Text variant="caption" className="text-text-muted mb-1">spm</Text>
           </View>
           <LineChart
-            height={110}
+            height={120}
+            interactive
             yFormat={(v) => String(Math.round(v))}
-            series={[{ values: cadSeries, color: "#cbe896", width: 2.2 }]}
+            yFormatRight={(v) => `${Math.round(v)}cm`}
             refLine={{ y: 180, color: "#77c8d1" }}
+            series={[
+              { values: cadSeries, color: "#cbe896", width: 2.2, label: "Cadence" },
+              ...(hasStride ? [{ values: strideSeries, color: "#8b9df0", width: 1.8, axis: "right" as const, label: "Stride" }] : []),
+            ]}
           />
-          <Text variant="micro" className="text-text-muted">Dashed line = 180 spm target.</Text>
+          {hasStride ? (
+            <ChartLegend items={[{ color: "#cbe896", label: "Cadence spm (L)" }, { color: "#8b9df0", label: "Stride cm (R)" }, { color: "#77c8d1", label: "180 target", dashed: true }]} />
+          ) : (
+            <Text variant="micro" className="text-text-muted">Dashed line = 180 spm target.</Text>
+          )}
         </Card>
       ) : null}
     </View>

--- a/universal/src/components/running-fitness-scores.tsx
+++ b/universal/src/components/running-fitness-scores.tsx
@@ -1,49 +1,61 @@
 import { View } from "react-native";
-import { Text, Card, Sparkline } from "soma-style";
+import { Text, Card } from "soma-style";
+import { LineChart, ChartLegend, chartDateLabel } from "./line-chart";
 import type { FitnessScores } from "../lib/api";
 
 const ENDURANCE_CLASS: Record<number, string> = {
   1: "Novice", 2: "Trained", 3: "Well trained", 4: "Expert", 5: "Superior", 6: "Elite",
 };
 
-/** Endurance + hill fitness score cards, fed by /api/running/fitness-scores. */
+/** Endurance + hill fitness scores as one dual-axis chart (endurance left,
+ *  hill right), tap-to-read. Web parity — fed by /api/running/fitness-scores. */
 export function RunningFitnessScores({ scores }: { scores: FitnessScores | null | undefined }) {
   if (!scores) return null;
   const end = scores.endurance.latest;
   const hill = scores.hill.latest;
-  const endSeries = scores.endurance.trend.map((p) => p.score).filter((v): v is number => v != null);
-  const hillSeries = scores.hill.trend.map((p) => p.score).filter((v): v is number => v != null);
-
   if (!end && !hill) return null;
 
-  return (
-    <View className="gap-4">
-      {end ? (
-        <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Endurance score</Text>
-            {end.classification != null ? (
-              <Text variant="micro" className="text-text-muted">{ENDURANCE_CLASS[end.classification] ?? `class ${end.classification}`}</Text>
-            ) : null}
-          </View>
-          <Text variant="display" className="text-teal">{end.score != null ? end.score.toLocaleString() : "—"}</Text>
-          {endSeries.length >= 2 ? <Sparkline data={endSeries} color="#77c8d1" height={34} baseline /> : null}
-        </Card>
-      ) : null}
+  // Align both series on the endurance date axis (hill looked up by date).
+  const dates = scores.endurance.trend.map((p) => p.date);
+  const hillByDate = new Map(scores.hill.trend.map((p) => [p.date, p.score]));
+  const endVals = scores.endurance.trend.map((p) => (p.score != null && isFinite(p.score) ? p.score : null));
+  const hillVals = dates.map((d) => { const v = hillByDate.get(d); return v != null && isFinite(v) ? v : null; });
+  const hasChart = endVals.filter((v) => v != null).length >= 2 || hillVals.filter((v) => v != null).length >= 2;
 
-      {hill ? (
-        <Card className="gap-2">
-          <Text variant="eyebrow">Hill score</Text>
-          <View className="flex-row items-end gap-2">
-            <Text variant="display" className="text-lime">{hill.score ?? "—"}</Text>
-            <View className="mb-1 flex-row gap-3">
-              {hill.strength != null ? <Text variant="micro" className="text-text-muted">strength {hill.strength}</Text> : null}
-              {hill.endurance != null ? <Text variant="micro" className="text-text-muted">endurance {hill.endurance}</Text> : null}
-            </View>
+  return (
+    <Card className="gap-2">
+      <Text variant="eyebrow">Fitness scores</Text>
+      <View className="flex-row flex-wrap gap-x-6 gap-y-1">
+        {end ? (
+          <View className="gap-0.5">
+            <Text variant="micro" className="text-text-muted">Endurance{end.classification != null ? ` · ${ENDURANCE_CLASS[end.classification] ?? end.classification}` : ""}</Text>
+            <Text variant="title" className="text-teal">{end.score != null ? end.score.toLocaleString() : "—"}</Text>
           </View>
-          {hillSeries.length >= 2 ? <Sparkline data={hillSeries} color="#cbe896" height={34} baseline /> : null}
-        </Card>
+        ) : null}
+        {hill ? (
+          <View className="gap-0.5">
+            <Text variant="micro" className="text-text-muted">Hill{hill.strength != null ? ` · str ${hill.strength}` : ""}{hill.endurance != null ? ` · end ${hill.endurance}` : ""}</Text>
+            <Text variant="title" className="text-lime">{hill.score ?? "—"}</Text>
+          </View>
+        ) : null}
+      </View>
+      {hasChart ? (
+        <>
+          <LineChart
+            height={150}
+            interactive
+            labels={dates.map((d) => chartDateLabel(d))}
+            xTicks={4}
+            yFormat={(v) => String(Math.round(v))}
+            yFormatRight={(v) => String(Math.round(v))}
+            series={[
+              { values: endVals, color: "#77c8d1", width: 2.2, label: "Endurance" },
+              { values: hillVals, color: "#cbe896", width: 2.2, axis: "right", label: "Hill" },
+            ]}
+          />
+          <ChartLegend items={[{ color: "#77c8d1", label: "Endurance (L)" }, { color: "#cbe896", label: "Hill (R)" }]} />
+        </>
       ) : null}
-    </View>
+    </Card>
   );
 }

--- a/universal/src/components/running-pace-vo2-charts.tsx
+++ b/universal/src/components/running-pace-vo2-charts.tsx
@@ -1,20 +1,17 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
-import { LineChart } from "./line-chart";
+import { LineChart, ExpandableChart } from "./line-chart";
 
 /** Decimal minutes → "M:SS" pace label. */
 function paceLabel(mins: number): string {
   const t = Math.round(mins * 60);
-  const m = Math.floor(t / 60);
-  const s = t % 60;
-  return `${m}:${String(s).padStart(2, "0")}`;
+  return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`;
 }
 
 /**
- * Dedicated Pace Progression + VO2max Trend charts (web parity, #435).
- * Both series come from /api/running/stats `trends` (already fetched by the
- * screen) — the summary cards show these as sparklines; these render them as
- * full LineCharts with axis labels, matching the web's ExpandableChartCards.
+ * Dedicated Pace Progression + VO2max Trend charts (web parity). Both tap-to-
+ * read and fullscreen-expandable; VO2max carries an average reference line.
+ * Series come from /api/running/stats `trends`.
  */
 export function RunningPaceVo2Charts({
   pace,
@@ -26,34 +23,31 @@ export function RunningPaceVo2Charts({
   const paceVals = (pace ?? []).filter((v) => isFinite(v));
   const vo2Vals = (vo2max ?? []).filter((v) => isFinite(v));
   if (paceVals.length < 2 && vo2Vals.length < 2) return null;
+  const vo2Avg = vo2Vals.length ? vo2Vals.reduce((a, b) => a + b, 0) / vo2Vals.length : 0;
 
   return (
     <View className="gap-4">
       {paceVals.length >= 2 ? (
         <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Pace progression</Text>
-            <Text variant="micro" className="text-text-muted">min/km · lower is faster</Text>
-          </View>
-          <LineChart
-            height={140}
-            yFormat={(v) => paceLabel(v)}
-            series={[{ values: paceVals, color: "#cbe896", width: 2.2 }]}
-          />
+          <ExpandableChart
+            title="Pace progression"
+            chart={{ series: [{ values: paceVals, color: "#cbe896", width: 2.2 }], yFormat: paceLabel }}
+          >
+            <LineChart height={140} interactive yFormat={paceLabel} series={[{ values: paceVals, color: "#cbe896", width: 2.2 }]} />
+          </ExpandableChart>
+          <Text variant="micro" className="text-text-muted">min/km · lower is faster · tap to read</Text>
         </Card>
       ) : null}
 
       {vo2Vals.length >= 2 ? (
         <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">VO₂max trend</Text>
-            <Text variant="micro" className="text-text-muted">ml/kg/min</Text>
-          </View>
-          <LineChart
-            height={140}
-            yFormat={(v) => v.toFixed(1)}
-            series={[{ values: vo2Vals, color: "#e0a458", width: 2.2 }]}
-          />
+          <ExpandableChart
+            title="VO₂max trend"
+            chart={{ series: [{ values: vo2Vals, color: "#e0a458", width: 2.2 }], yFormat: (v) => v.toFixed(1), refLine: { y: vo2Avg, color: "#5a7a8a" } }}
+          >
+            <LineChart height={140} interactive yFormat={(v) => v.toFixed(1)} refLine={{ y: vo2Avg, color: "#5a7a8a" }} series={[{ values: vo2Vals, color: "#e0a458", width: 2.2 }]} />
+          </ExpandableChart>
+          <Text variant="micro" className="text-text-muted">ml/kg/min · dashed = average {vo2Avg.toFixed(1)}</Text>
         </Card>
       ) : null}
     </View>


### PR DESCRIPTION
## Foundation: shared LineChart upgrade + Running chart fidelity

First remediation PR (tracked in #473). Upgrades the shared `LineChart` (the recurring "chart fidelity" gap across every screen) and proves it on Running.

### `LineChart` (backward-compatible — new behavior is opt-in)
- **Tap/drag readout** (`interactive`): a vertical cursor + a per-series callout showing exact values at the touched point.
- **Dual right y-axis** (`series.axis:"right"` + `yFormatRight`).
- **Dated multi-tick x-axis** (`xTicks`) + a `chartDateLabel` helper.
- **Scatter dot sizing** (`series.sizes`).
- **`ExpandableChart`** wrapper — a ⤢ affordance opens the chart taller + interactive in a Modal.

### Running (first consumer)
- Fitness scores → a single **dual-axis** chart (endurance L / hill R), tap-read.
- Cadence & stride → **dual-axis** (stride on the right) + 180 spm line + legend.
- Pace + VO₂max → tap-read + **fullscreen expand**; VO₂max gains an **average** reference line.
- Recent-runs table → **Duration + Calories** sortable columns + a dur/cal subline.
- VO₂max summary card → **latest** value (peak moved to the subtitle).

### Verification
`tsc` 0, `vitest` 5/5. Playwright (390×844): the tap cursor + "5:28" callout on the pace chart; both dual-axis charts (cadence/stride L/R with the 180 line; endurance/hill L/R with a **dated 4-tick axis** Apr 17→Aug 28); the VO₂ average line (53.4); and the expand modal opening a large tap-readable chart.

Part of #473
