### PR TITLE
feat(app): Overview reuses shared activity detail modal + Details tab (#585)

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -5,7 +5,8 @@ import { LineChart, ChartLegend, ExpandableChart, chartDateLabel } from "../../c
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { TrendArrow } from "../../components/trend-arrow";
 import { ThisWeekCard, type WeeklyTraining } from "../../components/this-week-card";
-import { ActivityHeatmap, RecentActivityFeed, ActivityBreakdown, LastGymSession, GymFrequency, ActivityDetailModal } from "../../components/activity-content";
+import { ActivityHeatmap, RecentActivityFeed, ActivityBreakdown, LastGymSession, GymFrequency } from "../../components/activity-content";
+import { ActivityDetailModal } from "../../components/activity-detail-modal";
 import {
   useToday,
   useTraining,

--- a/universal/src/components/activity-content.tsx
+++ b/universal/src/components/activity-content.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import { View, Pressable, ScrollView } from "react-native";
-import { Text, Card, Badge, Modal } from "soma-style";
+import { Text, Card } from "soma-style";
 import type { ActivityRow, MonthSports } from "../lib/api";
 import { LineChart } from "./line-chart";
 
@@ -126,40 +126,6 @@ export function ActivityHeatmap({ activities }: { activities: ActivityRow[] }) {
         </View>
       ) : null}
     </Card>
-  );
-}
-
-/** Detail dialog for a single activity. */
-export function ActivityDetailModal({ activity, onClose }: { activity: ActivityRow | null; onClose: () => void }) {
-  if (!activity) return null;
-  const m = meta(activity.type_key);
-  const rows: [string, string][] = [];
-  if (activity.distance_km && activity.distance_km > 0) rows.push(["Distance", `${activity.distance_km.toFixed(2)} km`]);
-  if (activity.duration_min && activity.duration_min > 0) rows.push(["Duration", `${Math.round(activity.duration_min)} min`]);
-  if (activity.calories && activity.calories > 0) rows.push(["Calories", `${Math.round(activity.calories)} kcal`]);
-  if (activity.avg_hr && activity.avg_hr > 0) rows.push(["Avg HR", `${Math.round(activity.avg_hr)} bpm`]);
-  if (activity.elev_gain && activity.elev_gain > 0) rows.push(["Elev gain", `${Math.round(activity.elev_gain)} m`]);
-  return (
-    <Modal visible={!!activity} onClose={onClose} title="Activity">
-      <View className="gap-3">
-        <View className="flex-row items-center gap-2">
-          <Text variant="title">{m.emoji}</Text>
-          <View className="flex-1">
-            <Text variant="title" numberOfLines={2}>{activity.name || m.label}</Text>
-            <Text variant="micro" className="text-text-muted">{niceDate(activity.date)}</Text>
-          </View>
-          <Badge label={m.label} tone="teal" />
-        </View>
-        <View className="gap-1">
-          {rows.length ? rows.map(([k, v]) => (
-            <View key={k} className="flex-row justify-between border-b border-border-subtle py-1.5">
-              <Text variant="caption" className="text-text-muted">{k}</Text>
-              <Text variant="caption" className="tabular-nums">{v}</Text>
-            </View>
-          )) : <Text variant="caption" className="text-text-muted">No metrics recorded.</Text>}
-        </View>
-      </View>
-    </Modal>
   );
 }
 

