### PR TITLE
feat(app): shared 10-range time selector across screens (#579)

### DIFF
--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl } from "react-native";
-import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
+import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
+import { TimeRangeSelector } from "../../components/time-range-selector";
+import { useRangePref } from "../../lib/time-range";
 import { fetchJson, usePullRefresh, useActivitiesDeep } from "../../lib/api";
 import { ActivitiesMonthly, KiteDeepDive, SnowDeepDive, ActivitiesList } from "../../components/activities-deep";
 import { ActivitySports } from "../../components/activity-sports";
@@ -23,9 +25,6 @@ function useSessionsTrend() {
   return series;
 }
 
-type RangeKey = "30d" | "90d" | "1y" | "all";
-const RANGES: readonly RangeKey[] = ["30d", "90d", "1y", "all"] as const;
-const RANGE_LABEL: Record<RangeKey, string> = { "30d": "30d", "90d": "90d", "1y": "1y", all: "All" };
 
 /** Per-sport rollup (mirrors the web getActivitySummary grouping, labelled). */
 interface SportSummary {
@@ -71,7 +70,7 @@ interface ActivitiesSummary {
  * page currently queries the DB directly in a server component, so the universal app
  * consumes a JSON rollup of the same data instead.
  */
-function useActivities(range: RangeKey) {
+function useActivities(range: string) {
   const [data, setData] = useState<ActivitiesSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -116,7 +115,7 @@ function fmtDate(iso: string): string {
 }
 
 export default function ActivitiesScreen() {
-  const [range, setRange] = useState<RangeKey>("1y");
+  const [range, setRange] = useRangePref();
   const { data, loading, error, refetch } = useActivities(range);
   const { data: deep } = useActivitiesDeep(range);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
@@ -146,11 +145,7 @@ export default function ActivitiesScreen() {
           </Text>
         </View>
 
-        <SegmentedControl
-          options={RANGES}
-          value={range}
-          onChange={(v) => setRange(v as RangeKey)}
-        />
+        <TimeRangeSelector value={range} onChange={setRange} />
 
         {error ? (
           <Card>

--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
-import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
+import { Text, Card, Badge, ProgressBar, Sparkline } from "soma-style";
+import { TimeRangeSelector } from "../../components/time-range-selector";
+import { useRangePref, rangeLabel } from "../../lib/time-range";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { fetchJson, usePullRefresh, useRunningTrends, useFitnessScores, useRunningSplits, useHrPace, useRecentRoutes, useRunHeatmap } from "../../lib/api";
 import { RunningMileage } from "../../components/running-mileage";
@@ -170,7 +172,7 @@ const ZONE_HEX = ["#77c8d1", "#6ad4a0", "#e0c458", "#e0a458", "#e06060"];
 export default function RunningScreen() {
   const { data, error, refetch } = useRunning();
   // Range drives the trend sections (all four endpoints accept 90d/1y/2y).
-  const [range, setRange] = useState<"90d" | "1y" | "2y">("1y");
+  const [range, setRange] = useRangePref();
   const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
   const { data: runTrends } = useRunningTrends(range);
   const { data: fitScores } = useFitnessScores(range);
@@ -374,12 +376,8 @@ export default function RunningScreen() {
 
         {/* Range governs the trend charts below (stats above are all-time). */}
         <View className="gap-1">
-          <Text variant="eyebrow" className="text-text-muted">Trends — last {range}</Text>
-          <SegmentedControl
-            options={["90d", "1y", "2y"] as const}
-            value={range}
-            onChange={(v) => setRange(v as "90d" | "1y" | "2y")}
-          />
+          <Text variant="eyebrow" className="text-text-muted">Trends — last {rangeLabel(range)}</Text>
+          <TimeRangeSelector value={range} onChange={setRange} />
         </View>
 
         {/* Training load/ACWR + cadence trends (new /api/running/trends) */}

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
-import { Text, Card, Badge, SegmentedControl, Sparkline } from "soma-style";
+import { Text, Card, Badge, Sparkline } from "soma-style";
+import { TimeRangeSelector } from "../../components/time-range-selector";
+import { useRangePref, statsRange } from "../../lib/time-range";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { LineChart, ChartLegend } from "../../components/line-chart";
 import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule, useWeekdayWeekend } from "../../lib/api";
@@ -39,15 +41,13 @@ interface StatSeries {
   };
 }
 
-type Range = "7d" | "30d" | "90d";
-const RANGES: readonly Range[] = ["7d", "30d", "90d"] as const;
 
 /**
  * Sleep & Recovery data, fetched from soma's /api/stats/[metric] endpoints.
  * The web page reads the DB directly; the RN app has no DB, so it uses the
  * public stats API which serves the same daily_health_summary rows.
  */
-function useSleepRecovery(range: Range) {
+function useSleepRecovery(range: string) {
   const [sleep, setSleep] = useState<StatSeries | null>(null);
   const [rhr, setRhr] = useState<StatSeries | null>(null);
   const [stress, setStress] = useState<StatSeries | null>(null);
@@ -60,7 +60,8 @@ function useSleepRecovery(range: Range) {
   useEffect(() => {
     let alive = true;
     setLoading(true);
-    const get = (m: string) => fetchJson<StatSeries>(`/api/stats/${m}?range=${range}`);
+    // /api/stats/* only accepts 7d/30d/90d/1y — clamp the shared range to it.
+    const get = (m: string) => fetchJson<StatSeries>(`/api/stats/${m}?range=${statsRange(range)}`);
 
     Promise.all([
       get("sleep"),
@@ -108,7 +109,7 @@ function delta(series: StatSeries | null): number | null {
 }
 
 export default function SleepScreen() {
-  const [range, setRange] = useState<Range>("30d");
+  const [range, setRange] = useRangePref();
   const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
   const { sleep, rhr, stress, battery, recovery, loading, error, refetch } =
     useSleepRecovery(range);
@@ -240,11 +241,7 @@ export default function SleepScreen() {
           ) : null}
         </View>
 
-        <SegmentedControl
-          options={RANGES}
-          value={range}
-          onChange={(v) => setRange(v as Range)}
-        />
+        <TimeRangeSelector value={range} onChange={setRange} />
 
         {error ? (
           <Card>

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,6 +1,8 @@
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { useEffect, useState } from "react";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
+import { TimeRangeSelector } from "../../components/time-range-selector";
+import { useRangePref } from "../../lib/time-range";
 import { fetchJson, usePullRefresh, useWorkoutsSummary, useWorkoutInsights, useWorkoutTimeline, useBodyMap, type TimelinePoint } from "../../lib/api";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { WorkoutsDashboard } from "../../components/workouts-dashboard";
@@ -62,7 +64,7 @@ function formatDate(dateStr: string): string {
 
 export default function WorkoutsScreen() {
   const { data, error, refetch } = useWorkouts();
-  const [range, setRange] = useState<"30d" | "90d" | "1y">("90d");
+  const [range, setRange] = useRangePref();
   const [unit, setUnit] = useState<"kg" | "lb">("kg");
   const { data: wkSum } = useWorkoutsSummary(range);
   const { data: insights } = useWorkoutInsights(range);
@@ -216,11 +218,7 @@ export default function WorkoutsScreen() {
         {/* Workout data — volume, stats, top exercises, recent (new /api/workouts/summary) */}
         <View className="flex-row items-center gap-3">
           <View className="flex-1">
-            <SegmentedControl
-              options={["30d", "90d", "1y"] as const}
-              value={range}
-              onChange={(v) => setRange(v as "30d" | "90d" | "1y")}
-            />
+            <TimeRangeSelector value={range} onChange={setRange} />
           </View>
           <View className="w-24">
             <SegmentedControl options={["kg", "lb"] as const} value={unit} onChange={(v) => setUnit(v as "kg" | "lb")} />

--- a/universal/src/components/time-range-selector.tsx
+++ b/universal/src/components/time-range-selector.tsx
@@ -1,0 +1,29 @@
+import { ScrollView, Pressable, View } from "react-native";
+import { Text } from "soma-style";
+import { RANGES } from "../lib/time-range";
+
+/** Horizontal-scrolling 10-range picker, mirroring the web TimeRangeSelector.
+ *  Replaces the per-screen 3–4-range SegmentedControls. */
+export function TimeRangeSelector({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerClassName="gap-1.5 py-0.5 pr-4"
+    >
+      {RANGES.map((r) => {
+        const active = value === r.value;
+        return (
+          <Pressable key={r.value} onPress={() => onChange(r.value)} hitSlop={4} accessibilityRole="button" accessibilityLabel={r.label}>
+            <View
+              className="rounded-full px-3 py-1.5"
+              style={{ backgroundColor: active ? "#77c8d1" : "#152232", borderWidth: 1, borderColor: active ? "#77c8d1" : "#1a3040" }}
+            >
+              <Text variant="caption" style={{ color: active ? "#0a1720" : "#a0b4c0", fontWeight: active ? "700" : "500" }}>{r.label}</Text>
+            </View>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/universal/src/lib/time-range.ts
+++ b/universal/src/lib/time-range.ts
@@ -1,0 +1,57 @@
+import { useState } from "react";
+
+/** The 10 time ranges, matching web/lib/time-ranges.ts (same tokens hit the same
+ *  :3456 backend). */
+export interface TimeRange { label: string; value: string; days: number; }
+export const RANGES: TimeRange[] = [
+  { label: "1W", value: "1w", days: 7 },
+  { label: "2W", value: "2w", days: 14 },
+  { label: "1M", value: "1m", days: 30 },
+  { label: "3M", value: "3m", days: 90 },
+  { label: "6M", value: "6m", days: 180 },
+  { label: "9M", value: "9m", days: 270 },
+  { label: "1Y", value: "1y", days: 365 },
+  { label: "2Y", value: "2y", days: 730 },
+  { label: "3Y", value: "3y", days: 1095 },
+  { label: "All", value: "all", days: 3650 },
+];
+
+export function rangeToDays(range: string | undefined): number {
+  if (!range) return 180;
+  const f = RANGES.find((r) => r.value === range);
+  return f ? f.days : 180;
+}
+
+export function rangeLabel(range: string): string {
+  return RANGES.find((r) => r.value === range)?.label ?? range;
+}
+
+/** Clamp a range to the nearest token the /api/stats/* endpoint accepts
+ *  (only 7d/30d/90d/1y). Used where a shared range must call that endpoint. */
+export function statsRange(range: string): string {
+  const d = rangeToDays(range);
+  if (d <= 10) return "7d";
+  if (d <= 45) return "30d";
+  if (d <= 200) return "90d";
+  return "1y";
+}
+
+const STORAGE_KEY = "soma_time_range";
+
+/** Shared, persisted selected time range — mirrors the web's single
+ *  `localStorage["soma_time_range"]` so the choice carries across screens and
+ *  sessions. Falls back to in-memory on native (until AsyncStorage is added). */
+export function useRangePref(defaultRange = "6m"): [string, (r: string) => void] {
+  const [range, setRangeState] = useState<string>(() => {
+    try {
+      const raw = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+      if (raw && RANGES.some((r) => r.value === raw)) return raw;
+    } catch { /* native / unavailable */ }
+    return defaultRange;
+  });
+  const setRange = (r: string) => {
+    setRangeState(r);
+    try { if (typeof localStorage !== "undefined") localStorage.setItem(STORAGE_KEY, r); } catch { /* native */ }
+  };
+  return [range, setRange];
+}


### PR DESCRIPTION
## What
First of the shared-component parity fixes (#578). Replaces each screen's local 3–4-range control with one shared `TimeRangeSelector` (web's 10 ranges: 1W/2W/1M/3M/6M/9M/1Y/2Y/3Y/All) + a persisted, cross-screen range (`localStorage["soma_time_range"]`, the same key web uses). Wired into **running, sleep, activities, workouts**.

New: `lib/time-range.ts` (RANGES, `useRangePref`, `rangeLabel`, `statsRange`) and `components/time-range-selector.tsx`. No backend change — the app hooks already accept `range` and hit the same `:3456` backend web uses.

## Caught mid-flight
- `/api/stats/{metric}` accepts only `7d/30d/90d/1y` (400 on the longer tokens). Sleep uses it for headline stats, so its calls now clamp via `statsRange()`. The running/activities/workouts endpoints accept all 10 (verified live). `StatDetailModal` owns its own 4-range toggle, unaffected.

## Validation (Expo web + Playwright, real screenshots read)
- Running: selector renders all 10 ranges (6M default); switching to 3Y updates the label and persists `soma_time_range=3y`; charts refetch.
- Sleep: shows the shared selector at the persisted 3Y; **0 console errors** — its `/api/stats/*` requests clamp to `range=1y` (verified in the network log); data renders.
- `tsc --noEmit` clean; universal vitest 21/21.

Part of #578.
