### PR TITLE
feat(nutrition): per-meal protein-quality (MPS) pill (#485)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -10,7 +10,7 @@ import { BodyCompChart } from "../../components/body-comp-chart";
 import { ActivitySelector } from "../../components/activity-selector";
 import { ComposeMealView } from "../../components/compose-meal-view";
 import { MealDetailModal } from "../../components/meal-detail-modal";
-import { MacroGoalBar, buildMacroMarkers } from "../../components/macro-goal-bar";
+import { MacroGoalBar, buildMacroMarkers, ProteinQualityPill } from "../../components/macro-goal-bar";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -366,7 +366,10 @@ export default function NutritionScreen() {
                       {slotMeals.map((m) => (
                         <Pressable key={m.id} onPress={() => setDetailMeal(m)} className="flex-row items-center gap-2 border-b border-border-subtle py-1.5">
                           <View className="flex-1">
-                            <Text variant="body" className="text-text" numberOfLines={1}>{mealName(m)}</Text>
+                            <View className="flex-row items-center gap-1.5">
+                              <Text variant="body" className="text-text" numberOfLines={1} style={{ flexShrink: 1 }}>{mealName(m)}</Text>
+                              <ProteinQualityPill grams={m.protein} weightKg={bd?.weightKg} />
+                            </View>
                             <Text variant="micro" className="tabular-nums">
                               {Math.round(m.calories)} kcal · P{Math.round(m.protein)} C{Math.round(m.carbs)} F{Math.round(m.fat)}
                             </Text>

--- a/universal/src/components/macro-goal-bar.tsx
+++ b/universal/src/components/macro-goal-bar.tsx
@@ -1,6 +1,51 @@
 import { View } from "react-native";
 import { Text } from "soma-style";
 
+/* ── Per-meal protein quality (MPS signaling) ──────────────────────────────
+ * Schoenfeld & Aragon 2018 / Trommelen 2023: the muscle-protein-synthesis
+ * floor is ~0.4 g/kg per eating event (≈30 g at 75 kg, scaling with mass).
+ * A pill flags a logged meal that falls below that floor; meals at/above it
+ * show nothing. Mirrors web/lib/per-meal-protein.tsx. */
+export type PerMealProteinLevel = "red" | "amber" | "yellow" | "green" | "plenty";
+const MPS_G_PER_KG = 0.4;
+const PLENTY_G_PER_KG = 0.55;
+const FALLBACK_MPS_G = 30;
+
+function proteinThresholds(weightKg: number | null | undefined) {
+  if (!weightKg || weightKg <= 0) return { red: 15, amber: 25, yellow: 30, plenty: 55 };
+  const mps = Math.max(20, Math.round(weightKg * MPS_G_PER_KG));
+  const plenty = Math.max(40, Math.round(weightKg * PLENTY_G_PER_KG));
+  return { red: Math.max(10, Math.round(mps * 0.5)), amber: Math.max(15, Math.round(mps * 0.83)), yellow: mps, plenty };
+}
+
+export function perMealProteinLevel(g: number, weightKg?: number | null): PerMealProteinLevel {
+  const t = proteinThresholds(weightKg);
+  if (g < t.red) return "red";
+  if (g < t.amber) return "amber";
+  if (g < t.yellow) return "yellow";
+  if (g <= t.plenty) return "green";
+  return "plenty";
+}
+
+const PILL: Record<"red" | "amber" | "yellow", { fg: string; bg: string; label: string }> = {
+  red: { fg: "#f2868c", bg: "#3a1e24", label: "low protein" },
+  amber: { fg: "#e0a458", bg: "#33291a", label: "below MPS" },
+  yellow: { fg: "#e0d060", bg: "#31311c", label: "near MPS" },
+};
+
+/** MPS-floor pill for one logged meal. Renders nothing when the meal's protein
+ *  is already at or above the floor (green / plenty). */
+export function ProteinQualityPill({ grams, weightKg }: { grams: number; weightKg?: number | null }) {
+  const level = perMealProteinLevel(grams, weightKg);
+  if (level === "green" || level === "plenty") return null;
+  const p = PILL[level];
+  return (
+    <View className="rounded px-1.5 py-[1px]" style={{ backgroundColor: p.bg }}>
+      <Text variant="micro" style={{ color: p.fg }}>{p.label}</Text>
+    </View>
+  );
+}
+
 /** One research-anchored goalpost on a macro bar. Mirrors web's MacroBar. */
 export interface MacroMarker {
   value: number;


### PR DESCRIPTION
## What

The web meal cards flag meals whose protein is below the muscle-protein-synthesis (MPS) floor; the mobile meal rows showed only kcal + macros. This adds the same signal.

Each logged meal below its body-weight-scaled MPS floor (~0.4 g/kg per eating event, min 20 g; Schoenfeld & Aragon 2018 / Trommelen 2023) shows a pill:
- **low protein** (red) below ~0.2 g/kg
- **below MPS** (amber) below ~0.33 g/kg
- **near MPS** (yellow) approaching the floor
- meals at or above the floor show no pill

## Data

Uses `meal.protein` + `breakdown.weightKg`, both already in `/api/nutrition/plan`. No API change. Logic ported verbatim from `web/lib/per-meal-protein.tsx`.

## Verified

- `tsc --noEmit` clean
- Playwright on Expo web: rendered real meal rows through the component — a P8 meal shows a red "low protein" pill, a P22 meal shows "below MPS", a P47 meal shows no pill; layout of the meal row is intact.

## Files

- `universal/src/components/macro-goal-bar.tsx` — `ProteinQualityPill` + `perMealProteinLevel`
- `universal/src/app/(main)/nutrition.tsx` — pill on each meal row

Part of #473.

Closes #485
