### PR TITLE
feat(training): readiness drivers from graph edges (#511)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -63,7 +63,7 @@ export default function TrainingScreen() {
   const { data, error, refetch } = useTraining(todayISO());
   const { cal, refetch: refetchCal } = useCalibration(todayISO());
   const { data: sim, refetch: refetchSim } = useForwardSim(todayISO());
-  const { nodes: graphNodes, overrides: graphOverrides } = useTrainingGraph(todayISO());
+  const { nodes: graphNodes, edges: graphEdges, overrides: graphOverrides } = useTrainingGraph(todayISO());
   const { byDay: matches } = useActivityMatches();
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
@@ -244,7 +244,7 @@ export default function TrainingScreen() {
         <TrainingPaces vdot={vdot} />
 
         {/* Pace computation breakdown — mobile replacement for the web DAG */}
-        <PaceComputation nodes={graphNodes} />
+        <PaceComputation nodes={graphNodes} edges={graphEdges} />
 
         {/* Fitness trajectory — the centerpiece: model vs Garmin across
             Fitness (VDOT) / Readiness / Load. Replaces the flat VO2 sparkline. */}

--- a/universal/src/components/pace-computation.tsx
+++ b/universal/src/components/pace-computation.tsx
@@ -1,14 +1,23 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
-import type { GraphNode } from "../lib/api";
+import type { GraphNode, GraphEdge } from "../lib/api";
 import { paceStr } from "../lib/vdot";
+
+const READINESS_INPUTS = [
+  { id: "hrv_z", label: "HRV" },
+  { id: "sleep_z", label: "Sleep" },
+  { id: "rhr_z", label: "RHR" },
+  { id: "bb_z", label: "Body Batt" },
+];
 
 /**
  * Mobile-native replacement for the web's draggable computation-graph DAG.
  * Shows the same signals → factors → adjusted-pace flow as a compact breakdown:
- * raw signals, then the multiplicative factors that bend today's pace.
+ * the multiplicative factors that bend today's pace, then the calibrated
+ * readiness drivers (each signal's z-value + its weight into the readiness
+ * factor — the graph edges).
  */
-export function PaceComputation({ nodes }: { nodes: Record<string, GraphNode> }) {
+export function PaceComputation({ nodes, edges = [] }: { nodes: Record<string, GraphNode>; edges?: GraphEdge[] }) {
   const val = (id: string): number | null => {
     const v = nodes[id]?.value;
     return v == null || !isFinite(Number(v)) ? null : Number(v);
@@ -16,6 +25,15 @@ export function PaceComputation({ nodes }: { nodes: Record<string, GraphNode> })
 
   const adjusted = val("adjusted_pace"); // seconds/km
   const vdot = val("vdot");
+
+  // Readiness drivers: each z-signal's calibrated weight (edge → readiness_factor).
+  const drivers = READINESS_INPUTS
+    .map((s) => {
+      const e = edges.find((ed) => ed.from === s.id && ed.to === "readiness_factor");
+      return { ...s, weight: e != null ? Math.abs(e.weight) : null, z: val(s.id) };
+    })
+    .filter((d) => d.weight != null);
+  const totalW = drivers.reduce((sum, d) => sum + (d.weight ?? 0), 0) || 1;
 
   const factors = [
     { label: "Readiness", v: val("readiness_factor"), color: "#6ad4a0" },
@@ -68,8 +86,28 @@ export function PaceComputation({ nodes }: { nodes: Record<string, GraphNode> })
         })}
       </View>
 
-      {/* raw readiness signals feeding the factors */}
-      {signals.length ? (
+      {/* Readiness drivers: each signal's calibrated weight into the readiness factor */}
+      {drivers.length ? (
+        <View className="gap-1.5 border-t border-border-subtle pt-2.5">
+          <Text variant="micro" className="text-text-muted">READINESS DRIVERS · calibrated weights</Text>
+          {drivers.map((d) => {
+            const wPct = Math.round(((d.weight as number) / totalW) * 100);
+            return (
+              <View key={d.id} className="gap-0.5">
+                <View className="flex-row items-center justify-between">
+                  <Text variant="micro" className="text-text-secondary">
+                    {d.label}{d.z != null ? ` · ${(d.z as number) >= 0 ? "+" : ""}${(d.z as number).toFixed(2)} z` : ""}
+                  </Text>
+                  <Text variant="micro" className="tabular-nums text-text-muted">{wPct}%</Text>
+                </View>
+                <View className="h-1.5 overflow-hidden rounded-full" style={{ backgroundColor: "#16242c" }}>
+                  <View className="h-full rounded-full" style={{ width: `${wPct}%`, backgroundColor: "#6aa0e0" }} />
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      ) : signals.length ? (
         <View className="flex-row flex-wrap gap-2 border-t border-border-subtle pt-2.5">
           {signals.map((s) => (
             <View key={s.label} className="rounded-full bg-surface-subtle px-2.5 py-1">

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -719,30 +719,35 @@ export function useWeekdayWeekend(range: string) {
 
 // ---- Training computation graph (nodes → the mobile pace-computation breakdown) ----
 export interface GraphNode { id: string; label: string; value: number | null }
+/** A weighted edge in the readiness/pace computation graph (signal → factor). */
+export interface GraphEdge { from: string; to: string; weight: number }
 /** A hard readiness override (sleep < 5h, Body Battery < 25, HRV/majority flags). */
 export interface TrainingOverride { rule: string; triggered: boolean; message: string; severity: "red" | "yellow" }
 
-/** The computation-graph nodes keyed by id (readiness_factor, tsb, adjusted_pace, …)
- *  plus the TRIGGERED hard-override banners (forced RED / YELLOW safety rails). */
+/** The computation-graph nodes keyed by id (readiness_factor, tsb, adjusted_pace, …),
+ *  the weighted edges (which signal drives each factor), plus the TRIGGERED
+ *  hard-override banners (forced RED / YELLOW safety rails). */
 export function useTrainingGraph(date: string) {
   const [nodes, setNodes] = useState<Record<string, GraphNode>>({});
+  const [edges, setEdges] = useState<GraphEdge[]>([]);
   const [overrides, setOverrides] = useState<TrainingOverride[]>([]);
   const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
-    fetchJson<{ graph?: { nodes?: GraphNode[]; overrides?: TrainingOverride[] }; nodes?: GraphNode[] }>(`/api/training/graph?date=${date}`)
+    fetchJson<{ graph?: { nodes?: GraphNode[]; edges?: GraphEdge[]; overrides?: TrainingOverride[] }; nodes?: GraphNode[] }>(`/api/training/graph?date=${date}`)
       .then((d) => {
         if (!alive) return;
         const arr = d.graph?.nodes ?? d.nodes ?? [];
         const map: Record<string, GraphNode> = {};
         for (const nd of arr) map[nd.id] = nd;
         setNodes(map);
+        setEdges(d.graph?.edges ?? []);
         setOverrides((d.graph?.overrides ?? []).filter((o) => o.triggered));
       })
       .catch(() => {});
     return () => { alive = false; };
   }, [date, reload]);
-  return { nodes, overrides, refetch: () => setReload((n) => n + 1) };
+  return { nodes, edges, overrides, refetch: () => setReload((n) => n + 1) };
 }
 
 export function useSomaPlan(date: string) {


### PR DESCRIPTION
## What

The web computation-graph draws weighted edges showing how much each signal drives the readiness factor. The mobile PaceComputation discarded `graph.edges` and showed a flat signal-chip list. This adds a **readiness drivers** breakdown:

- each signal (HRV / Sleep / RHR / Body Battery) with its z-value
- its **calibrated weight** into the readiness factor (the edge weight), as a bar + %

This surfaces the adaptive calibration (which signal the model trusts most today). Falls back to the old signal chips when edges aren't present.

## Data

Uses `graph.edges` (`{ from, to, weight }`), already returned by `/api/training/graph` but previously dropped by `useTrainingGraph`. No API change.

## Verified

- `tsc --noEmit` clean; 0 console errors
- Playwright on Expo web (real seeds): the card renders "READINESS DRIVERS · calibrated weights" with HRV +0.00z / Sleep +0.00z / RHR −0.04z / Body Batt +0.00z each at 25% (default equal calibration, summing to 100%) with weight bars.

## Files

- `universal/src/lib/api.ts` — `GraphEdge` + `useTrainingGraph` returns `edges`
- `universal/src/components/pace-computation.tsx`
- `universal/src/app/(main)/training.tsx`

Part of #473.

Closes #511
