### PR TITLE
feat(activities): per-sport top speed + swim SWOLF (#515)

### DIFF
--- a/universal/src/components/activity-sports.tsx
+++ b/universal/src/components/activity-sports.tsx
@@ -27,12 +27,18 @@ function SportSection({ sport, rows }: { sport: string; rows: ActivityRow[] }) {
   const hours = mine.reduce((s, a) => s + num(a.duration_min), 0) / 60;
   const hrVals = mine.map((a) => num(a.avg_hr)).filter((v) => v > 0);
   const avgHr = hrVals.length ? Math.round(hrVals.reduce((a, b) => a + b, 0) / hrVals.length) : null;
+  const speeds = mine.map((a) => num(a.max_speed_ms)).filter((v) => v > 0);
+  const topKmh = speeds.length ? Math.max(...speeds) * 3.6 : null;
+  const swolfVals = mine.map((a) => num(a.swolf)).filter((v) => v > 0);
+  const avgSwolf = swolfVals.length ? Math.round(swolfVals.reduce((a, b) => a + b, 0) / swolfVals.length) : null;
   const stats: [string, string][] = [
     ["Sessions", `${mine.length}`],
     ["Distance", km > 0 ? `${km.toFixed(0)} km` : "—"],
     ["Time", `${hours.toFixed(0)}h`],
     ["Avg HR", avgHr != null ? `${avgHr} bpm` : "—"],
   ];
+  if (topKmh != null) stats.push(["Top speed", `${topKmh.toFixed(0)} km/h`]);
+  if (avgSwolf != null) stats.push(["Avg SWOLF", `${avgSwolf}`]);
 
   return (
     <Card className="gap-3">

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -442,6 +442,7 @@ export interface ActivityRow {
   activity_id: string; type_key: string; sport: string; date: string; name: string | null;
   distance_km: number | null; duration_min: number | null; avg_hr: number | null;
   calories: number | null; elev_gain: number;
+  max_speed_ms?: number | null; swolf?: number | null;
 }
 export interface ActivitiesDeep {
   monthly: MonthSports[];

--- a/web/app/api/activities/deep/route.ts
+++ b/web/app/api/activities/deep/route.ts
@@ -90,14 +90,16 @@ export async function GET(request: Request) {
       (raw_json->>'duration')::float / 60.0 as duration_min,
       (raw_json->>'averageHR')::float as avg_hr,
       (raw_json->>'calories')::float as calories,
-      COALESCE((raw_json->>'elevationGain')::float, 0) as elev_gain
+      COALESCE((raw_json->>'elevationGain')::float, 0) as elev_gain,
+      (raw_json->>'maxSpeed')::float as max_speed_ms,
+      (raw_json->>'averageSwolf')::float as swolf
     FROM garmin_activity_raw
     WHERE endpoint_name = 'summary'
       AND raw_json->'activityType'->>'typeKey' NOT IN ('running', 'treadmill_running', 'strength_training', 'indoor_cycling')
       AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
     ORDER BY (raw_json->>'startTimeLocal')::text DESC
     LIMIT 200
-  `) as { activity_id: string; type_key: string; date: string; name: string | null; distance_km: number | null; duration_min: number | null; avg_hr: number | null; calories: number | null; elev_gain: number }[];
+  `) as { activity_id: string; type_key: string; date: string; name: string | null; distance_km: number | null; duration_min: number | null; avg_hr: number | null; calories: number | null; elev_gain: number; max_speed_ms: number | null; swolf: number | null }[];
 
   return NextResponse.json({
     monthly,


### PR DESCRIPTION
## What

The web shows top-speed for cycling/wind sports and average SWOLF for swimming; the mobile per-sport sections showed only sessions/distance/time/avg-HR, because `/api/activities/deep` never returned those fields.

- **web** — the deep endpoint's `all` rows now include `max_speed_ms` and `swolf`, extracted from the Garmin `raw_json` (`maxSpeed`, `averageSwolf`), which already stores both.
- **app** — the per-sport section adds a **Top speed** stat (km/h) when the sport has a recorded speed, and an **Avg SWOLF** stat for swimming.

## Verified the data first (the "proper way")

Before touching the endpoint I inspected the DB: `maxSpeed` is present on cycling (40.7 / 37.9 km/h) and `averageSwolf` on swims (25 / 36 / 39). I also checked **run split power and dropped it** — runs have no power data (`averagePower` null, split laps have no power), so it's not buildable.

## Verified end-to-end

- web `tsc --noEmit` clean + `vitest run` 177/177 pass; mobile `tsc` clean
- With the web change hot-reloaded on the local dev server, the mobile app renders **Cycling · Top speed 45 km/h** and **Swimming · Top speed 10 km/h · Avg SWOLF 35** (Playwright screenshot).

## Files

- `web/app/api/activities/deep/route.ts`
- `universal/src/lib/api.ts` — `ActivityRow` gains `max_speed_ms` / `swolf`
- `universal/src/components/activity-sports.tsx`

Additive endpoint change (new fields only) — backward-compatible.

Part of #473.

Closes #515
