### PR TITLE
feat(nutrition): full compose parity + save-as-preset (#573)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -11,7 +11,7 @@ import { ActivitySelector } from "../../components/activity-selector";
 import { ComposeMealView } from "../../components/compose-meal-view";
 import { PresetPanel } from "../../components/preset-panel";
 import { MealDetailModal } from "../../components/meal-detail-modal";
-import { MacroGoalBar, buildMacroMarkers, ProteinQualityPill } from "../../components/macro-goal-bar";
+import { MacroGoalBar, buildMacroMarkers, ProteinQualityPill, type MacroMarker } from "../../components/macro-goal-bar";
 import { NutritionContextStrip } from "../../components/nutrition-context-strip";
 import { PrepSummary } from "../../components/prep-summary";
 
@@ -294,6 +294,32 @@ export default function NutritionScreen() {
       : logMode === "compose" ? composePreview : null
     : null;
   const previewActive = !!previewTotals && previewTotals.calories > 0;
+
+  // The live "day after this meal" strip: 5 stacked bars (kcal + P/C/F/Fi). Each
+  // shows the already-eaten portion dimmer + this meal stacked on top, over the
+  // research goalposts (kcal bar adds a goal soft-ceiling + burn hard-ceiling).
+  const renderDayStrip = (preview: { calories: number; protein: number; carbs: number; fat: number; fiber: number }) => {
+    const t = {
+      protein: Number(plan?.target_protein) || 0,
+      carbs: Number(plan?.target_carbs) || 0,
+      fat: Number(plan?.target_fat) || 0,
+      fiber: Number(plan?.target_fiber) || 0,
+    };
+    const marks = buildMacroMarkers(Number(bd?.weightKg) || 0, t);
+    const kcalMarkers: MacroMarker[] = [];
+    if (targetCal > 0) kcalMarkers.push({ value: targetCal, label: "goal", kind: "softCeiling", optimal: true, description: "Daily deficit target" });
+    if ((totalBurn ?? 0) > 0) kcalMarkers.push({ value: totalBurn, label: "burn", kind: "hardCeiling", description: "Total burn — past this is surplus" });
+    const c = consumed as Record<string, number> | undefined;
+    const bars: { key: string; label: string; color: string; target: number; markers: MacroMarker[]; unit: string }[] = [
+      { key: "calories", label: "Calories", color: "#77c8d1", target: targetCal, markers: kcalMarkers, unit: "" },
+      ...MACROS.map((m) => ({ key: m.key, label: m.label, color: m.color, target: t[m.key as keyof typeof t], markers: marks[m.key as keyof typeof marks], unit: "g" })),
+    ];
+    return bars.map((b) => {
+      const base = c?.[b.key] ?? 0;
+      const cur = base + ((preview as Record<string, number>)[b.key] ?? 0);
+      return <MacroGoalBar key={b.key} label={b.label} current={cur} base={base} target={b.target} color={b.color} markers={b.markers} unit={b.unit} />;
+    });
+  };
 
   // Render the 4 macro goal bars; `extra` folds an in-progress meal's macros in.
   const renderMacroBars = (extra?: { protein: number; carbs: number; fat: number; fiber: number } | null) => {
@@ -670,7 +696,7 @@ export default function NutritionScreen() {
                 <Text variant="caption" className="tabular-nums text-text-secondary">+{Math.round(previewTotals.calories).toLocaleString()} kcal</Text>
               )}
             </View>
-            <View className="gap-2.5">{renderMacroBars(previewTotals)}</View>
+            <View className="gap-2.5">{renderDayStrip(previewTotals)}</View>
           </View>
         ) : null}
 

--- a/universal/src/components/compose-meal-view.tsx
+++ b/universal/src/components/compose-meal-view.tsx
@@ -1,7 +1,11 @@
 import { useState, useMemo, useEffect } from "react";
 import { View, ScrollView, TextInput, Pressable } from "react-native";
 import { Text, Button } from "soma-style";
