### PR TITLE
feat(connections): surface sync-rule activity type + priority (#489)

### DIFF
--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -410,21 +410,28 @@ export default function ConnectionsScreen() {
                 key={g.key}
                 className="flex-row items-center justify-between border-b border-border-subtle py-2 last:border-0"
               >
-                <View className="flex-1 flex-row items-center gap-2 pr-2">
-                  <Text variant="caption" className="text-text-secondary">
-                    {g.source}
-                  </Text>
-                  <Text variant="caption" className="text-text-muted">
-                    →
-                  </Text>
-                  <Text variant="caption" className="text-text">
-                    {g.dest}
-                  </Text>
-                  {g.count > 1 ? (
-                    <Text variant="micro" className="text-text-muted">
-                      ×{g.count}
+                <View className="flex-1 gap-0.5 pr-2">
+                  <View className="flex-row items-center gap-2">
+                    <Text variant="caption" className="text-text-secondary">
+                      {g.source}
                     </Text>
-                  ) : null}
+                    <Text variant="caption" className="text-text-muted">
+                      →
+                    </Text>
+                    <Text variant="caption" className="text-text">
+                      {g.dest}
+                    </Text>
+                    {g.count > 1 ? (
+                      <Text variant="micro" className="text-text-muted">
+                        ×{g.count}
+                      </Text>
+                    ) : null}
+                  </View>
+                  <Text variant="micro" className="text-text-muted">
+                    {g.effective.activity_type && g.effective.activity_type !== "all" && g.effective.activity_type !== "*" ? g.effective.activity_type : "all activities"}
+                    {g.effective.preprocessing?.length ? ` · ${g.effective.preprocessing.join(", ")}` : ""}
+                    {` · priority ${g.effective.priority}`}
+                  </Text>
                 </View>
                 <View className="flex-row items-center gap-3">
                   <Pressable onPress={() => toggleRule(g.effective.id, g.effective.enabled)} hitSlop={8}>


### PR DESCRIPTION
## What

Each mobile sync-rule row showed only source → destination + on/off. The web rules manager also surfaces the rule's activity-type filter, preprocessing and priority. This adds a detail line under each row:

- activity-type filter ("all activities" for `*`/`all`, otherwise the sport, e.g. "strength")
- preprocessing steps, when present
- the effective rule's priority

## Data

Uses `activity_type`, `preprocessing[]`, `priority` from `/api/connections` `rules[]` (already returned). No API change.

## Verified

- `tsc --noEmit` clean
- Playwright on Expo web (real local rules): rows render "garmin → telegram ×2 · all activities · priority 10", "hevy → strava · strength · priority 0", etc.; the `*` activity type reads "all activities"; on/off + delete controls unchanged.

## Files

- `universal/src/app/(main)/connections.tsx`

Note: per-route sync **error counts** (the other connections gap) need a new field on `/api/sync/status`; deferred to the web-side batch.

Part of #473.

Closes #489
