### PR TITLE
feat(app): interactive route heatmap on MapLibre (#589)

### DIFF
--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -12,6 +12,7 @@
         "@bacons/apple-targets": "^5.0.0",
         "@expo/ui": "~57.0.6",
         "@expo/vector-icons": "^15.0.2",
+        "@maplibre/maplibre-react-native": "^11.3.8",
         "expo": "~57.0.6",
         "expo-constants": "~57.0.5",
         "expo-device": "~57.0.1",
@@ -2681,6 +2682,71 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.2.1.tgz",
+      "integrity": "sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-react-native": {
+      "version": "11.3.8",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-react-native/-/maplibre-react-native-11.3.8.tgz",
+      "integrity": "sha512-TwEFC1mhk3q308OhHKP8Xe1MwzJgTeh1mcqjbnF8tCny3qYjhOPFcRVRlXLudcZRRGE/uxSca06+2iQxByKVRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "26.2.1",
+        "@turf/distance": "^7.3.5",
+        "@turf/helpers": "^7.3.5",
+        "@turf/length": "^7.3.5",
+        "@turf/nearest-point-on-line": "^7.3.5"
+      },
+      "peerDependencies": {
+        "@types/geojson": "^7946.0.0",
+        "@types/react": ">=19.1.0",
+        "expo": ">=54.0.0",
+        "react": ">=19.1.0",
+        "react-native": ">=0.80.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/geojson": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3904,6 +3970,95 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@turf/distance": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.4.0.tgz",
+      "integrity": "sha512-ODkopQDG1m/U6Mx7OMmShncaCvneomwX3lZY1CDA7x40bhDdTTRYP/n/6LicZVyIO4/oK+aXkov4NOtWYthA2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.4.0.tgz",
+      "integrity": "sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.4.0.tgz",
+      "integrity": "sha512-OAsc3qdNx+tRqzWmMNFMnVlWWACIqnYqIejZKvb2oKkKPYJJrURPXZ6OdrGD58ljJMolLoqwIZGSx3VndaEjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.4.0.tgz",
+      "integrity": "sha512-vQsJLuL7uy8m6HAMuJJKoiOHYY1de1Hd6mY/fM90qfu2RyIrkoF8J4bRUb72XZNCVnvob/eHpUMdhZeoUhSyfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.4.0.tgz",
+      "integrity": "sha512-3cLUvlEyDuSnMSzrjhaLAEiYR8xhbfWyTVQlrlEw40xL81d4KF4PqUWbjTXKpXZStdYbet2GCurl79KMypNw6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.4.0.tgz",
+      "integrity": "sha512-eKTKf/qODIsPankYMZrNfI3LjLaVtQvYV/1hcj9kH/Zr3GfLUszevjhTRDZtMgTFrv8+awW3+MyhmN+PJGuLdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.4.0",
+        "@turf/helpers": "7.4.0",
+        "@turf/invariant": "7.4.0",
+        "@turf/meta": "7.4.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3916,6 +4071,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/hammerjs": {
@@ -7130,6 +7291,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -8098,7 +8265,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8956,6 +9122,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -10561,6 +10733,12 @@
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",

--- a/universal/package.json
+++ b/universal/package.json
@@ -6,6 +6,7 @@
     "@bacons/apple-targets": "^5.0.0",
     "@expo/ui": "~57.0.6",
     "@expo/vector-icons": "^15.0.2",
+    "@maplibre/maplibre-react-native": "^11.3.8",
     "expo": "~57.0.6",
     "expo-constants": "~57.0.5",
     "expo-device": "~57.0.1",

--- a/universal/src/components/run-heatmap.native.tsx
+++ b/universal/src/components/run-heatmap.native.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import { Map, Camera, GeoJSONSource, Layer } from "@maplibre/maplibre-react-native";
+import type { HeatRoute } from "../lib/api";
+
+/** OpenFreeMap dark vector basemap — free, no API key, beautiful streets/labels. */
+const DARK_STYLE = "https://tiles.openfreemap.org/styles/dark";
+
+type Feature = { type: "Feature"; geometry: { type: "LineString"; coordinates: [number, number][] }; properties: Record<string, never> };
+
+/**
+ * Route heatmap (native): recent run GPS paths overlaid on a real MapLibre
+ * vector basemap (OpenFreeMap dark), matching the web's map. Fits to the
+ * dominant location cluster so a run abroad doesn't zoom out to the whole world.
+ * The web SVG fallback (run-heatmap.tsx) is used instead. Fed by
+ * /api/running/heatmap.
+ */
+export function RunHeatmap({ routes }: { routes: HeatRoute[] }) {
+  const valid = (routes ?? []).filter((r) => Array.isArray(r) && r.length >= 2);
+
+  const { geojson, bounds, count } = useMemo(() => {
+    // Per-route center (mean of its points), aligned to `valid`.
+    const centers = valid.map((r) => {
+      let slng = 0, slat = 0, c = 0;
+      for (const [lng, lat] of r) if (isFinite(lng) && isFinite(lat)) { slng += lng; slat += lat; c++; }
+      return c ? ([slng / c, slat / c] as [number, number]) : null;
+    });
+    const lngs = centers.filter((c): c is [number, number] => !!c).map((c) => c[0]).sort((a, b) => a - b);
+    const lats = centers.filter((c): c is [number, number] => !!c).map((c) => c[1]).sort((a, b) => a - b);
+    const empty = { geojson: { type: "FeatureCollection" as const, features: [] as Feature[] }, bounds: null as [number, number, number, number] | null, count: 0 };
+    if (!lngs.length) return empty;
+    const cLng = lngs[Math.floor(lngs.length / 2)];
+    const cLat = lats[Math.floor(lats.length / 2)];
+
+    // Keep only the dominant cluster (within ~1.5° of the median center).
+    let w = Infinity, s = Infinity, e = -Infinity, n = -Infinity;
+    const features: Feature[] = [];
+    valid.forEach((r, i) => {
+      const ctr = centers[i];
+      if (!ctr || Math.abs(ctr[0] - cLng) > 1.5 || Math.abs(ctr[1] - cLat) > 1.5) return;
+      const coordinates: [number, number][] = [];
+      for (const [lng, lat] of r) {
+        if (!isFinite(lng) || !isFinite(lat)) continue;
+        coordinates.push([lng, lat]);
+        if (lng < w) w = lng;
+        if (lng > e) e = lng;
+        if (lat < s) s = lat;
+        if (lat > n) n = lat;
+      }
+      if (coordinates.length >= 2) features.push({ type: "Feature", geometry: { type: "LineString", coordinates }, properties: {} });
+    });
+    return {
+      geojson: { type: "FeatureCollection" as const, features },
+      bounds: isFinite(w) ? ([w, s, e, n] as [number, number, number, number]) : null,
+      count: features.length,
+    };
+  }, [valid]);
+
+  if (!bounds || count < 1) return null;
+
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <Text variant="eyebrow">Route heatmap</Text>
+        <Text variant="micro" className="text-text-muted">{count} routes · last 12 mo</Text>
+      </View>
+      <View className="rounded-lg overflow-hidden" style={{ aspectRatio: 1 }}>
+        <Map style={{ flex: 1 }} mapStyle={DARK_STYLE} attribution={false} logo={false}>
+          <Camera bounds={bounds} padding={{ top: 30, bottom: 30, left: 30, right: 30 }} />
+          <GeoJSONSource id="routes" data={geojson}>
+            <Layer
+              id="routeLines"
+              type="line"
+              paint={{ "line-color": "#77c8d1", "line-width": 1.6, "line-opacity": 0.5 }}
+              layout={{ "line-cap": "round", "line-join": "round" }}
+            />
+          </GeoJSONSource>
+        </Map>
+      </View>
+      <Text variant="micro" className="text-text-muted">Brighter lines = roads you run most.</Text>
+    </Card>
+  );
+}


### PR DESCRIPTION
## What
The maps piece of the shared-component parity work (#578). Replaces the SVG-polyline route heatmap with a real **MapLibre** vector basemap on native, matching the web's map.

- Adds `@maplibre/maplibre-react-native` (v11).
- New `run-heatmap.native.tsx` renders a `Map` + `GeoJSONSource` + line `Layer` on the **OpenFreeMap dark** style (free, no API key — CartoDB now requires one). Platform-split: Expo web keeps the SVG fallback (`run-heatmap.tsx`), so web builds are unaffected.
- Fits the camera to the **dominant route cluster** (median-center + 1.5° filter) so a run in another country doesn't zoom the map out to the whole world.

## Validation (Android emulator — arm64, host GPU — adb screencap read)
This required standing up a native validation loop: booted an arm64 AVD headless, built the app with `expo run:android` (MapLibre autolinked, JDK 17), and screenshotted via `adb exec-out screencap`.
- The heatmap renders the OpenFreeMap dark basemap with real streets + labels (Knoxville / Morristown), zoomed to the dominant cluster (30 of 40 routes), with the teal route trace drawn.
- Caught + fixed two issues on-device: CartoDB's free tiles now show an "API KEY REQUIRED" watermark (switched to OpenFreeMap), and software-GPU (SwiftShader) crashed on live GL — host GPU is stable.
- `tsc --noEmit` clean; universal vitest 21/21. (CI does tsc+tests, not a native build.)

Follow-ups (reuse this MapLibre setup, JS-only): route-thumbnail mini-maps and the activity-detail Map tab.

Closes #589. Part of #578.
