### PR TITLE
fix(app): UX-parity sweep — maps + activity-detail modal (#593)

### DIFF
--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -154,7 +154,13 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
     if (!activity) { setData(null); return; }
     let alive = true; setLoading(true); setTab("Overview");
     fetchJson<ActivityDetail>(`/api/activity/${activity.activity_id}`)
-      .then((d) => alive && setData(d))
+      .then((d) => {
+        if (!alive) return;
+        setData(d);
+        // Web opens on the Map tab when there's a GPS route (defaultValue).
+        const rp = (d?.gps_route ?? []).filter((p) => p != null && p.lat != null && p.lng != null);
+        if (rp.length > 10) setTab("Map");
+      })
       .catch(() => alive && setData(null))
       .finally(() => alive && setLoading(false));
     return () => { alive = false; };
@@ -166,8 +172,9 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
   const ts = data?.time_series ?? [];
   const hasTS = ts.length > 1;
   const routePts = (data?.gps_route ?? []).filter((p): p is { lat: number; lng: number; speed?: number | null } => p != null && p.lat != null && p.lng != null && isFinite(Number(p.lat)) && isFinite(Number(p.lng))).map((p) => ({ lat: Number(p.lat), lng: Number(p.lng), speed: p.speed }));
-  const hasRoute = routePts.length > 1;
-  const tabOptions = ["Overview", ...(hasRoute ? ["Map"] : []), ...(laps.length > 1 ? ["Splits"] : []), ...(hasTS ? ["Charts"] : []), ...(s ? ["Details"] : []), "Share"];
+  const hasRoute = routePts.length > 10; // web run-map bar: needs >10 points
+  // Web tab order: Map (first, when present), Overview, Charts, Splits, Details, Share.
+  const tabOptions = [...(hasRoute ? ["Map"] : []), "Overview", ...(hasTS ? ["Charts"] : []), ...(laps.length > 1 ? ["Splits"] : []), ...(s ? ["Details"] : []), "Share"];
   const img = activityImageSource(activity.activity_id);
   const onShare = () => { Share.share({ url: img.uri, message: activity.name || activity.sport }).catch(() => {}); };
   const zones = (data?.hr_zones ?? []).filter((z) => z && (z.secsInZone ?? 0) > 0);
@@ -297,7 +304,7 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
           ) : tab === "Details" ? (
             <View className="gap-1">
               {s ? Object.entries(s)
-                .filter(([, v]) => v != null && (typeof v === "number" || typeof v === "string" || typeof v === "boolean"))
+                .filter(([k, v]) => v != null && v !== 0 && v !== "" && typeof v !== "object" && !["activityUUID", "userProfilePK", "deviceId"].includes(k))
                 .sort((a, b) => a[0].localeCompare(b[0]))
                 .map(([k, v]) => (
                   <View key={k} className="flex-row justify-between gap-3 border-b border-border-subtle py-1">

--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -338,6 +338,17 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
                   </View>
                 );
               })}
+              {/* Summary footer (web parity): split count + averages */}
+              {laps.length ? (
+                <View className="mt-1 flex-row items-center justify-between border-t border-border-subtle pt-2">
+                  <Text variant="micro" className="text-text-muted">{laps.length} splits</Text>
+                  <View className="flex-row gap-3">
+                    {s?.averageSpeed ? <Text variant="micro" className="tabular-nums text-text-secondary">{paceFromMs(s.averageSpeed)} avg</Text> : null}
+                    {s?.averageHR ? <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(n(s.averageHR))} bpm</Text> : null}
+                    {s?.duration ? <Text variant="micro" className="tabular-nums text-text-muted">{hm(s.duration)}</Text> : null}
+                  </View>
+                </View>
+              ) : null}
             </View>
           )}
         </ScrollView>

--- a/universal/src/components/route-map.native.tsx
+++ b/universal/src/components/route-map.native.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { View } from "react-native";
 import { Text } from "soma-style";
 import { Map, Camera, GeoJSONSource, Layer } from "@maplibre/maplibre-react-native";
+import Svg, { Defs, LinearGradient, Stop, Rect as SvgRect } from "react-native-svg";
 
 /** One GPS sample of a run/ride. lat+lng required; speed drives pace colour. */
 export interface RoutePoint { lat: number; lng: number; speed?: number | null }
