### PR TITLE
feat(app): chart reference bands + wire missing goal lines (#581)

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -348,12 +348,28 @@ export default function SleepScreen() {
               <Text variant="micro" className="text-text-muted">score · 30 days</Text>
             </View>
             <LineChart
-              height={130}
+              height={140}
+              interactive
+              yMin={0}
+              yMax={100}
               labels={recoveryVitals!.readiness.trend.map((p) => chartLabel(p.date))}
               yFormat={(v) => String(Math.round(v))}
-              refLine={{ y: 50, color: "#3a5563" }}
-              series={[{ values: recoveryVitals!.readiness.trend.map((p) => finiteOrNull(p.score)), color: "#6ad4a0", width: 2.2 }]}
+              refAreas={[
+                { y1: 70, y2: 100, color: "#6ad4a0" },
+                { y1: 40, y2: 70, color: "#e0a458" },
+                { y1: 0, y2: 40, color: "#e06060" },
+              ]}
+              refLines={[
+                { y: 70, color: "#6ad4a0", dashed: true },
+                { y: 40, color: "#e0a458", dashed: true },
+              ]}
+              series={[{ values: recoveryVitals!.readiness.trend.map((p) => finiteOrNull(p.score)), color: "#c9d4de", width: 2.2 }]}
             />
+            <ChartLegend items={[
+              { color: "#6ad4a0", label: "Ready ≥70" },
+              { color: "#e0a458", label: "Moderate 40–70" },
+              { color: "#e06060", label: "Low <40" },
+            ]} />
           </Card>
         ) : null}
 

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactNode } from "react";
 import { View, type LayoutChangeEvent, type GestureResponderEvent } from "react-native";
-import Svg, { Polyline, Line, Circle } from "react-native-svg";
+import Svg, { Polyline, Line, Circle, Rect } from "react-native-svg";
 import { Text, Modal } from "soma-style";
 
 /**
@@ -31,6 +31,8 @@ export interface LineChartProps {
   yFormatRight?: (v: number) => string;
   refLine?: { y: number; color?: string };
   refLines?: { y: number; color?: string; dashed?: boolean }[];
+  /** Translucent horizontal zones (e.g. Ready ≥70 / Moderate 40–70 bands). */
+  refAreas?: { y1: number; y2: number; color: string; opacity?: number }[];
   yMin?: number;
   yMax?: number;
   /** Number of evenly-spaced x labels to draw (default 2 = first + last). */
