### PR TITLE
feat(app): clickable workout stat cards open per-workout timelines

### DIFF
--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,7 +1,7 @@
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useWorkoutsSummary, useWorkoutInsights } from "../../lib/api";
+import { fetchJson, usePullRefresh, useWorkoutsSummary, useWorkoutInsights, useWorkoutTimeline, type TimelinePoint } from "../../lib/api";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { WorkoutsDashboard } from "../../components/workouts-dashboard";
 import { WorkoutActivity } from "../../components/workout-activity";
@@ -65,6 +65,7 @@ export default function WorkoutsScreen() {
   const [unit, setUnit] = useState<"kg" | "lb">("kg");
   const { data: wkSum } = useWorkoutsSummary(range);
   const { data: insights } = useWorkoutInsights(range);
+  const { data: timeline } = useWorkoutTimeline();
   const { refreshing, onRefresh } = usePullRefresh(refetch);
   const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
 
@@ -102,24 +103,33 @@ export default function WorkoutsScreen() {
     .filter((k) => k > 0)
     .reverse();
 
-  const stats: { label: string; value: string; sub: string; cls: string; spark?: { data: number[]; color: string } }[] = [
+  // Each stat card opens a dated per-workout timeline (web ClickableSummaryStats
+  // parity): cumulative count, duration/workout, calories/workout, workouts/month.
+  type Stat = {
+    label: string; value: string; sub: string; cls: string; color: string; unit?: string;
+    timeline?: TimelinePoint[]; timelineMode?: "line" | "dots"; timelineNoun?: string; spark?: { data: number[]; color: string };
+  };
+  const stats: Stat[] = [
     {
       label: "Total Synced",
       value: `${totalSynced}`,
       sub: `${syncedThisWeek} this week`,
-      cls: "text-teal",
+      cls: "text-teal", color: "#77c8d1", unit: "workouts",
+      timeline: timeline?.cumulative, timelineMode: "line",
     },
     {
       label: "Recent Sessions",
       value: `${recent.length}`,
       sub: `${syncedCount} on Garmin`,
-      cls: "text-lime",
+      cls: "text-lime", color: "#8fc866", unit: "min",
+      timeline: timeline?.duration, timelineMode: "dots",
     },
     {
       label: "Avg Calories",
       value: avgKcal != null ? `${avgKcal}` : "—",
       sub: "kcal via Garmin HR",
-      cls: "text-warm",
+      cls: "text-warm", color: "#b17850", unit: "kcal",
+      timeline: timeline?.calories, timelineMode: "dots",
       spark: { data: kcalTrend, color: "#b17850" },
     },
     ...(trainingSpan
@@ -127,8 +137,9 @@ export default function WorkoutsScreen() {
           label: "Training Span",
           value: trainingSpan.years >= 1 ? `${trainingSpan.years.toFixed(1)}y` : `${trainingSpan.months}mo`,
           sub: `${trainingSpan.count} workouts logged`,
-          cls: "text-indigo",
-        }]
+          cls: "text-indigo", color: "#8b8fd6", unit: "workouts",
+          timeline: timeline?.monthly, timelineMode: "line" as const, timelineNoun: "months",
+        } satisfies Stat]
       : []),
   ];
 
