### PR TITLE
feat(app): activity-detail Map tab — MapLibre single route (#591)

### DIFF
--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -2,10 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import { View, ScrollView, Image, Share } from "react-native";
 import { Text, Modal, Badge, SegmentedControl, Button, Sparkline } from "soma-style";
 import { LineChart } from "./line-chart";
+import { RouteMap } from "./route-map";
 import { fetchJson, activityImageSource, type ActivityRow } from "../lib/api";
 
 interface TSPoint { elapsed_sec: number; hr?: number | null; speed?: number | null; elevation?: number | null; cadence?: number | null }
-interface GpsPoint { dist_m?: number | null; hr?: number | null; speed?: number | null; elev?: number | null }
+interface GpsPoint { lat?: number | null; lng?: number | null; dist_m?: number | null; hr?: number | null; speed?: number | null; elev?: number | null }
 
 /* ---- response shape from /api/activity/[id] (Garmin summary + laps + weather) ---- */
 interface Summary {
@@ -147,7 +148,7 @@ function Metric({ label, value }: { label: string; value: string }) {
 export function ActivityDetailModal({ activity, onClose }: { activity: ActivityRow | null; onClose: () => void }) {
   const [data, setData] = useState<ActivityDetail | null>(null);
   const [loading, setLoading] = useState(false);
-  const [tab, setTab] = useState<"Overview" | "Splits" | "Charts" | "Details" | "Share">("Overview");
+  const [tab, setTab] = useState<"Overview" | "Map" | "Splits" | "Charts" | "Details" | "Share">("Overview");
 
   useEffect(() => {
     if (!activity) { setData(null); return; }
@@ -164,7 +165,9 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
   const laps = data?.splits?.lapDTOs ?? [];
   const ts = data?.time_series ?? [];
   const hasTS = ts.length > 1;
-  const tabOptions = ["Overview", ...(laps.length > 1 ? ["Splits"] : []), ...(hasTS ? ["Charts"] : []), ...(s ? ["Details"] : []), "Share"];
+  const routePts = (data?.gps_route ?? []).filter((p): p is { lat: number; lng: number; speed?: number | null } => p != null && p.lat != null && p.lng != null && isFinite(Number(p.lat)) && isFinite(Number(p.lng))).map((p) => ({ lat: Number(p.lat), lng: Number(p.lng), speed: p.speed }));
+  const hasRoute = routePts.length > 1;
+  const tabOptions = ["Overview", ...(hasRoute ? ["Map"] : []), ...(laps.length > 1 ? ["Splits"] : []), ...(hasTS ? ["Charts"] : []), ...(s ? ["Details"] : []), "Share"];
   const img = activityImageSource(activity.activity_id);
   const onShare = () => { Share.share({ url: img.uri, message: activity.name || activity.sport }).catch(() => {}); };
   const zones = (data?.hr_zones ?? []).filter((z) => z && (z.secsInZone ?? 0) > 0);
@@ -210,7 +213,7 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
         ) : null}
 
         {tabOptions.length > 1 ? (
-          <SegmentedControl options={tabOptions} value={tab} onChange={(v) => setTab(v as "Overview" | "Splits" | "Charts" | "Details" | "Share")} />
+          <SegmentedControl options={tabOptions} value={tab} onChange={(v) => setTab(v as "Overview" | "Map" | "Splits" | "Charts" | "Details" | "Share")} />
         ) : null}
 
         <ScrollView style={{ maxHeight: 460 }} showsVerticalScrollIndicator={false}>
@@ -274,6 +277,11 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
                   </Text>
                 </View>
               ) : null}
+            </View>
+          ) : tab === "Map" ? (
+            <View className="gap-2">
+              <RouteMap points={routePts} height={340} />
+              <RouteProfile gps={data?.gps_route ?? []} />
             </View>
           ) : tab === "Charts" ? (
             <View className="gap-3">

--- a/universal/src/components/route-map.native.tsx
+++ b/universal/src/components/route-map.native.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import { View } from "react-native";
+import { Text } from "soma-style";
+import { Map, Camera, GeoJSONSource, Layer } from "@maplibre/maplibre-react-native";
+
+/** One GPS sample of a run/ride. lat+lng required; speed drives pace colour. */
+export interface RoutePoint { lat: number; lng: number; speed?: number | null }
+
+/** OpenFreeMap dark vector basemap — free, no API key, matches run-heatmap. */
+const DARK_STYLE = "https://tiles.openfreemap.org/styles/dark";
+
+// Pace colour ramp (min/km): red fast → amber → cyan slow. Mirrors web run-map.
+// Cast to `any` like the web run-map — the style-spec expression tuple types
+// are too strict to satisfy inline (@maplibre/maplibre-react-native v11).
+const PACE_COLOR: any = [
+  "interpolate", ["linear"], ["coalesce", ["get", "pace"], 5.5],
+  3.5, "#ff1744", 5.0, "#ffab00", 7.0, "#00e5ff",
+];
+const END_COLOR: any = ["match", ["get", "markerType"], "start", "#22c55e", "#ef4444"];
+
+type LineF = { type: "Feature"; properties: { pace: number | null }; geometry: { type: "LineString"; coordinates: [number, number][] } };
+type PointF = { type: "Feature"; properties: { markerType: "start" | "end" }; geometry: { type: "Point"; coordinates: [number, number] } };
+
+/**
+ * Single-route map (native, web run-map.tsx parity): the activity's GPS trace on
+ * a real MapLibre vector basemap, coloured by pace (red fast → cyan slow) with a
+ * subtle glow and green/red start/end dots. Camera fits the route. The web SVG
+ * fallback (route-map.tsx) is used on Expo web. Fed by /api/activity/[id].gps_route.
+ */
+export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; height?: number }) {
+  const { routes, ends, bounds } = useMemo(() => {
+    const pts = (points ?? []).filter((p) => p && isFinite(p.lat) && isFinite(p.lng));
+    if (pts.length < 2) return { routes: null as null | { type: "FeatureCollection"; features: LineF[] }, ends: null as null | { type: "FeatureCollection"; features: PointF[] }, bounds: null as null | [number, number, number, number] };
+    // Downsample long tracks (~300 segments max) so the emulator stays smooth.
+    const step = Math.max(1, Math.floor(pts.length / 300));
+    const sampled = pts.filter((_, i) => i % step === 0);
+    if (sampled[sampled.length - 1] !== pts[pts.length - 1]) sampled.push(pts[pts.length - 1]);
+    const features: LineF[] = [];
+    let w = Infinity, s = Infinity, e = -Infinity, nn = -Infinity;
+    for (let i = 0; i < sampled.length - 1; i++) {
+      const a = sampled[i], b = sampled[i + 1];
+      const sp = a.speed ?? b.speed;
+      const pace = sp != null && sp > 0.3 ? 1000 / sp / 60 : null;
+      features.push({ type: "Feature", properties: { pace }, geometry: { type: "LineString", coordinates: [[a.lng, a.lat], [b.lng, b.lat]] } });
+    }
+    for (const p of sampled) { if (p.lng < w) w = p.lng; if (p.lng > e) e = p.lng; if (p.lat < s) s = p.lat; if (p.lat > nn) nn = p.lat; }
+    const first = sampled[0], last = sampled[sampled.length - 1];
+    return {
+      routes: { type: "FeatureCollection" as const, features },
+      ends: { type: "FeatureCollection" as const, features: [
+        { type: "Feature" as const, properties: { markerType: "start" as const }, geometry: { type: "Point" as const, coordinates: [first.lng, first.lat] as [number, number] } },
+        { type: "Feature" as const, properties: { markerType: "end" as const }, geometry: { type: "Point" as const, coordinates: [last.lng, last.lat] as [number, number] } },
+      ] },
+      bounds: [w, s, e, nn] as [number, number, number, number],
+    };
+  }, [points]);
+
+  if (!bounds || !routes) return null;
+
+  return (
+    <View className="gap-1.5">
+      <View className="relative rounded-lg overflow-hidden" style={{ height }}>
+        <Map style={{ flex: 1 }} mapStyle={DARK_STYLE} attribution={false} logo={false}>
+          <Camera bounds={bounds} padding={{ top: 40, bottom: 40, left: 40, right: 40 }} />
+          <GeoJSONSource id="route" data={routes}>
+            <Layer id="route-glow" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 9, "line-opacity": 0.14, "line-blur": 5 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+            <Layer id="route-core" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 2.5, "line-opacity": 1 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+          </GeoJSONSource>
+          {ends ? (
+            <GeoJSONSource id="route-ends" data={ends}>
+              <Layer id="route-end-dots" type="circle" paint={{
+                "circle-radius": 5,
+                "circle-color": END_COLOR,
+                "circle-stroke-width": 2, "circle-stroke-color": "#ffffff", "circle-opacity": 0.95,
+              }} />
+            </GeoJSONSource>
+          ) : null}
+        </Map>
+        {/* Pace legend */}
+        <View className="absolute bottom-2 left-2 rounded-md px-2 py-1" style={{ backgroundColor: "rgba(15,20,26,0.8)" }}>
+          <Text variant="micro" className="text-text-muted">Pace</Text>
+          <View className="flex-row items-center gap-1.5">
+            <Text variant="micro" style={{ color: "#ff1744" }}>Fast</Text>
+            <View style={{ width: 44, height: 4, borderRadius: 2, backgroundColor: "#ffab00" }} />
+            <Text variant="micro" style={{ color: "#00e5ff" }}>Slow</Text>
+          </View>
+        </View>
+      </View>
+      <Text variant="micro" className="text-text-muted">GPS route · green start, red finish · colour = pace.</Text>
+    </View>
+  );
+}

