### PR TITLE
feat(training): client-side forward simulation (#503)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -15,6 +15,7 @@ import {
   type PlanDay,
 } from "../../lib/api";
 import { TrainingSchedule } from "../../components/training-schedule";
+import { projectDays } from "../../lib/project-days";
 import { RaceHeader } from "../../components/race-header";
 import { WhatIfSlider } from "../../components/whatif-slider";
 import { TrainingPaces } from "../../components/training-paces";
@@ -88,6 +89,7 @@ export default function TrainingScreen() {
   const fit = data?.fitness;
   const readiness = data?.readiness;
   const vdot = fit?.vdot_adjusted ?? sim?.fitness?.vdotAdjusted ?? null;
+  const projected = useMemo(() => projectDays(sim), [sim]);
   const vo2Trend = useVo2Trend();
 
   // External comparison signals (Garmin-side + PMC) with trend sparklines.
@@ -200,6 +202,7 @@ export default function TrainingScreen() {
             today={sim?.today ?? todayISO()}
             matches={matches}
             vdot={vdot}
+            projected={projected}
             onToggleComplete={onToggleComplete}
           />
         ) : null}

--- a/universal/src/components/training-schedule.tsx
+++ b/universal/src/components/training-schedule.tsx
@@ -3,6 +3,7 @@ import { View, Pressable } from "react-native";
 import { Text, Card } from "soma-style";
 import { requestGarminPush, type ActivityMatch, type PlanDay, type WorkoutStep } from "../lib/api";
 import { getBasePace, getHRZone } from "../lib/vdot-pace-zones";