@@ -163,13 +174,22 @@ export default function WorkoutsScreen() {
         {/* Summary stats */}
         <View className="flex-row flex-wrap gap-3">
           {stats.map((s) => {
-            const tappable = !!(s.spark && s.spark.data.length >= 2);
+            const hasTimeline = !!(s.timeline && s.timeline.length >= 2);
+            const hasSpark = !!(s.spark && s.spark.data.length >= 2);
+            const tappable = hasTimeline || hasSpark;
+            const previewData = hasTimeline ? s.timeline!.map((p) => p.value) : s.spark?.data;
             return (
               <Pressable
                 key={s.label}
                 className="min-w-[46%] flex-1"
                 disabled={!tappable}
-                onPress={() => s.spark && setStatDetail({ label: s.label, value: s.value, sub: s.sub, spark: s.spark.data, color: s.spark.color, unit: s.label === "Avg Calories" ? "kcal" : undefined })}
+                onPress={() => {
+                  if (hasTimeline) {
+                    setStatDetail({ label: s.label, value: s.value, sub: s.sub, color: s.color, unit: s.unit, timeline: s.timeline, timelineMode: s.timelineMode, timelineNoun: s.timelineNoun });
+                  } else if (hasSpark) {
+                    setStatDetail({ label: s.label, value: s.value, sub: s.sub, spark: s.spark!.data, color: s.spark!.color, unit: s.unit });
+                  }
+                }}
               >
                 <Card className="gap-1">
                   <View className="flex-row items-center justify-between">
@@ -180,9 +200,9 @@ export default function WorkoutsScreen() {
                     {s.value}
                   </Text>
                   <Text variant="micro">{s.sub}</Text>
-                  {tappable && s.spark ? (
+                  {tappable && previewData && previewData.length >= 2 ? (
                     <View className="mt-1">
-                      <Sparkline data={s.spark.data} color={s.spark.color} height={24} baseline />
+                      <Sparkline data={previewData} color={s.color} height={24} baseline />
                     </View>
                   ) : null}
                 </Card>

--- a/universal/src/components/stat-detail-modal.tsx
+++ b/universal/src/components/stat-detail-modal.tsx
@@ -14,6 +14,12 @@ export interface StatDetail {
   unit?: string;
   /** If set, the modal fetches /api/stats/[metric] for a range toggle + previous-period overlay. */
   metric?: string;
+  /** Pre-supplied dated timeline (e.g. per-workout duration/calories); renders a dated chart with tap-to-read. */
+  timeline?: { date: string; value: number; label?: string }[];
+  /** How to draw the timeline: connected line (cumulative/monthly) or scatter dots (per-workout). */
+  timelineMode?: "line" | "dots";
+  /** Plural noun for the timeline point count in the eyebrow (default "workouts"). */
+  timelineNoun?: string;
 }
 
 interface StatPoint { date: string; value: number | null; value2?: number | null }
@@ -52,6 +58,50 @@ export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; on
   if (!stat) return null;
   const unit = stat.unit ? ` ${stat.unit}` : "";
   const fmt = (v: number | null) => (v == null ? "–" : `${Math.round(v).toLocaleString()}${unit}`);
+
+  // Timeline path: pre-supplied dated points (per-workout duration/calories,
+  // cumulative count, workouts/month) — matches the web ClickableSummaryStats modal.
+  if (stat.timeline) {
+    const pts = stat.timeline.filter((p) => isFinite(p.value));
+    const vals = pts.map((p) => p.value);
+    const labels = pts.map((p) => chartDateLabel(p.date));
+    const min = vals.length ? Math.min(...vals) : null;
+    const max = vals.length ? Math.max(...vals) : null;
+    const avg = vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
+    const dots = stat.timelineMode === "dots";
+    return (
+      <Modal visible={!!stat} onClose={onClose} title={stat.label}>
+        <View className="gap-3">
+          <View className="flex-row items-end gap-2">
+            <Text variant="display" className="tabular-nums" style={{ color: stat.color }}>{stat.value}</Text>
+            <Text variant="body" className="mb-1 text-text-muted">{stat.sub}</Text>
+          </View>
+          {pts.length >= 2 ? (
+            <View className="gap-1">
+              <Text variant="eyebrow" className="text-text-muted">{pts.length} {stat.timelineNoun ?? "workouts"}</Text>
+              <LineChart
+                height={170}
+                interactive
+                labels={labels}
+                xTicks={4}
+                yFormat={(v) => `${Math.round(v).toLocaleString()}`}
+                series={dots
+                  ? [{ values: vals, color: stat.color, mode: "dots" as const, width: 3 }]
+                  : [{ values: vals, color: stat.color, width: 2.2 }]}
+              />
+              <View className="mt-1 flex-row justify-between">
+                <Text variant="micro" className="text-text-muted tabular-nums">min {fmt(min)}</Text>
+                <Text variant="micro" className="text-text-muted tabular-nums">avg {fmt(avg)}</Text>
+                <Text variant="micro" className="text-text-muted tabular-nums">max {fmt(max)}</Text>
+              </View>
+            </View>
+          ) : (
+            <Text variant="caption" className="text-text-muted">No timeline data yet.</Text>
+          )}
+        </View>
+      </Modal>
+    );
+  }
 
   // Rich path: real endpoint with range + previous overlay
   if (stat.metric) {

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -613,6 +613,27 @@ export function useWorkoutInsights(range: string) {
   return { data, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- Per-workout timelines for the clickable summary-stat cards (web parity) ----
+export interface TimelinePoint { date: string; value: number; label?: string }
+export interface WorkoutTimeline {
+  cumulative: TimelinePoint[];
+  duration: TimelinePoint[];
+  calories: TimelinePoint[];
+  monthly: TimelinePoint[];
+}
+/** Per-workout duration/calories/count series from /api/workouts/timeline. */
+export function useWorkoutTimeline() {
+  const [data, setData] = useState<WorkoutTimeline | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<WorkoutTimeline>("/api/workouts/timeline")
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+  return { data };
+}
+
 // ---- Per-night sleep data (stages, score, sleep HR, SpO2) for the sleep dashboard ----
 export interface SleepNight {
   date: string;

--- a/web/app/api/workouts/timeline/route.ts
+++ b/web/app/api/workouts/timeline/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Per-workout timelines for the native app's clickable summary-stat cards.
+ * Ports the web /workouts page's `getWorkoutTimeline` (hevy_raw_data joined to
+ * workout_enrichment) plus the four client-side series it derives
+ * (cumulative count, duration/workout, calories/workout, workouts/month), so
+ * each mobile stat card can open the same dated timeline the web modal shows.
+ */
+export async function GET() {
+  const sql = getDb();
+
+  const rows = (await sql`
+    SELECT
+      (h.raw_json->>'start_time')::date AS date,
+      h.raw_json->>'title'              AS title,
+      ROUND(EXTRACT(EPOCH FROM ((h.raw_json->>'end_time')::timestamp - (h.raw_json->>'start_time')::timestamp)) / 60)::int AS duration_min,
+      we.calories
+    FROM hevy_raw_data h
+    LEFT JOIN workout_enrichment we ON we.hevy_id = h.raw_json->>'id'
+    WHERE h.endpoint_name = 'workout'
+    ORDER BY date ASC
+  `) as { date: string | Date; title: string | null; duration_min: number | null; calories: number | null }[];
+
+  const norm = (d: string | Date) => (d instanceof Date ? d.toISOString().slice(0, 10) : String(d).slice(0, 10));
+
+  const cumulative = rows.map((w, i) => ({ date: norm(w.date), value: i + 1, label: `#${i + 1}: ${w.title ?? "Workout"}` }));
+  const duration = rows
+    .filter((w) => (w.duration_min ?? 0) > 0)
+    .map((w) => ({ date: norm(w.date), value: Number(w.duration_min), label: w.title ?? "Workout" }));
+  const calories = rows
+    .filter((w) => w.calories != null)
+    .map((w) => ({ date: norm(w.date), value: Number(w.calories), label: w.title ?? "Workout" }));
+
+  const monthlyMap = new Map<string, number>();
+  for (const w of rows) {
+    const month = norm(w.date).slice(0, 7);
+    monthlyMap.set(month, (monthlyMap.get(month) || 0) + 1);
+  }
+  const monthly = [...monthlyMap.entries()]
+    .sort()
+    .map(([month, count]) => ({ date: month + "-01", value: count }));
+
+  return NextResponse.json({ cumulative, duration, calories, monthly });
+}


### PR DESCRIPTION
Part of #473. Closes #535.

Web `/workouts` renders four clickable summary-stat cards, each opening a dated per-workout timeline. The mobile Workouts screen had four cards but only **Avg Calories** was tappable, showing an undated sparkline. This closes that gap.

## What changed
- **`web/app/api/workouts/timeline/route.ts`** (new) — ports the web page's `getWorkoutTimeline` (`hevy_raw_data` joined to `workout_enrichment`) plus the four derived series: cumulative count, duration/workout, calories/workout, workouts/month.
- **`universal/src/lib/api.ts`** — `useWorkoutTimeline()` hook + `WorkoutTimeline` / `TimelinePoint` types.
- **`universal/src/components/stat-detail-modal.tsx`** — a pre-supplied dated-timeline render path (interactive tap-to-read, line or scatter, min/avg/max footer, accurate point-count noun).
- **`universal/src/app/(main)/workouts.tsx`** — all four cards now open their timeline: Total Synced to cumulative, Recent Sessions to duration, Avg Calories to calories (dated), Training Span to workouts/month.

## Verified
- DB: 333 workouts (2021 to 2026), `workout_enrichment` 334 rows all with calories (avg 378, max 1418).
- Endpoint returns 200 with all four series.
- Playwright (390x844) against :3456: each card opens the correct dated chart. Footers match the DB (duration avg 68 min, calories avg 378 / max 1418 kcal). Console clean.
- `tsc --noEmit` clean on web + universal.
