### PR TITLE
feat(app): This-Week per-day comparison bars (Mon-Sun)

### DIFF
--- a/universal/src/components/this-week-card.tsx
+++ b/universal/src/components/this-week-card.tsx
@@ -1,9 +1,20 @@
 import { useState } from "react";
 import { View, Pressable } from "react-native";
-import { Text, Card, Badge, Modal } from "soma-style";
+import { Text, Card, Badge, Modal, SegmentedControl } from "soma-style";
+import { useWeeklyComparison, type WeekDay } from "../lib/api";
 
 interface WeekTotals { sessions: number; total_hours: number; total_km: number; total_cal: number }
 export interface WeeklyTraining { this_week: WeekTotals | null; last_week: WeekTotals | null; streak: number }
+
+// Per-day metric config (keys match /api/weekly-comparison day rows).
+const DAY_METRICS = ["Sessions", "Duration", "Distance", "Calories"] as const;
+type DayMetric = typeof DAY_METRICS[number];
+const DAY_CFG: Record<DayMetric, { get: (d: WeekDay) => number; fmt: (v: number) => string }> = {
+  Sessions: { get: (d) => d.sessions, fmt: (v) => String(Math.round(v)) },
+  Duration: { get: (d) => d.hours, fmt: (v) => `${v.toFixed(1)}h` },
+  Distance: { get: (d) => d.km, fmt: (v) => `${Math.round(v)}km` },
+  Calories: { get: (d) => d.calories, fmt: (v) => Math.round(v).toLocaleString() },
+};
 
 type MetricKey = "sessions" | "total_hours" | "total_km" | "total_cal";
 const METRICS: { key: MetricKey; label: string; unit: string; fmt: (v: number) => string }[] = [
@@ -27,9 +38,20 @@ function pctChange(cur: number, prev: number | null): number | null {
  *  comparison dialog. Mobile-adapted from the web InteractiveThisWeek. */
 export function ThisWeekCard({ data }: { data: WeeklyTraining | null }) {
   const [open, setOpen] = useState(false);
+  const [dayMetric, setDayMetric] = useState<DayMetric>("Sessions");
+  const { data: comparison } = useWeeklyComparison(open);
   if (!data || !data.this_week) return null;
   const tw = num(data.this_week);
   const lw = data.last_week ? num(data.last_week) : null;
+
+  const cmpCfg = DAY_CFG[dayMetric];
+  const twDays = comparison?.this_week ?? [];
+  const lwDays = comparison?.last_week ?? [];
+  const dayMax = Math.max(
+    ...twDays.map((d) => cmpCfg.get(d)),
+    ...lwDays.map((d) => cmpCfg.get(d)),
+    1,
+  );
 
   return (
     <>
@@ -58,7 +80,38 @@ export function ThisWeekCard({ data }: { data: WeeklyTraining | null }) {
       </Pressable>
 
       <Modal visible={open} onClose={() => setOpen(false)} title="This week vs last">
-        <View className="gap-1">
+        <View className="gap-3">
+          {twDays.length ? (
+            <View className="gap-1.5">
+              <SegmentedControl options={DAY_METRICS} value={dayMetric} onChange={(v) => setDayMetric(v as DayMetric)} />
+              {twDays.map((d, i) => {
+                const cur = cmpCfg.get(d);
+                const prev = lwDays[i] ? cmpCfg.get(lwDays[i]) : 0;
+                return (
+                  <View key={d.date} className="gap-0.5">
+                    <View className="flex-row items-center gap-2">
+                      <Text variant="micro" className="w-8 text-text-muted">{d.day}</Text>
+                      <View className="flex-1 gap-0.5">
+                        <View className="h-2 overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
+                          <View style={{ width: `${Math.max((cur / dayMax) * 100, cur > 0 ? 3 : 0)}%`, height: "100%", backgroundColor: "#77c8d1" }} />
+                        </View>
+                        <View className="h-1 overflow-hidden rounded-full" style={{ backgroundColor: "#101c24" }}>
+                          <View style={{ width: `${Math.max((prev / dayMax) * 100, prev > 0 ? 3 : 0)}%`, height: "100%", backgroundColor: "#3a5563" }} />
+                        </View>
+                      </View>
+                      <Text variant="micro" className="w-16 text-right text-text tabular-nums">{cur > 0 ? cmpCfg.fmt(cur) : "–"}</Text>
+                    </View>
+                  </View>
+                );
+              })}
+              <View className="flex-row items-center gap-3">
+                <View className="flex-row items-center gap-1"><View style={{ width: 10, height: 4, borderRadius: 2, backgroundColor: "#77c8d1" }} /><Text variant="micro" className="text-text-muted">This week</Text></View>
+                <View className="flex-row items-center gap-1"><View style={{ width: 10, height: 4, borderRadius: 2, backgroundColor: "#3a5563" }} /><Text variant="micro" className="text-text-muted">Last week</Text></View>
+              </View>
+            </View>
+          ) : null}
+
+          <View className="gap-1">
           <View className="flex-row border-b border-border-subtle pb-1.5">
             <Text variant="micro" className="flex-1 text-text-muted">Metric</Text>
             <Text variant="micro" className="w-24 text-right text-text-muted">This week</Text>
@@ -84,6 +137,7 @@ export function ThisWeekCard({ data }: { data: WeeklyTraining | null }) {
               <Badge label={`${data.streak}-day training streak 🔥`} tone="teal" />
             </View>
           ) : null}
+          </View>
         </View>
       </Modal>
     </>

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -123,6 +123,23 @@ export function useToday() {
   return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
+// ---- This-week vs last-week per-day breakdown (Overview This-Week drill-down) ----
+export interface WeekDay { day: string; date: string; sessions: number; hours: number; km: number; calories: number }
+export interface WeeklyComparison { this_week: WeekDay[]; last_week: WeekDay[]; totals?: unknown }
+/** Per-day Mon–Sun training breakdown from /api/weekly-comparison. */
+export function useWeeklyComparison(enabled: boolean) {
+  const [data, setData] = useState<WeeklyComparison | null>(null);
+  useEffect(() => {
+    if (!enabled) return;
+    let alive = true;
+    fetchJson<WeeklyComparison>("/api/weekly-comparison")
+      .then((d) => alive && setData(d))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [enabled]);
+  return { data };
+}
+
 export interface TrainingBreakdown {
   date: string;
   readiness: {


### PR DESCRIPTION
Part of #473. Closes #553.

The web "This Week" card opens tabbed Mon-Sun grouped bars (Sessions / Duration / Distance / Calories) comparing this week vs last, from `/api/weekly-comparison`. The mobile This-Week card opened only a this-vs-last totals table — and the app never fetched `/api/weekly-comparison` at all. The endpoint was fully built; this is a client-only fetch add.

## What changed
- **`universal/src/lib/api.ts`** — `useWeeklyComparison(enabled)` hook + `WeeklyComparison`/`WeekDay` types (fetches on demand).
- **`universal/src/components/this-week-card.tsx`** — the modal gains a metric toggle over Mon-Sun bars (this week solid cyan, last week a faint underlay), above the existing totals table.

## Verified
- Endpoint: `/api/weekly-comparison` returns 7-day `this_week`/`last_week` (sessions/hours/km/calories) + totals.
- Playwright (390×844) against :3456, Overview → This week: the modal shows the per-day bars (Sessions: Tue 1, Wed 1 this week; faint last-week bars) with the toggle and totals table; switching to Distance re-renders (Tue 4 km = the Tuesday run, Wed – = gym day), matching the totals. `tsc --noEmit` clean; console clean.
