### PR TITLE
feat(nutrition): goalpost macro bars on mobile (#479)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -10,6 +10,7 @@ import { BodyCompChart } from "../../components/body-comp-chart";
 import { ActivitySelector } from "../../components/activity-selector";
 import { ComposeMealView } from "../../components/compose-meal-view";
 import { MealDetailModal } from "../../components/meal-detail-modal";
+import { MacroGoalBar, buildMacroMarkers } from "../../components/macro-goal-bar";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -51,23 +52,6 @@ function shiftDate(iso: string, days: number): string {
   const dt = new Date(y, (mo ?? 1) - 1, (d ?? 1) + days);
   const p = (n: number) => String(n).padStart(2, "0");
   return `${dt.getFullYear()}-${p(dt.getMonth() + 1)}-${p(dt.getDate())}`;
-}
-
-/** A macro progress bar with goalposts: a teal floor marker at the target
- *  ("eat at least here") and, where a research ceiling applies (fiber 60 g),
- *  a warm ceiling marker — the fill turns amber when the ceiling is crossed. */
-function MacroGoalBar({ eaten, target, ceiling, color }: { eaten: number; target: number; ceiling?: number; color: string }) {
-  const max = ceiling ?? (target > 0 ? target * 1.3 : Math.max(eaten, 1));
-  const pct = Math.max(0, Math.min(eaten / max, 1));
-  const floorPct = target > 0 ? Math.min(target / max, 1) : 0;
-  const over = ceiling != null && eaten > ceiling;
-  return (
-    <View className="relative h-2 overflow-hidden rounded-full" style={{ backgroundColor: "#16242c" }}>
-      <View className="absolute left-0 top-0 h-full rounded-full" style={{ width: `${pct * 100}%`, backgroundColor: over ? "#e0a458" : color }} />
-      {target > 0 ? <View className="absolute top-0 h-full" style={{ left: `${floorPct * 100}%`, width: 2, backgroundColor: "#77c8d1" }} /> : null}
-      {ceiling != null ? <View className="absolute top-0 h-full" style={{ left: `${Math.min(ceiling / max, 1) * 100}%`, width: 2, backgroundColor: "#e0a458" }} /> : null}
-    </View>
-  );
 }
 
 export default function NutritionScreen() {
@@ -279,22 +263,34 @@ export default function NutritionScreen() {
           </View>
 
           <View className="gap-2.5">
-            {MACROS.map((m) => {
-              const target = (plan as Record<string, number> | null | undefined)?.[m.tKey] ?? 0;
-              const eaten = (consumed as Record<string, number> | undefined)?.[m.key] ?? 0;
-              const over = m.ceiling != null && eaten > m.ceiling;
-              return (
-                <View key={m.key} className="gap-1">
-                  <View className="flex-row justify-between">
-                    <Text variant="caption" className="text-text-secondary">{m.label}</Text>
-                    <Text variant="caption" className={`tabular-nums ${over ? "text-warm" : "text-text-muted"}`}>
-                      {Math.round(eaten)}{target > 0 ? ` / ${Math.round(target)}` : ""}g{m.ceiling != null ? ` · max ${m.ceiling}` : ""}
-                    </Text>
-                  </View>
-                  <MacroGoalBar eaten={eaten} target={target} ceiling={m.ceiling} color={m.color} />
-                </View>
-              );
-            })}
+            {(() => {
+              const t = {
+                protein: Number(plan?.target_protein) || 0,
+                carbs: Number(plan?.target_carbs) || 0,
+                fat: Number(plan?.target_fat) || 0,
+                fiber: Number(plan?.target_fiber) || 0,
+              };
+              const marks = buildMacroMarkers(Number(bd?.weightKg) || 0, t);
+              return MACROS.map((m) => {
+                const eaten = (consumed as Record<string, number> | undefined)?.[m.key] ?? 0;
+                const markers = marks[m.key as keyof typeof marks];
+                return (
+                  <MacroGoalBar
+                    key={m.key}
+                    label={m.label}
+                    current={eaten}
+                    target={t[m.key as keyof typeof t]}
+                    color={m.color}
+                    markers={markers}
+                  />
+                );
+              });
+            })()}
+            <Text variant="micro" className="text-text-muted">
+              {(bd?.weightKg ?? 0) > 0
+                ? "Protein & fat ticks are g/kg tiers · green = optimal · red = ceiling"
+                : "green = optimal target · red = ceiling"}
+            </Text>
           </View>
         </Card>
 

--- a/universal/src/components/macro-goal-bar.tsx
+++ b/universal/src/components/macro-goal-bar.tsx
@@ -1,0 +1,143 @@
+import { View } from "react-native";
+import { Text } from "soma-style";
+
+/** One research-anchored goalpost on a macro bar. Mirrors web's MacroBar. */
+export interface MacroMarker {
+  value: number;
+  label: string;
+  /** 'achievement' (default): a tier mark, no overlay past it.
+   *  'softCeiling': amber overlay past this value (warning).
+   *  'hardCeiling': red overlay + red marker past this value (real ceiling). */
+  kind?: "achievement" | "softCeiling" | "hardCeiling";
+  /** Optimal hit-this target — renders the marker line green. */
+  optimal?: boolean;
+  /** Short reason shown under the bar when this is the leading marker. */
+  description?: string;
+}
+
+const TRACK = "#16242c";
+const GREEN = "#6ad4a0";
+const RED = "#e06060";
+const AMBER = "#e0a458";
+const FOREGROUND = "#c9d4de";
+
+/** Multi-goalpost macro progress bar. When `markers` is passed it renders the
+ *  research-anchored tier set (crossed dim, ahead bright), an amber overlay past
+ *  a soft ceiling and a red overlay past a hard ceiling — the same goalpost
+ *  system as the web dashboard. Falls back to a simple floor bar otherwise. */
+export function MacroGoalBar({
+  label,
+  current,
+  target,
+  color,
+  markers,
+  unit = "g",
+}: {
+  label: string;
+  current: number;
+  target: number;
+  color: string;
+  markers?: MacroMarker[];
+  unit?: string;
+}) {
+  const useMulti = !!markers && markers.length > 0;
+  const highest = useMulti ? Math.max(...markers!.map((m) => m.value)) : 0;
+  const softCeiling = useMulti ? markers!.find((m) => m.kind === "softCeiling") : undefined;
+  const hardCeiling = useMulti ? markers!.find((m) => m.kind === "hardCeiling") : undefined;
+
+  const axisAnchors = useMulti
+    ? [highest * 1.15, current * 1.05, highest + 1]
+    : [target * 1.15, current * 1.05, target + 1];
+  const maxVal = Math.max(...axisAnchors, 1);
+  const fillPct = Math.min(100, (current / maxVal) * 100);
+
+  const pastSoft = !!softCeiling && current > softCeiling.value;
+  const pastHard = !!hardCeiling && current > hardCeiling.value;
+  const softStartPct = softCeiling ? Math.min(100, (softCeiling.value / maxVal) * 100) : 0;
+  const orangeEndValue = hardCeiling ? Math.min(current, hardCeiling.value) : current;
+  const orangeEndPct = useMulti ? Math.min(100, (orangeEndValue / maxVal) * 100) : 0;
+  const hardStartPct = hardCeiling ? Math.min(100, (hardCeiling.value / maxVal) * 100) : 100;
+
+  const displayRef = useMulti ? (softCeiling?.value ?? hardCeiling?.value ?? highest) : target;
+  const floorPct = !useMulti && target > 0 ? Math.min(100, (target / maxVal) * 100) : null;
+  const underFloor = current < (useMulti ? (markers!.find((m) => m.optimal)?.value ?? 0) : target);
+
+  const valueTone = pastHard ? "text-danger" : pastSoft ? "text-warm" : "text-text-muted";
+
+  return (
+    <View className="gap-1">
+      <View className="flex-row justify-between">
+        <Text variant="caption" className="text-text-secondary">{label}</Text>
+        <Text variant="caption" className={`tabular-nums ${valueTone}`}>
+          {Math.round(current)}/{Math.round(displayRef)}{unit}
+        </Text>
+      </View>
+      <View className="relative h-2 overflow-hidden rounded-full" style={{ backgroundColor: TRACK }}>
+        {/* Base fill */}
+        <View className="absolute left-0 top-0 h-full rounded-full" style={{ width: `${fillPct}%`, backgroundColor: color }} />
+        {/* Soft-ceiling amber overlay */}
+        {useMulti && pastSoft && orangeEndPct > softStartPct ? (
+          <View className="absolute top-0 h-full" style={{ left: `${softStartPct}%`, width: `${orangeEndPct - softStartPct}%`, backgroundColor: AMBER }} />
+        ) : null}
+        {/* Hard-ceiling red overlay */}
+        {useMulti && pastHard && fillPct > hardStartPct ? (
+          <View className="absolute top-0 h-full" style={{ left: `${hardStartPct}%`, width: `${fillPct - hardStartPct}%`, backgroundColor: RED }} />
+        ) : null}
+        {/* Multi-markers */}
+        {useMulti
+          ? markers!.map((m, i) => {
+              const pct = Math.min(99.5, (m.value / maxVal) * 100);
+              const crossed = current >= m.value;
+              const base = m.kind === "hardCeiling" ? RED : m.optimal ? GREEN : FOREGROUND;
+              return (
+                <View
+                  key={i}
+                  className="absolute top-0 h-full"
+                  style={{ left: `${pct}%`, width: 2, backgroundColor: base, opacity: crossed ? 0.4 : 1, shadowColor: "#000", shadowOpacity: 0.7, shadowRadius: 0.5, shadowOffset: { width: 0, height: 0 }, elevation: 2 }}
+                />
+              );
+            })
+          : floorPct !== null && target > 0
+            ? <View className="absolute top-0 h-full" style={{ left: `${Math.min(floorPct, 99.5)}%`, width: 2, backgroundColor: "#77c8d1" }} />
+            : null}
+      </View>
+    </View>
+  );
+}
+
+const PROTEIN_DESC: Record<string, string> = {
+  "1.6": "Hypertrophy minimum",
+  "1.8": "Common cutting target",
+  "2.0": "Conservative high",
+  "2.2": "Best muscle preservation in a deficit",
+};
+const FAT_DESC: Record<string, string> = {
+  "0.6": "Hormone-risk floor",
+  "0.8": "Cutting consensus",
+  "1.0": "Maintenance / bulk target",
+};
+
+/** Build the per-macro goalpost sets from body weight + today's matrix targets,
+ *  matching the web dashboard's research anchors (g/kg protein & fat tiers,
+ *  100 g carb floor, 60 g fiber ceiling). weightKg=0 falls back to targets. */
+export function buildMacroMarkers(
+  weightKg: number,
+  t: { protein: number; carbs: number; fat: number; fiber: number },
+): { protein: MacroMarker[]; carbs: MacroMarker[]; fat: MacroMarker[]; fiber: MacroMarker[] } {
+  const w = weightKg > 0 ? weightKg : 0;
+  const protein: MacroMarker[] = w > 0
+    ? [1.6, 1.8, 2.0, 2.2].map((g) => ({ value: w * g, label: g.toFixed(1), optimal: g === 2.2, description: PROTEIN_DESC[g.toFixed(1)] }))
+    : [{ value: t.protein, label: "target", optimal: true }];
+  const fat: MacroMarker[] = w > 0
+    ? [0.6, 0.8, 1.0].map((g) => ({ value: w * g, label: g.toFixed(1), optimal: g === 0.8, description: FAT_DESC[g.toFixed(1)] }))
+    : [{ value: t.fat, label: "target", optimal: true }];
+  const carbs: MacroMarker[] = [
+    { value: 100, label: "min", description: "Health floor" },
+    { value: t.carbs, label: "target", optimal: true, description: "Matrix carb target" },
+  ].sort((a, b) => a.value - b.value);
+  const fiber: MacroMarker[] = [
+    { value: t.fiber || 30, label: "target", optimal: true, description: "Gut health + satiety" },
+    { value: 60, label: "ceil", kind: "hardCeiling", description: "GI distress threshold" },
+  ];
+  return { protein, carbs, fat, fiber };
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -51,6 +51,7 @@ export interface SomaBreakdown {
   runCalories?: number; runActual?: number; runPredicted?: number; runEnabled?: boolean; runActualDistKm?: number; runDistanceKm?: number;
   gymCalories?: number; gymBreakdown?: { title: string; calories: number; predicted?: number; actual?: number }[];
   drinkCalories?: number; deficit?: number; manualOverride?: boolean;
+  weightKg?: number;
 }
 export interface TrendDay { date: string; ate: number; burn: number; deficit: number; closed: boolean; isToday: boolean }
 export interface LoggedDrink {


### PR DESCRIPTION
## What

Ports the web nutrition dashboard's **research-anchored goalpost macro-bar system** to the mobile app. The macro bars previously showed a single teal floor marker; they now render the full goalpost set the web uses.

| Macro | Goalposts |
|---|---|
| Protein | g/kg tiers 1.6 / 1.8 / 2.0 / 2.2 × body weight, 2.2 = optimal |
| Fat | g/kg tiers 0.6 / 0.8 / 1.0, 0.8 = optimal |
| Carbs | 100 g health floor + matrix carb target |
| Fiber | daily target + 60 g hard ceiling |

Markers are color-coded (green = optimal, red = hard ceiling, white = tier), dim once crossed. An amber overlay marks the region past a soft ceiling and a red overlay past a hard ceiling, matching `web/components/nutrition-dashboard.tsx`.

## Data

`weightKg` was already returned in the `/api/nutrition/plan` payload (`breakdown.weightKg`); only the mobile `SomaBreakdown` type needed to declare it. No API change.

## Verified

- `tsc --noEmit` clean
- Playwright on Expo web: all four bars render with g/kg-derived references (Protein 0/161 = 73.2×2.2, Fat 0/73 = 73.2×1.0, Carbs 0/100 floor, Fiber 0/60 ceiling); green optimal + red fiber-ceiling markers positioned correctly; g/kg hint line present.

## Files

- `universal/src/components/macro-goal-bar.tsx` (new) — `MacroGoalBar` + `buildMacroMarkers`
- `universal/src/app/(main)/nutrition.tsx` — use goalpost markers
- `universal/src/lib/api.ts` — declare `weightKg` on `SomaBreakdown`

Part of #473.

Closes #479
