### PR TITLE
feat(app): burn-vs-eaten chart + projection stats on nutrition Trend

### DIFF
--- a/universal/src/components/body-comp-chart.tsx
+++ b/universal/src/components/body-comp-chart.tsx
@@ -92,7 +92,25 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
             <Text variant="caption" className="tabular-nums">{p.daysRemaining}</Text>
           </View>
         ) : null}
+        {p.fatToLose != null && p.fatToLose > 0 ? (
+          <View>
+            <Text variant="micro" className="text-text-muted">Fat to lose</Text>
+            <Text variant="caption" className="tabular-nums">{p.fatToLose.toFixed(1)} kg</Text>
+          </View>
+        ) : null}
+        {p.avgActualDeficit != null ? (
+          <View>
+            <Text variant="micro" className="text-text-muted">Avg deficit</Text>
+            <Text variant="caption" className="tabular-nums">{Math.round(p.avgActualDeficit).toLocaleString()}/day</Text>
+          </View>
+        ) : null}
       </View>
+      {p.requiredDeficit != null && p.requiredDeficit > 0 ? (
+        <Text variant="micro" className="text-text-muted">
+          Need {Math.round(p.requiredDeficit).toLocaleString()} kcal/day{p.targetDate ? ` to hit ${shortLabel(p.targetDate)}` : ""}
+          {p.avgActualDeficit != null ? ` · averaging ${Math.round(p.avgActualDeficit).toLocaleString()}` : ""}
+        </Text>
+      ) : null}
     </Card>
   );
 }
@@ -123,6 +141,11 @@ export function BodyCompChart({ visible }: { visible: boolean }) {
   const dLabels = dAxis.map(shortLabel);
   const cumulative = dailyDeficits.map((d) => d.cumulative);
   const goalPace = dailyDeficits.map((d) => d.goalPace);
+  // Burn-vs-eaten: total burn (BMR + steps + runs + gym) against calories eaten;
+  // the gap is the day's deficit.
+  const burn = dailyDeficits.map((d) => (d.totalBurn != null ? d.totalBurn : null));
+  const eaten = dailyDeficits.map((d) => (d.consumed != null ? d.consumed : null));
+  const hasBurn = dailyDeficits.some((d) => d.totalBurn != null && d.consumed != null);
 
   const legend = [
     { color: C.actual, label: "Weigh-in" },
@@ -186,6 +209,26 @@ export function BodyCompChart({ visible }: { visible: boolean }) {
             { color: C.deficit, label: "Actual" },
             { color: "#3a5563", label: "Goal pace", dashed: true },
           ]} />
+        </Card>
+      ) : null}
+
+      {hasBurn && dailyDeficits.length >= 2 ? (
+        <Card className="gap-2">
+          <Text variant="eyebrow">Burn vs eaten</Text>
+          <LineChart
+            height={140}
+            labels={dLabels}
+            yFormat={(v) => `${Math.round(v).toLocaleString()}`}
+            series={[
+              { values: burn, color: C.goal, width: 2.2, label: "Burn" },
+              { values: eaten, color: C.smooth, mode: "dots", width: 3, label: "Eaten" },
+            ]}
+          />
+          <ChartLegend items={[
+            { color: C.goal, label: "Total burn" },
+            { color: C.smooth, label: "Eaten" },
+          ]} />
+          <Text variant="micro" className="text-text-muted">The gap is the day&apos;s deficit — burn from BMR + steps + runs + gym.</Text>
         </Card>
       ) : null}
     </View>

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -957,13 +957,17 @@ export interface BodyCompProfile {
   deficit: number; onTrack?: boolean;
   trendSlope?: number; daysRemaining?: number; weeklyRate?: number;
   totalActualDeficit?: number; realisticDate?: string | null;
+  fatToLose?: number; requiredDeficit?: number; avgActualDeficit?: number;
 }
 export interface BodyComp {
   profile: BodyCompProfile;
   weights: { date: string; weight: number; smoothed: number; bf: number; smoothedBf: number }[];
   goalLine: { date: string; weight: number; bf: number }[];
   trendPrediction: { date: string; weight: number; bf: number }[];
-  dailyDeficits: { date: string; deficit: number; cumulative: number; goalPace: number; closed: boolean; isToday: boolean }[];
+  dailyDeficits: {
+    date: string; deficit: number; cumulative: number; goalPace: number; closed: boolean; isToday: boolean;
+    bmr?: number; dailyActivity?: number; runCal?: number; gymCal?: number; totalBurn?: number; consumed?: number;
+  }[];
   goalDeficit: number;
 }
 export function useBodyComp(enabled: boolean) {


### PR DESCRIPTION
Part of #473. Closes #549.

The web body-comp trend has a burn-vs-eaten daily chart and a status card with fat-to-lose / goal rate / avg deficit / required kcal-per-day. The mobile trend had only Weight, Body-Fat % and Cumulative-deficit charts and a thinner status card — even though `/api/nutrition/body-comp` already returns per-day `bmr/dailyActivity/runCal/gymCal/totalBurn/consumed` in `dailyDeficits[]` and `profile.fatToLose/requiredDeficit/avgActualDeficit`, all discarded by the app's stripped TS types.

## What changed
- **`universal/src/lib/api.ts`** — widened `dailyDeficits[]` (burn fields) and `BodyCompProfile` (fatToLose / requiredDeficit / avgActualDeficit).
- **`universal/src/components/body-comp-chart.tsx`** —
  - New **Burn vs eaten** chart after Cumulative deficit: total-burn line vs eaten dots (the gap is the deficit), shown only when the burn fields are present.
  - Status card gains **Fat to lose**, **Avg deficit**, and a **"Need X kcal/day to hit DATE"** line (guarded on `requiredDeficit > 0`).

## Verified
- Endpoint: last day totalBurn 2696 / consumed 401; profile fatToLose 1.9, avgActualDeficit 916, requiredDeficit 0.
- Playwright (390×844) against :3456, nutrition → Trend: the Burn-vs-eaten chart renders (amber burn line, teal eaten dots, y 161→6661); the status card shows Fat to lose 1.9 kg and Avg deficit 916/day; the "need kcal/day" line is correctly hidden (requiredDeficit 0, target passed). `tsc --noEmit` clean; console clean.
