### PR TITLE
feat(nutrition): today's context strip (#509)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -11,6 +11,7 @@ import { ActivitySelector } from "../../components/activity-selector";
 import { ComposeMealView } from "../../components/compose-meal-view";
 import { MealDetailModal } from "../../components/meal-detail-modal";
 import { MacroGoalBar, buildMacroMarkers, ProteinQualityPill } from "../../components/macro-goal-bar";
+import { NutritionContextStrip } from "../../components/nutrition-context-strip";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -334,6 +335,8 @@ export default function NutritionScreen() {
             </Text>
           </View>
         </Card>
+
+        {tab === "Day" && isToday ? <NutritionContextStrip /> : null}
 
         {tab === "Day" ? (
           <>

--- a/universal/src/components/nutrition-context-strip.tsx
+++ b/universal/src/components/nutrition-context-strip.tsx
@@ -1,0 +1,50 @@
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import { useToday, useTraining, useSleepSummary, todayLocal } from "../lib/api";
+
+const TL_COLOR: Record<string, string> = {
+  green: "#6ad4a0", yellow: "#e0c458", red: "#e06060", amber: "#e0a458",
+};
+const tlColor = (t: string | null | undefined) => TL_COLOR[(t ?? "").toLowerCase()] ?? "#8aa0ac";
+
+function Chip({ icon, label, value, color }: { icon?: string; label: string; value: string; color?: string }) {
+  return (
+    <View className="flex-row items-center gap-1.5">
+      {color ? <View className="h-2 w-2 rounded-full" style={{ backgroundColor: color }} /> : icon ? <Text variant="micro">{icon}</Text> : null}
+      <Text variant="micro" className="tabular-nums" style={color ? { color } : undefined}>{value}</Text>
+      <Text variant="micro" className="text-text-muted">{label}</Text>
+    </View>
+  );
+}
+
+/**
+ * Today's training + recovery context on the nutrition screen (web parity):
+ * steps, training readiness/form, and last night's sleep — the signals that
+ * explain why today's targets look the way they do. Renders only what's
+ * present; nothing when no context has loaded.
+ */
+export function NutritionContextStrip() {
+  const { data: today } = useToday();
+  const { data: training } = useTraining(todayLocal());
+  const { data: sleep } = useSleepSummary("7d");
+
+  const steps = today?.total_steps;
+  const tl = training?.readiness?.traffic_light;
+  const tsb = training?.pmc?.tsb;
+  const ln = sleep?.lastNight;
+  const sleepH = ln?.total != null ? ln.total / 3600 : null;
+
+  const chips: React.ReactNode[] = [];
+  if (steps != null && steps > 0) chips.push(<Chip key="steps" icon="👟" value={steps.toLocaleString()} label="steps" />);
+  if (tl) chips.push(<Chip key="rdy" color={tlColor(tl)} value={tl} label="readiness" />);
+  if (tsb != null && isFinite(tsb)) chips.push(<Chip key="form" icon="📈" value={`${tsb > 0 ? "+" : ""}${Math.round(tsb)}`} label="form" />);
+  if (sleepH != null && sleepH > 0) chips.push(<Chip key="sleep" icon="💤" value={`${sleepH.toFixed(1)}h${ln?.score != null ? ` · ${ln.score}` : ""}`} label="slept" />);
+
+  if (!chips.length) return null;
+
+  return (
+    <Card className="flex-row flex-wrap items-center gap-x-4 gap-y-1.5 py-2.5">
+      {chips}
+    </Card>
+  );
+}


### PR DESCRIPTION
## What

The web nutrition screen shows a strip of today's training + recovery context; the mobile screen omitted it. This adds a compact context strip near the top of the Day view (today only):

- 👟 steps (`useToday.total_steps`)
- readiness (traffic-light colored) + 📈 form/TSB (`useTraining`)
- 💤 last night's sleep hours + score (`useSleepSummary.lastNight`)

Each chip renders only when its data is present (graceful — readiness omits when the breakdown has no readiness).

## Data

Uses existing hooks (`useToday`, `useTraining`, `useSleepSummary`). No API change.

## Verified

- `tsc --noEmit` clean; 0 console errors
- Playwright on Expo web (real local data): strip renders "👟 8,321 steps · 💤 3.7h · 49 slept" plus the form/TSB chip; readiness gracefully omits (null in the local breakdown today).

## Files

- `universal/src/components/nutrition-context-strip.tsx` (new)
- `universal/src/app/(main)/nutrition.tsx`

Part of #473.

Closes #509