@@ -60,10 +61,15 @@ export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; heigh
   return (
     <View className="gap-1.5">
       <View className="relative rounded-lg overflow-hidden" style={{ height }}>
-        <Map style={{ flex: 1 }} mapStyle={DARK_STYLE} attribution={false} logo={false}>
-          <Camera bounds={bounds} padding={{ top: 40, bottom: 40, left: 40, right: 40 }} />
+        {/* Gestures locked to match web run-map (interactive={false}); a pannable
+            map inside the modal ScrollView would also trap vertical scroll drags. */}
+        <Map style={{ flex: 1 }} mapStyle={DARK_STYLE} attribution={false} logo={false}
+          dragPan={false} touchZoom={false} doubleTapZoom={false} doubleTapHoldZoom={false} touchRotate={false} touchPitch={false}>
+          <Camera bounds={bounds} padding={{ top: 48, bottom: 48, left: 48, right: 48 }} />
           <GeoJSONSource id="route" data={routes}>
-            <Layer id="route-glow" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 9, "line-opacity": 0.14, "line-blur": 5 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+            {/* Two-layer glow + core, matching web run-map.tsx exactly. */}
+            <Layer id="route-glow-outer" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 10, "line-opacity": 0.06, "line-blur": 6 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+            <Layer id="route-glow-mid" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 4, "line-opacity": 0.22, "line-blur": 2 }} layout={{ "line-cap": "round", "line-join": "round" }} />
             <Layer id="route-core" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 2.5, "line-opacity": 1 }} layout={{ "line-cap": "round", "line-join": "round" }} />
           </GeoJSONSource>
           {ends ? (
@@ -81,7 +87,16 @@ export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; heigh
           <Text variant="micro" className="text-text-muted">Pace</Text>
           <View className="flex-row items-center gap-1.5">
             <Text variant="micro" style={{ color: "#ff1744" }}>Fast</Text>
-            <View style={{ width: 44, height: 4, borderRadius: 2, backgroundColor: "#ffab00" }} />
+            <Svg width={50} height={4}>
+              <Defs>
+                <LinearGradient id="paceleg" x1="0" y1="0" x2="1" y2="0">
+                  <Stop offset="0" stopColor="#ff1744" />
+                  <Stop offset="0.5" stopColor="#ffab00" />
+                  <Stop offset="1" stopColor="#00e5ff" />
+                </LinearGradient>
+              </Defs>
+              <SvgRect width={50} height={4} rx={2} fill="url(#paceleg)" />
+            </Svg>
             <Text variant="micro" style={{ color: "#00e5ff" }}>Slow</Text>
           </View>
         </View>

--- a/universal/src/components/route-map.tsx
+++ b/universal/src/components/route-map.tsx
@@ -1,5 +1,5 @@
 import { View } from "react-native";
-import Svg, { Polyline, Circle } from "react-native-svg";
+import Svg, { Polyline, Circle, Defs, LinearGradient, Stop, Rect as SvgRect } from "react-native-svg";
 import { Text } from "soma-style";
 
 /** One GPS sample of a run/ride. lat+lng required; speed drives pace colour. */
@@ -74,7 +74,16 @@ export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; heigh
           <Text variant="micro" className="text-text-muted">Pace</Text>
           <View className="flex-row items-center gap-1.5">
             <Text variant="micro" style={{ color: "#ff1744" }}>Fast</Text>
-            <View style={{ width: 44, height: 4, borderRadius: 2, backgroundColor: "#ffab00" }} />
+            <Svg width={50} height={4}>
+              <Defs>
+                <LinearGradient id="paceleg-web" x1="0" y1="0" x2="1" y2="0">
+                  <Stop offset="0" stopColor="#ff1744" />
+                  <Stop offset="0.5" stopColor="#ffab00" />
+                  <Stop offset="1" stopColor="#00e5ff" />
+                </LinearGradient>
+              </Defs>
+              <SvgRect width={50} height={4} rx={2} fill="url(#paceleg-web)" />
+            </Svg>
             <Text variant="micro" style={{ color: "#00e5ff" }}>Slow</Text>
           </View>
         </View>

--- a/universal/src/components/run-heatmap.native.tsx
+++ b/universal/src/components/run-heatmap.native.tsx
@@ -66,13 +66,18 @@ export function RunHeatmap({ routes }: { routes: HeatRoute[] }) {
         <Text variant="micro" className="text-text-muted">{count} routes · last 12 mo</Text>
       </View>
       <View className="rounded-lg overflow-hidden" style={{ aspectRatio: 1 }}>
-        <Map style={{ flex: 1 }} mapStyle={DARK_STYLE} attribution={false} logo={false}>
-          <Camera bounds={bounds} padding={{ top: 30, bottom: 30, left: 30, right: 30 }} />
+        {/* Gestures locked to match web run-heatmap (interactive={false}); the
+            heatmap sits mid-scroll so a pannable map would trap vertical drags. */}
+        <Map style={{ flex: 1 }} mapStyle={DARK_STYLE} attribution={false} logo={false}
+          dragPan={false} touchZoom={false} doubleTapZoom={false} doubleTapHoldZoom={false} touchRotate={false} touchPitch={false}>
+          <Camera bounds={bounds} padding={{ top: 40, bottom: 40, left: 40, right: 40 }} />
           <GeoJSONSource id="routes" data={geojson}>
+            {/* width 2 / opacity 0.4 match web run-heatmap.tsx; app-teal token kept
+                (web uses hsl(166,80%,65%)) for consistency with the rest of the app. */}
             <Layer
               id="routeLines"
               type="line"
-              paint={{ "line-color": "#77c8d1", "line-width": 1.6, "line-opacity": 0.5 }}
+              paint={{ "line-color": "#77c8d1", "line-width": 2, "line-opacity": 0.4 }}
               layout={{ "line-cap": "round", "line-join": "round" }}
             />
           </GeoJSONSource>


### PR DESCRIPTION
## What

A **differential UX-parity sweep** of the app's maps + activity-detail modal against the web reference source. Method: read each web component as the spec, diff the app property by property, fix every felt/measurable divergence or document it as an intentional mobile adaptation. Screenshots alone were not treated as proof — this is source-diff + two-sided measurement.

### Fixes (each validated on Expo web AND the Android emulator)

**Route map** (`route-map.native.tsx` / `route-map.tsx`) vs web `run-map.tsx`
- Lock native map gestures to match web `interactive={false}` (also stops the map trapping vertical scroll drags in the modal). Confirmed with a drag test: the map does not pan.
- Match web's two-layer glow (outer w10/op.06/blur6 + mid w4/op.22/blur2 + core) instead of one collapsed glow.
- Camera fit padding 40 → 48.
- Pace legend bar is now a real red→amber→cyan gradient, not a solid amber block.

**Route heatmap** (`run-heatmap.native.tsx`) vs web `run-heatmap.tsx`
- Lock gestures (mid-scroll map was trapping vertical drags).
- line-width 1.6 → 2, line-opacity 0.5 → 0.4.
- Camera padding 30 → 40.

**Activity-detail modal** (`activity-detail-modal.tsx`) vs web `activity-detail-modal.tsx`
- Open on the **Map** tab when there is a GPS route (web `defaultValue`), instead of always Overview.
- Tab order now **Map, Overview, Charts, Splits, Details, Share** (was Overview-first, Splits-before-Charts).
- Map tab requires >10 GPS points (web bar), not >1.
- Details tab excludes 0 / "" / internal ids (`activityUUID`, `userProfilePK`, `deviceId`).
- Splits tab gained web's summary footer (`N splits · avg pace · avg HR · duration`).

### Kept as intentional mobile / house-style differences (documented in code)
OpenFreeMap dark basemap (web's CartoDB now needs an API key); app-teal `#77c8d1` line colour; run count in the card header vs web's on-map overlay; sentence-case + abbreviated metric labels; 3-col dense metric grid; VO₂ subscript; hide-unavailable tabs; short date with inline badges; broader activity-type map support; horizontal per-lap split bars vs web's vertical bar chart.

### Surfaced, not silently changed (needs your call)
HR-zone colours are **inconsistent across the app** and differ from web: activity-detail uses teal/green/yellow/orange/red, workout-detail uses slate/teal/green/orange/red, web uses slate/blue/green/orange/red. I did not unilaterally change the palette since it is brand territory. Want me to standardise both modals on one ramp (web's, or an app-token version)? I'll do it in a follow-up.

Closes #593
