### PR TITLE
feat(nutrition): energy-budget bar with live deficit (#493)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -262,6 +262,35 @@ export default function NutritionScreen() {
             )}
           </View>
 
+          {/* Energy budget bar: eaten vs goal (ceiling marker) on the total-burn scale, with the live deficit */}
+          {plan && (bd?.totalBurn ?? 0) > 0 ? (() => {
+            const totalBurn = bd?.totalBurn ?? 0;
+            const consumedCal = consumed?.calories ?? 0;
+            const goalIntake = targetCal;
+            const deficitGoal = bd?.deficit ?? 0;
+            const eatPct = Math.min(100, (consumedCal / totalBurn) * 100);
+            const goalPct = Math.min(99.5, (goalIntake / totalBurn) * 100);
+            const currentDeficit = consumedCal - totalBurn;
+            const overGoal = consumedCal > goalIntake;
+            return (
+              <View className="gap-1">
+                <View className="relative h-2.5 overflow-hidden rounded-full" style={{ backgroundColor: "#16242c" }}>
+                  <View className="absolute left-0 top-0 h-full rounded-full" style={{ width: `${eatPct}%`, backgroundColor: overGoal ? "#e0a458" : "#77c8d1" }} />
+                  <View className="absolute top-0 h-full" style={{ left: `${goalPct}%`, width: 2, backgroundColor: "#6ad4a0" }} />
+                </View>
+                <View className="flex-row justify-between">
+                  <Text variant="micro" className="text-text-muted">{goalIntake.toLocaleString()} goal{deficitGoal > 0 ? ` (−${deficitGoal})` : ""}</Text>
+                  <Text variant="micro" className="text-text-muted">{totalBurn.toLocaleString()} burn</Text>
+                </View>
+                <Text variant="micro" style={{ color: currentDeficit <= 0 ? "#6ad4a0" : "#f2868c" }}>
+                  {currentDeficit <= 0
+                    ? `${Math.abs(Math.round(currentDeficit)).toLocaleString()} kcal current deficit`
+                    : `+${Math.round(currentDeficit).toLocaleString()} kcal surplus`}
+                </Text>
+              </View>
+            );
+          })() : null}
+
           <View className="gap-2.5">
             {(() => {
               const t = {


### PR DESCRIPTION
## What

The web nutrition hero draws an energy-budget bar and a live deficit callout; the mobile hero showed only the "kcal left" number. This adds the same:

- eaten calories as a fill on the **total-burn** scale (amber if over goal, teal otherwise)
- a green **goal-ceiling** marker (eat ≤ goal)
- "1,563 goal (−537)" and "2,100 burn" labels
- a live **current deficit / surplus** callout (green in deficit, red in surplus)

## Data

Uses `consumed.calories`, `plan.target_calories`, `breakdown.totalBurn`, `breakdown.deficit` — all already in `/api/nutrition/plan`. No API change.

## Verified

- `tsc --noEmit` clean
- Playwright on Expo web (route-mocked plan+burn, since the local backend has no plan today): renders "1,563 goal (−537) · 2,100 burn" with the eaten fill + green goal marker, and "1,850 kcal current deficit" in green; sits above the macro goalpost bars.

## Files

- `universal/src/app/(main)/nutrition.tsx`

Part of #473.

Closes #493
