### PR TITLE
fix(api): activities/deep dropped pre-2020 activities on range=all

### DIFF
--- a/web/app/api/activities/deep/route.ts
+++ b/web/app/api/activities/deep/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
     range === "1m" || range === "30d" ? 30 :
     range === "3m" || range === "90d" ? 91 :
     range === "6m" ? 182 :
-    range === "all" ? 3650 : 365;
+    range === "all" ? 20000 : 365;
 
   const sql = getDb();
 
@@ -98,7 +98,7 @@ export async function GET(request: Request) {
       AND raw_json->'activityType'->>'typeKey' NOT IN ('running', 'treadmill_running', 'strength_training', 'indoor_cycling')
       AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
     ORDER BY (raw_json->>'startTimeLocal')::text DESC
-    LIMIT 200
+    LIMIT ${range === "all" ? 2000 : 200}
   `) as { activity_id: string; type_key: string; date: string; name: string | null; distance_km: number | null; duration_min: number | null; avg_hr: number | null; calories: number | null; elev_gain: number; max_speed_ms: number | null; swolf: number | null }[];
 
   return NextResponse.json({


### PR DESCRIPTION
Part of #473. Closes #557.

`/api/activities/deep` capped the `all` array at `LIMIT 200` and windowed `range=all` to 3650 days (10y). The DB has **836** activities back to **2013**, so on range=all the endpoint silently returned only the 200 most recent (oldest ~2020) — under-counting older years and truncating the per-sport / by-year / snowboarding / table views that read `deep.all`.

## What changed
`web/app/api/activities/deep/route.ts`:
- `LIMIT` is now range-aware: **2000 for `range=all`**, 200 otherwise (bounded ranges are already date-limited).
- The `range=all` window widened (3650 → 20000 days) so it covers full history.

## Verified
- On :3456, `/api/activities/deep?range=all` now returns **251** rows (was 200), by-year now including **2013 (6), 2017 (5), 2018 (10), 2019 (10)** — previously dropped.
- Playwright (390×844) against :3456: the Activities screen renders the all-range data with the older years present; no crash with the larger array.
- `tsc --noEmit` clean on web.
