### PR TITLE
feat(running): rich activity detail modal for run rows (#481)

### DIFF
--- a/universal/src/components/run-table.tsx
+++ b/universal/src/components/run-table.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
 import { View, Pressable } from "react-native";
-import { Text, Card, Modal, Badge } from "soma-style";
+import { Text, Card } from "soma-style";
+import { ActivityDetailModal } from "./activity-detail-modal";
+import type { ActivityRow } from "../lib/api";
 
 /** One run row — structurally matches the screen's RecentRun. */
 export interface RunRow {
@@ -35,40 +37,22 @@ function shortDate(iso: string | null | undefined): string {
   const d = new Date(iso);
   return isNaN(d.getTime()) ? "—" : d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
-function longDate(iso: string | null | undefined): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
-}
-
-/** Detail dialog for one run (the drill-in behind a table row). */
-function RunDetailModal({ run, onClose }: { run: RunRow | null; onClose: () => void }) {
-  if (!run) return null;
-  const rows: [string, string][] = [
-    ["Distance", run.distance != null ? `${num(run.distance).toFixed(2)} km` : "—"],
-    ["Duration", run.duration_min != null ? `${Math.round(num(run.duration_min))} min` : "—"],
-    ["Avg pace", run.pace != null ? `${paceLabel(run.pace)} /km` : "—"],
-    ["Avg HR", run.avg_hr != null ? `${Math.round(num(run.avg_hr))} bpm` : "—"],
-    ["Calories", run.calories != null ? `${Math.round(num(run.calories))} kcal` : "—"],
-  ];
-  return (
-    <Modal visible={!!run} onClose={onClose} title={run.name ?? "Run"}>
-      <View className="gap-3">
-        <View className="flex-row items-end gap-2">
-          <Text variant="display" className="text-teal">{run.distance != null ? num(run.distance).toFixed(1) : "—"}</Text>
-          <Text variant="body" className="mb-1 text-text-muted">km · {longDate(run.date)}</Text>
-        </View>
-        <View className="gap-2">
-          {rows.map(([label, value]) => (
-            <View key={label} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
-              <Text variant="body" className="text-text-secondary">{label}</Text>
-              <Text variant="body" className="tabular-nums text-text">{value}</Text>
-            </View>
-          ))}
-        </View>
-      </View>
-    </Modal>
-  );
+/** Adapt a run row into the ActivityRow the rich detail modal expects. The
+ *  modal fetches /api/activity/<id> for splits, HR zones, weather, gear and
+ *  running dynamics; these row fields seed its header + overview metrics. */
+function toActivityRow(r: RunRow): ActivityRow {
+  return {
+    activity_id: r.activity_id,
+    type_key: "running",
+    sport: "Running",
+    date: r.date ?? "",
+    name: r.name,
+    distance_km: r.distance,
+    duration_min: r.duration_min,
+    avg_hr: r.avg_hr,
+    calories: r.calories,
+    elev_gain: 0,
+  };
 }
 
 /**
@@ -140,7 +124,7 @@ export function RunTable({ runs }: { runs: RunRow[] }) {
         </Pressable>
       ))}
 
-      <RunDetailModal run={selected} onClose={() => setSelected(null)} />
+      <ActivityDetailModal activity={selected ? toActivityRow(selected) : null} onClose={() => setSelected(null)} />
     </Card>
   );
 }


### PR DESCRIPTION
## What

The Running screen's run table opened a thin detail modal (distance / duration / pace / HR / calories only). The Activities screen already drills into the rich shared `ActivityDetailModal`. This wires the run table's row tap to that same modal.

Tapping a run now shows the full detail — Overview/Splits tabs, per-lap splits, HR-zone bars, weather, gear/shoe mileage, VO2max, cadence, stride, ground-contact time and vertical oscillation, plus the Strava link — instead of a five-line summary.

## How

`RunRow` is adapted into the `ActivityRow` the modal expects (`type_key: "running"`, `sport: "Running"`); the modal fetches `/api/activity/<id>` for the rest. The old inline `RunDetailModal` is removed.

## Verified

- `tsc --noEmit` clean
- Playwright on Expo web (fresh Metro): tapped a run row on `/running` — the rich modal opened with RUNNING + ON STRAVA badges, Overview/Splits tabs, the full metric grid (VO2max 54.0, Cadence 155 spm, Stride 99 cm, GCT 265 ms, Vert osc 8.2 cm), Z1–Z4 HR-zone bars, weather, and gear (Asics Gel Nimbus 25).

## Files

- `universal/src/components/run-table.tsx`

Part of #473.

Closes #481
