### PR TITLE
feat(running): dated pace scatter + mileage labels + weather (#517)

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -84,7 +84,12 @@ interface RecentRun {
   pace: number | null;
   avg_hr: number | null;
   calories: number | null;
+  temp_c?: number | null;
+  max_speed_ms?: number | null;
 }
+
+export interface PacePoint { date: string; pace: number; distance: number }
+export interface MileageMonth { month: string; km: number; runs: number }
 
 interface RunningPayload {
   stats: RunningStats | null;
@@ -93,7 +98,7 @@ interface RunningPayload {
   records: Records | null;
   shoeMileage: ShoeMileage[];
   recentRuns: RecentRun[];
-  trends: { pace: number[]; vo2max: number[]; mileage: number[] } | null;
+  trends: { pace: number[]; vo2max: number[]; mileage: number[]; paceDetail?: PacePoint[]; mileageDetail?: MileageMonth[] } | null;
 }
 
 /* ------------------------------------------------------------------ */
@@ -356,10 +361,10 @@ export default function RunningScreen() {
         ) : null}
 
         {/* Monthly mileage bar chart (web parity) */}
-        <RunningMileage mileage={trends?.mileage} />
+        <RunningMileage mileage={trends?.mileage} months={trends?.mileageDetail} />
 
         {/* Dedicated Pace Progression + VO2max Trend charts (web parity) */}
-        <RunningPaceVo2Charts pace={trends?.pace} vo2max={trends?.vo2max} />
+        <RunningPaceVo2Charts pace={trends?.pace} vo2max={trends?.vo2max} paceDetail={trends?.paceDetail} />
 
         {/* Recent route thumbnails (SVG shapes from /api/running/recent-routes) */}
         <RunningRoutes routes={routes} />

--- a/universal/src/components/run-table.tsx
+++ b/universal/src/components/run-table.tsx
@@ -14,6 +14,7 @@ export interface RunRow {
   pace: number | null; // min/km
   avg_hr: number | null;
   calories: number | null;
+  temp_c?: number | null;
 }
 
 type SortKey = "date" | "distance" | "duration_min" | "pace" | "avg_hr" | "calories";
@@ -110,6 +111,7 @@ export function RunTable({ runs }: { runs: RunRow[] }) {
               {shortDate(r.date)}
               {r.duration_min != null ? ` · ${Math.round(num(r.duration_min))} min` : ""}
               {r.calories != null && r.calories > 0 ? ` · ${Math.round(num(r.calories))} kcal` : ""}
+              {r.temp_c != null && isFinite(Number(r.temp_c)) ? ` · ${Math.round(num(r.temp_c))}°C` : ""}
             </Text>
           </View>
           <Text variant="caption" className="w-14 text-right tabular-nums text-text">

--- a/universal/src/components/running-mileage.tsx
+++ b/universal/src/components/running-mileage.tsx
@@ -1,23 +1,34 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
 
-/** Monthly mileage bar chart (last N months), peak month highlighted — the
-    web's dedicated monthly-mileage chart, adapted to a compact mobile bar row. */
-export function RunningMileage({ mileage }: { mileage: number[] | null | undefined }) {
-  const data = (mileage ?? []).filter((v) => isFinite(v));
-  if (data.length < 2) return null;
-  const max = Math.max(...data) || 1;
-  const maxIdx = data.indexOf(max);
-  const total = data.reduce((a, b) => a + b, 0);
+interface MileageMonth { month: string; km: number; runs: number }
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+function monthLabel(ym: string): string {
+  const [, m] = ym.split("-").map(Number);
+  return MONTHS[(m ?? 1) - 1] ?? ym;
+}
+
+/** Monthly mileage bar chart (last N months), peak month highlighted. When the
+    dated detail is available each bar is labelled with its month + run count
+    (web parity); otherwise it falls back to the value-only series. */
+export function RunningMileage({ mileage, months }: { mileage?: number[] | null; months?: MileageMonth[] | null }) {
+  const detail = (months ?? []).filter((m) => isFinite(m.km));
+  const useDetail = detail.length >= 2;
+  const values = useDetail ? detail.map((m) => m.km) : (mileage ?? []).filter((v) => isFinite(v));
+  if (values.length < 2) return null;
+  const max = Math.max(...values) || 1;
+  const maxIdx = values.indexOf(max);
+  const total = values.reduce((a, b) => a + b, 0);
 
   return (
     <Card className="gap-2">
       <View className="flex-row items-center justify-between">
         <Text variant="eyebrow">Monthly mileage</Text>
-        <Text variant="micro" className="text-text-muted">last {data.length} mo</Text>
+        <Text variant="micro" className="text-text-muted">last {values.length} mo</Text>
       </View>
       <View className="h-24 flex-row items-end gap-1">
-        {data.map((m, i) => (
+        {values.map((m, i) => (
           <View key={i} className="flex-1 items-center justify-end self-stretch">
             <View
               className="w-full rounded-t-sm"
@@ -26,9 +37,23 @@ export function RunningMileage({ mileage }: { mileage: number[] | null | undefin
           </View>
         ))}
       </View>
+      {useDetail ? (
+        <View className="flex-row gap-1">
+          {detail.map((m, i) => (
+            <View key={i} className="flex-1 items-center">
+              <Text variant="micro" className="text-text-muted">{monthLabel(m.month)}</Text>
+              <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(m.km)}·{m.runs}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
       <View className="flex-row justify-between">
-        <Text variant="micro" className="text-text-muted">peak {Math.round(max)} km</Text>
-        <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(total)} km total</Text>
+        <Text variant="micro" className="text-text-muted">
+          peak {Math.round(max)} km{useDetail ? ` · ${MONTHS.length && detail[maxIdx] ? monthLabel(detail[maxIdx].month) : ""}` : ""}
+        </Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">
+          {Math.round(total)} km{useDetail ? ` · ${detail.reduce((a, b) => a + b.runs, 0)} runs` : " total"}
+        </Text>
       </View>
     </Card>
   );

--- a/universal/src/components/running-pace-vo2-charts.tsx
+++ b/universal/src/components/running-pace-vo2-charts.tsx
@@ -1,6 +1,8 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
-import { LineChart, ExpandableChart } from "./line-chart";
+import { LineChart, ExpandableChart, ChartLegend, chartDateLabel } from "./line-chart";
+
+interface PacePoint { date: string; pace: number; distance: number }
 
 /** Decimal minutes → "M:SS" pace label. */
 function paceLabel(mins: number): string {
@@ -8,26 +10,58 @@ function paceLabel(mins: number): string {
   return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`;
 }
 
+/** Trailing moving average over a numeric series. */
+function movingAvg(vals: number[], window: number): (number | null)[] {
+  return vals.map((_, i) => {
+    const lo = Math.max(0, i - window + 1);
+    const slice = vals.slice(lo, i + 1);
+    return slice.length ? slice.reduce((a, b) => a + b, 0) / slice.length : null;
+  });
+}
+
 /**
- * Dedicated Pace Progression + VO2max Trend charts (web parity). Both tap-to-
- * read and fullscreen-expandable; VO2max carries an average reference line.
- * Series come from /api/running/stats `trends`.
+ * Dedicated Pace Progression + VO2max Trend charts (web parity). When the dated
+ * pace detail is available the pace chart is a per-run scatter (dots sized by
+ * distance) over a dated axis with a moving-average line; otherwise a value-only
+ * line. Both tap-to-read and fullscreen-expandable.
  */
 export function RunningPaceVo2Charts({
   pace,
   vo2max,
+  paceDetail,
 }: {
   pace: number[] | null | undefined;
   vo2max: number[] | null | undefined;
+  paceDetail?: PacePoint[] | null;
 }) {
   const paceVals = (pace ?? []).filter((v) => isFinite(v));
   const vo2Vals = (vo2max ?? []).filter((v) => isFinite(v));
   if (paceVals.length < 2 && vo2Vals.length < 2) return null;
   const vo2Avg = vo2Vals.length ? vo2Vals.reduce((a, b) => a + b, 0) / vo2Vals.length : 0;
 
+  const detail = (paceDetail ?? []).filter((p) => isFinite(p.pace));
+  const useScatter = detail.length >= 3;
+  const labels = detail.map((p) => chartDateLabel(p.date));
+  const paceSeries = detail.map((p) => p.pace);
+  const maxD = Math.max(...detail.map((p) => p.distance || 0), 1);
+  const sizes = detail.map((p) => 2 + ((p.distance || 0) / maxD) * 4);
+  const ma = movingAvg(paceSeries, Math.max(2, Math.round(detail.length / 5)));
+  const scatterSeries = [
+    { values: paceSeries, color: "#cbe896", mode: "dots" as const, sizes },
+    { values: ma, color: "#e0a458", width: 1.8 },
+  ];
+
   return (
     <View className="gap-4">
-      {paceVals.length >= 2 ? (
+      {useScatter ? (
+        <Card className="gap-2">
+          <ExpandableChart title="Pace progression" chart={{ series: scatterSeries, labels, yFormat: paceLabel }}>
+            <LineChart height={150} interactive xTicks={4} labels={labels} yFormat={paceLabel} series={scatterSeries} />
+          </ExpandableChart>
+          <ChartLegend items={[{ color: "#cbe896", label: "per run (dot = distance)" }, { color: "#e0a458", label: "moving avg" }]} />
+          <Text variant="micro" className="text-text-muted">min/km · lower is faster · tap to read</Text>
+        </Card>
+      ) : paceVals.length >= 2 ? (
         <Card className="gap-2">
           <ExpandableChart
             title="Pace progression"

--- a/web/app/api/running/stats/route.ts
+++ b/web/app/api/running/stats/route.ts
@@ -94,8 +94,11 @@ export async function GET() {
           (s.raw_json->>'duration')::float / NULLIF((s.raw_json->>'distance')::float / 1000.0, 0) / 60.0 as pace,
           (s.raw_json->>'averageHR')::float as avg_hr,
           (s.raw_json->>'calories')::float as calories,
-          (s.raw_json->>'elevationGain')::float as elev_gain
+          (s.raw_json->>'elevationGain')::float as elev_gain,
+          ((w.raw_json->>'temp')::float - 32) * 5.0 / 9.0 as temp_c,
+          (s.raw_json->>'maxSpeed')::float as max_speed_ms
         FROM garmin_activity_raw s
+        LEFT JOIN garmin_activity_raw w ON w.activity_id = s.activity_id AND w.endpoint_name = 'weather'
         WHERE s.endpoint_name = 'summary'
           AND s.raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
         ORDER BY (s.raw_json->>'startTimeLocal')::text DESC
@@ -132,7 +135,9 @@ export async function GET() {
       `,
       // Trend series for tier-1 sparklines (recent → chronological), value-only.
       sql`
-        SELECT (raw_json->>'duration')::float / NULLIF((raw_json->>'distance')::float / 1000.0, 0) / 60.0 as v
+        SELECT (raw_json->>'duration')::float / NULLIF((raw_json->>'distance')::float / 1000.0, 0) / 60.0 as v,
+          LEFT((raw_json->>'startTimeLocal')::text, 10) as date,
+          (raw_json->>'distance')::float / 1000.0 as distance
         FROM garmin_activity_raw
         WHERE endpoint_name = 'summary'
           AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
@@ -153,9 +158,10 @@ export async function GET() {
         ) t ORDER BY d ASC
       `,
       sql`
-        SELECT v FROM (
+        SELECT m, v, runs FROM (
           SELECT TO_CHAR((raw_json->>'startTimeLocal')::timestamp, 'YYYY-MM') as m,
-            SUM((raw_json->>'distance')::float) / 1000.0 as v
+            SUM((raw_json->>'distance')::float) / 1000.0 as v,
+            COUNT(*) as runs
           FROM garmin_activity_raw
           WHERE endpoint_name = 'summary'
             AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
@@ -238,6 +244,9 @@ export async function GET() {
         pace: paceRows.map((r) => Number(r.v)).reverse(),
         vo2max: vo2Rows.map((r) => Number(r.v)),
         mileage: mileageRows.map((r) => Number(r.v)),
+        // Dated detail for richer app charts (scatter / labelled bars).
+        paceDetail: paceRows.map((r) => ({ date: r.date as string, pace: Number(r.v), distance: Number(r.distance) })).reverse(),
+        mileageDetail: mileageRows.map((r) => ({ month: r.m as string, km: Number(r.v), runs: Number(r.runs) })),
       },
     });
   } catch (err) {


### PR DESCRIPTION
## What

The web running screen has a dated per-run pace scatter, month-labelled mileage bars, and per-run weather; the mobile versions were value-only. This closes all three.

**web** (`/api/running/stats`, additive — existing arrays kept):
- `trends.paceDetail` — `{date, pace, distance}` per run
- `trends.mileageDetail` — `{month, km, runs}` per month
- `recentRuns.temp_c` — weather-joined temp, converted °F→°C, + `max_speed_ms`

**app**:
- pace progression → a **dated scatter** (dots sized by distance) with a **moving-average** line
- monthly mileage → bars **labelled with month + run count**, peak month + total runs
- run table → a **weather temp** on each row

## Verified the data first

Confirmed against the DB that `maxSpeed` and the weather `temp` exist and that the temp is Fahrenheit (Athens runs 92°F → 33°C). Run **split power was checked and dropped** — `averagePower` is null on runs.

## Verified end-to-end

- web `tsc --noEmit` clean + `vitest run` 177/177; mobile `tsc` clean
- With the web change hot-reloaded locally, the app renders: pace scatter (40 distance-sized dots + moving avg, dated Mar 7→Aug 26); mileage bars (Mar 199·24 peak, 593 km · 91 runs); run row "Athens Running · Aug 26 · 26 min · 296 kcal · 33°C" (Playwright screenshots).

## Files

- `web/app/api/running/stats/route.ts`
- `universal/src/app/(main)/running.tsx` (types + wiring)
- `universal/src/components/running-mileage.tsx`, `running-pace-vo2-charts.tsx`, `run-table.tsx`

Part of #473.

Closes #517
