### PR TITLE
feat(training): live what-if preview (#505)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -89,7 +89,9 @@ export default function TrainingScreen() {
   const fit = data?.fitness;
   const readiness = data?.readiness;
   const vdot = fit?.vdot_adjusted ?? sim?.fitness?.vdotAdjusted ?? null;
-  const projected = useMemo(() => projectDays(sim), [sim]);
+  const [whatIfFactor, setWhatIfFactor] = useState(1.0);
+  // Re-run the forward simulation live as the what-if slider moves (no save).
+  const projected = useMemo(() => projectDays(sim, whatIfFactor), [sim, whatIfFactor]);
   const vo2Trend = useVo2Trend();
 
   // External comparison signals (Garmin-side + PMC) with trend sparklines.
@@ -211,9 +213,10 @@ export default function TrainingScreen() {
         {planDays.length ? (
           <WhatIfSlider
             planDays={planDays}
+            onPreview={setWhatIfFactor}
             onApply={async (factor, dayIds) => {
               const ok = await applyIntensity(factor, dayIds);
-              if (ok) refetchSim();
+              if (ok) { setWhatIfFactor(1.0); refetchSim(); }
               return ok;
             }}
           />

--- a/universal/src/components/whatif-slider.tsx
+++ b/universal/src/components/whatif-slider.tsx
@@ -14,9 +14,11 @@ type SaveState = "idle" | "saving" | "saved" | "error";
  * trim) previews scaling the upcoming plan, then "Apply changes" persists the
  * deltas via onApply. An override banner shows while intensity ≠ 1.0×.
  */
-export function WhatIfSlider({ planDays, onApply }: { planDays: PlanDay[]; onApply?: (factor: number, dayIds: number[]) => Promise<boolean> }) {
+export function WhatIfSlider({ planDays, onApply, onPreview }: { planDays: PlanDay[]; onApply?: (factor: number, dayIds: number[]) => Promise<boolean>; onPreview?: (factor: number) => void }) {
   const [factor, setFactor] = useState(1.0);
   const [state, setState] = useState<SaveState>("idle");
+  const setFactorPreview = (next: number) => { setFactor(next); onPreview?.(next); };
+  const stepFactor = (delta: number) => setFactor((f) => { const next = clamp(f + delta); onPreview?.(next); return next; });
 
   const upcoming = useMemo(
     () => (planDays ?? []).filter((d) => !d.completed && d.targetDistanceKm != null && num(d.targetDistanceKm) > 0),
@@ -26,7 +28,7 @@ export function WhatIfSlider({ planDays, onApply }: { planDays: PlanDay[]; onApp
   const scaledKm = baseKm * factor;
   const changed = Math.abs(factor - 1) > 0.001;
 
-  const step = (delta: number) => { setFactor((f) => clamp(f + delta)); setState("idle"); };
+  const step = (delta: number) => { stepFactor(delta); setState("idle"); };
   const pct = Math.round(factor * 100);
   const label = factor < 0.98 ? "Easier" : factor > 1.02 ? "Harder" : "Normal";
   const labelColor = factor < 0.98 ? "#6ad4a0" : factor > 1.02 ? "#e0a458" : "#8aa0ac";
@@ -36,7 +38,7 @@ export function WhatIfSlider({ planDays, onApply }: { planDays: PlanDay[]; onApp
     setState("saving");
     const ok = await onApply(factor, upcoming.map((d) => d.id));
     setState(ok ? "saved" : "error");
-    if (ok) setFactor(1.0);
+    if (ok) setFactorPreview(1.0);
   }
 
   if (!upcoming.length) return null;
@@ -77,7 +79,7 @@ export function WhatIfSlider({ planDays, onApply }: { planDays: PlanDay[]; onApp
       {changed ? (
         <View className="rounded-lg px-3 py-2" style={{ backgroundColor: (factor > 1 ? "#e0a458" : "#6ad4a0") + "1a" }}>
           <Text variant="micro" style={{ color: factor > 1 ? "#e0a458" : "#6ad4a0" }}>
-            Override active — upcoming workouts scaled to {pct}%. Apply to persist.
+            Previewing the schedule at {pct}% — paces above update live. Apply to persist.
           </Text>
         </View>
       ) : null}


### PR DESCRIPTION
## What

The mobile what-if slider only previewed total km and needed Apply before any pace effect showed. The web slider recomputes the whole plan live. Now that the forward-simulation engine is in the app (#503), the slider drives it:

- moving the slider re-runs `projectDays(sim, factor)` and the schedule's adjusted paces + "% vs base" badges update **live**, no save
- **Apply** still persists the deltas and resets the preview to 100%
- the banner now reads "Previewing the schedule at N% — paces above update live"

## How

`WhatIfSlider` gains an `onPreview(factor)` callback fired on every step; training holds a `whatIfFactor` state and memoizes `projectDays(sim, whatIfFactor)`. The stepper uses a functional `setFactor` updater so rapid taps compound.

## Verified

- `tsc --noEmit` clean; 0 app console errors
- Playwright on Expo web (forced future days so the slider renders + the projection is live): stepping to "Harder · 125%" changes the km preview 48→60 (+12) AND the schedule's live badges shift from −4.2% / −5.1% / −4% (100%) to −5.4% / −6.2% / −4.5% (125%); the stepper accumulates correctly (5 taps → 125%).

## Files

- `universal/src/components/whatif-slider.tsx`
- `universal/src/app/(main)/training.tsx`

Part of #473.

Closes #505