--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -42,6 +42,8 @@ function secMMSS(sec: number): string { const t = Math.round(sec); return `${Mat
 function paceFromMs(ms: number | null | undefined): string { if (ms == null || ms <= 0) return "—"; const secKm = 1000 / ms; return `${secMMSS(secKm)}/km`; }
 function kmh(ms: number | null | undefined): string { return ms == null ? "—" : `${(ms * 3.6).toFixed(1)} km/h`; }
 function longDate(iso: string | null | undefined): string { if (!iso) return ""; const d = new Date(iso); return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" }); }
+function prettyKey(k: string): string { return k.replace(/([A-Z])/g, " $1").replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase()).trim(); }
+function fmtVal(v: number | string | boolean): string { return typeof v === "number" ? (Number.isInteger(v) ? String(v) : v.toFixed(2)) : String(v); }
 
 const PERF_METRICS = ["HR", "Pace", "Elevation", "Cadence"] as const;
 type PerfMetric = typeof PERF_METRICS[number];
@@ -145,7 +147,7 @@ function Metric({ label, value }: { label: string; value: string }) {
 export function ActivityDetailModal({ activity, onClose }: { activity: ActivityRow | null; onClose: () => void }) {
   const [data, setData] = useState<ActivityDetail | null>(null);
   const [loading, setLoading] = useState(false);
-  const [tab, setTab] = useState<"Overview" | "Splits" | "Charts" | "Share">("Overview");
+  const [tab, setTab] = useState<"Overview" | "Splits" | "Charts" | "Details" | "Share">("Overview");
 
   useEffect(() => {
     if (!activity) { setData(null); return; }
@@ -162,7 +164,7 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
   const laps = data?.splits?.lapDTOs ?? [];
   const ts = data?.time_series ?? [];
   const hasTS = ts.length > 1;
-  const tabOptions = ["Overview", ...(laps.length > 1 ? ["Splits"] : []), ...(hasTS ? ["Charts"] : []), "Share"];
+  const tabOptions = ["Overview", ...(laps.length > 1 ? ["Splits"] : []), ...(hasTS ? ["Charts"] : []), ...(s ? ["Details"] : []), "Share"];
   const img = activityImageSource(activity.activity_id);
   const onShare = () => { Share.share({ url: img.uri, message: activity.name || activity.sport }).catch(() => {}); };
   const zones = (data?.hr_zones ?? []).filter((z) => z && (z.secsInZone ?? 0) > 0);
@@ -208,7 +210,7 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
         ) : null}
 
         {tabOptions.length > 1 ? (
-          <SegmentedControl options={tabOptions} value={tab} onChange={(v) => setTab(v as "Overview" | "Splits" | "Charts")} />
+          <SegmentedControl options={tabOptions} value={tab} onChange={(v) => setTab(v as "Overview" | "Splits" | "Charts" | "Details" | "Share")} />
         ) : null}
 
         <ScrollView style={{ maxHeight: 460 }} showsVerticalScrollIndicator={false}>
@@ -283,6 +285,18 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
               <Image source={img} style={{ width: "100%", aspectRatio: 4 / 3, borderRadius: 12, backgroundColor: "#0e1a22" }} resizeMode="contain" />
               <Button label="Share activity" onPress={onShare} />
               <Text variant="micro" className="text-center text-text-muted">A shareable card for this activity.</Text>
+            </View>
+          ) : tab === "Details" ? (
+            <View className="gap-1">
+              {s ? Object.entries(s)
+                .filter(([, v]) => v != null && (typeof v === "number" || typeof v === "string" || typeof v === "boolean"))
+                .sort((a, b) => a[0].localeCompare(b[0]))
+                .map(([k, v]) => (
+                  <View key={k} className="flex-row justify-between gap-3 border-b border-border-subtle py-1">
+                    <Text variant="micro" className="text-text-muted">{prettyKey(k)}</Text>
+                    <Text variant="micro" className="tabular-nums text-text" numberOfLines={1} style={{ flexShrink: 1 }}>{fmtVal(v as number | string | boolean)}</Text>
+                  </View>
+                )) : <Text variant="caption" className="text-text-muted">No detail fields.</Text>}
             </View>
           ) : (
             /* Splits tab: per-lap pace bars + stats */


### PR DESCRIPTION
## What
Fourth shared-component fix (#578) — the biggest single lift for Overview (its flat detail modal is what dragged it to ~60%).

- **Overview** now opens the **shared** `ActivityDetailModal` (Overview/Charts/**Details**/Share tabs, 16-metric grid, HR-zone bars, weather, gear, per-lap splits) instead of a thin 5-field list. One-line import swap — both modals already share the exact `{ activity, onClose }` signature.
- **New Details tab** on the shared modal: all raw summary fields, prettified + sorted (benefits running/activities too).
- Removed the now-dead thin modal from `activity-content.tsx`.

Gym/Hevy sessions (no Garmin `/api/activity/[id]`) degrade gracefully — the Overview tab falls back to the row's basic metrics, same as before. Map tab remains deferred (native).

## Validation (Expo web + Playwright, real screenshots read)
- Tapped a recent activity on Overview → shared modal opened with **Overview / Charts / Details / Share** tabs, the full metric grid (distance/pace/HR/elevation/calories/aerobic TE), HR-zone bars, and weather.
- Details tab dumps all raw fields (Activity Training Load, Aerobic/Anaerobic TE, BMR calories, timestamps…), formatted.
- `tsc --noEmit` clean; universal vitest 21/21.

Closes #585. Part of #578.
