### PR TITLE
fix(app): recent-routes full modal + Overview metric parity (#595)

### DIFF
--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -168,6 +168,10 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
 
   if (!activity) return null;
   const s = data?.summary ?? null;
+  const tkey = (activity.type_key || "").toLowerCase();
+  const isRun = tkey === "running" || tkey === "treadmill_running";
+  const isStrengthAct = tkey === "strength_training";
+  const isKiteAct = tkey.includes("kite");
   const laps = data?.splits?.lapDTOs ?? [];
   const ts = data?.time_series ?? [];
   const hasTS = ts.length > 1;
@@ -190,8 +194,8 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
   const metrics: [string, string][] = s ? ([
     ["Distance", s.distance != null ? `${(n(s.distance) / 1000).toFixed(2)} km` : "—"],
     ["Duration", hm(s.duration)],
-    ["Avg pace", paceFromMs(s.averageSpeed)],
-    ["Max speed", kmh(s.maxSpeed)],
+    ["Avg pace", isRun ? paceFromMs(s.averageSpeed) : "—"],
+    ["Max speed", !isRun && !isStrengthAct && s.maxSpeed != null ? (isKiteAct ? `${(n(s.maxSpeed) * 1.94384).toFixed(1)} kts` : kmh(s.maxSpeed)) : "—"],
     ["Avg HR", s.averageHR != null ? `${Math.round(n(s.averageHR))} bpm` : "—"],
     ["Max HR", s.maxHR != null ? `${Math.round(n(s.maxHR))} bpm` : "—"],
     ["Elev gain", s.elevationGain != null ? `↑ ${Math.round(n(s.elevationGain))} m` : "—"],
@@ -203,6 +207,7 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
     ["Stride", s.avgStrideLength != null ? `${Math.round(n(s.avgStrideLength))} cm` : "—"],
     ["Grnd contact", s.avgGroundContactTime != null ? `${Math.round(n(s.avgGroundContactTime))} ms` : "—"],
     ["Vert osc", s.avgVerticalOscillation != null ? `${n(s.avgVerticalOscillation).toFixed(1)} cm` : "—"],
+    ["Vert ratio", s.avgVerticalRatio != null ? `${n(s.avgVerticalRatio).toFixed(1)}%` : "—"],
     ["Avg power", s.averagePower != null ? `${Math.round(n(s.averagePower))} W` : "—"],
   ] as [string, string][]).filter(([, v]) => v !== "—") : [];
 

--- a/universal/src/components/running-routes.tsx
+++ b/universal/src/components/running-routes.tsx
@@ -1,17 +1,30 @@
 import { useState } from "react";
 import { View, Pressable } from "react-native";
 import Svg, { Polyline } from "react-native-svg";
-import { Text, Card, Modal } from "soma-style";
-import type { RouteItem, RoutePoint } from "../lib/api";
+import { Text, Card } from "soma-style";
+import { ActivityDetailModal } from "./activity-detail-modal";
+import type { RouteItem, RoutePoint, ActivityRow } from "../lib/api";
 
 function shortDate(iso: string): string {
   const d = new Date(iso);
   return isNaN(d.getTime()) ? "" : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
-function paceLabel(mins: number | null): string {
-  if (mins == null || !isFinite(mins)) return "—";
-  const t = Math.round(mins * 60);
-  return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`;
+/** Adapt a recent-route item into the ActivityRow the full detail modal expects
+ *  (it fetches /api/activity/<id> for map/splits/HR-zones/charts) — matching web,
+ *  where a route thumbnail opens the full ActivityDetailModal, not a mini preview. */
+function toActivityRow(r: RouteItem): ActivityRow {
+  return {
+    activity_id: r.activity_id,
+    type_key: "running",
+    sport: "Running",
+    date: r.date ?? "",
+    name: r.name,
+    distance_km: r.distance_km,
+    duration_min: r.duration_s != null ? r.duration_s / 60 : null,
+    avg_hr: null,
+    calories: null,
+    elev_gain: 0,
+  };
 }
 
 /** One route's GPS path as a normalized SVG polyline (north up), no map tiles. */
@@ -33,37 +46,6 @@ function RouteThumb({ points, stroke = 2 }: { points: RoutePoint[]; stroke?: num
         <Polyline points={poly} fill="none" stroke="#77c8d1" strokeWidth={stroke} strokeLinejoin="round" strokeLinecap="round" />
       </Svg>
     </View>
-  );
-}
-
-/** Enlarged route + stats (drill-in behind a thumbnail). */
-function RouteDetailModal({ route, onClose }: { route: RouteItem | null; onClose: () => void }) {
-  if (!route) return null;
-  const km = route.distance_km;
-  const durMin = route.duration_s != null ? route.duration_s / 60 : null;
-  const pace = km && durMin ? durMin / km : null;
-  const rows: [string, string][] = [
-    ["Distance", km != null ? `${km.toFixed(2)} km` : "—"],
-    ["Duration", durMin != null ? `${Math.round(durMin)} min` : "—"],
-    ["Avg pace", pace != null ? `${paceLabel(pace)} /km` : "—"],
-  ];
-  return (
-    <Modal visible={!!route} onClose={onClose} title={route.name ?? "Run"}>
-      <View className="gap-3">
-        <View className="rounded-lg bg-surface-subtle overflow-hidden" style={{ aspectRatio: 1 }}>
-          <RouteThumb points={route.gps_points} stroke={2.4} />
-        </View>
-        <Text variant="micro" className="text-text-muted">{shortDate(route.date)}</Text>
-        <View className="gap-2">
-          {rows.map(([label, value]) => (
-            <View key={label} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
-              <Text variant="body" className="text-text-secondary">{label}</Text>
-              <Text variant="body" className="tabular-nums text-text">{value}</Text>
-            </View>
-          ))}
-        </View>
-      </View>
-    </Modal>
   );
 }
 
@@ -97,7 +79,7 @@ export function RunningRoutes({ routes }: { routes: RouteItem[] }) {
           <Text variant="caption" className="text-teal">{showAll ? "Show fewer" : `Show all ${withGps.length}`}</Text>
         </Pressable>
       ) : null}
-      <RouteDetailModal route={selected} onClose={() => setSelected(null)} />
+      <ActivityDetailModal activity={selected ? toActivityRow(selected) : null} onClose={() => setSelected(null)} />
     </Card>
   );
 }


### PR DESCRIPTION
## What

A deeper parity pass, prompted by "you didn't check everything really" — because I hadn't. Diffing the **full** Overview metric set and the **recent-routes tap target** against web surfaced real gaps the first sweep (#593) missed:

- **Recent-routes thumbnail now opens the full `ActivityDetailModal`** (fetches `/api/activity/[id]`; Map/Overview/Charts/Splits/Details/Share, opens on Map) instead of a lightweight 3-stat preview. Matches web `recent-routes-gallery.tsx`, which opens the full modal. Removed the local `RouteDetailModal`; added a `toActivityRow` adapter.
- **Overview: added Vert Ratio** (`avgVerticalRatio`) — web shows it, the app was silently missing it.
- **Overview: gate Avg Pace to running, Max Speed to non-running/non-strength** (kite → kts), matching web — so a run no longer shows a stray "Max speed", and non-running activities show the right speed unit.

## Validation
Expo web (Playwright): clicked a recent-route thumbnail → the full modal opened on the Map tab (all six tabs present); on Overview, **Vert ratio 9.5%** shows and **Max speed is absent** for the run. Native modal rendering was already validated in #593.

## Honest status
The #593 sweep declared "complete" prematurely. This closes three more gaps, but the audit is still **not** exhaustive. Not yet checked: non-happy states (empty / one-point / very-long-name / huge-value), scroll retention across tab switches, tab persistence across reopen, and the web running/activities page structure. I'm not going to claim "done" again until those are actually diffed.

Closes #595
