### PR TITLE
feat(overview): fitness-age components (#523)

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -75,7 +75,9 @@ function useSleepGlance() {
   return s;
 }
 
-interface FitnessResp { fitness_age: number | null; chrono_age: number | null; achievable_age: number | null; total_activities: number }
+interface FitnessComponent { key: string; label: string; unit: string; value: number | null; target: number | null; priority: number | null }
+interface FitnessResp { fitness_age: number | null; chrono_age: number | null; achievable_age: number | null; total_activities: number; components?: FitnessComponent[] }
+const fmtComp = (v: number) => (v % 1 === 0 ? String(v) : v.toFixed(1));
 /** Garmin Fitness Age + lifetime activity count, from /api/overview/fitness. */
 function useOverviewFitness() {
   const [f, setF] = useState<FitnessResp | null>(null);
@@ -269,6 +271,24 @@ export default function OverviewScreen() {
                   chronological age {fitness.chrono_age}{fitness.achievable_age != null ? ` · achievable ${Math.round(fitness.achievable_age)}` : ""}
                 </Text>
               </>
+            ) : null}
+            {fitness.components && fitness.components.length ? (
+              <View className="mt-1 gap-1 border-t border-border-subtle pt-2">
+                <Text variant="micro" className="text-text-muted">WHAT LOWERS IT · most impact first</Text>
+                {fitness.components.map((c) => {
+                  const has = c.target != null && c.value != null;
+                  const met = has ? (c.key.startsWith("vigorous") ? (c.value as number) >= (c.target as number) : (c.value as number) <= (c.target as number)) : false;
+                  return (
+                    <View key={c.key} className="flex-row items-center justify-between">
+                      <Text variant="micro" className="text-text-secondary">{c.label}</Text>
+                      <Text variant="micro" className="tabular-nums" style={{ color: has ? (met ? "#6ad4a0" : "#e0a458") : "#8aa0ac" }}>
+                        {c.value != null ? `${fmtComp(c.value)}${c.unit ? ` ${c.unit}` : ""}` : "—"}
+                        {has ? `  →  ${fmtComp(c.target as number)}` : ""}
+                      </Text>
+                    </View>
+                  );
+                })}
+              </View>
             ) : null}
           </Card>
         ) : null}

--- a/web/app/api/overview/fitness/route.ts
+++ b/web/app/api/overview/fitness/route.ts
@@ -15,7 +15,8 @@ export async function GET() {
     SELECT
       (raw_json->>'fitnessAge')::float          as fitness_age,
       (raw_json->>'chronologicalAge')::int      as chrono_age,
-      (raw_json->>'achievableFitnessAge')::float as achievable_age
+      (raw_json->>'achievableFitnessAge')::float as achievable_age,
+      raw_json->'components'                     as components
     FROM garmin_raw_data
     WHERE endpoint_name = 'fitnessage_data'
       AND raw_json->>'fitnessAge' IS NOT NULL
@@ -33,10 +34,35 @@ export async function GET() {
   `;
 
   const fitness = (fitnessRows as Record<string, unknown>[])[0] ?? null;
+
+  // Normalize the Garmin fitness-age "components" blob into an ordered list of
+  // levers (current value → target, most-impactful first) the app can render.
+  const COMPONENT_META: Record<string, { label: string; unit: string }> = {
+    rhr: { label: "Resting HR", unit: "bpm" },
+    bmi: { label: "BMI", unit: "" },
+    vigorousMinutesAvg: { label: "Vigorous min/wk", unit: "min" },
+    vigorousDaysAvg: { label: "Vigorous days/wk", unit: "days" },
+  };
+  const comp = (fitness?.components ?? null) as Record<string, { value?: number; targetValue?: number; priority?: number }> | null;
+  const components = comp
+    ? Object.entries(comp)
+        .filter(([k]) => k in COMPONENT_META)
+        .map(([k, v]) => ({
+          key: k,
+          label: COMPONENT_META[k].label,
+          unit: COMPONENT_META[k].unit,
+          value: v?.value ?? null,
+          target: v?.targetValue ?? null,
+          priority: v?.priority ?? null,
+        }))
+        .sort((a, b) => (a.priority ?? 99) - (b.priority ?? 99))
+    : [];
+
   return NextResponse.json({
     fitness_age: fitness ? (fitness.fitness_age ?? null) : null,
     chrono_age: fitness ? (fitness.chrono_age ?? null) : null,
     achievable_age: fitness ? (fitness.achievable_age ?? null) : null,
     total_activities: Number((countRows as Record<string, unknown>[])[0]?.total ?? 0),
+    components,
   });
 }


### PR DESCRIPTION
## What

The web breaks the fitness age into its component levers with current→target; the mobile card showed only the age summary. This adds the breakdown.

- **web** — `/api/overview/fitness` now returns `components` (normalized from the fitnessage_data `raw_json->'components'`: vigorous minutes/days, BMI, resting HR), ordered by Garmin's improvement priority.
- **app** — a "WHAT LOWERS IT · most impact first" list in the fitness-age card: each lever's current value → target, colored amber when unmet, green when met, grey when it has no target (RHR).

## Verified the data first

Confirmed the `components` blob exists (in `garmin_raw_data`, not garmin_activity_raw): vigorous min 8.3→75, vigorous days 0.3→3, BMI 23.4→21, RHR 50.

## Verified end-to-end

- web `tsc --noEmit` clean + `vitest run`; mobile `tsc` clean
- With the web change hot-reloaded, the app renders "WHAT LOWERS IT" with Vigorous min/wk 8.3 → 75, Vigorous days/wk 0.3 → 3, BMI 23.4 → 21 (amber), Resting HR 50 bpm (Playwright screenshot).

## Files

- `web/app/api/overview/fitness/route.ts`
- `universal/src/app/(main)/overview.tsx`

Part of #473.

Closes #523
