### PR TITLE
feat(nutrition): live meal preview + preset scale/customize panel (#572)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -3,12 +3,13 @@ import { ScrollView, View, RefreshControl, TextInput, Pressable } from "react-na
 import { Text, Card, Badge, SegmentedControl, ProgressBar, Button, Modal, Pill, PillGroup, Sparkline } from "soma-style";
 import {
   useSomaPlan, usePresets, logPresetMeal, deleteMeal, quickAddMeal, skipSlot, useDrinks, logDrink, deleteDrink, closeDay,
-  reopenDay, copyDay, setManualOverride, rebalanceMeals,
+  reopenDay, copyDay, setManualOverride, rebalanceMeals, presetItems, presetBaseMacros,
   fetchJson, usePullRefresh, todayLocal, type Preset, type SomaMeal,
 } from "../../lib/api";
 import { BodyCompChart } from "../../components/body-comp-chart";
 import { ActivitySelector } from "../../components/activity-selector";
 import { ComposeMealView } from "../../components/compose-meal-view";
+import { PresetPanel } from "../../components/preset-panel";
 import { MealDetailModal } from "../../components/meal-detail-modal";
 import { MacroGoalBar, buildMacroMarkers, ProteinQualityPill } from "../../components/macro-goal-bar";
 import { NutritionContextStrip } from "../../components/nutrition-context-strip";
@@ -73,6 +74,7 @@ export default function NutritionScreen() {
   // day's locked slots from storage (guarded — no-ops on native).
   useEffect(() => {
     setCloseStatus(null); setLogMode("preset"); setLogOpen(false); setEditMeal(null); setDetailMeal(null); setRebalanceToast(null);
+    setSelectedPreset(null); setPresetSeed(null); setComposePreview(null); setPresetMult(1);
     let stored: string[] = [];
     try {
       const raw = typeof localStorage !== "undefined" ? localStorage.getItem(`locked-slots-${DATE}`) : null;
@@ -107,6 +109,12 @@ export default function NutritionScreen() {
   const [delDrinkId, setDelDrinkId] = useState<number | null>(null);
   const [detailMeal, setDetailMeal] = useState<SomaMeal | null>(null);
   const [editMeal, setEditMeal] = useState<{ id: number; grams: Record<string, number> } | null>(null);
+  // Preset scale/customize panel + live day-level meal preview.
+  const [selectedPreset, setSelectedPreset] = useState<Preset | null>(null);
+  const [presetMult, setPresetMult] = useState(1);
+  const [presetLinked, setPresetLinked] = useState(true);
+  const [presetSeed, setPresetSeed] = useState<Record<string, number> | null>(null);
+  const [composePreview, setComposePreview] = useState<{ calories: number; protein: number; carbs: number; fat: number; fiber: number } | null>(null);
   // Slots the user has locked (won't be rebalanced). Persisted per-date via
   // guarded localStorage (works on Expo web; in-memory fallback on native).
   const [lockedSlots, setLockedSlots] = useState<Set<string>>(new Set());
@@ -152,11 +160,30 @@ export default function NutritionScreen() {
     }
   }
 
-  async function onLog(preset: Preset) {
-    setBusyId(preset.id);
-    const ok = await logPresetMeal(DATE, slot, preset);
+  // Reset the log modal's transient state (previews, selected preset, seed).
+  function resetLogState() {
+    setEditMeal(null); setSelectedPreset(null); setPresetSeed(null); setComposePreview(null); setPresetMult(1);
+  }
+  function closeLog() { setLogOpen(false); resetLogState(); }
+  // Switch log mode from the tab buttons — clears any in-flight preview/preset.
+  function setMode(m: "preset" | "quick" | "compose") { resetLogState(); setLogMode(m); }
+
+  async function onLogSelectedPreset() {
+    if (!selectedPreset) return;
+    const s = slot;
+    setBusyId(selectedPreset.id);
+    const ok = await logPresetMeal(DATE, s, selectedPreset, presetMult);
     setBusyId(null);
-    if (ok) { refetch(); doRebalance(slot); }
+    if (ok) { closeLog(); refetch(); doRebalance(s); }
+  }
+  // "Customize" a preset — seed the compose view with its (scaled) grams.
+  function onCustomizePreset() {
+    if (!selectedPreset) return;
+    const seed: Record<string, number> = {};
+    for (const it of presetItems(selectedPreset)) seed[it.ingredient_id] = Math.round(it.grams * presetMult);
+    setSelectedPreset(null); setComposePreview(null);
+    setPresetSeed(seed);
+    setLogMode("compose");
   }
   async function onDetailDelete() {
     if (!detailMeal) return;
@@ -170,6 +197,7 @@ export default function NutritionScreen() {
     for (const it of m.items ?? []) {
       if (it.ingredient_id && it.grams) g[it.ingredient_id] = Math.round(it.grams);
     }
+    setSelectedPreset(null); setPresetSeed(null); setComposePreview(null);
     setEditMeal({ id: m.id, grams: g });
     setSlot(m.meal_slot);
     setLogMode("compose");
@@ -253,6 +281,43 @@ export default function NutritionScreen() {
   const totalBurn = bd?.totalBurn ?? (
     (bd?.bmr ?? 0) + (bd?.stepCalories ?? 0) + (bd?.runActual ?? bd?.runPredicted ?? bd?.runCalories ?? 0) + (bd?.gymCalories ?? 0)
   );
+
+  // Live day-level meal preview: the in-progress preset (base x scale) or compose
+  // meal, folded into remaining kcal + macro bars so the user sees the impact
+  // before logging — the web dashboard's preview plumbing, on mobile.
+  const previewTotals = logOpen
+    ? logMode === "preset" && selectedPreset
+      ? (() => {
+          const b = presetBaseMacros(selectedPreset);
+          return { calories: b.calories * presetMult, protein: b.protein * presetMult, carbs: b.carbs * presetMult, fat: b.fat * presetMult, fiber: b.fiber * presetMult };
+        })()
+      : logMode === "compose" ? composePreview : null
+    : null;
+  const previewActive = !!previewTotals && previewTotals.calories > 0;
+
+  // Render the 4 macro goal bars; `extra` folds an in-progress meal's macros in.
+  const renderMacroBars = (extra?: { protein: number; carbs: number; fat: number; fiber: number } | null) => {
+    const t = {
+      protein: Number(plan?.target_protein) || 0,
+      carbs: Number(plan?.target_carbs) || 0,
+      fat: Number(plan?.target_fat) || 0,
+      fiber: Number(plan?.target_fiber) || 0,
+    };
+    const marks = buildMacroMarkers(Number(bd?.weightKg) || 0, t);
+    return MACROS.map((m) => {
+      const eaten = ((consumed as Record<string, number> | undefined)?.[m.key] ?? 0) + (extra ? (extra as Record<string, number>)[m.key] ?? 0 : 0);
+      return (
+        <MacroGoalBar
+          key={m.key}
+          label={m.label}
+          current={eaten}
+          target={t[m.key as keyof typeof t]}
+          color={m.color}
+          markers={marks[m.key as keyof typeof marks]}
+        />
+      );
+    });
+  };
 
   return (
     <ScrollView
@@ -339,29 +404,7 @@ export default function NutritionScreen() {
           })() : null}
 
           <View className="gap-2.5">
-            {(() => {
-              const t = {
-                protein: Number(plan?.target_protein) || 0,
-                carbs: Number(plan?.target_carbs) || 0,
-                fat: Number(plan?.target_fat) || 0,
-                fiber: Number(plan?.target_fiber) || 0,
-              };
-              const marks = buildMacroMarkers(Number(bd?.weightKg) || 0, t);
-              return MACROS.map((m) => {
-                const eaten = (consumed as Record<string, number> | undefined)?.[m.key] ?? 0;
-                const markers = marks[m.key as keyof typeof marks];
-                return (
-                  <MacroGoalBar
-                    key={m.key}
-                    label={m.label}
-                    current={eaten}
-                    target={t[m.key as keyof typeof t]}
-                    color={m.color}
-                    markers={markers}
-                  />
-                );
-              });
-            })()}
+            {renderMacroBars()}
             <Text variant="micro" className="text-text-muted">
               {(bd?.weightKg ?? 0) > 0
                 ? "Protein & fat ticks are g/kg tiers · green = optimal · red = ceiling"
@@ -600,25 +643,46 @@ export default function NutritionScreen() {
       </View>
 
       {/* Log-meal modal — preset picker, prefilled to the tapped slot */}
-      <Modal visible={logOpen} onClose={() => { setLogOpen(false); setEditMeal(null); }} title={editMeal ? `Edit ${slotLabel(slot)}` : `Log ${slotLabel(slot)}`}>
+      <Modal visible={logOpen} onClose={closeLog} title={editMeal ? `Edit ${slotLabel(slot)}` : `Log ${slotLabel(slot)}`}>
         <PillGroup className="mb-3">
           {slots.map((s) => (
             <Pill key={s} label={slotLabel(s)} active={slot === s} onPress={() => setSlot(s)} />
           ))}
         </PillGroup>
         <View className="mb-3 flex-row gap-1.5">
-          <Button label="Presets" variant={logMode === "preset" ? "secondary" : "ghost"} size="sm" onPress={() => { setLogMode("preset"); setEditMeal(null); }} />
-          <Button label="Quick add" variant={logMode === "quick" ? "secondary" : "ghost"} size="sm" onPress={() => { setLogMode("quick"); setEditMeal(null); }} />
-          <Button label={editMeal ? "Editing" : "Compose"} variant={logMode === "compose" ? "secondary" : "ghost"} size="sm" onPress={() => { setLogMode("compose"); setEditMeal(null); }} />
+          <Button label="Presets" variant={logMode === "preset" ? "secondary" : "ghost"} size="sm" onPress={() => setMode("preset")} />
+          <Button label="Quick add" variant={logMode === "quick" ? "secondary" : "ghost"} size="sm" onPress={() => setMode("quick")} />
+          <Button label={editMeal ? "Editing" : "Compose"} variant={logMode === "compose" ? "secondary" : "ghost"} size="sm" onPress={() => setMode("compose")} />
         </View>
+
+        {/* Live "day after this meal" preview — remaining kcal + macro bars folded
+            with the in-progress preset/compose meal, so the impact is visible
+            before logging. */}
+        {previewActive && previewTotals ? (
+          <View className="mb-3 gap-2 rounded-lg border p-3" style={{ borderColor: "#2a5560", backgroundColor: "#0f1e24" }}>
+            <View className="flex-row items-center justify-between">
+              <Text variant="eyebrow" style={{ color: "#77c8d1" }}>Day after this meal</Text>
+              {plan ? (
+                <Text variant="caption" className="tabular-nums text-text-secondary">
+                  {Math.round((remaining?.calories ?? 0) - previewTotals.calories).toLocaleString()} kcal left
+                </Text>
+              ) : (
+                <Text variant="caption" className="tabular-nums text-text-secondary">+{Math.round(previewTotals.calories).toLocaleString()} kcal</Text>
+              )}
+            </View>
+            <View className="gap-2.5">{renderMacroBars(previewTotals)}</View>
+          </View>
+        ) : null}
+
         {logMode === "compose" ? (
           <ComposeMealView
             ingredients={ingredients}
             date={DATE}
             slot={slot}
-            initialGrams={editMeal?.grams}
+            initialGrams={editMeal?.grams ?? presetSeed ?? undefined}
             editMealId={editMeal?.id ?? null}
-            onLogged={() => { setLogOpen(false); setEditMeal(null); refetch(); doRebalance(slot); }}
+            onTotalsChange={setComposePreview}
+            onLogged={() => { closeLog(); refetch(); doRebalance(slot); }}
           />
         ) : logMode === "quick" ? (
           <View className="gap-2 rounded-lg border border-border-subtle p-3">
@@ -636,28 +700,47 @@ export default function NutritionScreen() {
               <TextInput placeholder="F" placeholderTextColor="#5a7a8a" keyboardType="numeric" value={qF} onChangeText={setQF} className="flex-1 rounded-md border border-border-subtle px-2 py-2 text-text tabular-nums" />
             </View>
             <View className="flex-row justify-end gap-2">
-              <Button label="Cancel" variant="ghost" size="sm" onPress={() => setLogMode("preset")} />
+              <Button label="Cancel" variant="ghost" size="sm" onPress={() => setMode("preset")} />
               <Button label={qBusy ? "…" : "Add"} variant="primary" size="sm" disabled={qBusy || !qCal} onPress={onQuickAdd} />
             </View>
           </View>
+        ) : selectedPreset ? (
+          <PresetPanel
+            preset={selectedPreset}
+            ingredients={ingredients}
+            multiplier={presetMult}
+            linked={presetLinked}
+            onMultiplier={setPresetMult}
+            onToggleLinked={() => setPresetLinked((v) => !v)}
+            onCancel={() => { setSelectedPreset(null); setPresetMult(1); }}
+            onCustomize={onCustomizePreset}
+            onLog={onLogSelectedPreset}
+            logging={busyId != null}
+          />
         ) : (
           <ScrollView className="max-h-80">
             {pickerPresets.map((p) => (
-              <View key={p.id} className="flex-row items-center gap-2 border-b border-border-subtle py-2.5">
+              <Pressable
+                key={p.id}
+                onPress={() => { setSelectedPreset(p); setPresetMult(1); setPresetLinked(true); }}
+                className="flex-row items-center gap-2 border-b border-border-subtle py-2.5"
+              >
                 <View className="flex-1">
                   <Text variant="body" className="text-text" numberOfLines={1}>{p.name}</Text>
                   <Text variant="micro" className="tabular-nums">
                     {p.meal_slot ? slotLabel(p.meal_slot) + " · " : ""}{Math.round(p.total_calories)} kcal · P{Math.round(p.total_protein)} C{Math.round(p.total_carbs)} F{Math.round(p.total_fat)}
                   </Text>
                 </View>
-                <Button label={busyId === p.id ? "…" : "Log"} variant="secondary" size="sm" disabled={busyId != null} onPress={() => onLog(p)} />
-              </View>
+                <Text variant="body" className="text-text-muted">›</Text>
+              </Pressable>
             ))}
           </ScrollView>
         )}
-        <View className="mt-4 flex-row justify-end">
-          <Button label={logMode === "compose" ? "Cancel" : "Done"} variant={logMode === "compose" ? "ghost" : "primary"} onPress={() => { setLogOpen(false); setEditMeal(null); }} />
-        </View>
+        {!(logMode === "preset" && selectedPreset) ? (
+          <View className="mt-4 flex-row justify-end">
+            <Button label={logMode === "compose" ? "Cancel" : "Done"} variant={logMode === "compose" ? "ghost" : "primary"} onPress={closeLog} />
+          </View>
+        ) : null}
       </Modal>
 
       {/* Logged-meal detail — tap a meal to see macros + ingredients, edit or delete */}

--- a/universal/src/components/compose-meal-view.tsx
+++ b/universal/src/components/compose-meal-view.tsx
@@ -14,13 +14,16 @@ const CATEGORY_ORDER = ["protein", "carbs", "grain", "vegetable", "fat", "dairy"
  *  Mobile-adapted from the web ComposeMealView (grams-based; the raw/cooked
  *  and count editors + save-as-preset stay a web-only power feature for now). */
 export function ComposeMealView({
-  ingredients, date, slot, onLogged, initialGrams, editMealId,
+  ingredients, date, slot, onLogged, initialGrams, editMealId, onTotalsChange,
 }: {
   ingredients: Ingredient[]; date: string; slot: string; onLogged: () => void;
   /** Pre-select ingredients (id -> grams) — used when editing a logged meal. */
   initialGrams?: Record<string, number>;
   /** When set, saving deletes this meal after re-logging (edit = replace). */
   editMealId?: number | null;
+  /** Emits the in-progress meal totals on every change, so the screen can fold
+   *  them into the day's live preview (remaining kcal + macro bars). */
+  onTotalsChange?: (t: { calories: number; protein: number; carbs: number; fat: number; fiber: number }) => void;
 }) {
   const [search, setSearch] = useState("");
   const [grams, setGrams] = useState<Record<string, number>>(initialGrams ?? {});
@@ -52,6 +55,11 @@ export function ComposeMealView({
     },
     { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
   );
+
+  // Push the running totals up so the screen's day preview updates live.
+  useEffect(() => {
+    onTotalsChange?.(totals);
+  }, [totals.calories, totals.protein, totals.carbs, totals.fat, totals.fiber]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const add = (id: string) => setGrams((g) => ({ ...g, [id]: g[id] && g[id] > 0 ? g[id] : 100 }));
   const setG = (id: string, v: number) => setGrams((g) => ({ ...g, [id]: Math.max(0, Math.round(v)) }));

--- a/universal/src/components/preset-panel.tsx
+++ b/universal/src/components/preset-panel.tsx
@@ -1,0 +1,100 @@
+import { useMemo } from "react";
+import { View, ScrollView, Pressable } from "react-native";
+import { Text, Button } from "soma-style";
+import { ingredientMacros, presetItems, presetBaseMacros, type Ingredient, type Preset } from "../lib/api";
+
+const MACRO_COLOR: Record<string, string> = { protein: "#b17850", carbs: "#6366b0", fat: "#cbe896" };
+
+/** Selected-preset panel: scaled ingredient list + live macro preview + a
+ *  Linked/Free proportions toggle with a 0.5–2.0x scale, plus Customize (seed a
+ *  compose meal) and Log. Mirrors the web MealCard's selected-preset view so the
+ *  app gets the same pre-log preview instead of a bare "Log" button. */
+export function PresetPanel({
+  preset, ingredients, multiplier, linked, onMultiplier, onToggleLinked, onCancel, onCustomize, onLog, logging,
+}: {
+  preset: Preset;
+  ingredients: Ingredient[];
+  multiplier: number;
+  linked: boolean;
+  onMultiplier: (v: number) => void;
+  onToggleLinked: () => void;
+  onCancel: () => void;
+  onCustomize: () => void;
+  onLog: () => void;
+  logging: boolean;
+}) {
+  const byId = useMemo(() => new Map(ingredients.map((i) => [i.id, i])), [ingredients]);
+  const items = useMemo(() => presetItems(preset), [preset]);
+  const base = useMemo(() => presetBaseMacros(preset), [preset]);
+  const clamp = (v: number) => Math.max(0.5, Math.min(2, Math.round(v * 20) / 20));
+  const M = (n: number) => Math.round(n * multiplier);
+
+  const grid: [string, number, string][] = [
+    ["kcal", M(base.calories), "#c9d4de"],
+    ["P", M(base.protein), MACRO_COLOR.protein],
+    ["C", M(base.carbs), MACRO_COLOR.carbs],
+    ["F", M(base.fat), MACRO_COLOR.fat],
+  ];
+
+  return (
+    <View className="gap-3 rounded-lg border border-border-subtle p-3">
+      <View className="flex-row items-center justify-between gap-2">
+        <Text variant="body" className="font-semibold text-text" numberOfLines={1} style={{ flexShrink: 1 }}>{preset.name}</Text>
+        <View className="flex-row items-center gap-2">
+          <Pressable onPress={onToggleLinked} hitSlop={6}>
+            <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: linked ? "#e0a45822" : "#142530" }}>
+              <Text variant="micro" style={{ color: linked ? "#e0a458" : "#8aa0ac" }}>{linked ? "Linked" : "Free"}</Text>
+            </View>
+          </Pressable>
+          <Pressable onPress={onCancel} hitSlop={8}><Text variant="body" className="text-text-muted">✕</Text></Pressable>
+        </View>
+      </View>
+
+      {items.length ? (
+        <ScrollView className="max-h-40" keyboardShouldPersistTaps="handled">
+          {items.map((it) => {
+            const ing = byId.get(it.ingredient_id);
+            const g = Math.round(it.grams * multiplier);
+            const mm = ing ? ingredientMacros(ing, g) : null;
+            return (
+              <View key={it.ingredient_id} className="flex-row items-center justify-between border-b border-border-subtle py-1">
+                <Text variant="caption" className="flex-1 text-text-secondary" numberOfLines={1}>{ing?.name ?? it.ingredient_id}</Text>
+                {mm ? <Text variant="micro" className="mr-2 text-text-muted tabular-nums">{Math.round(mm.calories)} kcal</Text> : null}
+                <Text variant="micro" className="text-text-muted tabular-nums">{g} g</Text>
+              </View>
+            );
+          })}
+        </ScrollView>
+      ) : null}
+
+      {/* Live macro preview (base x multiplier) */}
+      <View className="flex-row justify-between rounded-md px-1" style={{ backgroundColor: "#11202066" }}>
+        {grid.map(([lab, val, col]) => (
+          <View key={lab} className="items-center py-1">
+            <Text variant="body" className="font-bold tabular-nums" style={{ color: col }}>{val}{lab === "kcal" ? "" : "g"}</Text>
+            <Text variant="micro" className="text-text-muted">{lab}</Text>
+          </View>
+        ))}
+      </View>
+
+      {linked ? (
+        <View className="flex-row items-center justify-between">
+          <Text variant="caption" className="text-text-secondary">Scale</Text>
+          <View className="flex-row items-center gap-1">
+            <Button label="−" variant="ghost" size="sm" onPress={() => onMultiplier(clamp(multiplier - 0.05))} />
+            <Text variant="caption" className="w-14 text-center tabular-nums">{multiplier.toFixed(2)}x</Text>
+            <Button label="+" variant="ghost" size="sm" onPress={() => onMultiplier(clamp(multiplier + 0.05))} />
+          </View>
+        </View>
+      ) : (
+        <Text variant="micro" className="text-center text-text-muted">Tap Customize to adjust individual portions.</Text>
+      )}
+
+      <View className="flex-row gap-2">
+        <Button label="Cancel" variant="ghost" size="sm" className="flex-1" onPress={onCancel} />
+        <Button label="Customize" variant="secondary" size="sm" className="flex-1" onPress={onCustomize} />
+        <Button label={logging ? "…" : "Log"} variant="primary" size="sm" className="flex-1" disabled={logging} onPress={onLog} />
+      </View>
+    </View>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -860,6 +860,41 @@ export interface Preset {
   total_carbs: number;
   total_fat: number;
   total_fiber: number;
+  /** Raw preset blob `{ items:[{ingredient_id,grams}], calories,... }` — the
+   *  presets endpoint returns it; used by the scale/customize panel to show the
+   *  scaled ingredient list and to seed a compose meal. */
+  items?: unknown;
+  tags?: string[] | null;
+}
+
+/** The `{ingredient_id, grams}` list inside a preset's items blob. */
+export function presetItems(p: Preset): { ingredient_id: string; grams: number }[] {
+  const blob = p.items as unknown;
+  const arr = Array.isArray(blob)
+    ? blob
+    : blob && typeof blob === "object"
+      ? (blob as { items?: unknown }).items
+      : null;
+  if (!Array.isArray(arr)) return [];
+  return arr
+    .map((it) => ({ ingredient_id: String((it as { ingredient_id?: unknown })?.ingredient_id ?? ""), grams: Number((it as { grams?: unknown })?.grams) || 0 }))
+    .filter((it) => it.ingredient_id);
+}
+
+/** A preset's base (1x) macros — from the items blob when present, else the
+ *  stored flat totals. Scale by the portion multiplier for the live preview. */
+export function presetBaseMacros(p: Preset): { calories: number; protein: number; carbs: number; fat: number; fiber: number } {
+  const blob = p.items as { calories?: unknown; protein?: unknown; carbs?: unknown; fat?: unknown; fiber?: unknown } | null;
+  if (blob && typeof blob === "object" && !Array.isArray(blob) && blob.calories != null) {
+    return {
+      calories: Number(blob.calories) || 0, protein: Number(blob.protein) || 0,
+      carbs: Number(blob.carbs) || 0, fat: Number(blob.fat) || 0, fiber: Number(blob.fiber) || 0,
+    };
+  }
+  return {
+    calories: Number(p.total_calories) || 0, protein: Number(p.total_protein) || 0,
+    carbs: Number(p.total_carbs) || 0, fat: Number(p.total_fat) || 0, fiber: Number(p.total_fiber) || 0,
+  };
 }
 
 /** soma's saved preset meals (log-meal is preset-based, not free-food search). */


### PR DESCRIPTION
## What
Brings the Expo app's nutrition screen to web parity on live meal preview (part of #571). All client-side: the app already fetches the same `/api/nutrition/*` backend as web, so no backend/data changes.

### Preset scale / customize panel
Tapping a preset now opens a panel (mirrors the web MealCard selected-preset view) instead of a bare "Log":
- scaled ingredient list with per-ingredient kcal
- live macro preview grid (kcal / P / C / F)
- Linked/Free proportions toggle + a 0.5–2.0x scale stepper
- Customize → seeds a compose meal from the preset's (scaled) ingredients

### Live day-level preview
A "Day after this meal" strip inside the log modal folds the in-progress preset or compose meal into the remaining kcal + the four macro goal bars, so the impact is visible before logging. `ComposeMealView` now emits its running totals for this.

## Validation (Expo web + Playwright, real screenshots read)
- Opened Log Lunch → selected a preset → panel + day strip render.
- Scaling to 1.05x live-recalculated the ingredient grams (Chicken 150→158g), the macro grid (443→465 kcal), and the day strip (1,005→983 kcal left, Protein 108→110).
- Customize seeded the compose view with the scaled ingredients and the day strip switched to the compose totals.
- `tsc --noEmit` clean; universal vitest 21/21.
- No writes changed; no prod nutrition data mutated.

Closes #572. Part of #571.
