### PR TITLE
feat(app): day prep list on Nutrition (raw ingredients to cook)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -12,6 +12,7 @@ import { ComposeMealView } from "../../components/compose-meal-view";
 import { MealDetailModal } from "../../components/meal-detail-modal";
 import { MacroGoalBar, buildMacroMarkers, ProteinQualityPill } from "../../components/macro-goal-bar";
 import { NutritionContextStrip } from "../../components/nutrition-context-strip";
+import { PrepSummary } from "../../components/prep-summary";
 
 /** 14-day daily-calories series for the adherence trend sparkline. */
 function useCaloriesTrend() {
@@ -407,6 +408,9 @@ export default function NutritionScreen() {
                 <Text variant="micro">Informational — your targets are unchanged.</Text>
               </Card>
             ) : null}
+
+            {/* Day prep list — raw ingredients to cook, grouped across meals */}
+            <PrepSummary meals={meals} ingredients={ingredients} />
 
             {/* Per-slot meal cards — logged meals + delete + quick-log + skip */}
             {slots.map((s) => {

--- a/universal/src/components/prep-summary.tsx
+++ b/universal/src/components/prep-summary.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from "react";
+import { View, Pressable } from "react-native";
+import { Text, Card } from "soma-style";
+import type { SomaMeal, Ingredient } from "../lib/api";
+
+const SLOT_LABELS: Record<string, string> = {
+  breakfast: "bfast",
+  lunch: "lunch",
+  dinner: "dinner",
+  pre_sleep: "presleep",
+  during_workout: "workout",
+};
+
+interface PrepItem {
+  id: string;
+  name: string;
+  totalGrams: number;
+  meals: { slot: string; grams: number }[];
+}
+
+/**
+ * The day's prep list (web nutrition prep-summary parity): groups the day's
+ * meal items by ingredient, keeps only cookable (`is_raw`) ones, sums grams and
+ * lists the per-slot split. Collapsible; hides itself when nothing needs cooking.
+ */
+export function PrepSummary({ meals, ingredients }: { meals: SomaMeal[]; ingredients: Ingredient[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const prepItems = useMemo<PrepItem[]>(() => {
+    const ingLookup = new Map(ingredients.map((i) => [i.id, i]));
+    const groups: Record<string, { name: string; isRaw: boolean; meals: { slot: string; grams: number }[] }> = {};
+
+    for (const meal of meals) {
+      for (const item of meal.items ?? []) {
+        const id = item.ingredient_id;
+        if (!id) continue;
+        const grams = Number(item.grams) || 0;
+        if (grams <= 0) continue;
+        if (!groups[id]) {
+          const ing = ingLookup.get(id);
+          const name = ing?.name || (item.name || id)
+            .replace(/_raw$/, "")
+            .replace(/_(dry|whole)$/i, "")
+            .replace(/_\d+pct$/i, "")
+            .replace(/_/g, " ")
+            .replace(/\b\w/g, (c) => c.toUpperCase())
+            .trim();
+          groups[id] = { name, isRaw: !!ing?.is_raw, meals: [] };
+        }
+        groups[id].meals.push({ slot: meal.meal_slot, grams });
+      }
+    }
+
+    return Object.entries(groups)
+      .filter(([, g]) => g.isRaw)
+      .map(([id, g]): PrepItem => ({
+        id,
+        name: g.name,
+        totalGrams: g.meals.reduce((s, m) => s + m.grams, 0),
+        meals: g.meals,
+      }))
+      .sort((a, b) => b.totalGrams - a.totalGrams);
+  }, [meals, ingredients]);
+
+  if (prepItems.length === 0) return null;
+
+  return (
+    <Card className="gap-2">
+      <Pressable onPress={() => setExpanded((e) => !e)} hitSlop={6}>
+        <View className="flex-row items-center justify-between">
+          <Text variant="eyebrow">Prep list · {prepItems.length} to cook</Text>
+          <Text variant="micro" className="text-text-muted">{expanded ? "▲" : "▼"}</Text>
+        </View>
+      </Pressable>
+      {expanded ? (
+        <View className="gap-1.5">
+          {prepItems.map((item) => (
+            <View key={item.id} className="flex-row items-baseline justify-between gap-2">
+              <Text variant="caption" className="flex-shrink text-text">{item.name}</Text>
+              <View className="flex-row items-baseline gap-1.5">
+                <Text variant="caption" className="text-text tabular-nums">{Math.round(item.totalGrams)}g</Text>
+                <Text variant="micro" className="text-text-muted">
+                  ({item.meals.map((m) => `${Math.round(m.grams)}g ${SLOT_LABELS[m.slot] ?? m.slot}`).join(" + ")})
+                </Text>
+              </View>
+            </View>
+          ))}
+          <Text variant="micro" className="text-text-muted">Raw weights to cook, grouped across the day.</Text>
+        </View>
+      ) : null}
+    </Card>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -844,6 +844,8 @@ export interface Ingredient {
   id: string; name: string; category: string;
   calories_per_100g: number; protein_per_100g: number; carbs_per_100g: number; fat_per_100g: number; fiber_per_100g: number;
   unit?: string | null; grams_per_unit?: number | null;
+  /** Cookable/raw ingredient (drives the day's prep list). */
+  is_raw?: boolean;
 }
 /** Macros for `grams` of an ingredient (linear per-100g scaling). */
 export function ingredientMacros(ing: Ingredient, grams: number) {


### PR DESCRIPTION
Part of #473. Closes #539.

Web nutrition renders a **Prep List** (`prep-summary.tsx`): the day's meal items grouped by ingredient, filtered to cookable (`is_raw`) ones, with total grams and the per-slot split. The mobile Nutrition screen had no equivalent. This closes that gap.

## What changed
- **`universal/src/components/prep-summary.tsx`** (new) — collapsible card: groups `meals[].items` by `ingredient_id`, keeps `is_raw` ingredients, sums grams, lists the per-slot breakdown (`60g bfast + 70g lunch`), sorted by total grams. Hides itself when nothing is cookable.
- **`universal/src/lib/api.ts`** — `is_raw?` added to the `Ingredient` type (the presets endpoint already `SELECT *`s it, so no web change).
- **`universal/src/app/(main)/nutrition.tsx`** — renders `<PrepSummary>` above the per-slot meal cards, fed by the day's meals + presets.

## Verified
- DB: `ingredients.is_raw` present (13 of 86 raw); 2026-05-05 yields 4 raw prep items.
- Playwright (390x844) against :3456: the Prep list reads "4 to cook" and expands to Cherry Tomatoes 130g (60g bfast + 70g lunch), Carrots (raw) 120g, Broccoli (raw) 70g, Oats (dry) 30g — sorted by grams, per-slot split correct. 0 console errors.
- `tsc --noEmit` clean on universal.
