### PR TITLE
feat(app): anatomical muscle activation map on Workouts

### DIFF
--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "universal",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@bacons/apple-targets": "^5.0.0",
         "@expo/ui": "~57.0.6",
@@ -28,6 +29,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.86.0",
+        "react-native-body-highlighter": "^3.2.0",
         "react-native-gesture-handler": "~2.32.0",
         "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
@@ -9076,6 +9078,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-body-highlighter": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-body-highlighter/-/react-native-body-highlighter-3.2.0.tgz",
+      "integrity": "sha512-BxWwcX8PtbKr3X0bW0n4OyPT6b+2R9IUqDyMgq8PP6IhJouSt9ik10a3c7PRYOlA2DdrBjLFiwamqhsMS2BfeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-svg": "^15.9.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-css-interop": {

--- a/universal/package.json
+++ b/universal/package.json
@@ -23,6 +23,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
+    "react-native-body-highlighter": "^3.2.0",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,11 +1,12 @@
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
-import { fetchJson, usePullRefresh, useWorkoutsSummary, useWorkoutInsights, useWorkoutTimeline, type TimelinePoint } from "../../lib/api";
+import { fetchJson, usePullRefresh, useWorkoutsSummary, useWorkoutInsights, useWorkoutTimeline, useBodyMap, type TimelinePoint } from "../../lib/api";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { WorkoutsDashboard } from "../../components/workouts-dashboard";
 import { WorkoutActivity } from "../../components/workout-activity";
 import { WorkoutMuscle } from "../../components/workout-muscle";
+import { MuscleBodyMapSection } from "../../components/muscle-body-map-section";
 import { WorkoutStrength } from "../../components/workout-strength";
 
 interface RecentWorkout {
@@ -66,6 +67,7 @@ export default function WorkoutsScreen() {
   const { data: wkSum } = useWorkoutsSummary(range);
   const { data: insights } = useWorkoutInsights(range);
   const { data: timeline } = useWorkoutTimeline();
+  const { data: bodyMap } = useBodyMap(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
   const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
 
@@ -225,6 +227,9 @@ export default function WorkoutsScreen() {
           </View>
         </View>
         <WorkoutsDashboard summary={wkSum} unit={unit} topRich={insights?.topExercises} />
+
+        {/* Anatomical muscle activation map + 4-metric toggle (new /api/workouts/bodymap) */}
+        <MuscleBodyMapSection data={bodyMap} />
 
         {/* Muscle-group distribution + monthly-by-muscle (new /api/workouts/insights) */}
         <WorkoutMuscle insights={insights} />

--- a/universal/src/components/muscle-body-map-section.tsx
+++ b/universal/src/components/muscle-body-map-section.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { View, Pressable } from "react-native";
+import { Text, Card, SegmentedControl } from "soma-style";
+import { MuscleBodyMap, type MuscleVolumes } from "./muscle-body-map";
+import { ALL_MUSCLE_GROUPS, MUSCLE_COLORS, MUSCLE_LABELS, type MuscleGroup } from "../lib/muscle-groups";
+import type { BodyMapData } from "../lib/api";
+
+const METRICS = ["Volume", "Sets", "Reps", "Sessions"] as const;
+type Metric = typeof METRICS[number];
+const METRIC_KEY: Record<Metric, keyof BodyMapData> = { Volume: "volume", Sets: "sets", Reps: "reps", Sessions: "exercises" };
+const METRIC_UNIT: Record<Metric, string> = { Volume: "kg", Sets: "sets", Reps: "reps", Sessions: "sessions" };
+
+/**
+ * Muscle activation map (web /workouts MuscleBodyMapSection parity): a
+ * 4-metric toggle (Volume / Sets / Reps / Sessions) over the anatomical body
+ * map plus a per-muscle breakdown with primary/secondary split bars, sorted by
+ * activation. Selecting a row or a muscle highlights it on the figure and dims
+ * the rest. Fed by /api/workouts/bodymap; hides itself when there is no data.
+ */
+export function MuscleBodyMapSection({ data }: { data: BodyMapData | null | undefined }) {
+  const [metric, setMetric] = useState<Metric>("Volume");
+  const [selected, setSelected] = useState<MuscleGroup | null>(null);
+
+  const volumes: MuscleVolumes = (data?.[METRIC_KEY[metric]] as MuscleVolumes) ?? {};
+  const sorted = ALL_MUSCLE_GROUPS
+    .filter((mg) => (volumes[mg]?.total ?? 0) > 0)
+    .sort((a, b) => (volumes[b]?.total ?? 0) - (volumes[a]?.total ?? 0));
+  if (!data || sorted.length === 0) return null;
+
+  const maxTotal = volumes[sorted[0]]?.total ?? 1;
+  const unit = METRIC_UNIT[metric];
+  const sel = selected ? volumes[selected] : null;
+  const selPct = selected ? Math.round(((volumes[selected]?.total ?? 0) / maxTotal) * 100) : 0;
+
+  return (
+    <Card className="gap-3">
+      <Text variant="eyebrow">Muscle activation</Text>
+      <SegmentedControl options={METRICS} value={metric} onChange={(v) => { setSelected(null); setMetric(v as Metric); }} />
+
+      <MuscleBodyMap volumes={volumes} selected={selected} onSelect={setSelected} scale={0.85} />
+
+      {sel ? (
+        <View className="flex-row flex-wrap items-center justify-center gap-x-2 gap-y-0.5">
+          <Text variant="caption" style={{ color: MUSCLE_COLORS[selected!] }}>{MUSCLE_LABELS[selected!]}</Text>
+          <Text variant="caption" className="text-text-muted tabular-nums">{selPct}%</Text>
+          {sel.primary > 0 ? <Text variant="micro" className="text-text-muted tabular-nums">{Math.round(sel.primary).toLocaleString()} primary</Text> : null}
+          {sel.secondary > 0 ? <Text variant="micro" className="text-text-muted tabular-nums">+{Math.round(sel.secondary).toLocaleString()} sec</Text> : null}
+        </View>
+      ) : (
+        <Text variant="micro" className="text-text-muted text-center">Tap a muscle or a row to focus it</Text>
+      )}
+
+      <View className="gap-1.5">
+        {sorted.map((mg) => {
+          const d = volumes[mg];
+          if (!d) return null;
+          const frac = d.total / maxTotal; // 0..1 of the top muscle
+          const primaryFrac = d.total > 0 ? d.primary / d.total : 1;
+          const isSel = selected === mg;
+          const dim = selected !== null && !isSel;
+          return (
+            <Pressable key={mg} onPress={() => setSelected(isSel ? null : mg)} style={{ opacity: dim ? 0.35 : 1 }}>
+              <View className="gap-0.5">
+                <View className="flex-row items-center justify-between">
+                  <View className="flex-row items-center gap-1.5">
+                    <View style={{ width: 10, height: 10, borderRadius: 2, backgroundColor: MUSCLE_COLORS[mg] }} />
+                    <Text variant="caption" className={isSel ? "text-text" : "text-text-secondary"}>{MUSCLE_LABELS[mg]}</Text>
+                  </View>
+                  <Text variant="caption" className="text-text-secondary tabular-nums">{Math.round(d.total).toLocaleString()} {unit}</Text>
+                </View>
+                <View className="h-1.5 flex-row overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
+                  <View style={{ flex: Math.max(frac * primaryFrac, 0.02), backgroundColor: MUSCLE_COLORS[mg] }} />
+                  {d.secondary > 0 ? <View style={{ flex: Math.max(frac * (1 - primaryFrac), 0.01), backgroundColor: MUSCLE_COLORS[mg], opacity: 0.4 }} /> : null}
+                  <View style={{ flex: Math.max(1 - frac, 0.001) }} />
+                </View>
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View className="flex-row items-center gap-4 pt-1">
+        <View className="flex-row items-center gap-1">
+          <View style={{ width: 12, height: 6, borderRadius: 2, backgroundColor: "#10b981" }} />
+          <Text variant="micro" className="text-text-muted">Primary</Text>
+        </View>
+        <View className="flex-row items-center gap-1">
+          <View style={{ width: 12, height: 6, borderRadius: 2, backgroundColor: "#10b981", opacity: 0.4 }} />
+          <Text variant="micro" className="text-text-muted">Secondary</Text>
+        </View>
+      </View>
+    </Card>
+  );
+}

--- a/universal/src/components/muscle-body-map.tsx
+++ b/universal/src/components/muscle-body-map.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { View } from "react-native";
+import { Text } from "soma-style";
+import Body, { type ExtendedBodyPart, type Slug } from "react-native-body-highlighter";
+import {
+  ALL_MUSCLE_GROUPS, MUSCLE_COLORS, MUSCLE_TO_SLUGS, SLUG_TO_MUSCLE, hexToRgba, type MuscleGroup,
+} from "../lib/muscle-groups";
+
+export interface MuscleVolumes { [key: string]: { primary: number; secondary: number; total: number } }
+
+/**
+ * Anatomical front + back figures coloured by per-muscle training intensity.
+ * Mobile port of the web MuscleBodyMap (which uses react-body-highlighter, a
+ * DOM-only lib) via react-native-body-highlighter — same intensity model
+ * (alpha = 0.2 + share*0.75, dimmed when another muscle is selected) driven by
+ * a per-part `color`, with tap-to-select mapped back through the slug table.
+ */
+export function MuscleBodyMap({ volumes, selected, onSelect, scale = 1 }: {
+  volumes: MuscleVolumes;
+  selected: MuscleGroup | null;
+  onSelect: (m: MuscleGroup | null) => void;
+  scale?: number;
+}) {
+  const maxTotal = useMemo(
+    () => Math.max(...ALL_MUSCLE_GROUPS.map((mg) => volumes[mg]?.total ?? 0), 1),
+    [volumes],
+  );
+
+  const data = useMemo<ExtendedBodyPart[]>(() => {
+    const out: ExtendedBodyPart[] = [];
+    for (const mg of ALL_MUSCLE_GROUPS) {
+      const total = volumes[mg]?.total ?? 0;
+      if (total <= 0) continue;
+      const intensity = total / maxTotal;
+      const alpha = selected
+        ? mg === selected ? Math.min(0.95, 0.5 + intensity * 0.45) : 0.06 + intensity * 0.12
+        : 0.2 + intensity * 0.75;
+      const color = hexToRgba(MUSCLE_COLORS[mg], alpha);
+      for (const slug of MUSCLE_TO_SLUGS[mg]) out.push({ slug: slug as Slug, color });
+    }
+    return out;
+  }, [volumes, maxTotal, selected]);
+
+  const onPress = (b: ExtendedBodyPart) => {
+    const mg = b.slug ? SLUG_TO_MUSCLE[b.slug] : undefined;
+    if (mg) onSelect(selected === mg ? null : mg);
+  };
+
+  return (
+    <View className="flex-row items-start justify-center gap-4">
+      <View className="items-center">
+        <Text variant="micro" className="text-text-muted mb-1">Front</Text>
+        <Body data={data} side="front" scale={scale} defaultFill="#2a2a2e" border="none" onBodyPartPress={onPress} />
+      </View>
+      <View className="items-center">
+        <Text variant="micro" className="text-text-muted mb-1">Back</Text>
+        <Body data={data} side="back" scale={scale} defaultFill="#2a2a2e" border="none" onBodyPartPress={onPress} />
+      </View>
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -634,6 +634,27 @@ export function useWorkoutTimeline() {
   return { data };
 }
 
+// ---- Per-muscle activation for the Workouts anatomical body map (web parity) ----
+export interface MuscleMetric { primary: number; secondary: number; total: number }
+export interface BodyMapData {
+  volume: Record<string, MuscleMetric>;
+  sets: Record<string, MuscleMetric>;
+  reps: Record<string, MuscleMetric>;
+  exercises: Record<string, MuscleMetric>;
+}
+/** Per-muscle volume/sets/reps/session maps from /api/workouts/bodymap. */
+export function useBodyMap(range: string) {
+  const [data, setData] = useState<BodyMapData | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<BodyMapData>(`/api/workouts/bodymap?range=${range}`)
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [range]);
+  return { data };
+}
+
 // ---- Per-night sleep data (stages, score, sleep HR, SpO2) for the sleep dashboard ----
 export interface SleepNight {
   date: string;

--- a/universal/src/lib/muscle-groups.ts
+++ b/universal/src/lib/muscle-groups.ts
@@ -1,0 +1,55 @@
+/**
+ * Muscle-group constants for the mobile Workouts body map. The exercise→muscle
+ * mapping itself runs server-side (web /api/workouts/bodymap ports
+ * getBodyMapVolumes), so the app only needs labels, colors, display order, and
+ * the mapping from our groups to react-native-body-highlighter's SVG slugs.
+ */
+export type MuscleGroup =
+  | "chest" | "back" | "shoulders" | "biceps" | "triceps" | "forearms"
+  | "quads" | "hamstrings" | "glutes" | "calves" | "core";
+
+export const ALL_MUSCLE_GROUPS: MuscleGroup[] = [
+  "chest", "back", "shoulders", "biceps", "triceps", "forearms",
+  "quads", "hamstrings", "glutes", "calves", "core",
+];
+
+export const MUSCLE_LABELS: Record<MuscleGroup, string> = {
+  chest: "Chest", back: "Back", shoulders: "Shoulders", biceps: "Biceps",
+  triceps: "Triceps", forearms: "Forearms", quads: "Quads", hamstrings: "Hamstrings",
+  glutes: "Glutes", calves: "Calves", core: "Core",
+};
+
+export const MUSCLE_COLORS: Record<MuscleGroup, string> = {
+  chest: "#ef4444", back: "#22c55e", shoulders: "#f97316", biceps: "#06b6d4",
+  triceps: "#a855f7", forearms: "#ec4899", quads: "#3b82f6", hamstrings: "#8b5cf6",
+  glutes: "#f59e0b", calves: "#10b981", core: "#eab308",
+};
+
+/** Our groups → react-native-body-highlighter slugs (rn uses a single
+ *  `deltoids`, `hamstring` singular, and splits back into upper/lower/traps). */
+export const MUSCLE_TO_SLUGS: Record<MuscleGroup, string[]> = {
+  chest: ["chest"],
+  back: ["upper-back", "lower-back", "trapezius"],
+  shoulders: ["deltoids"],
+  biceps: ["biceps"],
+  triceps: ["triceps"],
+  forearms: ["forearm"],
+  quads: ["quadriceps"],
+  hamstrings: ["hamstring"],
+  glutes: ["gluteal"],
+  calves: ["calves"],
+  core: ["abs", "obliques"],
+};
+
+export const SLUG_TO_MUSCLE: Record<string, MuscleGroup> = (() => {
+  const r: Record<string, MuscleGroup> = {};
+  for (const mg of ALL_MUSCLE_GROUPS) for (const slug of MUSCLE_TO_SLUGS[mg]) r[slug] = mg;
+  return r;
+})();
+
+export function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${Math.max(0, Math.min(1, alpha)).toFixed(2)})`;
+}

--- a/web/app/api/workouts/bodymap/route.ts
+++ b/web/app/api/workouts/bodymap/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { getExerciseMuscles, ALL_MUSCLE_GROUPS, type MuscleGroup } from "@/lib/muscle-groups";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Metric = { primary: number; secondary: number; total: number };
+type MetricMap = Record<MuscleGroup, Metric>;
+
+const initMetric = (): MetricMap => {
+  const r = {} as MetricMap;
+  for (const mg of ALL_MUSCLE_GROUPS) r[mg] = { primary: 0, secondary: 0, total: 0 };
+  return r;
+};
+
+/**
+ * Per-muscle activation for the native Workouts body map. Ports the web
+ * /workouts page's `getBodyMapVolumes`: aggregates each exercise's volume,
+ * sets, reps and workout-session count onto its primary/secondary muscle
+ * groups (secondary weighted 0.33), returning one map per metric so the app
+ * can drive the anatomical figure + 4-metric toggle.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const range = searchParams.get("range") || "1y";
+  const days = range === "30d" ? 30 : range === "90d" ? 90 : range === "6m" ? 182 : range === "all" ? 36500 : 365;
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT
+      e->>'title' as exercise,
+      SUM((s->>'weight_kg')::float * (s->>'reps')::int) as volume,
+      COUNT(*) as sets,
+      SUM((s->>'reps')::int) as reps,
+      COUNT(DISTINCT raw_json->>'id') as sessions
+    FROM hevy_raw_data,
+      jsonb_array_elements(raw_json->'exercises') as e,
+      jsonb_array_elements(e->'sets') as s
+    WHERE endpoint_name = 'workout'
+      AND (raw_json->>'start_time')::timestamp >= ${cutoff}::date
+      AND s->>'type' = 'normal'
+      AND (s->>'weight_kg')::float > 0
+      AND (s->>'reps')::int > 0
+    GROUP BY e->>'title'
+  `) as { exercise: string; volume: number; sets: number; reps: number; sessions: number }[];
+
+  const volume = initMetric();
+  const sets = initMetric();
+  const reps = initMetric();
+  const exercises = initMetric();
+
+  for (const row of rows) {
+    const mapping = getExerciseMuscles(String(row.exercise));
+    const vals = { volume: Number(row.volume), sets: Number(row.sets), reps: Number(row.reps), exercises: Number(row.sessions) };
+    for (const key of ["volume", "sets", "reps", "exercises"] as const) {
+      const target = { volume, sets, reps, exercises }[key];
+      const val = vals[key];
+      for (const mg of mapping.primary) { target[mg].primary += val; target[mg].total += val; }
+      for (const mg of mapping.secondary) { const c = val * 0.33; target[mg].secondary += c; target[mg].total += c; }
+    }
+  }
+
+  return NextResponse.json({ volume, sets, reps, exercises });
+}


### PR DESCRIPTION
Part of #473. Closes #537.

Web `/workouts` renders a **Muscle Activation Map** (`MuscleBodyMapSection` + `MuscleBodyMap` + `getBodyMapVolumes`): front/back anatomical figures coloured by per-muscle intensity, a 4-metric toggle, and a sorted breakdown with primary/secondary split bars. The mobile Workouts screen had only flat muscle-group bars. This closes that gap.

## What changed
- **`web/app/api/workouts/bodymap/route.ts`** (new) — ports `getBodyMapVolumes`: aggregates volume/sets/reps/session-count onto each exercise's primary/secondary muscle groups (secondary weighted 0.33) via `getExerciseMuscles`, one map per metric, range-aware (`?range=30d|90d|1y`).
- **`react-native-body-highlighter@3.2.0`** — the rn-svg twin of the web's DOM-only `react-body-highlighter`. All 11 muscle groups map cleanly to its slugs (shoulders to `deltoids`, back to `upper-back`+`lower-back`+`trapezius`, core to `abs`+`obliques`).
- **`universal/src/lib/muscle-groups.ts`** — labels / colours / display order + our-group to slug map (the mapping itself runs server-side).
- **`universal/src/components/muscle-body-map.tsx`** — front + back figures, per-part intensity colouring (same alpha model as web), tap-to-select.
- **`universal/src/components/muscle-body-map-section.tsx`** — 4-metric toggle, selected-muscle readout, sorted breakdown with primary/secondary split bars.
- **`universal/src/lib/api.ts`** — `useBodyMap(range)` hook + `BodyMapData` type.
- **`universal/src/app/(main)/workouts.tsx`** — renders the section, fed by the screen's range selector.

## Verified
- DB: 333 workouts; endpoint returns all 11 muscles per metric (volume top: calves / back / quads; sets top: back / biceps / triceps).
- Endpoint 200 on all four metrics.
- Playwright (390x844) against :3456: figures render coloured by intensity; the Volume to Sets toggle recolours; tapping Biceps highlights both biceps and dims the rest with a "65% - 21 primary - +15 sec" readout; breakdown sorted with split bars.
- `tsc --noEmit` clean on web + universal.
- Console warnings on the web preview are all from the library's legacy Touchable on react-native-web (web-preview-only, absent on the native iOS/Android target).
