### PR TITLE
feat(app): sleep chart fidelity — multi-series + ref lines + interactive + expand

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -145,6 +145,7 @@ export default function SleepScreen() {
     cls: string;
     spark?: { data: number[]; color: string };
     unit?: string;
+    metric?: string;
   }[] = [
     {
       label: "Avg Sleep",
@@ -153,6 +154,7 @@ export default function SleepScreen() {
       cls: "text-indigo",
       spark: { data: seriesVals(sleep?.current), color: "#6366b0" },
       unit: "h",
+      metric: "sleep",
     },
     {
       label: "Last Night",
@@ -170,6 +172,7 @@ export default function SleepScreen() {
       cls: "text-danger",
       spark: { data: seriesVals(rhr?.current), color: "#e06060" },
       unit: "bpm",
+      metric: "rhr",
     },
     {
       label: "HRV (weekly)",
@@ -268,7 +271,7 @@ export default function SleepScreen() {
                 key={s.label}
                 className="min-w-[46%] flex-1"
                 disabled={!tappable}
-                onPress={() => s.spark && setStatDetail({ label: s.label, value: s.value, sub: s.sub, spark: s.spark.data, color: s.spark.color, unit: s.unit })}
+                onPress={() => s.spark && setStatDetail({ label: s.label, value: s.value, sub: s.sub, spark: s.spark.data, color: s.spark.color, unit: s.unit, metric: s.metric })}
               >
                 <Card className="gap-1">
                   <View className="flex-row items-center justify-between">
@@ -299,29 +302,45 @@ export default function SleepScreen() {
             </View>
             <LineChart
               height={140}
+              interactive
               labels={stress!.current.map((p) => chartLabel(p.date))}
+              xTicks={4}
+              yMin={0}
+              yMax={100}
               yFormat={(v) => String(Math.round(v))}
-              refLine={{ y: 50, color: "#e0a458" }}
+              refLines={[
+                { y: 25, color: "#6ad4a0" },
+                { y: 50, color: "#e0c458" },
+                { y: 75, color: "#e06060" },
+              ]}
               series={[
-                { values: stress!.current.map((p) => finiteOrNull(p.value2)), color: "#e06060", dashed: true, width: 1.5 },
-                { values: stress!.current.map((p) => finiteOrNull(p.value)), color: "#e0a458", width: 2.2 },
+                { values: stress!.current.map((p) => finiteOrNull(p.value2)), color: "#e06060", dashed: true, width: 1.5, label: "Peak" },
+                { values: stress!.current.map((p) => finiteOrNull(p.value)), color: "#e0a458", width: 2.2, label: "Avg" },
               ]}
             />
-            <ChartLegend items={[{ color: "#e0a458", label: "Avg" }, { color: "#e06060", label: "Peak", dashed: true }]} />
+            <ChartLegend items={[{ color: "#e0a458", label: "Avg" }, { color: "#e06060", label: "Peak", dashed: true }, { color: "#6ad4a0", label: "low/med/high 25·50·75", dashed: true }]} />
           </Card>
         ) : null}
 
         {(battery?.current?.length ?? 0) >= 2 ? (
           <Card className="gap-2">
-            <Text variant="eyebrow">Body Battery</Text>
+            <View className="flex-row items-center justify-between">
+              <Text variant="eyebrow">Body Battery</Text>
+              <Text variant="micro" className="text-text-muted">charged + drained</Text>
+            </View>
             <LineChart
               height={130}
+              interactive
               labels={battery!.current.map((p) => chartLabel(p.date))}
+              xTicks={4}
               yFormat={(v) => String(Math.round(v))}
               yMin={0}
-              yMax={100}
-              series={[{ values: battery!.current.map((p) => finiteOrNull(p.value)), color: "#cbe896", width: 2.2 }]}
+              series={[
+                { values: battery!.current.map((p) => finiteOrNull(p.value2)), color: "#e06060", width: 1.5, dashed: true, label: "Drained" },
+                { values: battery!.current.map((p) => finiteOrNull(p.value)), color: "#cbe896", width: 2.2, label: "Charged" },
+              ]}
             />
+            <ChartLegend items={[{ color: "#cbe896", label: "Charged" }, { color: "#e06060", label: "Drained", dashed: true }]} />
           </Card>
         ) : null}
 
@@ -342,13 +361,13 @@ export default function SleepScreen() {
         ) : null}
 
         {/* Sleep dashboard — last night + stages + score (new /api/sleep/summary) */}
-        <SleepDashboard summary={sleepSum} onExpand={setStatDetail} />
+        <SleepDashboard summary={sleepSum} />
 
         {/* Recovery vitals — HRV + training readiness (new /api/recovery/summary) */}
-        <RecoveryVitals summary={recoveryVitals} onExpand={setStatDetail} />
+        <RecoveryVitals summary={recoveryVitals} />
 
         {/* Blood oxygen + respiration (new /api/sleep/respiratory) */}
-        <SleepRespiratory data={respiratory} onExpand={setStatDetail} />
+        <SleepRespiratory data={respiratory} />
 
         {/* Sleep schedule — per-night bedtime → wake band (new /api/sleep/schedule) */}
         <SleepScheduleChart schedule={schedule?.schedule} />

--- a/universal/src/components/recovery-vitals.tsx
+++ b/universal/src/components/recovery-vitals.tsx
@@ -1,7 +1,9 @@
-import { View, Pressable } from "react-native";
-import { Text, Card, Badge, Sparkline } from "soma-style";
+import { View } from "react-native";
+import { Text, Card, Badge } from "soma-style";
+import { LineChart, ChartLegend, ExpandableChart, chartDateLabel } from "./line-chart";
 import type { RecoverySummary } from "../lib/api";
-import type { StatDetail } from "./stat-detail-modal";
+
+const fin = (v: number | null | undefined): number | null => (v != null && isFinite(Number(v)) ? Number(v) : null);
 
 const HRV_TONE: Record<string, "success" | "warm" | "danger" | "teal"> = {
   BALANCED: "success",
@@ -16,18 +18,18 @@ const RDY_TONE = (level: string | null): "success" | "warm" | "danger" | "teal" 
 };
 
 /** HRV + training-readiness cards (recovery vitals), fed by /api/recovery/summary. */
-export function RecoveryVitals({
-  summary,
-  onExpand,
-}: {
-  summary: RecoverySummary | null | undefined;
-  onExpand?: (s: StatDetail) => void;
-}) {
+export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | undefined }) {
   if (!summary) return null;
   const hrv = summary.hrv.latest;
   const rdy = summary.readiness.latest;
-  const hrvSeries = summary.hrv.trend.map((p) => p.weekly_avg).filter((v): v is number => v != null);
-  const hrvTappable = !!(onExpand && hrvSeries.length >= 2);
+  const hrvLabels = summary.hrv.trend.map((p) => chartDateLabel(p.date));
+  const hrvWeekly = summary.hrv.trend.map((p) => fin(p.weekly_avg));
+  const hrvNight = summary.hrv.trend.map((p) => fin(p.last_night_avg));
+  const hrvHasChart = hrvWeekly.filter((v) => v != null).length >= 2 || hrvNight.filter((v) => v != null).length >= 2;
+  const hrvSeries = [
+    { values: hrvNight, color: "#a5b4fc", width: 1.4, dashed: true, label: "Last night" },
+    { values: hrvWeekly, color: "#77c8d1", width: 2.2, label: "Weekly avg" },
+  ];
 
   const factors: { label: string; v: number | null; color: string }[] = rdy
     ? [
@@ -44,37 +46,24 @@ export function RecoveryVitals({
   return (
     <View className="gap-4">
       {hrv ? (
-        <Pressable
-          disabled={!hrvTappable}
-          onPress={() =>
-            onExpand?.({
-              label: "Heart rate variability",
-              value: hrv.weekly_avg != null ? `${hrv.weekly_avg} ms` : "—",
-              sub: hrv.last_night_avg != null ? `last night ${hrv.last_night_avg} ms` : "weekly avg",
-              spark: hrvSeries,
-              color: "#77c8d1",
-              unit: "ms",
-            })
-          }
-        >
-          <Card className="gap-2">
-            <View className="flex-row items-center justify-between">
-              <Text variant="eyebrow">Heart rate variability</Text>
-              <View className="flex-row items-center gap-1.5">
-                {hrv.status ? <Badge label={hrv.status} tone={HRV_TONE[hrv.status] ?? "teal"} /> : null}
-                {hrvTappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+        <Card className="gap-2">
+          <ExpandableChart title="Heart rate variability" chart={{ series: hrvSeries, labels: hrvLabels, yFormat: (v) => `${Math.round(v)}` }}>
+            <View className="flex-row items-end justify-between">
+              <View className="flex-row items-end gap-2">
+                <Text variant="display" className="text-teal">{hrv.weekly_avg ?? "—"}</Text>
+                <Text variant="caption" className="text-text-muted mb-1">ms weekly avg</Text>
+                {hrv.last_night_avg != null ? (
+                  <Text variant="micro" className="text-text-muted mb-1">· last night {hrv.last_night_avg}</Text>
+                ) : null}
               </View>
+              {hrv.status ? <Badge label={hrv.status} tone={HRV_TONE[hrv.status] ?? "teal"} /> : null}
             </View>
-            <View className="flex-row items-end gap-2">
-              <Text variant="display" className="text-teal">{hrv.weekly_avg ?? "—"}</Text>
-              <Text variant="caption" className="text-text-muted mb-1">ms weekly avg</Text>
-              {hrv.last_night_avg != null ? (
-                <Text variant="micro" className="text-text-muted mb-1">· last night {hrv.last_night_avg}</Text>
-              ) : null}
-            </View>
-            {hrvSeries.length >= 2 ? <Sparkline data={hrvSeries} color="#77c8d1" height={36} baseline /> : null}
-          </Card>
-        </Pressable>
+            {hrvHasChart ? (
+              <LineChart height={110} interactive labels={hrvLabels} xTicks={4} yFormat={(v) => `${Math.round(v)}`} series={hrvSeries} />
+            ) : null}
+          </ExpandableChart>
+          {hrvHasChart ? <ChartLegend items={[{ color: "#77c8d1", label: "Weekly avg" }, { color: "#a5b4fc", label: "Last night", dashed: true }]} /> : null}
+        </Card>
       ) : null}
 
       {rdy ? (

--- a/universal/src/components/sleep-dashboard.tsx
+++ b/universal/src/components/sleep-dashboard.tsx
@@ -1,7 +1,7 @@
-import { View, Pressable } from "react-native";
-import { Text, Card, Sparkline, Badge } from "soma-style";
+import { View } from "react-native";
+import { Text, Card, Badge } from "soma-style";
+import { LineChart, ExpandableChart, chartDateLabel } from "./line-chart";
 import type { SleepSummary, SleepNight } from "../lib/api";
-import type { StatDetail } from "./stat-detail-modal";
 
 const DEEP = "#4f46e5";
 const LIGHT = "#a5b4fc";
@@ -86,18 +86,13 @@ function Legend() {
 }
 
 /** Sleep dashboard: last-night detail + stages trend + score trend. Fed by /api/sleep/summary. */
-export function SleepDashboard({
-  summary,
-  onExpand,
-}: {
-  summary: SleepSummary | null | undefined;
-  onExpand?: (s: StatDetail) => void;
-}) {
+export function SleepDashboard({ summary }: { summary: SleepSummary | null | undefined }) {
   if (!summary) return null;
   const ln = summary.lastNight;
-  const scores = summary.trend.map((n) => n.score).filter((v): v is number => v != null);
+  const scoreVals = summary.trend.map((n) => (n.score != null && isFinite(n.score) ? n.score : null));
+  const scoreLabels = summary.trend.map((n) => chartDateLabel(n.date));
+  const scoreCount = scoreVals.filter((v) => v != null).length;
   const lnQual = ln?.score != null ? scoreQualifier(ln.score) : null;
-  const scoreTappable = !!(onExpand && scores.length >= 2);
 
   return (
     <View className="gap-4">
@@ -134,32 +129,18 @@ export function SleepDashboard({
         <Legend />
       </Card>
 
-      {scores.length >= 2 ? (
-        <Pressable
-          disabled={!scoreTappable}
-          onPress={() =>
-            onExpand?.({
-              label: "Sleep score",
-              value: summary.stats.avg_score != null ? String(Math.round(summary.stats.avg_score)) : "—",
-              sub: `avg · last ${scores.length} nights`,
-              spark: scores,
-              color: "#a5b4fc",
-            })
-          }
-        >
-          <Card className="gap-2">
-            <View className="flex-row items-center justify-between">
-              <Text variant="eyebrow">Sleep score</Text>
-              <View className="flex-row items-center gap-1.5">
-                <Text variant="micro" className="tabular-nums text-text-muted">
-                  avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"}
-                </Text>
-                {scoreTappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
-              </View>
-            </View>
-            <Sparkline data={scores} color="#a5b4fc" height={40} baseline />
-          </Card>
-        </Pressable>
+      {scoreCount >= 2 ? (
+        <Card className="gap-2">
+          <ExpandableChart
+            title="Sleep score"
+            chart={{ series: [{ values: scoreVals, color: "#a5b4fc", width: 2.2 }], labels: scoreLabels, refLine: { y: 80, color: "#6ad4a0" }, yMin: 0, yMax: 100, yFormat: (v) => String(Math.round(v)) }}
+          >
+            <Text variant="micro" className="tabular-nums text-text-muted">
+              avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"} · "Good" ≥ 80
+            </Text>
+            <LineChart height={120} interactive labels={scoreLabels} xTicks={4} yMin={0} yMax={100} refLine={{ y: 80, color: "#6ad4a0" }} yFormat={(v) => String(Math.round(v))} series={[{ values: scoreVals, color: "#a5b4fc", width: 2.2 }]} />
+          </ExpandableChart>
+        </Card>
       ) : null}
     </View>
   );

--- a/universal/src/components/sleep-respiratory.tsx
+++ b/universal/src/components/sleep-respiratory.tsx
@@ -1,104 +1,77 @@
-import { View, Pressable } from "react-native";
-import { Text, Card, Sparkline } from "soma-style";
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import { LineChart, ChartLegend, ExpandableChart, chartDateLabel } from "./line-chart";
 import type { Respiratory } from "../lib/api";
-import type { StatDetail } from "./stat-detail-modal";
 
 function avg(vals: (number | null)[]): number | null {
   const nn = vals.filter((v): v is number => v != null && isFinite(v));
   return nn.length ? nn.reduce((a, b) => a + b, 0) / nn.length : null;
 }
+const fin = (v: number | null | undefined): number | null => (v != null && isFinite(Number(v)) ? Number(v) : null);
 
-/** SpO2 + respiration cards for the sleep screen, fed by /api/sleep/respiratory. */
-export function SleepRespiratory({
-  data,
-  onExpand,
-}: {
-  data: Respiratory | null | undefined;
-  onExpand?: (s: StatDetail) => void;
-}) {
+/** SpO2 (avg/sleep/low + 95% line) + respiration (sleep/awake) charts for the
+ *  sleep screen, tap-to-read + expandable. Fed by /api/sleep/respiratory. */
+export function SleepRespiratory({ data }: { data: Respiratory | null | undefined }) {
   if (!data) return null;
   const spo2 = data.spo2.latest;
   const resp = data.respiration.latest;
-  const spo2Series = data.spo2.trend.map((p) => p.avg_spo2).filter((v): v is number => v != null);
-  const respSeries = data.respiration.trend.map((p) => p.sleep_resp ?? p.awake_resp).filter((v): v is number => v != null);
-  const spo2Avg = avg(data.spo2.trend.slice(-7).map((p) => p.avg_spo2));
-  const spo2Tappable = !!(onExpand && spo2Series.length >= 2);
-  const respTappable = !!(onExpand && respSeries.length >= 2);
+  const sTrend = data.spo2.trend;
+  const rTrend = data.respiration.trend;
+  const sLabels = sTrend.map((p) => chartDateLabel(p.date));
+  const rLabels = rTrend.map((p) => chartDateLabel(p.date));
+  const spo2Avg = avg(sTrend.slice(-7).map((p) => p.avg_spo2));
+  const spo2HasChart = sTrend.filter((p) => p.avg_spo2 != null).length >= 2;
+  const respAvg = avg(rTrend.slice(-7).map((p) => p.sleep_resp ?? p.awake_resp));
+  const respHasChart = rTrend.filter((p) => (p.sleep_resp ?? p.awake_resp) != null).length >= 2;
 
   if (!spo2 && !resp) return null;
+  const spo2Series = [
+    { values: sTrend.map((p) => fin(p.low_spo2)), color: "#3a5563", width: 1.2, label: "Low" },
+    { values: sTrend.map((p) => fin(p.sleep_spo2)), color: "#8b9df0", width: 1.4, dashed: true, label: "Sleep" },
+    { values: sTrend.map((p) => fin(p.avg_spo2)), color: "#6aa0e0", width: 2.2, label: "Avg" },
+  ];
 
   return (
     <View className="gap-4">
       {spo2 ? (
-        <Pressable
-          disabled={!spo2Tappable}
-          onPress={() =>
-            onExpand?.({
-              label: "Blood oxygen (SpO₂)",
-              value: spo2.avg_spo2 != null ? `${Math.round(spo2.avg_spo2)}%` : "—",
-              sub: spo2.low_spo2 != null ? `low ${spo2.low_spo2}%` : "avg",
-              spark: spo2Series,
-              color: "#6aa0e0",
-              unit: "%",
-            })
-          }
-        >
-          <Card className="gap-2">
-            <View className="flex-row items-center justify-between">
-              <Text variant="eyebrow">Blood oxygen (SpO₂)</Text>
-              <View className="flex-row items-center gap-1.5">
-                {spo2.low_spo2 != null ? <Text variant="micro" className="text-text-muted">low {spo2.low_spo2}%</Text> : null}
-                {spo2Tappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
-              </View>
-            </View>
+        <Card className="gap-2">
+          <ExpandableChart
+            title="Blood oxygen (SpO₂)"
+            chart={{ series: spo2Series, refLine: { y: 95, color: "#3a5563" }, yFormat: (v) => `${Math.round(v)}%`, yMax: 100 }}
+          >
             <View className="flex-row items-end gap-2">
               <Text variant="display" className="text-teal">{spo2.avg_spo2 != null ? Math.round(spo2.avg_spo2) : "—"}</Text>
               <Text variant="caption" className="text-text-muted mb-1">% avg</Text>
               {spo2Avg != null ? <Text variant="micro" className="text-text-muted mb-1">· 7d avg {Math.round(spo2Avg)}%</Text> : null}
+              {spo2.low_spo2 != null ? <Text variant="micro" className="text-text-muted mb-1">· low {spo2.low_spo2}%</Text> : null}
             </View>
-            {spo2Series.length >= 2 ? <Sparkline data={spo2Series} color="#6aa0e0" height={34} baseline /> : null}
-          </Card>
-        </Pressable>
+            {spo2HasChart ? (
+              <LineChart height={120} interactive labels={sLabels} xTicks={4} yMax={100} refLine={{ y: 95, color: "#3a5563" }} yFormat={(v) => `${Math.round(v)}%`} series={spo2Series} />
+            ) : null}
+          </ExpandableChart>
+          {spo2HasChart ? <ChartLegend items={[{ color: "#6aa0e0", label: "Avg" }, { color: "#8b9df0", label: "Sleep", dashed: true }, { color: "#3a5563", label: "95% ref", dashed: true }]} /> : null}
+        </Card>
       ) : null}
 
       {resp ? (
-        <Pressable
-          disabled={!respTappable}
-          onPress={() =>
-            onExpand?.({
-              label: "Respiration rate",
-              value:
-                resp.sleep_resp != null
-                  ? `${Math.round(resp.sleep_resp)}`
-                  : resp.awake_resp != null
-                    ? `${Math.round(resp.awake_resp)}`
-                    : "—",
-              sub: `br/min ${resp.sleep_resp != null ? "sleeping" : "awake"}`,
-              spark: respSeries,
-              color: "#a5b4fc",
-              unit: "br/min",
-            })
-          }
-        >
-          <Card className="gap-2">
-            <View className="flex-row items-center justify-between">
-              <Text variant="eyebrow">Respiration rate</Text>
-              {respTappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
-            </View>
+        <Card className="gap-2">
+          <ExpandableChart
+            title="Respiration rate"
+            chart={{ series: [{ values: rTrend.map((p) => fin(p.sleep_resp)), color: "#a5b4fc", width: 2.2 }, { values: rTrend.map((p) => fin(p.awake_resp)), color: "#77c8d1", width: 1.4, dashed: true }], yFormat: (v) => `${v.toFixed(0)}` }}
+          >
             <View className="flex-row items-end gap-2">
               <Text variant="display" className="text-indigo">
                 {resp.sleep_resp != null ? Math.round(resp.sleep_resp) : resp.awake_resp != null ? Math.round(resp.awake_resp) : "—"}
               </Text>
               <Text variant="caption" className="text-text-muted mb-1">br/min {resp.sleep_resp != null ? "sleeping" : "awake"}</Text>
+              {respAvg != null ? <Text variant="micro" className="text-text-muted mb-1">· 7d avg {respAvg.toFixed(1)}</Text> : null}
             </View>
-            <View className="flex-row flex-wrap gap-x-5 gap-y-1">
-              {resp.awake_resp != null ? <Text variant="micro" className="text-text-secondary">Awake {Math.round(resp.awake_resp)}</Text> : null}
-              {resp.low_resp != null ? <Text variant="micro" className="text-text-secondary">Low {Math.round(resp.low_resp)}</Text> : null}
-              {resp.high_resp != null ? <Text variant="micro" className="text-text-secondary">High {Math.round(resp.high_resp)}</Text> : null}
-            </View>
-            {respSeries.length >= 2 ? <Sparkline data={respSeries} color="#a5b4fc" height={34} baseline /> : null}
-          </Card>
-        </Pressable>
+            {respHasChart ? (
+              <LineChart height={110} interactive labels={rLabels} xTicks={4} yFormat={(v) => `${v.toFixed(0)}`} series={[{ values: rTrend.map((p) => fin(p.sleep_resp)), color: "#a5b4fc", width: 2.2, label: "Sleep" }, { values: rTrend.map((p) => fin(p.awake_resp)), color: "#77c8d1", width: 1.4, dashed: true, label: "Awake" }]} />
+            ) : null}
+          </ExpandableChart>
+          {respHasChart ? <ChartLegend items={[{ color: "#a5b4fc", label: "Sleep" }, { color: "#77c8d1", label: "Awake", dashed: true }]} /> : null}
+        </Card>
       ) : null}
     </View>
   );


### PR DESCRIPTION
## Sleep chart fidelity (leverages the F1 LineChart)

Upgrades every Sleep **sparkline → a real multi-series chart** with reference lines, tap-to-read, and fullscreen-expand (#473):

- **SpO₂:** 3 series (avg / sleep / low) + **95% reference line**, 100 ceiling.
- **HRV:** weekly-avg + **last-night** two series (was weekly-only).
- **Respiration:** **sleep + awake** two series (was one sparkline).
- **Stress:** **25 / 50 / 75** low/med/high reference lines + fixed **0–100** domain.
- **Body Battery:** **charged + drained** two series (drained was unused).
- **Sleep Score:** **"Good" 80** reference line + fixed **0–100** domain.

All are tap-to-read + fullscreen-expandable with dated x-axes. The **Avg Sleep** and **Resting HR** summary cards now open the range-aware `StatDetailModal`.

### Verification
`tsc` 0, `vitest` 5/5. Playwright (390×844): the stress 25/50/75 bands, body-battery charged+drained, SpO₂ 3-series + 95% line, HRV weekly + dashed last-night (BALANCED badge), sleep-score 80 line + 0–100 — all dated. Caught + fixed a duplicate-title render (ExpandableChart title + inner header) so each title shows once.

Part of #473
