### PR TITLE
feat(app): Strava coverage view on Connections

### DIFF
--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -28,10 +28,13 @@ interface SyncRule {
 }
 
 interface SpotifyStatus { tracks: number; artists: number; last_sync: string | null }
+interface StravaActivity { name: string | null; date: string; type_key: string | null; onStrava: boolean }
+interface StravaCoverage { total: number; onStrava: number; recent: StravaActivity[] }
 interface ConnectionsResponse {
   platforms: PlatformStatus[];
   rules: SyncRule[];
   spotify?: SpotifyStatus | null;
+  stravaCoverage?: StravaCoverage | null;
 }
 
 interface SourceStatus {
@@ -540,6 +543,38 @@ export default function ConnectionsScreen() {
                 ))}
               </View>
             ) : null}
+          </Card>
+        ) : null}
+
+        {/* Strava coverage — how many recent Garmin activities reached Strava */}
+        {conn?.stravaCoverage && conn.stravaCoverage.total > 0 ? (
+          <Card className="gap-2">
+            <View className="flex-row items-center justify-between">
+              <View className="flex-1 pr-2">
+                <Text variant="eyebrow">Strava coverage</Text>
+                <Text variant="micro" className="text-text-muted">Garmin activities forwarded to Strava · last 90 days</Text>
+              </View>
+              <Text variant="caption" className="tabular-nums text-text">{conn.stravaCoverage.onStrava}/{conn.stravaCoverage.total}</Text>
+            </View>
+            <View className="h-2 overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
+              <View style={{ width: `${Math.round((conn.stravaCoverage.onStrava / conn.stravaCoverage.total) * 100)}%`, height: "100%", backgroundColor: "#fc5200" }} />
+            </View>
+            <View className="gap-0.5">
+              {conn.stravaCoverage.recent.map((a, i) => {
+                const sport = (a.type_key || "").replace(/_v2$/, "").replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+                return (
+                  <View key={`${a.date}-${i}`} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
+                    <View className="flex-1 pr-2">
+                      <Text variant="caption" className="text-text" numberOfLines={1}>{a.name || sport || "Activity"}</Text>
+                      <Text variant="micro" className="text-text-muted">{fmtDate(a.date)}{sport ? ` · ${sport}` : ""}</Text>
+                    </View>
+                    {a.onStrava
+                      ? <Badge label="On Strava" tone="warm" />
+                      : <Text variant="micro" className="text-text-muted">not synced</Text>}
+                  </View>
+                );
+              })}
+            </View>
           </Card>
         ) : null}
 

--- a/web/app/api/connections/route.ts
+++ b/web/app/api/connections/route.ts
@@ -32,6 +32,31 @@ export async function GET() {
       ? { tracks: Number(sp.tracks), artists: Number(sp.artists), last_sync: (sp.last_sync as string | null) ?? null }
       : null;
 
+    // Strava coverage: of recent Garmin activities, how many were forwarded to
+    // Strava (activity_sync_log, source_id cast to text; ids are bigint there).
+    const stravaRows = (await sql`
+      SELECT g.raw_json->>'activityName' AS name,
+        (g.raw_json->>'startTimeLocal')::date::text AS date,
+        g.raw_json->'activityType'->>'typeKey' AS type_key,
+        sl.destination_id AS strava_id
+      FROM garmin_activity_raw g
+      LEFT JOIN activity_sync_log sl
+        ON sl.source_id = g.activity_id::text AND sl.destination = 'strava' AND sl.status IN ('sent', 'external')
+      WHERE g.endpoint_name = 'summary'
+        AND (g.raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - 90
+      ORDER BY (g.raw_json->>'startTimeLocal')::text DESC
+      LIMIT 60
+    `) as { name: string | null; date: string; type_key: string | null; strava_id: string | null }[];
+    const stravaTotal = stravaRows.length;
+    const stravaOn = stravaRows.filter((r) => r.strava_id != null).length;
+    const stravaCoverage = stravaTotal > 0
+      ? {
+          total: stravaTotal,
+          onStrava: stravaOn,
+          recent: stravaRows.slice(0, 10).map((r) => ({ name: r.name, date: r.date, type_key: r.type_key, onStrava: r.strava_id != null })),
+        }
+      : null;
+
     // Build platform status including non-connected ones
     const platforms = ["garmin", "hevy", "strava", "surfr"];
     const credMap = Object.fromEntries(
@@ -53,7 +78,7 @@ export async function GET() {
       can_connect: p === "strava",
     }));
 
-    return NextResponse.json({ platforms: status, rules, spotify });
+    return NextResponse.json({ platforms: status, rules, spotify, stravaCoverage });
   } catch (err) {
     console.error("Error fetching connections status:", err);
     return NextResponse.json(


### PR DESCRIPTION
Part of #473. Closes #567.

The web ActivitySyncManager shows "N/M synced to Strava" with a per-activity badge. The mobile Connections screen had no per-activity Strava coverage. The mapping lives in `activity_sync_log` (source_id -> destination_id, destination='strava', status sent/external).

## What changed
- **`web/app/api/connections/route.ts`** — added a `stravaCoverage` block (total + onStrava + a recent list over the last 90 days), from `garmin_activity_raw` LEFT JOIN `activity_sync_log` with a `source_id = activity_id::text` cast (ids are bigint on one side, varchar on the other). Mirrors the existing `spotify` block.
- **`universal/src/app/(main)/connections.tsx`** — a **Strava coverage** card: a progress bar (onStrava/total) + the recent activities with name / date / sport and an **On Strava** / **not synced** badge. Read-only (no per-row manual push).

## Verified
- Endpoint on :3456 returns `stravaCoverage` (21/49 over 90 days, recent list of 10).
- Playwright (390x844): the card shows "STRAVA COVERAGE · 21/49", an orange progress bar, and the recent list; with two records mocked as synced, the "ON STRAVA" badges render alongside "not synced". `tsc --noEmit` clean on web + universal; console clean.
