### PR TITLE
feat(app): exercise modal metric toggle + session history + best-set volume

### DIFF
--- a/universal/src/components/exercise-detail-modal.tsx
+++ b/universal/src/components/exercise-detail-modal.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
-import { View } from "react-native";
-import { Text, Card, Modal, Badge } from "soma-style";
+import { View, ScrollView } from "react-native";
+import { Text, Modal, Badge, SegmentedControl } from "soma-style";
 import { LineChart } from "./line-chart";
 import { fetchJson } from "../lib/api";
+
+const PROG_METRICS = ["Weight", "Volume", "1RM", "Reps"] as const;
+type ProgMetric = typeof PROG_METRICS[number];
 
 interface Rec { value: number; date: string; reps?: number; weight?: number }
 interface ProgPoint {
@@ -33,6 +36,7 @@ function shortDate(iso: string | null): string {
 export function ExerciseDetailModal({ name, unit, onClose }: { name: string | null; unit: "kg" | "lb"; onClose: () => void }) {
   const [data, setData] = useState<ExerciseDetail | null>(null);
   const [loading, setLoading] = useState(false);
+  const [metric, setMetric] = useState<ProgMetric>("Weight");
   useEffect(() => {
     if (!name) { setData(null); return; }
     let alive = true;
@@ -46,10 +50,20 @@ export function ExerciseDetailModal({ name, unit, onClose }: { name: string | nu
 
   if (!name) return null;
   const w = (kg: number | null | undefined) => (kg == null ? "—" : `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10} ${unit}`);
+  const uw = (kg: number) => (unit === "lb" ? kg * KG_TO_LB : kg);
   const prog = data?.progression ?? [];
-  const wSeries = prog.map((p) => (unit === "lb" ? p.maxWeight * KG_TO_LB : p.maxWeight));
-  const last = prog.length ? prog[prog.length - 1] : null;
   const muscles = [...(data?.muscles.primary ?? [])];
+
+  const METRIC_CFG: Record<ProgMetric, { get: (p: ProgPoint) => number; color: string; fmt: (v: number) => string }> = {
+    Weight: { get: (p) => uw(p.maxWeight), color: "#cbe896", fmt: (v) => `${Math.round(v)}` },
+    Volume: { get: (p) => uw(p.totalVolume), color: "#77c8d1", fmt: (v) => (v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${Math.round(v)}`) },
+    "1RM": { get: (p) => uw(p.estimated1RM), color: "#6ad4a0", fmt: (v) => `${Math.round(v)}` },
+    Reps: { get: (p) => p.maxReps, color: "#e0a458", fmt: (v) => `${Math.round(v)}` },
+  };
+  const mcfg = METRIC_CFG[metric];
+  const series = prog.map((p) => mcfg.get(p));
+  // Recent sessions, newest first (bounded for the modal).
+  const sessions = [...prog].reverse().slice(0, 8);
 
   return (
     <Modal visible={!!name} onClose={onClose} title={name}>
@@ -88,25 +102,47 @@ export function ExerciseDetailModal({ name, unit, onClose }: { name: string | nu
                 <Text variant="title" className="text-text">{data.totalSessions}</Text>
                 <Text variant="micro" className="text-text-muted">{data.totalSets} sets · {data.totalReps} reps</Text>
               </View>
+              {data.records.maxVolume?.value ? (
+                <View className="min-w-[46%] flex-1">
+                  <Text variant="eyebrow" className="text-text-muted">Best set volume</Text>
+                  <Text variant="title" className="text-warm">{Math.round(uw(data.records.maxVolume.value)).toLocaleString()}</Text>
+                  <Text variant="micro" className="text-text-muted">
+                    {data.records.maxVolume.weight != null ? `${w(data.records.maxVolume.weight)} × ${data.records.maxVolume.reps ?? "—"} · ` : ""}{shortDate(data.records.maxVolume.date)}
+                  </Text>
+                </View>
+              ) : null}
             </View>
 
-            {wSeries.length >= 2 ? (
-              <View className="gap-1">
-                <Text variant="eyebrow" className="text-text-muted">Max weight · {wSeries.length} sessions</Text>
-                <LineChart height={140} series={[{ values: wSeries, color: "#cbe896", width: 2.2 }]} yFormat={(v) => `${Math.round(v)}`} />
+            {series.length >= 2 ? (
+              <View className="gap-2">
+                <Text variant="eyebrow" className="text-text-muted">Progression · {series.length} sessions</Text>
+                <SegmentedControl options={PROG_METRICS} value={metric} onChange={(v) => setMetric(v as ProgMetric)} />
+                <LineChart height={150} interactive series={[{ values: series, color: mcfg.color, width: 2.2 }]} yFormat={mcfg.fmt} />
               </View>
             ) : null}
 
-            {last?.sets?.length ? (
-              <View className="gap-1">
-                <Text variant="eyebrow" className="text-text-muted">Last session · {shortDate(last.date)}</Text>
-                <View className="flex-row flex-wrap gap-1.5">
-                  {last.sets.map((s, i) => (
-                    <View key={i} className="rounded-md bg-surface-subtle px-2 py-1">
-                      <Text variant="micro" className="tabular-nums text-text">{w(s.weight)} × {s.reps}</Text>
+            {sessions.length ? (
+              <View className="gap-1.5">
+                <Text variant="eyebrow" className="text-text-muted">Session history</Text>
+                <ScrollView style={{ maxHeight: 220 }} showsVerticalScrollIndicator={false}>
+                  {sessions.map((sess, si) => (
+                    <View key={si} className="gap-1 border-t border-border-subtle py-2">
+                      <View className="flex-row items-center justify-between">
+                        <Text variant="caption" className="text-text">{shortDate(sess.date)}{sess.program ? ` · ${sess.program}` : ""}</Text>
+                        <Text variant="micro" className="text-text-muted tabular-nums">
+                          {Math.round(uw(sess.totalVolume)).toLocaleString()} {unit}{sess.avgHr != null ? ` · ♥${Math.round(sess.avgHr)}` : ""}
+                        </Text>
+                      </View>
+                      <View className="flex-row flex-wrap gap-1.5">
+                        {sess.sets.map((s, i) => (
+                          <View key={i} className="rounded-md bg-surface-subtle px-2 py-1">
+                            <Text variant="micro" className="tabular-nums text-text-secondary">{w(s.weight)} × {s.reps}</Text>
+                          </View>
+                        ))}
+                      </View>
                     </View>
                   ))}
-                </View>
+                </ScrollView>
               </View>
             ) : null}
           </>


### PR DESCRIPTION
Part of #473. Closes #551.

The web exercise detail modal has a progression metric switcher (Max Weight / Total Volume / Est.1RM / Max Reps), a Best-Set-Volume card, and a full per-session History tab. The mobile modal charted only Max Weight, showed only the last session, and omitted maxVolume — even though `/api/workouts/exercise` already returns `records.maxVolume` and each `progression[]` point carries `maxWeight/totalVolume/maxReps/estimated1RM/avgHr/sets`. All client-side.

## What changed
`universal/src/components/exercise-detail-modal.tsx`:
- **Progression metric toggle** — a `SegmentedControl` (Weight / Volume / 1RM / Reps, unit-aware) feeding the progression `LineChart`.
- **Best-set-volume** record card from `records.maxVolume`.
- **Session history** — a scrollable recent-session list (newest first) with date + program + per-session total volume + avg HR + all sets, replacing the last-session-only block.

## Verified
- Playwright (390×844) against :3456: opened Bench Press (Barbell) — record cards incl. **Best set volume 782** (52.2 kg × 15); the toggle switches the chart (Weight 43→75 kg → 1RM 57→90); Session history lists Aug 26 Push (1,650 kg · ♥94, all sets), Jul 13, Jun 28. `tsc --noEmit` clean; no console errors from the modal (only the known body-map library noise on the screen behind it).
