### PR TITLE
feat(app): range-aware StatDetailModal (fetch /api/stats/[metric]) + Overview KPIs

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -174,14 +174,14 @@ export default function OverviewScreen() {
   const hrvLatest = recovery.data?.hrv?.latest ?? null;
   const hrvSpark = (recovery.data?.hrv?.trend ?? []).map((p) => Number(p.weekly_avg)).filter((v) => isFinite(v));
 
-  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string }[] = [
-    { label: "Steps", value: (data?.total_steps ?? 0).toLocaleString(), sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1" },
-    { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850", unit: "kcal" },
-    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060", unit: "bpm" },
-    { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458" },
-    { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${Math.abs(data?.body_battery_drained ?? 0)} drained`, cls: "text-lime", spark: trends?.bodyBattery, color: "#cbe896" },
+  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string; metric?: string }[] = [
+    { label: "Steps", value: (data?.total_steps ?? 0).toLocaleString(), sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1", metric: "steps" },
+    { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850", unit: "kcal", metric: "calories" },
+    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060", unit: "bpm", metric: "rhr" },
+    { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458", metric: "stress" },
+    { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${Math.abs(data?.body_battery_drained ?? 0)} drained`, cls: "text-lime", spark: trends?.bodyBattery, color: "#cbe896", metric: "body_battery" },
     { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0", unit: "min" },
-    { label: "VO₂max", value: vo2.current != null ? String(vo2.current) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1" },
+    { label: "VO₂max", value: vo2.current != null ? String(vo2.current) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1", metric: "vo2max" },
     { label: "HRV", value: hrvLatest?.weekly_avg != null ? String(hrvLatest.weekly_avg) : "—", sub: hrvLatest?.status ? String(hrvLatest.status) : "7-night avg", cls: "text-lime", spark: hrvSpark, color: "#cbe896", unit: "ms" },
     { label: "Total activities", value: fitness?.total_activities != null && fitness.total_activities > 0 ? fitness.total_activities.toLocaleString() : "—", sub: "all time", cls: "text-teal", color: "#77c8d1" },
   ];

--- a/universal/src/components/stat-detail-modal.tsx
+++ b/universal/src/components/stat-detail-modal.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from "react";
 import { View } from "react-native";
-import { Text, Modal } from "soma-style";
-import { LineChart } from "./line-chart";
+import { Text, Modal, SegmentedControl } from "soma-style";
+import { LineChart, ChartLegend, chartDateLabel } from "./line-chart";
+import { fetchJson } from "../lib/api";
 
 export interface StatDetail {
   label: string;
@@ -10,17 +12,98 @@ export interface StatDetail {
   color: string;
   /** Optional unit suffix for the axis labels (e.g. "bpm", "kcal"). */
   unit?: string;
+  /** If set, the modal fetches /api/stats/[metric] for a range toggle + previous-period overlay. */
+  metric?: string;
 }
 
-/** Detail dialog for an overview stat card: the current value + a full trend
- *  chart (upgraded from the card's sparkline) with min / avg / max. */
+interface StatPoint { date: string; value: number | null }
+interface StatSeries {
+  current: StatPoint[];
+  previous: StatPoint[];
+  summary: { current_avg: number | null; current_min: number | null; current_max: number | null; previous_avg: number | null };
+}
+type Range = "7d" | "30d" | "90d" | "1y";
+const RANGES: readonly Range[] = ["7d", "30d", "90d", "1y"] as const;
+
+/** Detail dialog for a stat card. With `metric`, fetches the real trend for a
+ *  chosen range with a dashed previous-period overlay, tap-to-read, and
+ *  avg/min/max + Δ-vs-previous; otherwise shows the card's sparkline trend. */
 export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; onClose: () => void }) {
+  const [range, setRange] = useState<Range>("30d");
+  const [data, setData] = useState<StatSeries | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!stat?.metric) { setData(null); return; }
+    let alive = true; setLoading(true);
+    fetchJson<StatSeries>(`/api/stats/${stat.metric}?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => alive && setData(null))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [stat?.metric, range]);
+
   if (!stat) return null;
+  const unit = stat.unit ? ` ${stat.unit}` : "";
+  const fmt = (v: number | null) => (v == null ? "–" : `${Math.round(v).toLocaleString()}${unit}`);
+
+  // Rich path: real endpoint with range + previous overlay
+  if (stat.metric) {
+    const cur = (data?.current ?? []).map((p) => (p.value != null && isFinite(p.value) ? p.value : null));
+    const prev = (data?.previous ?? []).map((p) => (p.value != null && isFinite(p.value) ? p.value : null));
+    const labels = (data?.current ?? []).map((p) => chartDateLabel(p.date));
+    const sm = data?.summary;
+    const delta = sm?.current_avg != null && sm?.previous_avg != null ? sm.current_avg - sm.previous_avg : null;
+    return (
+      <Modal visible={!!stat} onClose={onClose} title={stat.label}>
+        <View className="gap-3">
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="tabular-nums" style={{ color: stat.color }}>{stat.value}</Text>
+            <Text variant="body" className="mb-1 text-text-muted">{stat.sub}</Text>
+          </View>
+          <SegmentedControl options={RANGES} value={range} onChange={(v) => setRange(v as Range)} />
+          {loading && !data ? (
+            <Text variant="body" className="text-text-muted">Loading…</Text>
+          ) : cur.filter((v) => v != null).length >= 2 ? (
+            <View className="gap-1">
+              <LineChart
+                height={170}
+                interactive
+                labels={labels}
+                xTicks={4}
+                yFormat={(v) => `${Math.round(v).toLocaleString()}`}
+                series={[
+                  ...(prev.filter((v) => v != null).length >= 2 ? [{ values: prev, color: "#5a7a8a", width: 1.4, dashed: true, label: "Previous" }] : []),
+                  { values: cur, color: stat.color, width: 2.2, label: "Current" },
+                ]}
+              />
+              {prev.filter((v) => v != null).length >= 2 ? (
+                <ChartLegend items={[{ color: stat.color, label: "Current" }, { color: "#5a7a8a", label: "Previous", dashed: true }]} />
+              ) : null}
+              <View className="mt-1 flex-row justify-between">
+                <Text variant="micro" className="text-text-muted tabular-nums">min {fmt(sm?.current_min ?? null)}</Text>
+                <Text variant="micro" className="text-text-muted tabular-nums">avg {fmt(sm?.current_avg ?? null)}</Text>
+                <Text variant="micro" className="text-text-muted tabular-nums">max {fmt(sm?.current_max ?? null)}</Text>
+              </View>
+              {delta != null && sm?.previous_avg != null ? (
+                <Text variant="micro" className={`tabular-nums ${delta >= 0 ? "text-success" : "text-warning"}`}>
+                  {delta >= 0 ? "+" : ""}{Math.round(delta).toLocaleString()}{unit} vs previous {range} (avg {fmt(sm.previous_avg)})
+                </Text>
+              ) : null}
+            </View>
+          ) : (
+            <Text variant="caption" className="text-text-muted">No trend data for this range.</Text>
+          )}
+        </View>
+      </Modal>
+    );
+  }
+
+  // Fallback path: the card's sparkline values
   const s = (stat.spark ?? []).filter((v) => isFinite(v));
   const min = s.length ? Math.min(...s) : null;
   const max = s.length ? Math.max(...s) : null;
   const avg = s.length ? s.reduce((a, b) => a + b, 0) / s.length : null;
-  const fmt = (v: number | null) => (v == null ? "–" : `${Math.round(v).toLocaleString()}${stat.unit ? ` ${stat.unit}` : ""}`);
   return (
     <Modal visible={!!stat} onClose={onClose} title={stat.label}>
       <View className="gap-3">
@@ -31,11 +114,7 @@ export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; on
         {s.length >= 2 ? (
           <View className="gap-1">
             <Text variant="eyebrow" className="text-text-muted">Trend · last {s.length} days</Text>
-            <LineChart
-              height={160}
-              series={[{ values: s, color: stat.color, width: 2.2 }]}
-              yFormat={(v) => `${Math.round(v).toLocaleString()}`}
-            />
+            <LineChart height={160} interactive series={[{ values: s, color: stat.color, width: 2.2 }]} yFormat={(v) => `${Math.round(v).toLocaleString()}`} />
             <View className="mt-1 flex-row justify-between">
               <Text variant="micro" className="text-text-muted tabular-nums">min {fmt(min)}</Text>
               <Text variant="micro" className="text-text-muted tabular-nums">avg {fmt(avg)}</Text>


### PR DESCRIPTION
## Foundation: range-aware StatDetailModal + Overview KPIs

Third remediation foundation (#473). The stat detail dialog only re-charted the card's fixed 14-day sparkline; the rich `/api/stats/[metric]` endpoint (current + previous + summary) went unused. Now, when a stat carries a `metric`, the dialog:

- **7d / 30d / 90d / 1y** range toggle
- the **current** series + a **dashed previous-period** overlay (tap-to-read, dated axis)
- **avg / min / max** and the **Δ vs previous** period ("+N vs previous 30d (avg …)")

Falls back to the sparkline path when no metric is set. **Overview KPIs** (Steps / Active Calories / Resting HR / Avg Stress / Body Battery / VO₂max) now pass their metric.

### Verification
`tsc` 0. Playwright (390×844): tapping Steps opened the dialog, showed the 7d/30d/90d/1y toggle, drew Current + dashed Previous with a dated 4-tick axis (Jul 30→Aug 28), and "min 7,162 · avg 9,803 · max 12,675" + "+2,093 vs previous 30d (avg 7,711)".

Part of #473
