### PR TITLE
feat(app): 7-day trend arrows on stat cards (#583)

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -3,6 +3,7 @@ import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
 import { LineChart, ChartLegend, ExpandableChart, chartDateLabel } from "../../components/line-chart";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
+import { TrendArrow } from "../../components/trend-arrow";
 import { ThisWeekCard, type WeeklyTraining } from "../../components/this-week-card";
 import { ActivityHeatmap, RecentActivityFeed, ActivityBreakdown, LastGymSession, GymFrequency, ActivityDetailModal } from "../../components/activity-content";
 import {
@@ -188,11 +189,11 @@ export default function OverviewScreen() {
   const hrvLatest = recovery.data?.hrv?.latest ?? null;
   const hrvSpark = (recovery.data?.hrv?.trend ?? []).map((p) => Number(p.weekly_avg)).filter((v) => isFinite(v));
 
-  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string; metric?: string }[] = [
+  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string; metric?: string; inverted?: boolean }[] = [
     { label: "Steps", value: (data?.total_steps ?? 0).toLocaleString(), sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1", metric: "steps" },
     { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850", unit: "kcal", metric: "calories" },
-    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060", unit: "bpm", metric: "rhr" },
-    { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458", metric: "stress" },
+    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060", unit: "bpm", metric: "rhr", inverted: true },
+    { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458", metric: "stress", inverted: true },
     { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${Math.abs(data?.body_battery_drained ?? 0)} drained`, cls: "text-lime", spark: trends?.bodyBattery, color: "#cbe896", metric: "body_battery" },
     { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0", unit: "min" },
     { label: "VO₂max", value: vo2.current != null ? String(vo2.current) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1", metric: "vo2max" },
@@ -367,7 +368,10 @@ export default function OverviewScreen() {
               <Card className="gap-1">
                 <View className="flex-row items-center justify-between">
                   <Text variant="eyebrow">{s.label}</Text>
-                  <Text variant="micro" className="text-text-muted">›</Text>
+                  <View className="flex-row items-center gap-1.5">
+                    <TrendArrow series={s.spark} inverted={s.inverted} />
+                    <Text variant="micro" className="text-text-muted">›</Text>
+                  </View>
                 </View>
                 <Text variant="headline" className={s.cls}>{s.value}</Text>
                 <Text variant="micro">{s.sub}</Text>

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -4,6 +4,7 @@ import { Text, Card, Badge, Sparkline } from "soma-style";
 import { TimeRangeSelector } from "../../components/time-range-selector";
 import { useRangePref, statsRange } from "../../lib/time-range";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
+import { TrendArrow } from "../../components/trend-arrow";
 import { LineChart, ChartLegend } from "../../components/line-chart";
 import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule, useWeekdayWeekend } from "../../lib/api";
 import { SleepDashboard } from "../../components/sleep-dashboard";
@@ -147,6 +148,7 @@ export default function SleepScreen() {
     spark?: { data: number[]; color: string };
     unit?: string;
     metric?: string;
+    inverted?: boolean;
   }[] = [
     {
       label: "Avg Sleep",
@@ -174,6 +176,7 @@ export default function SleepScreen() {
       spark: { data: seriesVals(rhr?.current), color: "#e06060" },
       unit: "bpm",
       metric: "rhr",
+      inverted: true,
     },
     {
       label: "HRV (weekly)",
@@ -217,6 +220,7 @@ export default function SleepScreen() {
           cls: "text-danger",
           spark: sleepHrSeries.length >= 2 ? { data: sleepHrSeries, color: "#e06060" } : undefined,
           unit: "bpm",
+          inverted: true,
         },
       ]
     : [];
@@ -273,7 +277,10 @@ export default function SleepScreen() {
                 <Card className="gap-1">
                   <View className="flex-row items-center justify-between">
                     <Text variant="eyebrow">{s.label}</Text>
-                    {tappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+                    <View className="flex-row items-center gap-1.5">
+                      {s.spark ? <TrendArrow series={s.spark.data} inverted={s.inverted} /> : null}
+                      {tappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}
+                    </View>
                   </View>
                   <Text variant="headline" className={s.cls}>
                     {s.value}

--- a/universal/src/components/trend-arrow.tsx
+++ b/universal/src/components/trend-arrow.tsx
@@ -1,0 +1,23 @@
+import { Text } from "soma-style";
+
+/** A compact 7-day-vs-prior-week trend indicator computed from a metric's recent
+ *  series (e.g. a stat card's 14-day sparkline). Renders ↑/↓/→ + the % change,
+ *  colored by whether the change is an improvement. `inverted` = lower-is-better
+ *  (resting HR, stress), so a decrease reads as green. Matches the web StatCard
+ *  trend badge. Renders nothing when there isn't enough data. */
+export function TrendArrow({ series, inverted }: { series?: (number | null)[]; inverted?: boolean }) {
+  const vals = (series ?? []).filter((v): v is number => typeof v === "number" && isFinite(v));
+  if (vals.length < 4) return null;
+  const half = Math.floor(vals.length / 2);
+  const mean = (a: number[]) => a.reduce((s, v) => s + v, 0) / a.length;
+  const prior = mean(vals.slice(0, half));
+  const recent = mean(vals.slice(vals.length - half));
+  if (!prior) return null;
+  const pct = ((recent - prior) / Math.abs(prior)) * 100;
+  const flat = Math.abs(pct) < 1;
+  const up = pct > 0;
+  const improving = inverted ? !up : up;
+  const color = flat ? "#5a7a8a" : improving ? "#6ad4a0" : "#e06060";
+  const arrow = flat ? "→" : up ? "↑" : "↓";
+  return <Text variant="micro" className="tabular-nums" style={{ color }}>{arrow} {Math.abs(Math.round(pct))}%</Text>;
+}


### PR DESCRIPTION
## What
Third shared-component fix (#578). A shared `TrendArrow` computes a 7-day-vs-prior-week change from the series a stat card already has (its sparkline) and renders ↑/↓/→ + %, colored by whether it's an improvement. `inverted` handles lower-is-better metrics (resting HR, stress). Wired into **Overview** (KPI tiles) and **Sleep** (summary + extra cards), matching the web StatCard trend badge.

## Validation (Expo web + Playwright, real screenshots read)
- Overview: Steps ↑9% / Calories ↑19% / VO₂max ↑2% / Intensity ↑61% green; **Resting HR ↑3% red** and **Avg Stress ↓22% green** (inversion correct); Body Battery renders none (insufficient spark) — graceful.
- Sleep: Avg Score ↑12% green, Avg Sleep ↓26% red; **Resting HR ↑4% red** vs **Avg Sleep HR ↓4% green** (inversion correct).
- `tsc --noEmit` clean; universal vitest 21/21.

Part of #578.