--- a/universal/src/components/route-map.tsx
+++ b/universal/src/components/route-map.tsx
@@ -1,0 +1,85 @@
+import { View } from "react-native";
+import Svg, { Polyline, Circle } from "react-native-svg";
+import { Text } from "soma-style";
+
+/** One GPS sample of a run/ride. lat+lng required; speed drives pace colour. */
+export interface RoutePoint { lat: number; lng: number; speed?: number | null }
+
+// Pace colour ramp (min/km): red fast → amber → cyan slow. Mirrors web run-map.
+function paceColor(pace: number | null): string {
+  if (pace == null) return "#77c8d1";
+  const stops: [number, [number, number, number]][] = [
+    [3.5, [255, 23, 68]], [5.0, [255, 171, 0]], [7.0, [0, 229, 255]],
+  ];
+  if (pace <= stops[0][0]) return "#ff1744";
+  if (pace >= stops[2][0]) return "#00e5ff";
+  for (let i = 0; i < stops.length - 1; i++) {
+    const [p0, c0] = stops[i], [p1, c1] = stops[i + 1];
+    if (pace >= p0 && pace <= p1) {
+      const t = (pace - p0) / (p1 - p0);
+      const c = c0.map((v, k) => Math.round(v + (c1[k] - v) * t));
+      return `rgb(${c[0]},${c[1]},${c[2]})`;
+    }
+  }
+  return "#77c8d1";
+}
+
+/**
+ * Single-route map (Expo-web fallback for route-map.native.tsx): draws the
+ * activity's GPS trace as an aspect-corrected SVG polyline coloured by pace,
+ * with green/red start/end dots. No map library (native gets the real MapLibre
+ * basemap). Fed by /api/activity/[id].gps_route.
+ */
+export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; height?: number }) {
+  const pts = (points ?? []).filter((p) => p && isFinite(p.lat) && isFinite(p.lng));
+  if (pts.length < 2) return null;
+
+  let minLo = Infinity, maxLo = -Infinity, minLa = Infinity, maxLa = -Infinity;
+  for (const p of pts) { if (p.lng < minLo) minLo = p.lng; if (p.lng > maxLo) maxLo = p.lng; if (p.lat < minLa) minLa = p.lat; if (p.lat > maxLa) maxLa = p.lat; }
+  const rLa = maxLa - minLa || 1e-6;
+  const midLa = (minLa + maxLa) / 2;
+  const cos = Math.max(0.2, Math.cos((midLa * Math.PI) / 180));
+  const spanLo = (maxLo - minLo) * cos || 1e-6;
+  const span = Math.max(spanLo, rLa) || 1e-6;
+  const offX = (100 - (spanLo / span) * 92) / 2;
+  const offY = (100 - (rLa / span) * 92) / 2;
+  const X = (lng: number) => offX + ((lng - minLo) * cos / span) * 92;
+  const Y = (lat: number) => offY + (1 - (lat - minLa) / span) * 92;
+
+  // Downsample to ~120 segments for pace-coloured polyline chunks.
+  const step = Math.max(1, Math.floor(pts.length / 120));
+  const s = pts.filter((_, i) => i % step === 0);
+  if (s[s.length - 1] !== pts[pts.length - 1]) s.push(pts[pts.length - 1]);
+  const segs: { d: string; color: string }[] = [];
+  for (let i = 0; i < s.length - 1; i++) {
+    const a = s[i], b = s[i + 1];
+    const sp = a.speed ?? b.speed;
+    const pace = sp != null && sp > 0.3 ? 1000 / sp / 60 : null;
+    segs.push({ d: `${X(a.lng).toFixed(2)},${Y(a.lat).toFixed(2)} ${X(b.lng).toFixed(2)},${Y(b.lat).toFixed(2)}`, color: paceColor(pace) });
+  }
+  const first = pts[0], last = pts[pts.length - 1];
+
+  return (
+    <View className="gap-1.5">
+      <View className="relative rounded-lg bg-surface-subtle overflow-hidden" style={{ height }}>
+        <Svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
+          {segs.map((sg, i) => (
+            <Polyline key={i} points={sg.d} fill="none" stroke={sg.color} strokeWidth={1.1} strokeOpacity={0.95} strokeLinejoin="round" strokeLinecap="round" />
+          ))}
+          <Circle cx={X(first.lng)} cy={Y(first.lat)} r={2} fill="#22c55e" stroke="#ffffff" strokeWidth={0.6} />
+          <Circle cx={X(last.lng)} cy={Y(last.lat)} r={2} fill="#ef4444" stroke="#ffffff" strokeWidth={0.6} />
+        </Svg>
+        {/* Pace legend */}
+        <View className="absolute bottom-2 left-2 rounded-md px-2 py-1" style={{ backgroundColor: "rgba(15,20,26,0.8)" }}>
+          <Text variant="micro" className="text-text-muted">Pace</Text>
+          <View className="flex-row items-center gap-1.5">
+            <Text variant="micro" style={{ color: "#ff1744" }}>Fast</Text>
+            <View style={{ width: 44, height: 4, borderRadius: 2, backgroundColor: "#ffab00" }} />
+            <Text variant="micro" style={{ color: "#00e5ff" }}>Slow</Text>
+          </View>
+        </View>
+      </View>
+      <Text variant="micro" className="text-text-muted">GPS route · green start, red finish · colour = pace.</Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## What

Adds a **Map tab** to the activity-detail modal: the run/ride GPS trace on a real MapLibre vector basemap (OpenFreeMap dark), pace-coloured (red fast → cyan slow) with a subtle glow and green/red start/finish dots, camera fitted to the route. Matches the web `run-map.tsx`.

- `route-map.native.tsx` — MapLibre single-route map (line glow + core with a pace `interpolate` expression, circle layer for start/end dots, `Camera` fit-to-bounds).
- `route-map.tsx` — Expo-web fallback: aspect-corrected SVG polyline, same pace colouring + start/end dots, no map library.
- `activity-detail-modal.tsx` — `GpsPoint` now keeps `lat`/`lng` (previously fetched then discarded), new `Map` tab shown only when the route has ≥2 lat/lng points.

Follow-up to #589 (native heatmap), reuses the same `@maplibre/maplibre-react-native` setup. No backend change: coordinates were already in `/api/activity/[id].gps_route`.

## Validation

- **Expo web** (Playwright): Map tab renders the pace-coloured route, start/finish dots, legend, and by-distance route profile.
- **Android emulator** (real MapLibre basemap, arm64 / host GPU): route on the OpenFreeMap dark basemap with street labels, pace colouring, glow, green/red dots, camera fitted.
- `tsc --noEmit` clean in `universal/`.

Closes #591