-import { ingredientMacros, logComposedMeal, deleteMeal, type Ingredient } from "../lib/api";
+import {
+  ingredientMacros, logComposedMeal, deleteMeal, savePreset,
+  isCountBased, countToGrams, gramsToCount, rawToCooked, cookedToRaw, hasRawCookedToggle,
+  type Ingredient, type ComposeItem,
+} from "../lib/api";
 
 const CATEGORY_LABELS: Record<string, string> = {
   protein: "Protein", carbs: "Carbs", grain: "Grain", vegetable: "Vegetable", fat: "Fat",
@@ -9,10 +13,30 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 const CATEGORY_ORDER = ["protein", "carbs", "grain", "vegetable", "fat", "dairy", "fruit", "sauce", "supplement"];
 
+/** Readable name from meal items, e.g. "Chicken Breast, Rice & Broccoli".
+ *  Mirrors web's autoMealName (supplements/liquids sorted last). */
+function autoMealName(items: { ingredient_id: string; name?: string }[]): string {
+  if (!items.length) return "Custom meal";
+  const pr = (id: string) => {
+    const s = (id || "").toLowerCase();
+    if (/whey|protein_powder|creatine|supplement|flax/.test(s)) return 3;
+    if (/milk|water|juice|yogurt/.test(s)) return 2;
+    return 1;
+  };
+  const sorted = [...items].sort((a, b) => pr(a.ingredient_id || a.name || "") - pr(b.ingredient_id || b.name || ""));
+  const names = sorted.slice(0, 3).map((it) =>
+    (it.name || it.ingredient_id || "")
+      .replace(/_raw$/, "").replace(/_(dry|whole)$/i, "").replace(/_\d+pct$/i, "")
+      .replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()).trim());
+  if (names.length <= 1) return names[0] || "Custom meal";
+  if (names.length === 2) return `${names[0]} & ${names[1]}`;
+  return `${names[0]}, ${names[1]} & ${names[2]}`;
+}
+
 /** Compose a meal from raw ingredients: search + category-grouped picker,
- *  per-ingredient gram editors with live macros, running totals, and log.
- *  Mobile-adapted from the web ComposeMealView (grams-based; the raw/cooked
- *  and count editors + save-as-preset stay a web-only power feature for now). */
+ *  per-ingredient editors (grams, or pieces for count-based, or cooked weight),
+ *  a max-yolks clamp, live macros + running totals + a volume-score hint, and
+ *  a save-as-preset step after logging. Full parity with the web ComposeMealView. */
 export function ComposeMealView({
   ingredients, date, slot, onLogged, initialGrams, editMealId, onTotalsChange,
 }: {
@@ -28,6 +52,12 @@ export function ComposeMealView({
   const [search, setSearch] = useState("");
   const [grams, setGrams] = useState<Record<string, number>>(initialGrams ?? {});
   const [busy, setBusy] = useState(false);
+  const [cookedMode, setCookedMode] = useState<Set<string>>(new Set());
+  const [gramMode, setGramMode] = useState<Set<string>>(new Set());
+  const [maxYolks, setMaxYolks] = useState(1);
+  const [savePrompt, setSavePrompt] = useState<{ items: ComposeItem[]; totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number }; name: string } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveErr, setSaveErr] = useState<string | null>(null);
   const initKey = initialGrams ? Object.entries(initialGrams).map(([k, v]) => `${k}:${v}`).join(",") : "";
   useEffect(() => { if (initialGrams) setGrams(initialGrams); }, [initKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -55,6 +85,8 @@ export function ComposeMealView({
     },
     { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
   );
+  const totalGrams = selectedIds.reduce((s, id) => s + (grams[id] || 0), 0);
+  const volumeScore = totals.calories > 0 ? totalGrams / totals.calories : 0;
 
   // Push the running totals up so the screen's day preview updates live.
   useEffect(() => {
@@ -64,24 +96,76 @@ export function ComposeMealView({
   const add = (id: string) => setGrams((g) => ({ ...g, [id]: g[id] && g[id] > 0 ? g[id] : 100 }));
   const setG = (id: string, v: number) => setGrams((g) => ({ ...g, [id]: Math.max(0, Math.round(v)) }));
   const remove = (id: string) => setGrams((g) => { const n = { ...g }; delete n[id]; return n; });
+  const toggleSet = (setter: React.Dispatch<React.SetStateAction<Set<string>>>) => (id: string) =>
+    setter((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  const toggleCooked = toggleSet(setCookedMode);
+  const toggleGramMode = toggleSet(setGramMode);
 
-  async function onLog() {
-    setBusy(true);
-    const items = selectedIds.map((id) => {
+  // Clamp whole-egg grams to the yolk cap when the max changes (mirrors web).
+  useEffect(() => {
+    const ing = byId.get("eggs_whole");
+    if (!ing || !(grams["eggs_whole"] > 0)) return;
+    const maxGrams = (Number(ing.grams_per_unit) || 50) * maxYolks;
+    if (grams["eggs_whole"] > maxGrams) setG("eggs_whole", maxGrams);
+  }, [maxYolks]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function buildItems(): ComposeItem[] {
+    return selectedIds.map((id) => {
       const ing = byId.get(id)!;
       const m = ingredientMacros(ing, grams[id]);
       return { ingredient_id: id, name: ing.name, grams: grams[id], calories: m.calories, protein: m.protein, carbs: m.carbs, fat: m.fat, fiber: m.fiber };
     });
+  }
+
+  async function onLog() {
+    setBusy(true);
+    const items = buildItems();
     const ok = await logComposedMeal(date, slot, items);
-    // Edit = replace: only remove the original after the new one is logged.
     if (ok && editMealId != null) await deleteMeal(editMealId);
     setBusy(false);
-    if (ok) { setGrams({}); onLogged(); }
+    if (!ok) return;
+    if (editMealId == null) {
+      // New meal — offer to save it as a preset before closing.
+      const t = { calories: Math.round(totals.calories), protein: Math.round(totals.protein), carbs: Math.round(totals.carbs), fat: Math.round(totals.fat), fiber: Math.round(totals.fiber) };
+      setSavePrompt({ items, totals: t, name: autoMealName(items) });
+    } else {
+      setGrams({}); onLogged();
+    }
+  }
+
+  async function onSavePreset() {
+    if (!savePrompt) return;
+    setSaving(true); setSaveErr(null);
+    const ok = await savePreset(savePrompt.name.trim(), savePrompt.items, slot, savePrompt.totals);
+    setSaving(false);
+    if (ok) { setSavePrompt(null); setGrams({}); onLogged(); }
+    else setSaveErr("Couldn't save preset.");
+  }
+
+  // Save-as-preset step (after a new meal is logged).
+  if (savePrompt) {
+    return (
+      <View className="gap-3 rounded-lg border border-dashed border-border-subtle p-3">
+        <Text variant="caption" className="text-text-secondary">Meal logged. Save it as a preset for reuse?</Text>
+        <TextInput
+          value={savePrompt.name}
+          onChangeText={(v) => setSavePrompt((p) => (p ? { ...p, name: v } : p))}
+          placeholder="Preset name"
+          placeholderTextColor="#5a7a8a"
+          className="rounded-md border border-border-subtle px-3 py-2 text-text"
+        />
+        {saveErr ? <Text variant="micro" className="text-danger">{saveErr}</Text> : null}
+        <View className="flex-row justify-end gap-2">
+          <Button label="Skip" variant="ghost" size="sm" onPress={() => { setSavePrompt(null); setGrams({}); onLogged(); }} />
+          <Button label={saving ? "…" : "Save preset"} variant="primary" size="sm" disabled={saving || !savePrompt.name.trim()} onPress={onSavePreset} />
+        </View>
+      </View>
+    );
   }
 
   return (
     <View className="gap-3">
-      {/* Selected ingredients — gram editors + live macros */}
+      {/* Selected ingredients — grams / pieces / cooked-weight editors + live macros */}
       {selectedIds.length ? (
         <View className="gap-2 rounded-lg border border-border-subtle p-3">
           <Text variant="eyebrow" className="text-text-muted">In this meal</Text>
@@ -89,23 +173,86 @@ export function ComposeMealView({
             const ing = byId.get(id)!;
             const g = grams[id];
             const m = ingredientMacros(ing, g);
+            const asCount = isCountBased(ing) && !gramMode.has(id);
+            const canCook = hasRawCookedToggle(ing);
+            const asCooked = canCook && cookedMode.has(id);
+
+            let displayVal: string;
+            let onMinus: () => void;
+            let onPlus: () => void;
+            if (asCount) {
+              const count = gramsToCount(ing, g);
+              const step = Number(ing.unit_step) || 1;
+              displayVal = `${count} ${ing.unit || "pcs"}`;
+              onMinus = () => setG(id, countToGrams(ing, Math.max(0, count - step)));
+              onPlus = () => setG(id, countToGrams(ing, count + step));
+            } else if (asCooked) {
+              const cooked = rawToCooked(ing, g);
+              displayVal = `${cooked} g`;
+              onMinus = () => setG(id, cookedToRaw(ing, Math.max(0, cooked - 10)));
+              onPlus = () => setG(id, cookedToRaw(ing, cooked + 10));
+            } else {
+              displayVal = `${g} g`;
+              onMinus = () => setG(id, g - 10);
+              onPlus = () => setG(id, g + 10);
+            }
+
             return (
-              <View key={id} className="flex-row items-center gap-2 border-b border-border-subtle pb-1.5">
-                <View className="flex-1">
-                  <Text variant="caption" className="text-text" numberOfLines={1}>{ing.name}</Text>
-                  <Text variant="micro" className="text-text-muted tabular-nums">
-                    {Math.round(m.calories)} kcal · P{Math.round(m.protein)} C{Math.round(m.carbs)} F{Math.round(m.fat)}
-                  </Text>
+              <View key={id} className="border-b border-border-subtle pb-1.5">
+                <View className="flex-row items-center gap-2">
+                  <View className="flex-1">
+                    <Text variant="caption" className="text-text" numberOfLines={1}>{ing.name}</Text>
+                    <Text variant="micro" className="text-text-muted tabular-nums">
+                      {Math.round(m.calories)} kcal · P{Math.round(m.protein)} C{Math.round(m.carbs)} F{Math.round(m.fat)}
+                    </Text>
+                  </View>
+                  <View className="flex-row items-center gap-1">
+                    <Button label="−" variant="ghost" size="sm" onPress={onMinus} />
+                    <Text variant="caption" className="w-16 text-center tabular-nums">{displayVal}</Text>
+                    <Button label="+" variant="ghost" size="sm" onPress={onPlus} />
+                    <Button label="✕" variant="ghost" size="sm" onPress={() => remove(id)} />
+                  </View>
                 </View>
-                <View className="flex-row items-center gap-1">
-                  <Button label="−" variant="ghost" size="sm" onPress={() => setG(id, g - 10)} />
-                  <Text variant="caption" className="w-14 text-center tabular-nums">{g} g</Text>
-                  <Button label="+" variant="ghost" size="sm" onPress={() => setG(id, g + 10)} />
-                  <Button label="✕" variant="ghost" size="sm" onPress={() => remove(id)} />
-                </View>
+                {canCook || isCountBased(ing) ? (
+                  <View className="flex-row gap-4 pt-0.5">
+                    {canCook ? (
+                      <Pressable onPress={() => toggleCooked(id)} hitSlop={6}>
+                        <Text variant="micro" className="text-teal">{asCooked ? `cooked (${g}g raw)` : "switch to cooked weight"}</Text>
+                      </Pressable>
+                    ) : null}
+                    {isCountBased(ing) ? (
+                      <Pressable onPress={() => toggleGramMode(id)} hitSlop={6}>
+                        <Text variant="micro" className="text-teal">{gramMode.has(id) ? `switch to ${ing.unit || "pcs"}` : "switch to grams"}</Text>
+                      </Pressable>
+                    ) : null}
+                  </View>
+                ) : null}
               </View>
             );
           })}
+
+          {/* Max yolks/day — clamps whole-egg grams */}
+          {selectedIds.includes("eggs_whole") ? (
+            <View className="flex-row items-center justify-between rounded-md px-2 py-1.5" style={{ backgroundColor: "#11202066" }}>
+              <Text variant="micro" className="text-text-muted">Max yolks / day</Text>
+              <View className="flex-row items-center gap-1.5">
+                {[1, 2, 3].map((n) => (
+                  <Pressable key={n} onPress={() => setMaxYolks(n)} hitSlop={4}>
+                    <View className="h-7 w-7 items-center justify-center rounded-md" style={{ backgroundColor: maxYolks === n ? "#77c8d1" : "#152232" }}>
+                      <Text variant="caption" style={{ color: maxYolks === n ? "#0a1720" : "#a0b4c0" }}>{n}</Text>
+                    </View>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          ) : null}
+
+          {totals.calories > 0 ? (
+            <Text variant="micro" className="text-center" style={{ color: volumeScore >= 1.5 ? "#6ad4a0" : volumeScore >= 0.8 ? "#5a7a8a" : "#e0a458" }}>
+              {volumeScore >= 1.5 ? "High volume — great for satiety" : volumeScore >= 0.8 ? `${Math.round(totalGrams)}g total` : `${Math.round(totalGrams)}g total — low volume`}
+            </Text>
+          ) : null}
+
           <View className="flex-row items-center justify-between pt-1">
             <Text variant="caption" className="font-semibold tabular-nums">
               {Math.round(totals.calories)} kcal · P{Math.round(totals.protein)} C{Math.round(totals.carbs)} F{Math.round(totals.fat)}

--- a/universal/src/components/macro-goal-bar.tsx
+++ b/universal/src/components/macro-goal-bar.tsx
@@ -77,6 +77,7 @@ export function MacroGoalBar({
   color,
   markers,
   unit = "g",
+  base,
 }: {
   label: string;
   current: number;
@@ -84,6 +85,9 @@ export function MacroGoalBar({
   color: string;
   markers?: MacroMarker[];
   unit?: string;
+  /** When set, renders 0->base as a dimmer "already eaten" segment and
+   *  base->current as the full-strength "this meal" segment (stacked preview). */
+  base?: number;
 }) {
   const useMulti = !!markers && markers.length > 0;
   const highest = useMulti ? Math.max(...markers!.map((m) => m.value)) : 0;
@@ -118,8 +122,18 @@ export function MacroGoalBar({
         </Text>
       </View>
       <View className="relative h-2 overflow-hidden rounded-full" style={{ backgroundColor: TRACK }}>
-        {/* Base fill */}
-        <View className="absolute left-0 top-0 h-full rounded-full" style={{ width: `${fillPct}%`, backgroundColor: color }} />
+        {(() => {
+          // Optional 2-tone stacking: dim "eaten" segment + full "this meal".
+          const basePct = base != null && base > 0 ? Math.min(100, (base / maxVal) * 100) : 0;
+          return (
+            <>
+              {basePct > 0 ? (
+                <View className="absolute left-0 top-0 h-full" style={{ width: `${basePct}%`, backgroundColor: color, opacity: 0.5 }} />
+              ) : null}
+              <View className="absolute top-0 h-full" style={{ left: `${basePct}%`, width: `${Math.max(0, fillPct - basePct)}%`, backgroundColor: color }} />
+            </>
+          );
+        })()}
         {/* Soft-ceiling amber overlay */}
         {useMulti && pastSoft && orangeEndPct > softStartPct ? (
           <View className="absolute top-0 h-full" style={{ left: `${softStartPct}%`, width: `${orangeEndPct - softStartPct}%`, backgroundColor: AMBER }} />

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -902,9 +902,11 @@ export function presetBaseMacros(p: Preset): { calories: number; protein: number
 export interface Ingredient {
   id: string; name: string; category: string;
   calories_per_100g: number; protein_per_100g: number; carbs_per_100g: number; fat_per_100g: number; fiber_per_100g: number;
-  unit?: string | null; grams_per_unit?: number | null;
+  unit?: string | null; grams_per_unit?: number | null; unit_step?: number | null;
   /** Cookable/raw ingredient (drives the day's prep list). */
   is_raw?: boolean;
+  /** Cooked weight = raw grams x ratio (e.g. rice absorbs water, meat loses it). */
+  raw_to_cooked_ratio?: number | null;
 }
 /** Macros for `grams` of an ingredient (linear per-100g scaling). */
 export function ingredientMacros(ing: Ingredient, grams: number) {
@@ -916,6 +918,38 @@ export function ingredientMacros(ing: Ingredient, grams: number) {
     fat: (Number(ing.fat_per_100g) || 0) * f,
     fiber: (Number(ing.fiber_per_100g) || 0) * f,
   };
+}
+
+// ── Portion helpers — local twins of macro-engine-core's portion-solver, kept
+// bit-identical so the app's compose editors match the web (count/piece units
+// and raw<->cooked weight conversions). ──────────────────────────────────────
+/** True when the ingredient is measured in pieces/units, not grams. */
+export function isCountBased(ing: Ingredient): boolean {
+  return !!ing.unit && ing.unit !== "g" && !!ing.grams_per_unit;
+}
+export function countToGrams(ing: Ingredient, count: number): number {
+  return count * (Number(ing.grams_per_unit) || 100);
+}
+export function gramsToCount(ing: Ingredient, grams: number): number {
+  const raw = grams / (Number(ing.grams_per_unit) || 100);
+  const step = Number(ing.unit_step) || 0.25;
+  return Math.round(raw / step) * step;
+}
+/** Cooked weight for `rawGrams` (rounded); identity when no raw/cooked ratio. */
+export function rawToCooked(ing: Ingredient, rawGrams: number): number {
+  const r = Number(ing.raw_to_cooked_ratio);
+  if (!ing.is_raw || !r || r <= 0) return rawGrams;
+  return Math.round(rawGrams * r);
+}
+export function cookedToRaw(ing: Ingredient, cookedGrams: number): number {
+  const r = Number(ing.raw_to_cooked_ratio);
+  if (!ing.is_raw || !r || r <= 0) return cookedGrams;
+  return Math.round(cookedGrams / r);
+}
+/** True when this ingredient supports a raw<->cooked weight toggle. */
+export function hasRawCookedToggle(ing: Ingredient): boolean {
+  const r = Number(ing.raw_to_cooked_ratio);
+  return !!ing.is_raw && !!r && r > 0 && r !== 1;
 }
 
 export interface RebalanceChange { slot: string; ingredient: string; from: number; to: number }
@@ -945,6 +979,30 @@ export async function logComposedMeal(date: string, slot: string, items: Compose
       method: "POST",
       headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
       body: JSON.stringify({ date, meal_slot: slot, source: "compose", items }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Save a composed meal as a reusable preset (web /api/nutrition/presets POST). */
+export async function savePreset(
+  name: string,
+  items: ComposeItem[],
+  slot: string,
+  totals: { calories: number; protein: number; carbs: number; fat: number; fiber: number },
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/nutrition/presets`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({
+        name,
+        items: items.map((i) => ({ ingredient_id: i.ingredient_id, grams: i.grams })),
+        slot,
+        totals,
+      }),
     });
     return res.ok;
   } catch {


### PR DESCRIPTION
## What
Full compose parity for the Expo nutrition screen (part of #571). All client-side; same `/api/nutrition/*` backend as web.

- **Raw↔cooked toggle** per ingredient (`hasRawCookedToggle`/`rawToCooked`/`cookedToRaw`).
- **Grams↔pieces toggle** for count-based ingredients (`isCountBased`/`countToGrams`/`gramsToCount`), with a piece-aware stepper.
- **Max yolks/day** (1/2/3) clamping whole-egg grams.
- **Volume score** satiety hint (total grams / calories).
- **5 stacked day-progress bars** — the "Day after this meal" strip now shows kcal + P/C/F/Fi with a dim already-eaten segment + this-meal stacked on top, plus a kcal bar (goal soft-ceiling + burn hard-ceiling). `MacroGoalBar` gained an optional `base` prop.
- **Save-as-preset** after logging a new composed meal (auto-generated name → `POST /api/nutrition/presets`).

The portion helpers are local twins of `macro-engine-core`'s portion-solver, kept bit-identical.

## Validation (Expo web + Playwright, real screenshots read)
- Compose with Chicken Breast (raw) + Whole Egg: raw→cooked showed 100g raw → **72 g cooked** (macros unchanged); egg showed **"2 egg"** with a switch-to-grams link.
- Max yolks 2→1 clamped the egg **2 egg → 1 egg** (100g→50g).
- Volume score rendered ("200g total — low volume").
- The day strip showed all 5 bars with two-tone eaten/this-meal segments.
- Log meal → **save-as-preset** prompt with auto-name "Chicken Breast (Raw) & Whole Egg (With Yolk)".
- `tsc --noEmit` clean; universal vitest 21/21. Writes were mocked in-browser; no prod nutrition data mutated.

Closes #573. Part of #571.
