### PR TITLE
feat(overview): weekly intensity card (#525)

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -76,7 +76,8 @@ function useSleepGlance() {
 }
 
 interface FitnessComponent { key: string; label: string; unit: string; value: number | null; target: number | null; priority: number | null }
-interface FitnessResp { fitness_age: number | null; chrono_age: number | null; achievable_age: number | null; total_activities: number; components?: FitnessComponent[] }
+interface WeeklyIntensity { goal: number; total: number; moderate: number; vigorous: number }
+interface FitnessResp { fitness_age: number | null; chrono_age: number | null; achievable_age: number | null; total_activities: number; components?: FitnessComponent[]; intensity?: WeeklyIntensity | null }
 const fmtComp = (v: number) => (v % 1 === 0 ? String(v) : v.toFixed(1));
 /** Garmin Fitness Age + lifetime activity count, from /api/overview/fitness. */
 function useOverviewFitness() {
@@ -292,6 +293,27 @@ export default function OverviewScreen() {
             ) : null}
           </Card>
         ) : null}
+
+        {/* Weekly intensity minutes (vs Garmin goal) */}
+        {fitness?.intensity && fitness.intensity.goal > 0 ? (() => {
+          const im = fitness.intensity;
+          const pct = Math.min(100, (im.total / im.goal) * 100);
+          const met = im.total >= im.goal;
+          return (
+            <Card className="gap-2">
+              <View className="flex-row items-center justify-between">
+                <Text variant="eyebrow">Weekly intensity</Text>
+                <Text variant="micro" className="tabular-nums text-text-muted">{im.total} / {im.goal} min</Text>
+              </View>
+              <View className="h-2 overflow-hidden rounded-full" style={{ backgroundColor: "#16242c" }}>
+                <View className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: met ? "#6ad4a0" : "#6366b0" }} />
+              </View>
+              <Text variant="micro" className="text-text-muted">
+                {im.moderate} moderate · {im.vigorous} vigorous (2×) · {Math.round((im.total / im.goal) * 100)}% of goal
+              </Text>
+            </Card>
+          );
+        })() : null}
 
         {/* Cross-domain glance row */}
         <View className="flex-row flex-wrap gap-3">

--- a/web/app/api/overview/fitness/route.ts
+++ b/web/app/api/overview/fitness/route.ts
@@ -33,6 +33,20 @@ export async function GET() {
       (SELECT COUNT(*) FROM hevy_raw_data WHERE endpoint_name = 'workout') AS total
   `;
 
+  const intensityRows = await sql`
+    SELECT
+      (raw_json->>'weekGoal')::int      as goal,
+      (raw_json->>'weeklyTotal')::int   as total,
+      (raw_json->>'weeklyModerate')::int as moderate,
+      (raw_json->>'weeklyVigorous')::int as vigorous
+    FROM garmin_raw_data
+    WHERE endpoint_name = 'intensity_minutes_data'
+      AND raw_json->>'weekGoal' IS NOT NULL
+    ORDER BY date DESC
+    LIMIT 1
+  `;
+  const im = (intensityRows as Record<string, unknown>[])[0] ?? null;
+
   const fitness = (fitnessRows as Record<string, unknown>[])[0] ?? null;
 
   // Normalize the Garmin fitness-age "components" blob into an ordered list of
@@ -64,5 +78,13 @@ export async function GET() {
     achievable_age: fitness ? (fitness.achievable_age ?? null) : null,
     total_activities: Number((countRows as Record<string, unknown>[])[0]?.total ?? 0),
     components,
+    intensity: im
+      ? {
+          goal: Number(im.goal ?? 0),
+          total: Number(im.total ?? 0),
+          moderate: Number(im.moderate ?? 0),
+          vigorous: Number(im.vigorous ?? 0),
+        }
+      : null,
   });
 }


### PR DESCRIPTION
## What

The mobile overview had only a daily intensity KPI; the web shows a weekly total-vs-goal card. This adds it.

- **web** — `/api/overview/fitness` now returns `intensity` (`{goal, total, moderate, vigorous}` from garmin_raw_data `intensity_minutes_data`).
- **app** — a **Weekly intensity** card: total / goal min, a progress bar (green once the goal is met), and the moderate + vigorous (2×) split.

## Verified end-to-end

- web `tsc` clean + `vitest run`; mobile `tsc` clean
- With the web change hot-reloaded, the endpoint returns `{goal:180, total:20, moderate:14, vigorous:3}` and the app renders "WEEKLY INTENSITY · 20/180 min · 14 moderate · 3 vigorous (2×) · 11% of goal" (Playwright screenshot).

## Files

- `web/app/api/overview/fitness/route.ts`
- `universal/src/app/(main)/overview.tsx`

Part of #473.

Closes #525
