### PR TITLE
feat(training): decoupling threshold coloring (#519)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -110,7 +110,13 @@ export default function TrainingScreen() {
     const atl = nums(c?.load, "atl");
     if (atl.length) m.push({ label: "Fatigue (ATL)", value: String(Math.round(last(atl))), spark: atl, color: "#e0a458" });
     const dec = (fit as { decoupling_pct?: number | null } | undefined)?.decoupling_pct;
-    if (dec != null) m.push({ label: "Decoupling", value: `${Number(dec).toFixed(1)}%`, spark: [], color: "#6366b0", note: "aerobic drift" });
+    if (dec != null) {
+      const dv = Number(dec);
+      // Aerobic-decoupling thresholds (web parity): <3% tight, >5% high drift.
+      const decColor = dv < 3 ? "#6ad4a0" : dv > 5 ? "#e06060" : "#e0a458";
+      const decNote = dv < 3 ? "tight aerobic" : dv > 5 ? "high drift" : "moderate drift";
+      m.push({ label: "Decoupling", value: `${dv.toFixed(1)}%`, spark: [], color: decColor, note: decNote });
+    }
     return m;
   }, [sim, fit]);
 


### PR DESCRIPTION
## What

The web colors aerobic decoupling by its thresholds; the mobile tile was a flat indigo. This colors it green (<3% tight), amber (3–5%), or red (>5% high drift) with a matching note.

## Why EF was dropped (the "proper way")

The audit paired this with an Efficiency Factor tile. I checked the DB: `efficiency_factor` is a **constant placeholder** (0.0000214 for every recent date) that renders as `0.00` at the web's `toFixed(2)` — a meaningless tile — so I left it out rather than ship a broken stat.

## Verified

- `tsc --noEmit` clean
- Playwright on Expo web: the tile renders "Decoupling 13.2% · high drift" in red (#e06060), matching the >5% threshold.

## Files

- `universal/src/app/(main)/training.tsx`

Part of #473.

Closes #519
