### PR TITLE
feat(training): optimal-vs-actual VDOT trajectory (#533)

### DIFF
--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -5,6 +5,7 @@ import {
   useTraining,
   useCalibration,
   useForwardSim,
+  useTrajectory,
   useTrainingGraph,
   useActivityMatches,
   setDayCompletion,
@@ -63,6 +64,7 @@ export default function TrainingScreen() {
   const { data, error, refetch } = useTraining(todayISO());
   const { cal, refetch: refetchCal } = useCalibration(todayISO());
   const { data: sim, refetch: refetchSim } = useForwardSim(todayISO());
+  const { data: trajectory } = useTrajectory();
   const { nodes: graphNodes, edges: graphEdges, overrides: graphOverrides } = useTrainingGraph(todayISO());
   const { byDay: matches } = useActivityMatches();
   const { refreshing, onRefresh } = usePullRefresh(() => {
@@ -254,7 +256,7 @@ export default function TrainingScreen() {
 
         {/* Fitness trajectory — the centerpiece: model vs Garmin across
             Fitness (VDOT) / Readiness / Load. Replaces the flat VO2 sparkline. */}
-        <TrajectoryChart comparison={sim?.comparison ?? null} />
+        <TrajectoryChart comparison={sim?.comparison ?? null} trajectory={trajectory} />
 
         {vo2Trend.length >= 2 ? (
           <Card className="gap-2">

--- a/universal/src/components/trajectory-chart.tsx
+++ b/universal/src/components/trajectory-chart.tsx
@@ -1,8 +1,8 @@
 import { useState, useMemo } from "react";
 import { View, Pressable } from "react-native";
 import { Text, Card, SegmentedControl } from "soma-style";
-import { LineChart, ChartLegend } from "./line-chart";
-import type { ForwardSim } from "../lib/api";
+import { LineChart, ChartLegend, chartDateLabel } from "./line-chart";
+import type { ForwardSim, TrajectoryData } from "../lib/api";
 
 type Dim = "Fitness" | "Readiness" | "Load";
 const DIMS = ["Fitness", "Readiness", "Load"] as const;
@@ -23,10 +23,27 @@ function shortLabel(iso: string): string {
  *  the web trajectory chart — goal-zone/taper/race bands need goal+taper data
  *  absent from the mobile payload, and the rich hover tooltip + 7-line
  *  visibility dropdown are replaced by the dimension + compare toggles. */
-export function TrajectoryChart({ comparison }: { comparison: ForwardSim["comparison"] }) {
+export function TrajectoryChart({ comparison, trajectory }: { comparison: ForwardSim["comparison"]; trajectory?: TrajectoryData | null }) {
   const [dim, setDim] = useState<Dim>("Fitness");
   const [compare, setCompare] = useState(true);
   const cfg = CFG[dim];
+
+  // Optimal-vs-actual VDOT trajectory (banister projection to the race date).
+  // Replaces the model-vs-Garmin Fitness view when the endpoint has a plan.
+  const useTraj = dim === "Fitness" && (trajectory?.trajectory?.length ?? 0) >= 2;
+  const traj = useMemo(() => {
+    const t = trajectory?.trajectory ?? [];
+    const optimal = t.map((p) => (isFinite(p.optimal) && p.optimal > 0 ? p.optimal : null));
+    const actual = t.map((p) => (p.actual != null && isFinite(p.actual) && p.actual > 0 ? p.actual : null));
+    let hereIdx = -1;
+    for (let i = actual.length - 1; i >= 0; i--) if (actual[i] != null) { hereIdx = i; break; }
+    return {
+      labels: t.map((p) => chartDateLabel(p.date)),
+      optimal, actual,
+      hereDot: actual.map((v, i) => (i === hereIdx ? v : null)),
+      cur: hereIdx >= 0 ? actual[hereIdx] : null,
+    };
+  }, [trajectory]);
   const src = useMemo(() => {
     if (!comparison) return [];
     return dim === "Fitness" ? comparison.fitness : dim === "Readiness" ? comparison.readiness : comparison.load;
@@ -54,19 +71,42 @@ export function TrajectoryChart({ comparison }: { comparison: ForwardSim["compar
     <Card className="gap-3">
       <View className="flex-row items-center justify-between">
         <Text variant="eyebrow">Fitness trajectory</Text>
-        {cur != null ? <Text variant="body" className="text-teal tabular-nums">{cfg.fmt(cur)}{dim === "Fitness" ? " VDOT" : ""}</Text> : null}
+        {(useTraj ? traj.cur : cur) != null ? <Text variant="body" className="text-teal tabular-nums">{cfg.fmt((useTraj ? traj.cur : cur) as number)}{dim === "Fitness" ? " VDOT" : ""}</Text> : null}
       </View>
       <View className="flex-row items-center gap-2">
         <View className="flex-1">
           <SegmentedControl options={DIMS} value={dim} onChange={(v) => setDim(v as Dim)} />
         </View>
-        <Pressable onPress={() => setCompare((c) => !c)} hitSlop={6}>
-          <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: compare ? cfg.colorB + "33" : "#142530" }}>
-            <Text variant="micro" style={{ color: compare ? cfg.colorB : "#8aa0ac" }}>Garmin</Text>
-          </View>
-        </Pressable>
+        {!useTraj ? (
+          <Pressable onPress={() => setCompare((c) => !c)} hitSlop={6}>
+            <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: compare ? cfg.colorB + "33" : "#142530" }}>
+              <Text variant="micro" style={{ color: compare ? cfg.colorB : "#8aa0ac" }}>Garmin</Text>
+            </View>
+          </Pressable>
+        ) : null}
       </View>
-      {a.some((v) => v != null) || b.some((v) => v != null) ? (
+      {useTraj ? (
+        <>
+          <LineChart
+            height={175}
+            interactive
+            xTicks={4}
+            labels={traj.labels}
+            yFormat={(v) => v.toFixed(1)}
+            refLine={trajectory?.goalVdot != null ? { y: trajectory.goalVdot, color: "#e0c458" } : undefined}
+            series={[
+              { values: traj.optimal, color: "#77c8d1", width: 1.6, dashed: true, label: "Optimal" },
+              { values: traj.actual, color: "#6ad4a0", width: 2.4, label: "Actual" },
+              { values: traj.hereDot, color: "#ffffff", mode: "dots" as const, width: 3 },
+            ]}
+          />
+          <ChartLegend items={[
+            { color: "#6ad4a0", label: "Actual VDOT" },
+            { color: "#77c8d1", label: "Optimal (to race)", dashed: true },
+            ...(trajectory?.goalVdot != null ? [{ color: "#e0c458", label: `Goal ${trajectory.goalVdot.toFixed(1)}`, dashed: true }] : []),
+          ]} />
+        </>
+      ) : a.some((v) => v != null) || b.some((v) => v != null) ? (
         <>
           <LineChart
             height={170}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -249,6 +249,23 @@ export function useForwardSim(date: string) {
   return { data, loading, error, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Optimal-vs-actual VDOT trajectory (banister projection to race date) ----
+export interface TrajectoryPoint { date: string; optimal: number; actual: number | null }
+export interface TrajectoryData { trajectory: TrajectoryPoint[]; raceDate: string | null; goalVdot: number | null }
+
+/** Banister-projected optimal VDOT curve to the race date vs actual, + goal VDOT. */
+export function useTrajectory() {
+  const [data, setData] = useState<TrajectoryData | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<TrajectoryData>("/api/training/trajectory")
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+  return { data };
+}
+
 // ---- Activity match: per plan-day matched Garmin activity + completion score ----
 export interface MatchedActivity {
   distance_km: number | string | null; duration_min: number | string | null;

--- a/web/app/api/training/trajectory/route.ts
+++ b/web/app/api/training/trajectory/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { projectVdotSeries, DEFAULT_BANISTER, type DailyLoad } from "@/lib/banister-projection";
+import { vdotFromHmSeconds } from "@/lib/vdot-utils";
+
+/**
+ * Optimal-vs-actual VDOT trajectory for the mobile app. Ports the training
+ * page's server-side `getTrajectoryData`: the Banister-projected optimal VDOT
+ * curve from the athlete's real loads out to the race date, the actual Garmin
+ * VDOT, plus the race date and goal VDOT (for the goal band / race marker).
+ * Returns an empty trajectory (200) when the derived tables or an active plan
+ * are absent (e.g. the demo DB), so the app falls back to its model-vs-Garmin view.
+ */
+async function safeQuery<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
+  try { return await fn(); } catch { return fallback; }
+}
+
+export async function GET() {
+  const sql = getDb();
+
+  const raceRows = await safeQuery(
+    () => sql`SELECT race_date::text AS race_date, goal_time_seconds FROM training_plan WHERE status = 'active' LIMIT 1`,
+    [] as Record<string, unknown>[],
+  );
+  const race = raceRows[0] ?? null;
+  if (!race?.race_date) return NextResponse.json({ trajectory: [], raceDate: null, goalVdot: null });
+  const raceDate = String(race.race_date);
+  const goalVdot = race.goal_time_seconds ? vdotFromHmSeconds(Number(race.goal_time_seconds)) : null;
+
+  const banister = (await safeQuery(
+    () => sql`SELECT p0, k1, k2, tau1, tau2, current_vdot FROM banister_params ORDER BY fitted_at DESC LIMIT 1`,
+    [] as Record<string, unknown>[],
+  ))[0] ?? null;
+
+  const planDays = await safeQuery(
+    () => sql`SELECT day_date::text AS day_date, run_type, target_distance_km
+              FROM training_plan_day
+              WHERE plan_id = (SELECT id FROM training_plan WHERE status = 'active' LIMIT 1)
+              ORDER BY day_date`,
+    [] as Record<string, unknown>[],
+  );
+
+  const [actuals, pmcRows] = await Promise.all([
+    safeQuery(() => sql`SELECT date::text AS date, vo2max FROM fitness_trajectory WHERE vo2max IS NOT NULL ORDER BY date`, [] as Record<string, unknown>[]),
+    safeQuery(() => sql`SELECT date::text AS date, daily_load FROM pmc_daily ORDER BY date`, [] as Record<string, unknown>[]),
+  ]);
+  if (actuals.length === 0) return NextResponse.json({ trajectory: [], raceDate, goalVdot });
+
+  const currentVo2 = banister?.current_vdot ? Number(banister.current_vdot) : 0;
+  const rawP0 = banister ? Number(banister.p0) : 0;
+  const params = banister
+    ? {
+        p0: rawP0 > 0 ? rawP0 : currentVo2,
+        k1: Number(banister.k1) || DEFAULT_BANISTER.k1,
+        k2: Number(banister.k2) || DEFAULT_BANISTER.k2,
+        tau1: Number(banister.tau1) || DEFAULT_BANISTER.tau1,
+        tau2: Number(banister.tau2) || DEFAULT_BANISTER.tau2,
+      }
+    : { ...DEFAULT_BANISTER, p0: currentVo2 };
+
+  const INTENSITY: Record<string, number> = { easy: 0.6, recovery: 0.5, tempo: 1.0, threshold: 1.0, intervals: 1.2, long: 0.8, race: 1.3, rest: 0 };
+
+  const historicalLoadMap = new Map<string, number>();
+  for (const r of pmcRows) {
+    const load = Number(r.daily_load) || 0;
+    if (load > 0) historicalLoadMap.set(String(r.date), load);
+  }
+  const recentActual = [...historicalLoadMap.values()].slice(-30).filter((v) => v > 0);
+  const avgActual = recentActual.length ? recentActual.reduce((s, v) => s + v, 0) / recentActual.length : 0;
+  const rawPlan = planDays.map((d) => (Number(d.target_distance_km) || 0) * (INTENSITY[String(d.run_type)] || 0.6)).filter((v) => v > 0);
+  const avgRawPlan = rawPlan.length ? rawPlan.reduce((s, v) => s + v, 0) / rawPlan.length : 1;
+  const scale = avgActual > 0 ? avgActual / avgRawPlan : 1;
+  const planLoadMap = new Map<string, number>();
+  for (const d of planDays) {
+    const raw = (Number(d.target_distance_km) || 0) * (INTENSITY[String(d.run_type)] || 0.6);
+    if (raw > 0) planLoadMap.set(String(d.day_date), raw * scale);
+  }
+
+  const start = new Date(String(actuals[0].date) + "T00:00:00");
+  const end = new Date(raceDate + "T00:00:00");
+  const lookbackDays = Math.ceil(5 * Math.max(params.tau1, params.tau2));
+  const seriesStartMs = start.getTime() - lookbackDays * 86400000;
+  const endMs = end.getTime();
+
+  const allLoads: DailyLoad[] = [];
+  for (let ms = seriesStartMs; ms <= endMs; ms += 86400000) {
+    const dateStr = new Date(ms).toISOString().split("T")[0];
+    allLoads.push({ date: dateStr, load: historicalLoadMap.get(dateStr) ?? planLoadMap.get(dateStr) ?? 0 });
+  }
+  const projected = projectVdotSeries(allLoads, params);
+  const optimalMap = new Map<string, number>();
+  const firstActual = String(actuals[0].date);
+  allLoads.forEach((l, i) => { if (l.date >= firstActual) optimalMap.set(l.date, projected[i]); });
+  const actualMap = new Map(actuals.map((a) => [String(a.date), Number(a.vo2max)]));
+
+  const trajectory: { date: string; optimal: number; actual: number | null }[] = [];
+  for (let ms = start.getTime(); ms <= endMs; ms += 86400000) {
+    const dateStr = new Date(ms).toISOString().split("T")[0];
+    trajectory.push({
+      date: dateStr,
+      optimal: Math.round((optimalMap.get(dateStr) ?? currentVo2) * 10) / 10,
+      actual: actualMap.has(dateStr) ? Math.round((actualMap.get(dateStr) as number) * 10) / 10 : null,
+    });
+  }
+
+  return NextResponse.json({ trajectory, raceDate, goalVdot: goalVdot != null ? Math.round(goalVdot * 10) / 10 : null });
+}


### PR DESCRIPTION
## What

The web plots the Banister-projected **optimal** VDOT curve to the race date vs **actual**, with a **goal** line; the mobile chart plotted only model-VDOT vs Garmin over the recent window. This closes the gap.

- **web** — new `/api/training/trajectory` endpoint: a focused port of the training page's `getTrajectoryData` (banister projection over historical pmc_daily loads + scaled future plan loads out to the race date, actual VDOT from fitness_trajectory, race date + goal VDOT). Uses `safeQuery` so it returns an empty trajectory on the demo DB (missing derived tables).
- **app** — the Fitness dimension of the trajectory chart now shows **Optimal (to race)** (dashed) + **Actual VDOT** + a **Goal** reference line over a dated axis to the race; falls back to the model-vs-Garmin view when no trajectory is available.

## Verified the data first

Confirmed the tables have data: fitness_trajectory 184, pmc_daily 4798, banister_params 1348, active plan "Knoxville HM 2026" (race 2026-04-12, goal 5700s).

## Verified end-to-end

- web `tsc` clean + `vitest run`; mobile `tsc` clean
- Endpoint returns 119 points (optimal 43→55.5, actual to 53.7, goalVdot 47.9). App renders "53.7 VDOT" with the optimal dashed curve, actual line, "Goal 47.9" reference, dated axis Dec 13→Apr 10 (Playwright screenshot).

## Files

- `web/app/api/training/trajectory/route.ts` (new)
- `universal/src/lib/api.ts` — `useTrajectory`
- `universal/src/components/trajectory-chart.tsx`, `universal/src/app/(main)/training.tsx`

Part of #473.

Closes #533
