### PR TITLE
feat(training): readiness-override safety banners (#491)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -62,7 +62,7 @@ export default function TrainingScreen() {
   const { data, error, refetch } = useTraining(todayISO());
   const { cal, refetch: refetchCal } = useCalibration(todayISO());
   const { data: sim, refetch: refetchSim } = useForwardSim(todayISO());
-  const { nodes: graphNodes } = useTrainingGraph(todayISO());
+  const { nodes: graphNodes, overrides: graphOverrides } = useTrainingGraph(todayISO());
   const { byDay: matches } = useActivityMatches();
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
@@ -154,6 +154,25 @@ export default function TrainingScreen() {
 
         {error ? (
           <Card><Text variant="body" className="text-danger">API: {error} — is soma running on :3456?</Text></Card>
+        ) : null}
+
+        {/* Safety-rail overrides — hard readiness rules that force RED/YELLOW */}
+        {graphOverrides.length ? (
+          <View className="gap-2">
+            {graphOverrides.map((o) => {
+              const red = o.severity === "red";
+              return (
+                <View
+                  key={o.rule}
+                  className="flex-row items-start gap-2 rounded-lg border px-3 py-2.5"
+                  style={{ backgroundColor: red ? "#3a1e24" : "#33291a", borderColor: red ? "#e06060" : "#e0a458" }}
+                >
+                  <Text variant="body" style={{ color: red ? "#f2868c" : "#e0a458" }}>{red ? "⛔" : "⚠️"}</Text>
+                  <Text variant="caption" className="flex-1" style={{ color: red ? "#f2868c" : "#e0c458" }}>{o.message}</Text>
+                </View>
+              );
+            })}
+          </View>
         ) : null}
 
         <Card className="gap-3">

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -717,25 +717,30 @@ export function useWeekdayWeekend(range: string) {
 
 // ---- Training computation graph (nodes → the mobile pace-computation breakdown) ----
 export interface GraphNode { id: string; label: string; value: number | null }
+/** A hard readiness override (sleep < 5h, Body Battery < 25, HRV/majority flags). */
+export interface TrainingOverride { rule: string; triggered: boolean; message: string; severity: "red" | "yellow" }
 
-/** The computation-graph nodes keyed by id (readiness_factor, tsb, adjusted_pace, …). */
+/** The computation-graph nodes keyed by id (readiness_factor, tsb, adjusted_pace, …)
+ *  plus the TRIGGERED hard-override banners (forced RED / YELLOW safety rails). */
 export function useTrainingGraph(date: string) {
   const [nodes, setNodes] = useState<Record<string, GraphNode>>({});
+  const [overrides, setOverrides] = useState<TrainingOverride[]>([]);
   const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
-    fetchJson<{ graph?: { nodes?: GraphNode[] }; nodes?: GraphNode[] }>(`/api/training/graph?date=${date}`)
+    fetchJson<{ graph?: { nodes?: GraphNode[]; overrides?: TrainingOverride[] }; nodes?: GraphNode[] }>(`/api/training/graph?date=${date}`)
       .then((d) => {
         if (!alive) return;
         const arr = d.graph?.nodes ?? d.nodes ?? [];
         const map: Record<string, GraphNode> = {};
         for (const nd of arr) map[nd.id] = nd;
         setNodes(map);
+        setOverrides((d.graph?.overrides ?? []).filter((o) => o.triggered));
       })
       .catch(() => {});
     return () => { alive = false; };
   }, [date, reload]);
-  return { nodes, refetch: () => setReload((n) => n + 1) };
+  return { nodes, overrides, refetch: () => setReload((n) => n + 1) };
 }
 
 export function useSomaPlan(date: string) {


### PR DESCRIPTION
## What

The web training view hoists hard readiness overrides as red/amber banners. The mobile app fetched `/api/training/graph` but `useTrainingGraph` kept only `graph.nodes` and discarded `graph.overrides`, so the safety rails never showed.

This exposes the triggered overrides and renders them at the top of the training screen:
- **Red** banner for forced-RED rules (sleep < 5h, Body Battery < 25, 3/4 signals flagged)
- **Amber** banner for YELLOW rules (HRV below SWC, 2/4 flagged)

Non-triggered rules are filtered out.

## Data

Uses `graph.overrides[]` (`{ rule, triggered, message, severity }`), already returned by `/api/training/graph`. No API change.

## Verified

- `tsc --noEmit` clean
- Playwright on Expo web (route-mocked overrides): the red "Sleep under 5 hours (4.2h) — forced RED." and amber "2 of 4 readiness signals flagged — YELLOW." banners render with the right colors/icons; a `triggered: false` override is correctly not shown.

## Files

- `universal/src/lib/api.ts` — `TrainingOverride` + `useTrainingGraph` returns triggered overrides
- `universal/src/app/(main)/training.tsx` — override banners

Part of #473.

Closes #491