@@ -50,7 +52,7 @@ export function chartDateLabel(iso: string): string {
 /** A compact react-native-svg line/scatter chart with y-axis labels, dated x
  *  ticks, an optional right axis, and optional tap-to-read cursor + callout. */
 export function LineChart(props: LineChartProps) {
-  const { series, labels, height = 120, yFormat, yFormatRight, refLine, refLines, yMin, yMax, xTicks, interactive } = props;
+  const { series, labels, height = 120, yFormat, yFormatRight, refLine, refLines, refAreas, yMin, yMax, xTicks, interactive } = props;
   const fmtL = yFormat ?? ((v: number) => String(Math.round(v)));
   const fmtR = yFormatRight ?? fmtL;
   const [active, setActive] = useState<number | null>(null);
@@ -66,6 +68,7 @@ export function LineChart(props: LineChartProps) {
   const lExtra: number[] = [];
   if (refLine && isFinite(refLine.y)) lExtra.push(refLine.y);
   if (refLines) for (const r of refLines) if (isFinite(r.y)) lExtra.push(r.y);
+  if (refAreas) for (const a of refAreas) { if (isFinite(a.y1)) lExtra.push(a.y1); if (isFinite(a.y2)) lExtra.push(a.y2); }
   const lAll = gather(leftS, lExtra);
   const rAll = gather(rightS);
 
@@ -137,6 +140,14 @@ export function LineChart(props: LineChartProps) {
           onResponderRelease={() => interactive && setActive(null)}
         >
           <Svg width="100%" height={height} viewBox={`0 0 ${VBW} ${height}`}>
+            {/* reference bands (drawn under everything) */}
+            {refAreas?.map((a, ai) => {
+              const lo = Math.max(loL, Math.min(a.y1, a.y2));
+              const hi = Math.min(hiL, Math.max(a.y1, a.y2));
+              if (hi <= loL || lo >= hiL || hi <= lo) return null;
+              const yTop = yAtL(hi);
+              return <Rect key={`ra-${ai}`} x={0} y={yTop} width={VBW} height={Math.max(0, yAtL(lo) - yTop)} fill={a.color} fillOpacity={a.opacity ?? 0.12} />;
+            })}
             <Line x1={0} y1={yAtL(hiL)} x2={VBW} y2={yAtL(hiL)} stroke="#1e2f38" strokeWidth={1} />
             <Line x1={0} y1={yAtL(loL)} x2={VBW} y2={yAtL(loL)} stroke="#1e2f38" strokeWidth={1} />
             {refLine && refLine.y >= loL && refLine.y <= hiL ? (

--- a/universal/src/components/recovery-vitals.tsx
+++ b/universal/src/components/recovery-vitals.tsx
@@ -26,6 +26,8 @@ export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | 
   const hrvWeekly = summary.hrv.trend.map((p) => fin(p.weekly_avg));
   const hrvNight = summary.hrv.trend.map((p) => fin(p.last_night_avg));
   const hrvHasChart = hrvWeekly.filter((v) => v != null).length >= 2 || hrvNight.filter((v) => v != null).length >= 2;
+  const hrvAvgVals = hrvWeekly.filter((v): v is number => v != null);
+  const hrvRef = hrvAvgVals.length ? { y: hrvAvgVals.reduce((a, b) => a + b, 0) / hrvAvgVals.length, color: "#3a5563" } : undefined;
   const hrvSeries = [
     { values: hrvNight, color: "#a5b4fc", width: 1.4, dashed: true, label: "Last night" },
     { values: hrvWeekly, color: "#77c8d1", width: 2.2, label: "Weekly avg" },
@@ -51,7 +53,7 @@ export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | 
     <View className="gap-4">
       {hrv ? (
         <Card className="gap-2">
-          <ExpandableChart title="Heart rate variability" chart={{ series: hrvSeries, labels: hrvLabels, yFormat: (v) => `${Math.round(v)}` }}>
+          <ExpandableChart title="Heart rate variability" chart={{ series: hrvSeries, labels: hrvLabels, yFormat: (v) => `${Math.round(v)}`, refLine: hrvRef }}>
             <View className="flex-row items-end justify-between">
               <View className="flex-row items-end gap-2">
                 <Text variant="display" className="text-teal">{hrv.weekly_avg ?? "—"}</Text>
@@ -63,7 +65,7 @@ export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | 
               {hrv.status ? <Badge label={hrv.status} tone={HRV_TONE[hrv.status] ?? "teal"} /> : null}
             </View>
             {hrvHasChart ? (
-              <LineChart height={110} interactive labels={hrvLabels} xTicks={4} yFormat={(v) => `${Math.round(v)}`} series={hrvSeries} />
+              <LineChart height={110} interactive labels={hrvLabels} xTicks={4} yFormat={(v) => `${Math.round(v)}`} refLine={hrvRef} series={hrvSeries} />
             ) : null}
           </ExpandableChart>
           {hrvHasChart ? <ChartLegend items={[{ color: "#77c8d1", label: "Weekly avg" }, { color: "#a5b4fc", label: "Last night", dashed: true }]} /> : null}


### PR DESCRIPTION
## What
Second shared-component fix (#578). The shared `LineChart` already had reference lines, tap-to-read, and expand-to-fullscreen — the only missing capability was reference **bands**, so this adds that and wires the two clearest gaps.

- **`LineChart` `refAreas`**: translucent horizontal zones drawn under the series (auto-included in the y-domain).
- **Sleep training-readiness**: Ready ≥70 (green) / Moderate 40–70 (amber) / Low <40 (red) bands + dashed 70/40 threshold lines + `interactive` + a zone legend. Matches the web's readiness zones (was a single line with one 50 line).
- **HRV chart**: a weekly-average reference line (web has it; app didn't), on both the inline and expanded chart.

## Validation (Expo web + Playwright, real screenshots read)
- Readiness chart renders the three colored bands with the 70/40 dashed lines, y-axis 0–100, the score line legible over the bands, "tap to read", and the Ready/Moderate/Low legend.
- HRV chart shows the dashed weekly-avg line across the plot.
- `tsc --noEmit` clean; universal vitest 21/21.

Part of #578.
