### PR TITLE
feat(app): rich ActivityDetailModal (fetch /api/activity/[id] — metrics/HR-zones/weather/gear/splits)

### DIFF
--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -1,50 +1,210 @@
-import { View } from "react-native";
-import { Text, Card, Modal, Badge } from "soma-style";
-import type { ActivityRow } from "../lib/api";
+import { useEffect, useState } from "react";
+import { View, ScrollView } from "react-native";
+import { Text, Modal, Badge, SegmentedControl } from "soma-style";
+import { fetchJson, type ActivityRow } from "../lib/api";
 
-const num = (v: number | null | undefined): number => (v == null ? 0 : Number(v));
-function longDate(iso: string): string {
-  const d = new Date(iso);
-  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+/* ---- response shape from /api/activity/[id] (Garmin summary + laps + weather) ---- */
+interface Summary {
+  distance?: number | null; duration?: number | null; calories?: number | null;
+  averageHR?: number | null; maxHR?: number | null; maxSpeed?: number | null; averageSpeed?: number | null;
+  elevationGain?: number | null; elevationLoss?: number | null;
+  vO2MaxValue?: number | null; aerobicTrainingEffect?: number | null;
+  averageRunningCadenceInStepsPerMinute?: number | null; avgStrideLength?: number | null;
+  avgGroundContactTime?: number | null; avgVerticalOscillation?: number | null; avgVerticalRatio?: number | null;
+  averagePower?: number | null;
 }
-function hm(mins: number | null | undefined): string {
-  if (mins == null || !isFinite(mins)) return "—";
-  const h = Math.floor(mins / 60), m = Math.round(mins % 60);
-  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+interface Lap { distance?: number | null; duration?: number | null; averageSpeed?: number | null; averageHR?: number | null; averageRunCadence?: number | null; elevationGain?: number | null }
+interface Zone { zoneNumber: number; secsInZone?: number | null }
+interface Gear { gearTypeName?: string; customMakeModel?: string | null; displayName?: string | null; maximumMeters?: number | null; gearStatusName?: string | null }
+interface ActivityDetail {
+  summary?: Summary | null;
+  hr_zones?: Zone[] | null;
+  weather?: { temp?: number | null; relativeHumidity?: number | null; windSpeed?: number | null; windDirectionCompassPoint?: string | null; weatherTypeDTO?: { desc?: string } | null } | null;
+  splits?: { lapDTOs?: Lap[] } | null;
+  gear?: Gear[] | null;
+  strava_id?: string | null;
+}
+
+const n = (v: number | null | undefined): number => (v == null || !isFinite(Number(v)) ? 0 : Number(v));
+const ZONE_COLOR = ["#77c8d1", "#6ad4a0", "#e0c458", "#e0a458", "#e06060"];
+function hm(sec: number | null | undefined): string {
+  if (sec == null || !isFinite(sec)) return "—";
+  const t = Math.round(sec); const h = Math.floor(t / 3600); const m = Math.floor((t % 3600) / 60); const s = t % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}:${String(s).padStart(2, "0")}`;
+}
+function secMMSS(sec: number): string { const t = Math.round(sec); return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`; }
+function paceFromMs(ms: number | null | undefined): string { if (ms == null || ms <= 0) return "—"; const secKm = 1000 / ms; return `${secMMSS(secKm)}/km`; }
+function kmh(ms: number | null | undefined): string { return ms == null ? "—" : `${(ms * 3.6).toFixed(1)} km/h`; }
+function longDate(iso: string | null | undefined): string { if (!iso) return ""; const d = new Date(iso); return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" }); }
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <View className="min-w-[30%] flex-1 gap-0.5">
+      <Text variant="micro" className="text-text-muted">{label}</Text>
+      <Text variant="body" className="tabular-nums text-text">{value}</Text>
+    </View>
+  );
 }
 
 /**
- * Activity detail dialog (web parity, #441): the full stat line for one
- * activity (the drill-in behind a table row). The web modal also offers a
- * Strava photo upload + FIT download — those are native/file features left as
- * a documented mobile trim.
+ * Rich activity detail (web parity): fetches /api/activity/[id] and renders the
+ * full Garmin metric grid, HR-zone bars, weather, gear, and a per-lap splits
+ * tab. Falls back to the passed-in row's fields for the header while loading.
  */
 export function ActivityDetailModal({ activity, onClose }: { activity: ActivityRow | null; onClose: () => void }) {
+  const [data, setData] = useState<ActivityDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [tab, setTab] = useState<"Overview" | "Splits">("Overview");
+
+  useEffect(() => {
+    if (!activity) { setData(null); return; }
+    let alive = true; setLoading(true); setTab("Overview");
+    fetchJson<ActivityDetail>(`/api/activity/${activity.activity_id}`)
+      .then((d) => alive && setData(d))
+      .catch(() => alive && setData(null))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [activity]);
+
   if (!activity) return null;
-  const a = activity;
-  const rows: [string, string][] = [
-    ["Sport", a.sport],
-    ["Distance", a.distance_km != null && a.distance_km > 0 ? `${num(a.distance_km).toFixed(2)} km` : "—"],
-    ["Duration", hm(a.duration_min)],
-    ["Avg HR", a.avg_hr != null ? `${Math.round(num(a.avg_hr))} bpm` : "—"],
-    ["Calories", a.calories != null && a.calories > 0 ? `${Math.round(num(a.calories))} kcal` : "—"],
-    ["Elevation", a.elev_gain > 0 ? `↑ ${Math.round(a.elev_gain)} m` : "—"],
-  ];
+  const s = data?.summary ?? null;
+  const laps = data?.splits?.lapDTOs ?? [];
+  const zones = (data?.hr_zones ?? []).filter((z) => z && (z.secsInZone ?? 0) > 0);
+  const zTotal = zones.reduce((a, z) => a + n(z.secsInZone), 0);
+  const shoe = (data?.gear ?? []).find((g) => g.gearTypeName === "Shoes");
+  const w = data?.weather;
+  // lap pace range for the bar colouring
+  const lapPaces = laps.map((l) => (l.averageSpeed && l.averageSpeed > 0 ? 1000 / l.averageSpeed : null)).filter((v): v is number => v != null);
+  const minP = lapPaces.length ? Math.min(...lapPaces) : 0;
+  const maxP = lapPaces.length ? Math.max(...lapPaces) : 1;
+  const rangeP = maxP - minP || 1;
+
+  const metrics: [string, string][] = s ? ([
+    ["Distance", s.distance != null ? `${(n(s.distance) / 1000).toFixed(2)} km` : "—"],
+    ["Duration", hm(s.duration)],
+    ["Avg pace", paceFromMs(s.averageSpeed)],
+    ["Max speed", kmh(s.maxSpeed)],
+    ["Avg HR", s.averageHR != null ? `${Math.round(n(s.averageHR))} bpm` : "—"],
+    ["Max HR", s.maxHR != null ? `${Math.round(n(s.maxHR))} bpm` : "—"],
+    ["Elev gain", s.elevationGain != null ? `↑ ${Math.round(n(s.elevationGain))} m` : "—"],
+    ["Elev loss", s.elevationLoss != null ? `↓ ${Math.round(n(s.elevationLoss))} m` : "—"],
+    ["Calories", s.calories != null ? `${Math.round(n(s.calories))} kcal` : "—"],
+    ["VO₂max", s.vO2MaxValue != null ? n(s.vO2MaxValue).toFixed(1) : "—"],
+    ["Aerobic TE", s.aerobicTrainingEffect != null ? n(s.aerobicTrainingEffect).toFixed(1) : "—"],
+    ["Cadence", s.averageRunningCadenceInStepsPerMinute != null ? `${Math.round(n(s.averageRunningCadenceInStepsPerMinute))} spm` : "—"],
+    ["Stride", s.avgStrideLength != null ? `${Math.round(n(s.avgStrideLength))} cm` : "—"],
+    ["Grnd contact", s.avgGroundContactTime != null ? `${Math.round(n(s.avgGroundContactTime))} ms` : "—"],
+    ["Vert osc", s.avgVerticalOscillation != null ? `${n(s.avgVerticalOscillation).toFixed(1)} cm` : "—"],
+    ["Avg power", s.averagePower != null ? `${Math.round(n(s.averagePower))} W` : "—"],
+  ] as [string, string][]).filter(([, v]) => v !== "—") : [];
+
   return (
-    <Modal visible={!!activity} onClose={onClose} title={a.name || a.sport}>
-      <View className="gap-3">
+    <Modal visible={!!activity} onClose={onClose} title={activity.name || activity.sport}>
+      <View className="gap-3" style={{ maxHeight: 560 }}>
         <View className="flex-row items-center gap-2">
-          <Badge label={a.sport} tone="teal" />
-          <Text variant="micro" className="text-text-muted">{longDate(a.date)}</Text>
+          <Badge label={activity.sport} tone="teal" />
+          <Text variant="micro" className="text-text-muted">{longDate(activity.date)}</Text>
+          {data?.strava_id ? <Badge label="On Strava" tone="success" /> : null}
         </View>
-        <View className="gap-2">
-          {rows.map(([label, value]) => (
-            <View key={label} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
-              <Text variant="body" className="text-text-secondary">{label}</Text>
-              <Text variant="body" className="tabular-nums text-text">{value}</Text>
+
+        {loading && !data ? (
+          <Text variant="body" className="text-text-muted">Loading…</Text>
+        ) : null}
+
+        {laps.length > 1 ? (
+          <SegmentedControl options={["Overview", "Splits"] as const} value={tab} onChange={(v) => setTab(v as "Overview" | "Splits")} />
+        ) : null}
+
+        <ScrollView style={{ maxHeight: 460 }} showsVerticalScrollIndicator={false}>
+          {tab === "Overview" ? (
+            <View className="gap-3">
+              {/* metric grid (rich) or fall back to the row's basics */}
+              <View className="flex-row flex-wrap gap-y-3">
+                {metrics.length ? (
+                  metrics.map(([label, value]) => <Metric key={label} label={label} value={value} />)
+                ) : (
+                  <>
+                    <Metric label="Distance" value={activity.distance_km != null ? `${n(activity.distance_km).toFixed(2)} km` : "—"} />
+                    <Metric label="Duration" value={activity.duration_min != null ? `${Math.round(n(activity.duration_min))} min` : "—"} />
+                    <Metric label="Avg HR" value={activity.avg_hr != null ? `${Math.round(n(activity.avg_hr))} bpm` : "—"} />
+                    <Metric label="Calories" value={activity.calories != null ? `${Math.round(n(activity.calories))} kcal` : "—"} />
+                    <Metric label="Elevation" value={activity.elev_gain > 0 ? `↑ ${Math.round(activity.elev_gain)} m` : "—"} />
+                  </>
+                )}
+              </View>
+
+              {/* HR zones */}
+              {zones.length && zTotal > 0 ? (
+                <View className="gap-1.5 border-t border-border-subtle pt-2">
+                  <Text variant="eyebrow" className="text-text-muted">Heart-rate zones</Text>
+                  {zones.map((z) => {
+                    const pct = (n(z.secsInZone) / zTotal) * 100;
+                    return (
+                      <View key={z.zoneNumber} className="flex-row items-center gap-2">
+                        <Text variant="micro" className="w-6 text-text-muted">Z{z.zoneNumber}</Text>
+                        <View className="flex-1 h-2.5 rounded-full bg-surface-subtle overflow-hidden">
+                          <View className="h-full rounded-full" style={{ width: `${Math.max(2, pct)}%`, backgroundColor: ZONE_COLOR[z.zoneNumber - 1] ?? ZONE_COLOR[0] }} />
+                        </View>
+                        <Text variant="micro" className="tabular-nums text-text-muted w-20 text-right">{secMMSS(n(z.secsInZone))} · {Math.round(pct)}%</Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              ) : null}
+
+              {/* Weather */}
+              {w && (w.temp != null || w.windSpeed != null) ? (
+                <View className="gap-1 border-t border-border-subtle pt-2">
+                  <Text variant="eyebrow" className="text-text-muted">Weather</Text>
+                  <Text variant="micro" className="text-text-secondary">
+                    {w.temp != null ? `${Math.round(n(w.temp))}°C` : ""}
+                    {w.relativeHumidity != null ? ` · ${Math.round(n(w.relativeHumidity))}% humidity` : ""}
+                    {w.windSpeed != null ? ` · wind ${(n(w.windSpeed) * 3.6).toFixed(0)} km/h ${w.windDirectionCompassPoint ?? ""}` : ""}
+                    {w.weatherTypeDTO?.desc ? ` · ${w.weatherTypeDTO.desc}` : ""}
+                  </Text>
+                </View>
+              ) : null}
+
+              {/* Gear */}
+              {shoe ? (
+                <View className="gap-0.5 border-t border-border-subtle pt-2">
+                  <Text variant="eyebrow" className="text-text-muted">Gear</Text>
+                  <Text variant="micro" className="text-text-secondary">
+                    {shoe.customMakeModel || shoe.displayName || "Shoe"}
+                    {shoe.maximumMeters && shoe.maximumMeters > 0 ? ` · ${Math.round(n(shoe.maximumMeters) / 1000)} km max` : ""}
+                    {shoe.gearStatusName ? ` · ${shoe.gearStatusName}` : ""}
+                  </Text>
+                </View>
+              ) : null}
             </View>
-          ))}
-        </View>
+          ) : (
+            /* Splits tab: per-lap pace bars + stats */
+            <View className="gap-1.5">
+              {laps.map((l, i) => {
+                const p = l.averageSpeed && l.averageSpeed > 0 ? 1000 / l.averageSpeed : null;
+                const t = p != null ? (p - minP) / rangeP : 0;
+                const color = t < 0.4 ? "#6ad4a0" : t < 0.7 ? "#e0c458" : "#e0a458";
+                return (
+                  <View key={i} className="gap-0.5 py-0.5">
+                    <View className="flex-row items-center gap-2">
+                      <Text variant="micro" className="w-8 tabular-nums text-text-muted">{i + 1}</Text>
+                      <View className="flex-1 h-2.5 rounded-full bg-surface-subtle overflow-hidden">
+                        <View className="h-full rounded-full" style={{ width: `${p != null ? Math.max(6, (1 - t) * 100) : 6}%`, backgroundColor: color }} />
+                      </View>
+                      <Text variant="micro" className="w-16 text-right tabular-nums text-text">{paceFromMs(l.averageSpeed)}</Text>
+                    </View>
+                    <Text variant="micro" className="pl-10 tabular-nums text-text-muted">
+                      {l.distance != null ? `${(n(l.distance) / 1000).toFixed(2)} km` : ""}
+                      {l.averageHR != null ? ` · ${Math.round(n(l.averageHR))} bpm` : ""}
+                      {l.averageRunCadence != null ? ` · ${Math.round(n(l.averageRunCadence))} spm` : ""}
+                      {l.elevationGain != null && l.elevationGain > 0 ? ` · ↑${Math.round(n(l.elevationGain))}m` : ""}
+                    </Text>
+                  </View>
+                );
+              })}
+            </View>
+          )}
+        </ScrollView>
       </View>
     </Modal>
   );


### PR DESCRIPTION
## Foundation: rich ActivityDetailModal (fetch /api/activity/[id])

Second remediation foundation (#473). The activity detail modal **fetched nothing** — it re-rendered the 6 fields already on the row, while `/api/activity/[id]` returns the full Garmin payload. Now it fetches on open:

- **Overview tab:** a 16-metric grid (avg pace, max speed, elev gain/loss, VO₂max, aerobic TE, cadence, stride, ground-contact time, vertical oscillation, avg power, …), **HR-zone bars** (secs + %), a **weather** line, and **gear** (shoe + km life / status).
- **Splits tab:** per-lap pace bars (colored fast→slow) with distance / HR / cadence / elevation.

Speeds convert m/s → pace and km/h; falls back to the row's basics while loading. Keeps the `{activity}` prop, so the Activities list consumer is unchanged (Running/Overview detail modals will reuse this next). Closes the Activities detail-modal cluster (7 gaps).

### Verification
`tsc` 0. Playwright (390×844): tapping a run row fetched `/api/activity/[id]` and rendered the full metric grid, HR-zone bars (Z1–Z5 with mm:ss + %), weather ("14°C · 72% humidity · wind 12 km/h NW · Partly cloudy"), gear (Nike Pegasus 40 · 800 km · active), and the Splits tab (per-lap 5:13→5:41/km bars).

Part of #473
