### PR TITLE
feat(app): shareable activity image + native share sheet

### DIFF
--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { View, ScrollView } from "react-native";
-import { Text, Modal, Badge, SegmentedControl } from "soma-style";
+import { View, ScrollView, Image, Share } from "react-native";
+import { Text, Modal, Badge, SegmentedControl, Button } from "soma-style";
 import { LineChart } from "./line-chart";
-import { fetchJson, type ActivityRow } from "../lib/api";
+import { fetchJson, activityImageSource, type ActivityRow } from "../lib/api";
 
 interface TSPoint { elapsed_sec: number; hr?: number | null; speed?: number | null; elevation?: number | null; cadence?: number | null }
 
@@ -96,7 +96,7 @@ function Metric({ label, value }: { label: string; value: string }) {
 export function ActivityDetailModal({ activity, onClose }: { activity: ActivityRow | null; onClose: () => void }) {
   const [data, setData] = useState<ActivityDetail | null>(null);
   const [loading, setLoading] = useState(false);
-  const [tab, setTab] = useState<"Overview" | "Splits" | "Charts">("Overview");
+  const [tab, setTab] = useState<"Overview" | "Splits" | "Charts" | "Share">("Overview");
 
   useEffect(() => {
     if (!activity) { setData(null); return; }
@@ -113,7 +113,9 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
   const laps = data?.splits?.lapDTOs ?? [];
   const ts = data?.time_series ?? [];
   const hasTS = ts.length > 1;
-  const tabOptions = ["Overview", ...(laps.length > 1 ? ["Splits"] : []), ...(hasTS ? ["Charts"] : [])];
+  const tabOptions = ["Overview", ...(laps.length > 1 ? ["Splits"] : []), ...(hasTS ? ["Charts"] : []), "Share"];
+  const img = activityImageSource(activity.activity_id);
+  const onShare = () => { Share.share({ url: img.uri, message: activity.name || activity.sport }).catch(() => {}); };
   const zones = (data?.hr_zones ?? []).filter((z) => z && (z.secsInZone ?? 0) > 0);
   const zTotal = zones.reduce((a, z) => a + n(z.secsInZone), 0);
   const shoe = (data?.gear ?? []).find((g) => g.gearTypeName === "Shoes");
@@ -224,6 +226,12 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
             </View>
           ) : tab === "Charts" ? (
             <PerfCharts ts={ts} />
+          ) : tab === "Share" ? (
+            <View className="items-center gap-3">
+              <Image source={img} style={{ width: "100%", aspectRatio: 4 / 3, borderRadius: 12, backgroundColor: "#0e1a22" }} resizeMode="contain" />
+              <Button label="Share activity" onPress={onShare} />
+              <Text variant="micro" className="text-center text-text-muted">A shareable card for this activity.</Text>
+            </View>
           ) : (
             /* Splits tab: per-lap pace bars + stats */
             <View className="gap-1.5">

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useState } from "react";
 
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+export const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
 /** Personal API token for prod (soma.gkos.dev gates /api/* behind a session;
     the token bypasses that for this native client). Empty in local dev. */
 const API_TOKEN = process.env.EXPO_PUBLIC_API_TOKEN;
 const AUTH_HEADERS: Record<string, string> = API_TOKEN ? { Authorization: `Bearer ${API_TOKEN}` } : {};
+
+/** Image source for an activity's generated share card. Includes the auth
+ *  header (React Native <Image> forwards `headers` on native; prod gates /api/*). */
+export function activityImageSource(activityId: string) {
+  return { uri: `${API_BASE}/api/activity/${encodeURIComponent(activityId)}/image`, headers: AUTH_HEADERS };
+}
 
 /**
  * GET JSON with one automatic retry. Serverless DBs (Neon) can return a transient


### PR DESCRIPTION
Part of #473. Closes #559.

The web activity detail modal has a Share tab with a generated branded PNG. The mobile modal had no share/image tab — even though the image endpoint already exists, is public, and returns a 1080×810 (4:3) card. This adds a mobile-native affordance the web can't match.

## What changed
- **`universal/src/lib/api.ts`** — exported `API_BASE` + an `activityImageSource(id)` helper (returns `{ uri, headers }`; RN `<Image>` forwards `headers` on native, prod gates `/api/*` behind a token).
- **`universal/src/components/activity-detail-modal.tsx`** — a **Share** tab: the branded activity image (aspectRatio 4/3) + a "Share activity" button using react-native's built-in `Share.share({ url })`. No new dependency; the Strava-upload half is intentionally skipped (mutation).

## Verified
- Endpoint: `/api/activity/[id]/image` returns 200 `image/png`, 1080×810.
- Playwright (390×844) against :3456: opened a run → Share tab renders the full branded card (GPS map, stats 1.12 km / 6:07 / 137 HR, HR/pace/elevation mini-charts, SOMA branding — `<img>` `naturalWidth/Height` 1080×810, `complete`) + the Share button. The button wires to the native share sheet (not triggered in-browser to avoid a blocking share dialog). `tsc --noEmit` clean; console clean.
