### PR TITLE
feat(connections): per-source sync errors (#527)

### DIFF
--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -36,6 +36,7 @@ interface SourceStatus {
   status: string;
   lastSync: string;
   records: number;
+  error?: string | null;
 }
 
 interface SyncStatusResponse {
@@ -480,6 +481,7 @@ export default function ConnectionsScreen() {
                     {s.name}
                   </Text>
                   <Text variant="micro">{fmtDateTime(s.lastSync)}</Text>
+                  {s.error ? <Text variant="micro" className="text-danger" numberOfLines={2}>⚠ {s.error}</Text> : null}
                 </View>
                 <View className="flex-row items-center gap-2">
                   <Text variant="caption" className="tabular-nums text-text">

--- a/web/app/api/sync/status/route.ts
+++ b/web/app/api/sync/status/route.ts
@@ -16,6 +16,7 @@ interface SourceStatus {
   status: string;
   lastSync: string;
   records: number;
+  error: string | null;
 }
 
 export async function GET() {
@@ -55,6 +56,7 @@ export async function GET() {
         status: row.status,
         lastSync: row.completed_at ?? row.started_at,
         records: Number(row.records_synced) || 0,
+        error: row.error_message ?? null,
       };
     }
 


### PR DESCRIPTION
## What

The sync-pipeline list showed each source's last-sync + records + status but not the per-source error reason. This surfaces it.

- **web** — `/api/sync/status` per-source status now includes `error` (from `sync_log.error_message`).
- **app** — a red "⚠ <error>" line under a source when it has one.

## Verified

- web `tsc` clean + `vitest run`; mobile `tsc` clean
- Playwright on Expo web (route-mocked a failed garmin source): the connections pipeline renders "⚠ garmin: MFA required — re-auth the DI token" in red under the garmin source.

## Files

- `web/app/api/sync/status/route.ts`
- `universal/src/app/(main)/connections.tsx`

Part of #473.

Closes #527