+import { TRAFFIC_COLOR, type ProjectedDay } from "../lib/project-days";
 import { MatchedActivityPanel } from "./matched-activity-panel";
 
 /* Run-type → colour, matching the web training plan (easy green, quality orange,
@@ -54,6 +55,7 @@ function DayRow({
   isToday,
   match,
   vdot,
+  proj,
   onToggleComplete,
   onOpenMatch,
 }: {
@@ -61,6 +63,7 @@ function DayRow({
   isToday: boolean;
   match?: ActivityMatch;
   vdot: number | null;
+  proj?: ProjectedDay;
   onToggleComplete: (day: PlanDay) => void;
   onOpenMatch?: (day: PlanDay, match: ActivityMatch) => void;
 }) {
@@ -132,14 +135,33 @@ function DayRow({
               <Text variant="caption" className="tabular-nums text-text-secondary ml-2">{day.targetDistanceKm} km</Text>
             ) : null}
           </View>
-          {/* Target pace + HR zone for run days, from the athlete's current VDOT */}
-          {vdot != null && day.runType && day.runType.toLowerCase() !== "rest" && (day.targetDistanceKm ?? 0) > 0 ? (() => {
+          {/* Target pace + HR zone for run days. When the forward simulation has
+              projected this day, show its readiness-ADJUSTED pace + traffic light
+              (or a REST signal); otherwise the base VDOT pace. */}
+          {day.runType && day.runType.toLowerCase() !== "rest" && (day.targetDistanceKm ?? 0) > 0 ? (() => {
             const hz = getHRZone(day.runType);
+            if (proj) {
+              if (proj.adjustedPace == null) {
+                return <Text variant="micro" className="mt-0.5" style={{ color: "#e06060" }}>⛔ REST — readiness critical</Text>;
+              }
+              const tl = TRAFFIC_COLOR[proj.trafficLight] ?? "#77c8d1";
+              const changed = Math.abs(proj.paceChangePct) >= 0.5;
+              return (
+                <View className="flex-row flex-wrap items-center gap-x-2 mt-0.5">
+                  <View className="flex-row items-center gap-1">
+                    <View className="h-2 w-2 rounded-full" style={{ backgroundColor: tl }} />
+                    <Text variant="micro" className="tabular-nums" style={{ color: tl }}>{paceStr(proj.adjustedPace)}/km</Text>
+                  </View>
+                  {changed ? <Text variant="micro" className="tabular-nums text-text-muted">{proj.paceChangePct > 0 ? "+" : ""}{proj.paceChangePct}% vs base</Text> : null}
+                  <Text variant="micro" className="text-text-muted">·</Text>
+                  <Text variant="micro" className="tabular-nums text-text-muted">HR {hz.zone} {hz.low}–{hz.high}</Text>
+                </View>
+              );
+            }
+            if (vdot == null) return null;
             return (
               <View className="flex-row items-center gap-2 mt-0.5">
-                <Text variant="micro" className="tabular-nums" style={{ color: runColor(day.runType) }}>
-                  {paceStr(getBasePace(vdot, day.runType))}/km
-                </Text>
+                <Text variant="micro" className="tabular-nums" style={{ color: runColor(day.runType) }}>{paceStr(getBasePace(vdot, day.runType))}/km</Text>
                 <Text variant="micro" className="text-text-muted">·</Text>
                 <Text variant="micro" className="tabular-nums text-text-muted">HR {hz.zone} {hz.low}–{hz.high}</Text>
               </View>
@@ -203,12 +225,14 @@ export function TrainingSchedule({
   today,
   matches,
   vdot = null,
+  projected,
   onToggleComplete,
 }: {
   planDays: PlanDay[];
   today: string;
   matches?: Record<number, ActivityMatch>;
   vdot?: number | null;
+  projected?: Map<number, ProjectedDay> | null;
   onToggleComplete: (day: PlanDay) => void;
 }) {
   // group by week
@@ -271,7 +295,7 @@ export function TrainingSchedule({
             {isOpen ? (
               <View className="mt-1">
                 {days.map((d) => (
-                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} match={matches?.[d.id]} vdot={vdot} onToggleComplete={onToggleComplete}
+                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} match={matches?.[d.id]} vdot={vdot} proj={projected?.get(d.id)} onToggleComplete={onToggleComplete}
                     onOpenMatch={(day, match) => setOpenMatch({ day, match })} />
                 ))}
               </View>

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -216,10 +216,12 @@ export interface PlanDay {
 export interface ComparisonPoint { date: string; [k: string]: number | string }
 export interface ForwardSim {
   today: string;
+  epocScaleFactor?: number;
   pmc: { ctl: number; atl: number; tsb: number } | null;
+  banister?: { p0: number; k1: number; k2: number; tau1: number; tau2: number; nAnchors: number } | null;
   readiness: { compositeZ: number | null; trafficLight: string } | null;
   calibration: Calibration | null;
-  fitness: { vo2max: number | null; vdotAdjusted: number | null; weightKg: number | null } | null;
+  fitness: { vo2max: number | null; vdotAdjusted: number | null; weightKg: number | null; calibrationWeightKg?: number } | null;
   planDays: PlanDay[];
   comparison: {
     load: ComparisonPoint[];

--- a/universal/src/lib/banister-projection.ts
+++ b/universal/src/lib/banister-projection.ts
@@ -1,0 +1,164 @@
+/**
+ * Banister impulse-response model for client-side VDOT projection.
+ *
+ * Ported from sync/src/training_engine/banister.py — pure functions,
+ * no DB access, no React, no side effects.
+ *
+ * The classic Banister formula:
+ *   p(t) = p0 + k1 * Σ(w(i) * exp(-(t-i)/τ1)) - k2 * Σ(w(i) * exp(-(t-i)/τ2))
+ *
+ * Where:
+ *   p0   = baseline VDOT before training
+ *   k1   = fitness gain coefficient
+ *   k2   = fatigue gain coefficient
+ *   τ1   = fitness decay time constant (default 42 days)
+ *   τ2   = fatigue decay time constant (default 7 days)
+ *   w(i) = training load on day i
+ *
+ * References:
+ *   - Banister, E.W. (1991). "Modeling elite athletic performance."
+ *   - Busso, T. (2003). "Variable dose-response relationship."
+ */
+
+// ── Interfaces ────────────────────────────────────────────────
+
+export interface BanisterParams {
+  p0: number;   // baseline VDOT
+  k1: number;   // fitness gain coefficient
+  k2: number;   // fatigue gain coefficient
+  tau1: number; // fitness decay time constant (days)
+  tau2: number; // fatigue decay time constant (days)
+}
+
+export interface DailyLoad {
+  date: string; // YYYY-MM-DD
+  load: number;
+}
+
+// ── Defaults ──────────────────────────────────────────────────
+
+export const DEFAULT_BANISTER: BanisterParams = {
+  p0: 47.0, // Should be overridden with actual current VO2max
+  k1: 0.1,
+  k2: 0.1,
+  tau1: 42,
+  tau2: 7,
+};
+
+// ── Helpers ───────────────────────────────────────────────────
+
+/** Compute days between two YYYY-MM-DD date strings (b - a). */
+function daysBetween(a: string, b: string): number {
+  const msA = new Date(a + "T00:00:00").getTime();
+  const msB = new Date(b + "T00:00:00").getTime();
+  return Math.round((msB - msA) / 86_400_000);
+}
+
+// ── Core projection ───────────────────────────────────────────
+
+/**
+ * Project a VDOT time-series using the Banister impulse-response model.
+ *
+ * @param loads  Chronologically sorted array of daily loads.
+ * @param params Banister model parameters.
+ * @returns      Parallel array of projected VDOT values (one per load entry),
+ *               each rounded to 1 decimal place.
+ */
+export function projectVdotSeries(
+  loads: DailyLoad[],
+  params: BanisterParams,
+): number[] {
+  const { p0, k1, k2, tau1, tau2 } = params;
+  const result: number[] = [];
+
+  for (let t = 0; t < loads.length; t++) {
+    let fitnessSum = 0;
+    let fatigueSum = 0;
+
+    for (let i = 0; i < t; i++) {
+      const dt = daysBetween(loads[i].date, loads[t].date);
+      if (dt <= 0) continue;
+
+      const w = loads[i].load;
+      fitnessSum += w * Math.exp(-dt / tau1);
+      fatigueSum += w * Math.exp(-dt / tau2);
+    }
+
+    const vdot = p0 + k1 * fitnessSum - k2 * fatigueSum;
+    result.push(Math.round(vdot * 10) / 10);
+  }
+
+  return result;
+}
+
+/**
+ * Project fitness-only VDOT series (no fatigue term).
+ *
+ * Returns p0 + k1 * Σ(w(i) * exp(-(t-i)/τ1)) — the "performance potential"
+ * representing what the athlete could achieve with fresh legs.
+ *
+ * Use this for trajectory charts. Daily fatigue oscillation is handled
+ * separately by forward simulation merge factors (readiness, TSB).
+ *
+ * @param loads  Chronologically sorted array of daily loads.
+ * @param params Banister model parameters.
+ * @returns      Parallel array of projected fitness-only VDOT values.
+ */
+export function projectFitnessOnlySeries(
+  loads: DailyLoad[],
+  params: BanisterParams,
+): number[] {
+  const { p0, k1, tau1 } = params;
+  const result: number[] = [];
+
+  for (let t = 0; t < loads.length; t++) {
+    let fitnessSum = 0;
+
+    for (let i = 0; i < t; i++) {
+      const dt = daysBetween(loads[i].date, loads[t].date);
+      if (dt <= 0) continue;
+
+      const w = loads[i].load;
+      fitnessSum += w * Math.exp(-dt / tau1);
+    }
+
+    const vdot = p0 + k1 * fitnessSum;
+    result.push(Math.round(vdot * 10) / 10);
+  }
+
+  return result;
+}
+
+/**
+ * Project VDOT at a single target date.
+ *
+ * @param loads      Chronologically sorted array of daily loads.
+ * @param params     Banister model parameters.
+ * @param targetDate YYYY-MM-DD date to project for.
+ * @returns          Projected VDOT, or p0 if targetDate is not found in loads.
+ */
+export function projectVdotAt(
+  loads: DailyLoad[],
+  params: BanisterParams,
+  targetDate: string,
+): number {
+  const { p0, k1, k2, tau1, tau2 } = params;
+
+  let fitnessSum = 0;
+  let fatigueSum = 0;
+  let hasContribution = false;
+
+  for (const entry of loads) {
+    const dt = daysBetween(entry.date, targetDate);
+    if (dt <= 0) continue; // same-day or future loads don't contribute
+
+    fitnessSum += entry.load * Math.exp(-dt / tau1);
+    fatigueSum += entry.load * Math.exp(-dt / tau2);
+    hasContribution = true;
+  }
+
+  if (!hasContribution) return p0;
+
+  const vdot = p0 + k1 * fitnessSum - k2 * fatigueSum;
+  return Math.round(vdot * 10) / 10;
+}

--- a/universal/src/lib/forward-simulation.ts
+++ b/universal/src/lib/forward-simulation.ts
@@ -1,0 +1,421 @@
+/**
+ * Client-side forward simulation engine.
+ *
+ * Takes server-seeded state and projects every future workout's
+ * adapted pace, distance, and HR zones through the merge formula.
+ *
+ * Design doc: docs/plans/2026-03-08-adaptive-engine-design.md §1
+ */
+
+import {
+  readinessFactorCalc,
+  fatigueFactorCalc,
+  DEFAULT_BASE_PACE,
+} from "./training-engine";
+import { getBasePace, getHRZone } from "./vdot-pace-zones";
+import { projectVdotSeries, DEFAULT_BANISTER, type BanisterParams, type DailyLoad } from "./banister-projection";
+import { estimateHMSeconds } from "./vdot-utils";
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface ComparisonData {
+  load: { date: string; dailyLoad: number; ctl: number; atl: number }[];
+  readiness: { date: string; garminScore: number; ourScore: number }[];
+  fitness: { date: string; garminVo2max: number; ourVdot: number | null }[];
+  racePrediction: { date: string; garminSeconds: number | null; ourVdot: number | null }[];
+}
+
+export interface SimulationSeeds {
+  pmc: { ctl: number; atl: number; tsb: number };
+  banister: { p0: number; k1: number; k2: number; tau1: number; tau2: number; nAnchors: number };
+  readiness: { compositeZ: number; trafficLight: string };
+  fitness: { vdotAdjusted: number; weightKg: number; calibrationWeightKg: number };
+  planDays: PlanDay[];
+  sliderMultiplier: number;
+  comparison?: ComparisonData;
+  epocScaleFactor?: number; // scale plan loads (distance×intensity) to EPOC units
+}
+
+export interface PlanDay {
+  id: number;
+  dayDate: string;
+  runType: string;
+  runTitle: string;
+  targetDistanceKm: number;
+  workoutSteps: any;
+  loadLevel: string;
+  gymWorkout: string | null;
+  completed: boolean;
+}
+
+export interface ProjectedDay {
+  dayDate: string;
+  dayId: number;
+  runType: string;
+
+  // PMC state
+  ctl: number;
+  atl: number;
+  tsb: number;
+
+  // Readiness
+  projectedZ: number;
+
+  // Merge factors
+  readinessFactor: number;
+  fatigueFactor: number;
+  weightFactor: number;
+  combinedFactor: number;
+
+  // Adapted targets
+  originalPace: number;
+  adjustedPace: number | null; // null = REST signal
+  originalDistanceKm: number;
+  adjustedDistanceKm: number;
+
+  // Projected fitness
+  projectedVdot: number;
+
+  // Model output: predicted HM pace (base HM pace × merge factors)
+  predictedHmPace: number | null; // sec/km, null for rest days
+
+  // Adaptation delta
+  paceChangePct: number;
+  distanceChangePct: number;
+
+  // Estimated load for this day
+  estimatedLoad: number;
+
+  // VDOT-zone fields
+  basePaceForType: number;       // base pace from VDOT zone for this run type
+  hrZone: { low: number; high: number; zone: string } | null;
+  trafficLight: "green" | "yellow" | "red";
+  effectiveRunType: string;      // may be downgraded by yellow/red
+
+  // Flags
+  isRest: boolean;
+  hasSequencingConflict: boolean;
+}
+
+// ── Intensity multipliers by run type ────────────────────────
+
+const INTENSITY_MULTIPLIER: Record<string, number> = {
+  easy: 0.6,
+  recovery: 0.5,
+  tempo: 1.0,
+  threshold: 1.0,
+  intervals: 1.2,
+  long: 0.8,
+  race: 1.3,
+  strides: 0.7,
+  rest: 0,
+};
+
+// ── Hard run types for sequencing ────────────────────────────
+
+const HARD_RUN_TYPES = new Set(["tempo", "intervals", "threshold", "race"]);
+const LEG_WORKOUTS = new Set(["legs", "lower"]);
+
+// ── Traffic light rest decisions ─────────────────────────────
+
+function getTrafficLight(z: number): "green" | "yellow" | "red" {
+  if (z > -0.5) return "green";
+  if (z > -1.5) return "yellow";
+  return "red";
+}
+
+function downgradeRunType(runType: string, light: "yellow" | "red"): string {
+  if (light === "red") return "rest";
+  // yellow: downgrade hard sessions to easy
+  if (["tempo", "threshold", "intervals", "race"].includes(runType)) return "easy";
+  return runType;
+}
+
+// ── Forward simulation ──────────────────────────────────────
+
+export function runForwardSimulation(seeds: SimulationSeeds): ProjectedDay[] {
+  const { pmc, banister, readiness, fitness, planDays, sliderMultiplier } = seeds;
+  const epocScale = seeds.epocScaleFactor ?? 1;
+
+  const tau1 = banister.tau1;
+  const tau2 = banister.tau2;
+  const alphaCtl = 1 - Math.exp(-1 / tau1);
+  const alphaAtl = 1 - Math.exp(-1 / tau2);
+
+  const weightFactor = fitness.calibrationWeightKg > 0
+    ? fitness.weightKg / fitness.calibrationWeightKg
+    : 1.0;
+
+  let ctl = pmc.ctl;
+  let atl = pmc.atl;
+  let projectedZ = readiness.compositeZ;
+
+  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const results: ProjectedDay[] = [];
+
+  // Track recent gym days for sequencing
+  const recentGymDates: string[] = [];
+
+  // Banister projection: use fitted p0 (historical baseline) with calibrated warm-start
+  // so accumulated loads reproduce currentVdot at plan start, then plan loads add
+  // realistic incremental improvement (dips after hard days, recovery on rest, taper peak).
+  const k1 = seeds.banister?.k1 ?? DEFAULT_BANISTER.k1;
+  const k2 = seeds.banister?.k2 ?? DEFAULT_BANISTER.k2;
+  const currentVdot = seeds.fitness?.vdotAdjusted ?? DEFAULT_BANISTER.p0;
+  const fittedP0 = seeds.banister?.p0 ?? DEFAULT_BANISTER.p0;
+
+  const banisterParams: BanisterParams = {
+    p0: fittedP0,
+    k1,
+    k2,
+    tau1: seeds.banister?.tau1 ?? DEFAULT_BANISTER.tau1,
+    tau2: seeds.banister?.tau2 ?? DEFAULT_BANISTER.tau2,
+  };
+
+  // Calibrate warm-start: find load level that makes Banister output ≈ currentVdot at plan start.
+  // Solve: currentVdot = p0 + warmLoad * (k1·Σexp(-dt/τ1) - k2·Σexp(-dt/τ2))
+  const WARMUP_DAYS = 60;
+  let fitnessDecaySum = 0;
+  let fatigueDecaySum = 0;
+  for (let dt = 1; dt <= WARMUP_DAYS; dt++) {
+    fitnessDecaySum += Math.exp(-dt / tau1);
+    fatigueDecaySum += Math.exp(-dt / tau2);
+  }
+  const vdotGap = currentVdot - fittedP0;
+  const denominator = k1 * fitnessDecaySum - k2 * fatigueDecaySum;
+  const warmStartLoad = denominator > 0.001 ? vdotGap / denominator : 0;
+
+  // Build warm-start loads
+  const warmStartLoads: DailyLoad[] = [];
+  if (planDays.length > 0 && warmStartLoad > 0) {
+    const startMs = new Date(planDays[0].dayDate + "T00:00:00").getTime();
+    for (let i = WARMUP_DAYS; i >= 1; i--) {
+      warmStartLoads.push({
+        date: new Date(startMs - i * 86400000).toISOString().split("T")[0],
+        load: warmStartLoad,
+      });
+    }
+  }
+
+  // First pass: estimate EPOC-scaled loads for Banister (run only — gym doesn't affect VDOT)
+  const planLoads: DailyLoad[] = planDays.map(day => ({
+    date: day.dayDate,
+    load: estimateDayLoad(day, sliderMultiplier).runLoad * epocScale,
+  }));
+  const dailyLoads: DailyLoad[] = [...warmStartLoads, ...planLoads];
+
+  // Project VDOT for every day using full Banister model
+  const allVdots = projectVdotSeries(dailyLoads, banisterParams);
+  const vdotSeries = allVdots.slice(warmStartLoads.length);
+
+  for (let dayIndex = 0; dayIndex < planDays.length; dayIndex++) {
+    const day = planDays[dayIndex];
+    const isRest = day.runType === "rest";
+    const isCompleted = day.completed;
+    const isFuture = day.dayDate >= today;
+
+    // Sequencing conflict detection
+    const hasSequencingConflict = checkSequencingConflict(
+      day.dayDate, day.runType, recentGymDates,
+    );
+
+    // Track gym days
+    if (day.gymWorkout && LEG_WORKOUTS.has(day.gymWorkout.toLowerCase())) {
+      recentGymDates.push(day.dayDate);
+      if (recentGymDates.length > 5) recentGymDates.shift();
+    }
+
+    if (!isFuture || isCompleted) {
+      // Past/completed days: use actual data, just propagate PMC
+      const { runLoad, gymLoad } = estimateDayLoad(day, sliderMultiplier);
+      const epocLoad = runLoad * epocScale + gymLoad; // run load scaled to EPOC, gym already in EPOC
+      const totalLoad = runLoad + gymLoad;
+      ctl = epocLoad * alphaCtl + ctl * (1 - alphaCtl);
+      atl = epocLoad * alphaAtl + atl * (1 - alphaAtl);
+
+      // Use per-day Banister VDOT (varies over time) instead of static current VDOT
+      const pastVdot = vdotSeries[dayIndex] ?? fitness.vdotAdjusted;
+      const pastBasePace = getBasePace(pastVdot, day.runType);
+      const pastHmBase = isRest ? null : Math.round(estimateHMSeconds(pastVdot) / 21.0975);
+
+      results.push({
+        dayDate: day.dayDate,
+        dayId: day.id,
+        runType: day.runType,
+        ctl, atl, tsb: ctl - atl,
+        projectedZ,
+        readinessFactor: 1.0,
+        fatigueFactor: 1.0,
+        weightFactor,
+        combinedFactor: 1.0,
+        originalPace: pastBasePace,
+        adjustedPace: pastBasePace,
+        originalDistanceKm: day.targetDistanceKm,
+        adjustedDistanceKm: day.targetDistanceKm,
+        projectedVdot: pastVdot,
+        predictedHmPace: pastHmBase,
+        paceChangePct: 0,
+        distanceChangePct: 0,
+        estimatedLoad: totalLoad,
+        basePaceForType: pastBasePace,
+        hrZone: day.runType === "rest" ? null : getHRZone(day.runType),
+        trafficLight: "green",
+        effectiveRunType: day.runType,
+        isRest,
+        hasSequencingConflict: false,
+      });
+      continue;
+    }
+
+    // ── Future day: full projection ──
+
+    // 1. Estimate training load (run load in raw units, gym load in EPOC units)
+    const { runLoad, gymLoad } = estimateDayLoad(day, sliderMultiplier);
+    const epocLoad = runLoad * epocScale + gymLoad; // run scaled to EPOC, gym already EPOC
+    const totalLoad = runLoad + gymLoad;
+
+    // 2. Propagate PMC with personal tau (using EPOC-scale loads to match actual CTL/ATL)
+    ctl = epocLoad * alphaCtl + ctl * (1 - alphaCtl);
+    atl = epocLoad * alphaAtl + atl * (1 - alphaAtl);
+    const tsb = ctl - atl;
+
+    // 3. Project readiness (load-reactive model, using EPOC-scale loads)
+    if (isRest) {
+      projectedZ = projectedZ + (0 - projectedZ) * 0.4;
+    } else {
+      const intensity = INTENSITY_MULTIPLIER[day.runType] ?? 0.6;
+      if (intensity >= 0.9) {
+        // Hard session: z drops (denominator calibrated for EPOC-scale ~200)
+        projectedZ -= Math.min(epocLoad / 200, 1.0);
+      } else {
+        // Easy day: z recovers 0.2/day toward 0
+        projectedZ = projectedZ + (0 - projectedZ) * 0.2;
+      }
+    }
+
+    // Sequencing penalty
+    if (hasSequencingConflict) {
+      projectedZ -= 0.3;
+    }
+
+    // 4. Apply merge formula
+    const rf = readinessFactorCalc(projectedZ);
+    const ff = fatigueFactorCalc(tsb);
+
+    // Traffic light decision
+    const light = getTrafficLight(projectedZ);
+    const effectiveRunType = light === "green" ? day.runType :
+      downgradeRunType(day.runType, light);
+
+    // Get VDOT-based pace for this specific workout type
+    const dayVdot = vdotSeries[dayIndex] ?? fitness.vdotAdjusted;
+    const basePaceForType = getBasePace(dayVdot, effectiveRunType);
+    const hrZone = effectiveRunType === "rest" ? null : getHRZone(effectiveRunType);
+
+    let combinedFactor: number;
+    let adjustedPace: number | null;
+    let adjustedDistanceKm: number;
+    let predictedHmPace: number | null;
+
+    if (rf < 0) {
+      // REST signal (z <= -2.0)
+      combinedFactor = 1.0;
+      adjustedPace = null;
+      adjustedDistanceKm = 0;
+      predictedHmPace = null;
+    } else {
+      combinedFactor = rf * ff * weightFactor;
+      const delta = combinedFactor - 1.0;
+      const sliderAdjusted = 1.0 + delta * sliderMultiplier;
+
+      // Apply merge formula to the type-specific base pace
+      adjustedPace = Math.round(basePaceForType * sliderAdjusted);
+
+      // Distance: preserve training load (load ≈ distance × intensity)
+      adjustedDistanceKm = Math.round(
+        day.targetDistanceKm * (2.0 - combinedFactor) * 10,
+      ) / 10;
+
+      // Predicted HM pace: base HM pace from VDOT × merge factors
+      const dayVdot = vdotSeries[dayIndex] ?? fitness.vdotAdjusted;
+      const baseHmPace = estimateHMSeconds(dayVdot) / 21.0975;
+      predictedHmPace = Math.round(baseHmPace * sliderAdjusted);
+    }
+
+    // 5. Project VDOT via Banister model
+    const projectedVdot = vdotSeries[dayIndex] ?? fitness.vdotAdjusted;
+
+    // Compute deltas
+    const paceChangePct = adjustedPace != null
+      ? Math.round(((adjustedPace - basePaceForType) / basePaceForType) * 1000) / 10
+      : 0;
+    const distanceChangePct = day.targetDistanceKm > 0
+      ? Math.round(((adjustedDistanceKm - day.targetDistanceKm) / day.targetDistanceKm) * 1000) / 10
+      : 0;
+
+    results.push({
+      dayDate: day.dayDate,
+      dayId: day.id,
+      runType: day.runType,
+      ctl, atl, tsb,
+      projectedZ,
+      readinessFactor: rf < 0 ? -1 : Math.round(rf * 10000) / 10000,
+      fatigueFactor: Math.round(ff * 10000) / 10000,
+      weightFactor: Math.round(weightFactor * 10000) / 10000,
+      combinedFactor: Math.round(combinedFactor * 10000) / 10000,
+      originalPace: basePaceForType,
+      adjustedPace: adjustedPace != null ? Math.round(adjustedPace * 10) / 10 : null,
+      originalDistanceKm: day.targetDistanceKm,
+      adjustedDistanceKm,
+      projectedVdot,
+      predictedHmPace,
+      paceChangePct,
+      distanceChangePct,
+      estimatedLoad: totalLoad,
+      basePaceForType,
+      hrZone,
+      trafficLight: light,
+      effectiveRunType,
+      isRest: isRest || rf < 0,
+      hasSequencingConflict,
+    });
+  }
+
+  return results;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/** Estimate day's training load in raw units (distance × intensity).
+ *  Gym load is returned separately since it's already in EPOC-like units
+ *  and must NOT be multiplied by the EPOC scale factor.
+ */
+function estimateDayLoad(day: PlanDay, sliderMultiplier: number): { runLoad: number; gymLoad: number } {
+  if (day.runType === "rest") return { runLoad: 0, gymLoad: 0 };
+
+  const intensity = INTENSITY_MULTIPLIER[day.runType] ?? 0.6;
+  const runLoad = day.targetDistanceKm * intensity * sliderMultiplier;
+
+  // Gym load in EPOC units directly (~60 EPOC for a typical strength session)
+  const gymLoad = day.gymWorkout ? 60 : 0;
+
+  return { runLoad, gymLoad };
+}
+
+function checkSequencingConflict(
+  dayDate: string,
+  runType: string,
+  recentGymDates: string[],
+): boolean {
+  if (!HARD_RUN_TYPES.has(runType)) return false;
+
+  const dayMs = new Date(dayDate + "T00:00:00").getTime();
+
+  for (const gymDate of recentGymDates) {
+    const gymMs = new Date(gymDate + "T00:00:00").getTime();
+    const daysDiff = (dayMs - gymMs) / 86400000;
+    if (daysDiff > 0 && daysDiff <= 2) return true;
+  }
+
+  return false;
+}

--- a/universal/src/lib/project-days.ts
+++ b/universal/src/lib/project-days.ts
@@ -1,0 +1,51 @@
+import { runForwardSimulation, type ProjectedDay, type SimulationSeeds, type PlanDay as FsPlanDay } from "./forward-simulation";
+import type { ForwardSim } from "./api";
+
+export type { ProjectedDay };
+
+/**
+ * Run the client-side forward simulation over the forward-sim payload, mapping
+ * each plan day (by id) to its projected readiness-adjusted pace / traffic
+ * light. Mirrors the web dashboard, which runs the same `runForwardSimulation`
+ * client-side. Returns null when the seeds needed for the projection are
+ * absent (older payloads that don't carry banister / epoc scale).
+ */
+export function projectDays(
+  sim: ForwardSim | null | undefined,
+  sliderMultiplier = 1.0,
+): Map<number, ProjectedDay> | null {
+  if (!sim || !sim.pmc || !sim.banister || !sim.fitness || sim.fitness.vdotAdjusted == null) return null;
+  const seeds: SimulationSeeds = {
+    pmc: sim.pmc,
+    banister: sim.banister,
+    readiness: { compositeZ: sim.readiness?.compositeZ ?? 0, trafficLight: sim.readiness?.trafficLight ?? "green" },
+    fitness: {
+      vdotAdjusted: sim.fitness.vdotAdjusted,
+      weightKg: sim.fitness.weightKg ?? 70,
+      calibrationWeightKg: sim.fitness.calibrationWeightKg ?? 80.5,
+    },
+    planDays: sim.planDays as unknown as FsPlanDay[],
+    sliderMultiplier,
+    epocScaleFactor: sim.epocScaleFactor,
+  };
+  try {
+    const m = new Map<number, ProjectedDay>();
+    for (const d of runForwardSimulation(seeds)) m.set(d.dayId, d);
+    return m;
+  } catch {
+    return null;
+  }
+}
+
+/** sec/km → "M:SS". */
+export function paceStr(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = Math.round(sec % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export const TRAFFIC_COLOR: Record<string, string> = {
+  green: "#6ad4a0",
+  yellow: "#e0c458",
+  red: "#e06060",
+};

--- a/universal/src/lib/training-engine.ts
+++ b/universal/src/lib/training-engine.ts
@@ -1,0 +1,49 @@
+/**
+ * Minimal training-engine subset for the client-side forward simulation.
+ * These three exports are copied verbatim from web/lib/training-engine.ts
+ * (the only members forward-simulation.ts depends on); the rest of the web
+ * module pulls in server-only helpers the app doesn't need.
+ */
+
+/** Default B-goal base pace: 284 sec/km (4:44/km). */
+export const DEFAULT_BASE_PACE = 284.0;
+
+/**
+ * Map readiness composite-z to a pace adjustment factor.
+ * Linear interpolation between anchor points.
+ * Returns -1.0 as REST signal when z <= -2.
+ */
+export function readinessFactorCalc(z: number): number {
+  if (z <= -2.0) return -1.0; // REST
+  if (z >= 1.0) return 0.97;
+  if (z >= 0.0) {
+    // Linear: z=0 -> 1.00, z=1 -> 0.97 (slope = -0.03/unit)
+    return 1.0 - 0.03 * z;
+  }
+  if (z >= -1.0) {
+    // Linear: z=0 -> 1.00, z=-1 -> 1.05 (slope = -0.05/unit going negative)
+    return 1.0 - 0.05 * z;
+  }
+  // z in (-2, -1): clamp at 1.05 (max slowdown before REST)
+  return 1.05;
+}
+
+/**
+ * Map TSB (Training Stress Balance) to pace adjustment factor.
+ *
+ * TSB >= +10  -> 0.98 (fresh, slightly faster)
+ * TSB = 0     -> 1.00 (normal)
+ * TSB <= -20  -> 1.03 (fatigued, slower)
+ *
+ * Linear interpolation between anchor points.
+ */
+export function fatigueFactorCalc(tsb: number): number {
+  if (tsb >= 10.0) return 0.98;
+  if (tsb <= -20.0) return 1.03;
+  if (tsb >= 0.0) {
+    // Linear: tsb=0 -> 1.00, tsb=10 -> 0.98 (slope = -0.002/unit)
+    return 1.0 - 0.002 * tsb;
+  }
+  // tsb in (-20, 0): linear from 1.00 to 1.03 (slope = -0.0015/unit)
+  return 1.0 - 0.0015 * tsb;
+}

--- a/universal/src/lib/vdot-utils.ts
+++ b/universal/src/lib/vdot-utils.ts
@@ -1,0 +1,27 @@
+/** Estimate half-marathon time from VDOT using Daniels/Gilbert equations. */
+export function estimateHMSeconds(vdot: number): number {
+  const HM_M = 21097.5;
+  // Binary search: vdot_from_race(HM_M, t) == vdot
+  let lo = 60, hi = 86400;
+  for (let i = 0; i < 80; i++) {
+    const mid = (lo + hi) / 2;
+    const tMin = mid / 60;
+    const vel = HM_M / tMin;
+    const vo2 = -4.60 + 0.182258 * vel + 0.000104 * vel * vel;
+    const frac = 0.8 + 0.1894393 * Math.exp(-0.012778 * tMin) + 0.2989558 * Math.exp(-0.1932605 * tMin);
+    const computed = vo2 / frac;
+    if (computed > vdot) lo = mid; else hi = mid;
+  }
+  return Math.round((lo + hi) / 2);
+}
+
+/** Inverse of estimateHMSeconds: given HM time in seconds, return the VDOT. */
+export function vdotFromHmSeconds(seconds: number): number {
+  // Higher VDOT = faster (fewer seconds)
+  let lo = 20, hi = 85;
+  for (let i = 0; i < 80; i++) {
+    const mid = (lo + hi) / 2;
+    if (estimateHMSeconds(mid) > seconds) lo = mid; else hi = mid;
+  }
+  return Math.round((lo + hi) / 2 * 10) / 10;
+}


### PR DESCRIPTION
## What

The web training view runs `runForwardSimulation` client-side over the forward-sim seeds to project each plan day's readiness-adjusted pace, traffic light and REST signal. The mobile app fetched the same seeds but never ran the projection. This ports it.

Each run day of the schedule now shows:
- the **readiness-adjusted pace** with a **traffic-light dot** (green / yellow / red)
- a **"% vs base" badge** when the adjusted pace differs from the base VDOT pace by ≥0.5%
- a **"⛔ REST — readiness critical"** signal on days the model forces to rest (projected z ≤ −2)
- the HR zone for the run type

Falls back to the base VDOT pace (shipped in #499) when the projection seeds aren't present.

## How

- `forward-simulation.ts`, `banister-projection.ts`, `vdot-utils.ts` are **verbatim copies** of `web/lib`, so the projection is golden-matching by construction (same code, pure math).
- `training-engine.ts` is a minimal verbatim extract of the three members `forward-simulation` imports (`readinessFactorCalc`, `fatigueFactorCalc`, `DEFAULT_BASE_PACE`) — the full web module pulls in server-only helpers.
- `project-days.ts` assembles `SimulationSeeds` from the `ForwardSim` payload and returns a `Map<dayId, ProjectedDay>`.
- `ForwardSim` gains `banister`, `epocScaleFactor`, `fitness.calibrationWeightKg` — all already returned by `/api/training/forward-sim`, just previously undeclared. No API change.

## Verified

- `tsc --noEmit` clean; 0 console errors
- Playwright on Expo web, **real production seeds**: `projectDays` runs (35 plan days), every run day renders a traffic-light dot; today's green readiness (z ≈ −0.04) → green dots with adjusted ≈ base (no badge — correct).
- Playwright with **forced future days + critical readiness** (to exercise the projection, since the demo plan is entirely historical): renders adjusted paces (5:40/km) with red + yellow dots, "−4.2% vs base" / "−3.7% vs base" badges, and "⛔ REST — readiness critical" on the forced-rest days; the traffic light decays red→yellow→green across days as projected z regresses toward 0 — matching the web engine.

## Follow-up

The live what-if slider recompute (re-running the projection with a slider multiplier, no save) is a natural next step now that the engine is in place.

## Files

- `universal/src/lib/forward-simulation.ts`, `banister-projection.ts`, `vdot-utils.ts`, `training-engine.ts` (new, ported)
- `universal/src/lib/project-days.ts` (new)
- `universal/src/lib/api.ts` — `ForwardSim` seed fields
- `universal/src/components/training-schedule.tsx`, `universal/src/app/(main)/training.tsx`

Part of #473.

Closes #503
