### PR TITLE
feat(connections): data-pipeline detail (#531)

### DIFF
--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -41,12 +41,16 @@ interface SourceStatus {
   error?: string | null;
 }
 
+interface SyncRun { type: string; status: string; records: number; at: string }
+interface TableCount { label: string; count: number }
 interface SyncStatusResponse {
   lastSync: string | null;
   status: string;
   recordsSynced: number;
   error: string | null;
   sources: Record<string, SourceStatus>;
+  history?: SyncRun[];
+  tables?: TableCount[];
 }
 
 // ---- Inline data hooks (matching useToday / useTraining pattern) ----
@@ -506,6 +510,38 @@ export default function ConnectionsScreen() {
             ))
           )}
         </Card>
+
+        {/* Data pipeline — table coverage + recent runs */}
+        {sync && ((sync.tables?.length ?? 0) > 0 || (sync.history?.length ?? 0) > 0) ? (
+          <Card className="gap-3">
+            <Text variant="eyebrow">Data pipeline</Text>
+            {sync.tables?.length ? (
+              <View className="flex-row flex-wrap gap-x-6 gap-y-2">
+                {sync.tables.map((t) => (
+                  <View key={t.label} className="gap-0.5">
+                    <Text variant="micro" className="text-text-muted">{t.label}</Text>
+                    <Text variant="title" className="text-teal tabular-nums">{t.count.toLocaleString()}</Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+            {sync.history?.length ? (
+              <View className="gap-1 border-t border-border-subtle pt-2">
+                <Text variant="micro" className="text-text-muted">RECENT RUNS</Text>
+                {sync.history.map((r, i) => (
+                  <View key={i} className="flex-row items-center justify-between">
+                    <Text variant="micro" className="text-text-secondary">{r.type.replace(/_/g, " ")}</Text>
+                    <View className="flex-row items-center gap-2">
+                      <Text variant="micro" className="tabular-nums text-text-muted">{r.records.toLocaleString()} rec</Text>
+                      <View className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: r.status === "success" ? "#6ad4a0" : r.status === "error" ? "#e06060" : "#e0a458" }} />
+                      <Text variant="micro" className="tabular-nums text-text-muted">{fmtDateTime(r.at)}</Text>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </Card>
+        ) : null}
 
         {/* Spotify (music features) */}
         <Card className="gap-2">

--- a/web/app/api/sync/status/route.ts
+++ b/web/app/api/sync/status/route.ts
@@ -82,12 +82,41 @@ export async function GET() {
       overallStatus = mostRecent.status;
     }
 
+    // Recent run history + per-table data counts (pipeline operations detail).
+    const historyRows = await sql`
+      SELECT sync_type, status, records_synced, started_at::text AS started_at
+      FROM sync_log
+      ORDER BY started_at DESC
+      LIMIT 8
+    `;
+    const history = (historyRows as Record<string, unknown>[]).map((r) => ({
+      type: String(r.sync_type),
+      status: String(r.status),
+      records: Number(r.records_synced) || 0,
+      at: String(r.started_at),
+    }));
+
+    const countRows = await sql`
+      SELECT
+        (SELECT COUNT(*)::int FROM garmin_activity_raw WHERE endpoint_name = 'summary') AS activities,
+        (SELECT COUNT(*)::int FROM hevy_raw_data WHERE endpoint_name = 'workout')        AS workouts,
+        (SELECT COUNT(*)::int FROM daily_health_summary)                                 AS health_days
+    `;
+    const c = (countRows as Record<string, unknown>[])[0] ?? {};
+    const tables = [
+      { label: "Activities", count: Number(c.activities ?? 0) },
+      { label: "Workouts", count: Number(c.workouts ?? 0) },
+      { label: "Health days", count: Number(c.health_days ?? 0) },
+    ];
+
     return NextResponse.json({
       lastSync: mostRecent.completed_at ?? mostRecent.started_at,
       status: overallStatus,
       recordsSynced: Number(mostRecent.records_synced) || 0,
       error: mostRecent.error_message ?? null,
       sources,
+      history,
+      tables,
     });
   } catch (err) {
     console.error("Error fetching sync status:", err);


### PR DESCRIPTION
## What

The mobile connections screen had only a Sync-now button + records total; the web shows pipeline operations. This adds a Data-pipeline card.

- **web** — `/api/sync/status` now returns `tables` (garmin activities / hevy workouts / health days counts) and `history` (last 8 sync_log runs).
- **app** — a Data-pipeline card: the three table counts + a "recent runs" list with per-run records, a green/amber/red status dot, and the timestamp.

## Verified end-to-end

- web `tsc` clean + `vitest run`; mobile `tsc` clean
- With the web change hot-reloaded, the app renders "DATA PIPELINE · Activities 836 · Workouts 333 · Health days 1,925" and 8 recent "full pipeline · N rec · 🟢 · <time>" runs (Playwright screenshot).

## Files

- `web/app/api/sync/status/route.ts`
- `universal/src/app/(main)/connections.tsx`

Part of #473.

Closes #531
