### PR TITLE
feat(app): Sleep-Score readiness factor bar + HRV feedback

### DIFF
--- a/universal/src/components/recovery-vitals.tsx
+++ b/universal/src/components/recovery-vitals.tsx
@@ -38,8 +38,12 @@ export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | 
         { label: "ACWR", v: rdy.acwr_pct, color: "#6aa0e0" },
         { label: "Recovery", v: rdy.recovery_pct, color: "#c084fc" },
         { label: "Sleep hist.", v: rdy.sleep_history_pct, color: "#a5b4fc" },
+        { label: "Sleep Score", v: rdy.sleep_score_pct ?? null, color: "#77c8d1" },
       ].filter((f) => f.v != null)
     : [];
+  const hrvFeedback = rdy?.hrv_feedback && rdy.hrv_feedback !== "NONE"
+    ? rdy.hrv_feedback.replace(/_/g, " ").toLowerCase().replace(/^\w/, (c) => c.toUpperCase())
+    : null;
 
   if (!hrv && !rdy) return null;
 
@@ -75,6 +79,7 @@ export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | 
           <View className="flex-row items-end gap-2">
             <Text variant="display" className="text-lime">{rdy.score ?? "—"}</Text>
             <Text variant="caption" className="text-text-muted mb-1">/ 100</Text>
+            {hrvFeedback ? <Text variant="caption" className="text-text-muted mb-1">· HRV {hrvFeedback}</Text> : null}
           </View>
           {factors.length ? (
             <View className="gap-2">

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -715,6 +715,7 @@ export interface ReadinessPoint {
   date: string; score: number | null; level: string | null;
   hrv_pct: number | null; stress_pct: number | null; acwr_pct: number | null;
   recovery_pct: number | null; sleep_history_pct: number | null;
+  sleep_score_pct?: number | null; hrv_feedback?: string | null;
 }
 export interface RecoverySummary {
   hrv: { trend: HrvPoint[]; latest: HrvPoint | null };

--- a/web/app/api/recovery/summary/route.ts
+++ b/web/app/api/recovery/summary/route.ts
@@ -35,7 +35,9 @@ export async function GET(request: Request) {
       (raw_json->0->>'stressHistoryFactorPercent')::int   as stress_pct,
       (raw_json->0->>'acwrFactorPercent')::int            as acwr_pct,
       (raw_json->0->>'recoveryTimeFactorPercent')::int    as recovery_pct,
-      (raw_json->0->>'sleepHistoryFactorPercent')::int    as sleep_history_pct
+      (raw_json->0->>'sleepHistoryFactorPercent')::int    as sleep_history_pct,
+      (raw_json->0->>'sleepScoreFactorPercent')::int      as sleep_score_pct,
+      raw_json->0->>'hrvFactorFeedback'                   as hrv_feedback
     FROM garmin_raw_data
     WHERE endpoint_name = 'training_readiness'
       AND raw_json->0->>'score' IS NOT NULL
@@ -45,6 +47,7 @@ export async function GET(request: Request) {
     date: string; score: number | null; level: string | null;
     hrv_pct: number | null; stress_pct: number | null; acwr_pct: number | null;
     recovery_pct: number | null; sleep_history_pct: number | null;
+    sleep_score_pct: number | null; hrv_feedback: string | null;
   }[];
 
   return NextResponse.json({


### PR DESCRIPTION
Part of #473. Closes #565.

The web sleep page shows 6 training-readiness factor bars incl. Sleep Score plus an HRV feedback qualifier; the mobile recovery-vitals card showed only 5 factors and no qualifier. `/api/recovery/summary`'s readiness SELECT stopped before `sleepScoreFactorPercent` + `hrvFactorFeedback`, both present in the raw JSON (populated in 142/201 records).

## What changed
- **`web/app/api/recovery/summary/route.ts`** — added `sleepScoreFactorPercent as sleep_score_pct` + `hrvFactorFeedback as hrv_feedback` to the readiness SELECT + result type.
- **`universal/src/lib/api.ts`** — widened `ReadinessPoint`.
- **`universal/src/components/recovery-vitals.tsx`** — added the **Sleep Score** factor bar (6th) + an **"HRV <feedback>"** qualifier by the readiness score (hidden when NONE).

## Verified
- Endpoint on :3456 now returns both fields (142/201 readiness records populated; the latest record is 0/NONE).
- Playwright (390x844) against :3456 (data-rich record mocked in as `latest`, since the live latest is incomplete): the Training-readiness card shows 6 bars (HRV 100 / Stress 87 / ACWR 79 / Recovery 73 / Sleep hist. 32 / **Sleep Score 38**) + score **14 / 100 · HRV Very good**. `tsc --noEmit` clean on web + universal; console clean.
