### PR TITLE
feat(app): snowboarding deep dive (resorts + fastest sessions)

### DIFF
--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
 import { fetchJson, usePullRefresh, useActivitiesDeep } from "../../lib/api";
-import { ActivitiesMonthly, KiteDeepDive, ActivitiesList } from "../../components/activities-deep";
+import { ActivitiesMonthly, KiteDeepDive, SnowDeepDive, ActivitiesList } from "../../components/activities-deep";
 import { ActivitySports } from "../../components/activity-sports";
 
 /** Daily activity-count series (per-day sessions) for the Sessions trend. */
@@ -296,6 +296,9 @@ export default function ActivitiesScreen() {
 
         {/* Kite deep dive — speed progression + top spots + jump records */}
         {deep ? <KiteDeepDive sessions={deep.kite.sessions} /> : null}
+
+        {/* Snowboarding deep dive — resorts + fastest sessions */}
+        {deep ? <SnowDeepDive all={deep.all} /> : null}
 
         {/* Full activity list with sport filter + paging (replaces the recent log) */}
         {deep ? <ActivitiesList all={deep.all} /> : null}

--- a/universal/src/components/activities-deep.tsx
+++ b/universal/src/components/activities-deep.tsx
@@ -188,6 +188,85 @@ function KiteWind({ sessions }: { sessions: KiteSession[] }) {
   );
 }
 
+/** Resort name from a Garmin snowboarding activity title (ported from web). */
+function extractResort(name: string | null): string {
+  const n = name ?? "";
+  if (n.includes("Avoriaz") || n.includes("Portes du Soleil") || n.includes("Les")) return "Avoriaz";
+  if (n.includes("Bansko")) return "Bansko";
+  if (n.includes("Kalavryta")) return "Kalavryta";
+  if (n.includes("Akrata")) return "Akrata";
+  if (n.includes("Lefkasio")) return "Lefkasio";
+  if (n.includes("Vrachní") || n.includes("Elatófyto")) return "Vasilitsa";
+  return n.split(" ")[0] || "Resort";
+}
+
+/** Snowboarding deep dive (web parity): per-resort session count + total
+ *  vertical + top speed, and the fastest sessions. Built from the Snowboarding
+ *  rows already in the activities `all` feed (vertical is sparse in Garmin's
+ *  resort data, so sessions rank by top speed). */
+export function SnowDeepDive({ all }: { all: ActivityRow[] }) {
+  const snow = useMemo(() => (all ?? []).filter((a) => a.sport === "Snowboarding"), [all]);
+  const resorts = useMemo(() => {
+    const m = new Map<string, { days: number; vertical: number; topSpeed: number }>();
+    for (const s of snow) {
+      const r = extractResort(s.name);
+      const cur = m.get(r) ?? { days: 0, vertical: 0, topSpeed: 0 };
+      cur.days += 1;
+      cur.vertical += s.elev_gain || 0;
+      cur.topSpeed = Math.max(cur.topSpeed, (s.max_speed_ms ?? 0) * 3.6);
+      m.set(r, cur);
+    }
+    return [...m.entries()].sort((a, b) => b[1].days - a[1].days);
+  }, [snow]);
+  const fastest = useMemo(
+    () => [...snow].filter((s) => (s.max_speed_ms ?? 0) > 0).sort((a, b) => (b.max_speed_ms ?? 0) - (a.max_speed_ms ?? 0)).slice(0, 5),
+    [snow],
+  );
+  if (snow.length === 0) return null;
+
+  const maxDays = resorts[0]?.[1].days ?? 1;
+  const totalVert = snow.reduce((a, s) => a + (s.elev_gain || 0), 0);
+  return (
+    <Card className="gap-3">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Snowboarding deep dive</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{snow.length} days{totalVert > 0 ? ` · ${Math.round(totalVert).toLocaleString()} m` : ""}</Text>
+      </View>
+
+      {resorts.length ? (
+        <View className="gap-1.5">
+          <Text variant="micro" className="text-text-muted">RESORTS</Text>
+          {resorts.map(([r, d]) => (
+            <View key={r} className="flex-row items-center gap-2">
+              <Text variant="body" className="flex-1 text-text-secondary" numberOfLines={1}>{r}</Text>
+              <View className="h-2 overflow-hidden rounded-full bg-surface-subtle" style={{ width: 70 }}>
+                <View className="h-full rounded-full" style={{ width: `${(d.days / maxDays) * 100}%`, backgroundColor: "#93c5fd" }} />
+              </View>
+              <Text variant="micro" className="w-28 text-right tabular-nums text-text-muted">
+                {d.days}d{d.topSpeed > 0 ? ` · ${d.topSpeed.toFixed(0)} km/h` : ""}{d.vertical > 0 ? ` · ${(d.vertical / 1000).toFixed(1)}k m` : ""}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {fastest.length ? (
+        <View className="gap-1.5 border-t border-border-subtle pt-2.5">
+          <Text variant="micro" className="text-text-muted">FASTEST SESSIONS</Text>
+          {fastest.map((s, i) => (
+            <View key={`${s.activity_id}-${i}`} className="flex-row items-center justify-between">
+              <Text variant="micro" className="flex-1 text-text-secondary" numberOfLines={1}>{extractResort(s.name)} · {shortDate(s.date)}</Text>
+              <Text variant="micro" className="ml-2 tabular-nums text-teal">
+                {((s.max_speed_ms ?? 0) * 3.6).toFixed(0)} km/h{s.elev_gain > 0 ? ` · ↑${Math.round(s.elev_gain).toLocaleString()}m` : ""}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </Card>
+  );
+}
+
 const PAGE = 12;
 type SortKey = "date" | "distance_km" | "duration_min" | "avg_hr" | "calories" | "elev_gain";
 const SORTS: { key: SortKey; label: string }[] = [


### PR DESCRIPTION
Part of #473. Closes #555.

The web activities page has a Snowboarding Deep Dive (per-resort session count / vertical / top speed via `extractResort`, plus best sessions). The mobile Activities screen showed only a 4-metric snow summary card. This closes that gap — the data is already in the activities `all` feed.

## What changed
`universal/src/components/activities-deep.tsx` + `activities.tsx`:
- New **`SnowDeepDive`** (mirrors the existing `KiteDeepDive`): filters `deep.all` to Snowboarding, ports `extractResort` to group by resort (days + top speed + total vertical), renders day-bars ranked by frequency, and a **Fastest sessions** list.
- Sessions rank by top speed rather than vertical, because Garmin's resort activities populate `max_speed_ms` consistently but `elev_gain` only sparsely.

## Verified
- Data: 19 snowboarding activities (Bansko, Avoriaz, …) in `deep.all` with `name/elev_gain/max_speed_ms`.
- Playwright (390×844) against :3456 (range=all): the deep dive renders "19 days · 3,434 m", RESORTS (Avoriaz 8d·46km/h, Akrata 2d·34km/h, Bansko 1d·39km/h·3.4k m, …9 resorts with day-bars), and FASTEST SESSIONS (Avoriaz Mar 11 46km/h, …). `tsc --noEmit` clean; console clean.
