### PR TITLE
feat(app): HR timeline + zones + min HR + per-set detail in workout modal

### DIFF
--- a/universal/src/components/workout-detail-modal.tsx
+++ b/universal/src/components/workout-detail-modal.tsx
@@ -1,15 +1,30 @@
 import { useEffect, useState } from "react";
 import { View } from "react-native";
-import { Text, Card, Modal, Badge } from "soma-style";
+import { Text, Modal } from "soma-style";
+import { LineChart } from "./line-chart";
 import { fetchJson } from "../lib/api";
 
 interface WSet { weight_kg: number | null; reps: number | null; type?: string; avg_hr?: number }
 interface WExercise { title: string; sets: WSet[] }
+interface HrZone { zone: number; seconds: number; low: number; high: number }
 interface WorkoutDetail {
   id: string; title?: string; start_time?: string; end_time?: string;
   exercises: WExercise[];
-  garmin: { avg_hr: number | null; max_hr: number | null; calories: number | null } | null;
+  garmin: {
+    avg_hr: number | null; max_hr: number | null; min_hr?: number | null; calories: number | null;
+    hr_zones?: HrZone[] | null;
+    hr_timeline?: { elapsed_sec: number; hr: number }[];
+  } | null;
 }
+
+// Zone 1..5 palette (easy → max).
+const ZONE_COLORS = ["#5a7a8a", "#77c8d1", "#6ad4a0", "#e0a458", "#e06060"];
+// Distinct set types get a badge; "normal" is left plain.
+const SET_TYPE: Record<string, { label: string; color: string }> = {
+  warmup: { label: "W", color: "#8aa0ac" },
+  failure: { label: "F", color: "#e06060" },
+  dropset: { label: "D", color: "#e0a458" },
+};
 
 const KG_TO_LB = 2.20462;
 function longDate(iso: string | undefined): string {
@@ -87,26 +102,85 @@ export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | 
                 <View className="min-w-[30%] flex-1">
                   <Text variant="eyebrow" className="text-text-muted">Avg HR</Text>
                   <Text variant="title" className="text-danger">{Math.round(data.garmin.avg_hr)}</Text>
-                  <Text variant="micro" className="text-text-muted">{data.garmin.max_hr != null ? `max ${Math.round(data.garmin.max_hr)}` : "bpm"}</Text>
+                  <Text variant="micro" className="text-text-muted">
+                    {data.garmin.min_hr != null ? `${Math.round(data.garmin.min_hr)}–` : ""}{data.garmin.max_hr != null ? `${Math.round(data.garmin.max_hr)} bpm` : "bpm"}
+                  </Text>
                 </View>
               ) : null}
             </View>
 
