### PR TITLE
feat(connections): Spotify library status (#529)

### DIFF
--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -27,9 +27,11 @@ interface SyncRule {
   priority: number;
 }
 
+interface SpotifyStatus { tracks: number; artists: number; last_sync: string | null }
 interface ConnectionsResponse {
   platforms: PlatformStatus[];
   rules: SyncRule[];
+  spotify?: SpotifyStatus | null;
 }
 
 interface SourceStatus {
@@ -512,11 +514,27 @@ export default function ConnectionsScreen() {
               <Text variant="eyebrow">Spotify</Text>
               <Text variant="micro" className="text-text-muted">Tempo-matched running playlists</Text>
             </View>
-            <Badge label="Web sign-in" tone="neutral" />
+            <Badge label={conn?.spotify ? "Connected" : "Web sign-in"} tone={conn?.spotify ? "success" : "neutral"} />
           </View>
-          <Text variant="micro" className="text-text-secondary">
-            Spotify uses a one-tap OAuth sign-in handled on the soma web dashboard. Connect there, then your library status appears here.
-          </Text>
+          {conn?.spotify ? (
+            <>
+              <View className="flex-row flex-wrap gap-x-5 gap-y-1">
+                <View className="gap-0.5">
+                  <Text variant="micro" className="text-text-muted">Tracks analysed</Text>
+                  <Text variant="title" className="text-teal tabular-nums">{conn.spotify.tracks.toLocaleString()}</Text>
+                </View>
+                <View className="gap-0.5">
+                  <Text variant="micro" className="text-text-muted">Artists</Text>
+                  <Text variant="title" className="text-indigo tabular-nums">{conn.spotify.artists.toLocaleString()}</Text>
+                </View>
+              </View>
+              {conn.spotify.last_sync ? <Text variant="micro" className="text-text-muted">last synced {fmtDateTime(conn.spotify.last_sync)}</Text> : null}
+            </>
+          ) : (
+            <Text variant="micro" className="text-text-secondary">
+              Spotify uses a one-tap OAuth sign-in handled on the soma web dashboard. Connect there, then your library status appears here.
+            </Text>
+          )}
         </Card>
 
         {/* Push notification preferences */}

--- a/web/app/api/connections/route.ts
+++ b/web/app/api/connections/route.ts
@@ -20,6 +20,18 @@ export async function GET() {
       ORDER BY priority DESC, id
     `;
 
+    // Spotify library status (features cached for tempo-matched playlists).
+    const spotifyRows = await sql`
+      SELECT
+        (SELECT COUNT(*)::int FROM spotify_track_features)  AS tracks,
+        (SELECT COUNT(*)::int FROM spotify_artist_genres)   AS artists,
+        (SELECT MAX(cached_at) FROM spotify_track_features) AS last_sync
+    `;
+    const sp = (spotifyRows as Record<string, unknown>[])[0] ?? null;
+    const spotify = sp && Number(sp.tracks) > 0
+      ? { tracks: Number(sp.tracks), artists: Number(sp.artists), last_sync: (sp.last_sync as string | null) ?? null }
+      : null;
+
     // Build platform status including non-connected ones
     const platforms = ["garmin", "hevy", "strava", "surfr"];
     const credMap = Object.fromEntries(
@@ -41,7 +53,7 @@ export async function GET() {
       can_connect: p === "strava",
     }));
 
-    return NextResponse.json({ platforms: status, rules });
+    return NextResponse.json({ platforms: status, rules, spotify });
   } catch (err) {
     console.error("Error fetching connections status:", err);
     return NextResponse.json(


### PR DESCRIPTION
## What

The mobile Spotify card was a static placeholder; the web shows the library status. This adds it.

- **web** — `/api/connections` now returns `spotify` (`{tracks, artists, last_sync}` from spotify_track_features / spotify_artist_genres).
- **app** — the Spotify card shows a **Connected** badge, **tracks analysed**, **artists**, and **last synced** when a library is cached; otherwise the web sign-in placeholder.

## Verified end-to-end

- web `tsc` clean + `vitest run`; mobile `tsc` clean
- With the web change hot-reloaded, the endpoint returns `{tracks:4162, artists:583, last_sync:...}` and the app renders "SPOTIFY · CONNECTED · Tracks analysed 4,162 · Artists 583 · last synced 2/28/2026" (Playwright screenshot).

## Files

- `web/app/api/connections/route.ts`
- `universal/src/app/(main)/connections.tsx`

Part of #473.

Closes #529