-            <View className="gap-2">
-              {exercises.map((ex, ei) => (
-                <View key={ei} className="gap-1 border-t border-border-subtle pt-2">
-                  <Text variant="body" className="text-text" numberOfLines={1}>{ex.title || "Exercise"}</Text>
-                  <View className="flex-row flex-wrap gap-1.5">
-                    {ex.sets.map((s, si) => (
-                      <View key={si} className="rounded-md bg-surface-subtle px-2 py-1">
-                        <Text variant="micro" className="tabular-nums text-text-secondary">
-                          {s.weight_kg != null ? `${w(s.weight_kg)} × ` : ""}{s.reps ?? "—"}
-                        </Text>
-                      </View>
-                    ))}
-                  </View>
+            {/* Garmin HR over the session (from enrichment hr_samples) */}
+            {(() => {
+              const tl = data.garmin?.hr_timeline ?? [];
+              if (tl.length < 2) return null;
+              const hrs = tl.map((p) => p.hr);
+              const labels = tl.map((p) => `${Math.round(p.elapsed_sec / 60)}m`);
+              return (
+                <View className="gap-1">
+                  <Text variant="eyebrow" className="text-text-muted">Heart rate</Text>
+                  <LineChart height={130} interactive xTicks={4} labels={labels}
+                    yFormat={(v) => `${Math.round(v)}`}
+                    series={[{ values: hrs, color: "#e06060", width: 2 }]} />
                 </View>
-              ))}
+              );
+            })()}
+
+            {/* Time in HR zones (only for workouts matched to a Garmin cardio activity) */}
+            {data.garmin?.hr_zones && data.garmin.hr_zones.length > 0 ? (() => {
+              const zones = data.garmin!.hr_zones!;
+              const maxSec = Math.max(...zones.map((z) => z.seconds), 1);
+              return (
+                <View className="gap-1.5">
+                  <Text variant="eyebrow" className="text-text-muted">Time in zones</Text>
+                  {zones.map((z) => {
+                    const mins = z.seconds / 60;
+                    const color = ZONE_COLORS[Math.min(Math.max(z.zone - 1, 0), 4)];
+                    return (
+                      <View key={z.zone} className="flex-row items-center gap-2">
+                        <Text variant="micro" className="w-14 text-text-secondary tabular-nums">Z{z.zone} · {z.low}+</Text>
+                        <View className="h-2.5 flex-1 overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
+                          <View style={{ width: `${Math.max((z.seconds / maxSec) * 100, 2)}%`, height: "100%", backgroundColor: color }} />
+                        </View>
+                        <Text variant="micro" className="w-12 text-right text-text-muted tabular-nums">{mins >= 1 ? `${Math.round(mins)}m` : `${Math.round(z.seconds)}s`}</Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              );
+            })() : null}
+
+            <View className="gap-2">
+              {exercises.map((ex, ei) => {
+                let exVol = 0;
+                for (const s of ex.sets) if (s.weight_kg != null && s.reps != null) exVol += s.weight_kg * s.reps;
+                const exVolDisp = unit === "lb" ? exVol * KG_TO_LB : exVol;
+                return (
+                  <View key={ei} className="gap-1 border-t border-border-subtle pt-2">
+                    <View className="flex-row items-center justify-between">
+                      <Text variant="body" className="flex-shrink text-text" numberOfLines={1}>{ex.title || "Exercise"}</Text>
+                      {exVol > 0 ? (
+                        <Text variant="micro" className="text-text-muted tabular-nums">
+                          {exVolDisp >= 1000 ? `${(exVolDisp / 1000).toFixed(1)}k` : Math.round(exVolDisp)} {unit}
+                        </Text>
+                      ) : null}
+                    </View>
+                    <View className="flex-row flex-wrap gap-1.5">
+                      {ex.sets.map((s, si) => {
+                        const badge = s.type && s.type !== "normal" ? SET_TYPE[s.type] : undefined;
+                        return (
+                          <View key={si} className="flex-row items-center gap-1 rounded-md bg-surface-subtle px-2 py-1">
+                            {badge ? <Text variant="micro" style={{ color: badge.color }}>{badge.label}</Text> : null}
+                            <Text variant="micro" className="tabular-nums text-text-secondary">
+                              {s.weight_kg != null ? `${w(s.weight_kg)} × ` : ""}{s.reps ?? "—"}
+                            </Text>
+                            {s.avg_hr != null ? <Text variant="micro" className="tabular-nums" style={{ color: "#e06060" }}>♥{Math.round(s.avg_hr)}</Text> : null}
+                          </View>
+                        );
+                      })}
+                    </View>
+                  </View>
+                );
+              })}
             </View>
           </>
         )}


### PR DESCRIPTION
Part of #473. Closes #543.

The web workout detail modal has an HR tab (min HR, HR-over-time, time-in-zone bars) plus per-set HR, set-type badges and per-exercise volume. The mobile modal showed only avg/max HR and bare `weight × reps` — even though `/api/workout/[id]` already returns `garmin.min_hr`, `garmin.hr_timeline`, `garmin.hr_zones` and per-set `avg_hr`/`type`, all discarded by the app's stripped TS types.

## What changed
`universal/src/components/workout-detail-modal.tsx` (types widened, no new fetch):
- **Min HR** folded into the HR box readout (`62–128 bpm`).
- **HR timeline** — the Garmin per-session HR (from enrichment `hr_samples`) rendered via the shared interactive `LineChart`.
- **Time-in-zone bars** — one bar per zone (seconds → minutes), shown only when `hr_zones` is present (matched Garmin cardio activity; strength workouts have none, so it's guarded).
- **Per-set avg HR** (♥) on each set chip; **warmup/failure/dropset** badges.
- **Per-exercise volume subtotals** in each exercise header.

## Verified
- Endpoint: `/api/workout/fd806239…` returns `min_hr 62`, a 45-point `hr_timeline`, per-set `avg_hr` (`hr_zones` null for gym workouts).
- Playwright (390×844) against :3456: opened the workout modal — Avg HR `76` / `62–128 bpm`, the HR timeline chart (62→128 over 0→88m, interactive), per-set `♥75 / ♥63 / …`, and per-exercise volume subtotals (Bench 1.8k, Overhead 692, …). Console clean (only the known body-map library noise).
- `tsc --noEmit` clean on universal.
