### PR TITLE
fix(app): parity polish — display fixes across overview/sleep/activities (#599)

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -191,13 +191,13 @@ export default function OverviewScreen() {
   const hrvSpark = (recovery.data?.hrv?.trend ?? []).map((p) => Number(p.weekly_avg)).filter((v) => isFinite(v));
 
   const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string; metric?: string; inverted?: boolean }[] = [
-    { label: "Steps", value: (data?.total_steps ?? 0).toLocaleString(), sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1", metric: "steps" },
-    { label: "Active Calories", value: `${Math.round(data?.active_kilocalories ?? 0)}`, sub: `${Math.round(data?.total_kilocalories ?? 0)} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850", unit: "kcal", metric: "calories" },
+    { label: "Steps", value: data?.total_steps != null ? data.total_steps.toLocaleString() : "—", sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1", metric: "steps" },
+    { label: "Active Calories", value: data?.active_kilocalories != null ? Math.round(data.active_kilocalories).toLocaleString() : "—", sub: `${data?.total_kilocalories != null ? Math.round(data.total_kilocalories).toLocaleString() : "—"} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850", unit: "kcal", metric: "calories" },
     { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060", unit: "bpm", metric: "rhr", inverted: true },
     { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458", metric: "stress", inverted: true },
     { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${Math.abs(data?.body_battery_drained ?? 0)} drained`, cls: "text-lime", spark: trends?.bodyBattery, color: "#cbe896", metric: "body_battery" },
     { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0", unit: "min" },
-    { label: "VO₂max", value: vo2.current != null ? String(vo2.current) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1", metric: "vo2max" },
+    { label: "VO₂max", value: vo2.current != null ? Number(vo2.current).toFixed(1) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1", metric: "vo2max" },
     { label: "HRV", value: hrvLatest?.weekly_avg != null ? String(hrvLatest.weekly_avg) : "—", sub: hrvLatest?.status ? String(hrvLatest.status) : "7-night avg", cls: "text-lime", spark: hrvSpark, color: "#cbe896", unit: "ms" },
     { label: "Total activities", value: fitness?.total_activities != null && fitness.total_activities > 0 ? fitness.total_activities.toLocaleString() : "—", sub: "all time", cls: "text-teal", color: "#77c8d1" },
   ];

--- a/universal/src/components/activities-deep.tsx
+++ b/universal/src/components/activities-deep.tsx
@@ -37,8 +37,11 @@ function hm(mins: number | null | undefined): string {
 
 /** Monthly activity distribution — stacked columns by sport. */
 export function ActivitiesMonthly({ monthly }: { monthly: ActivitiesDeep["monthly"] }) {
-  const data = (monthly ?? []).slice(-12);
+  // Show the whole selected range (web parity); thin the month labels so long
+  // ranges (1Y/2Y/3Y/All) stay readable instead of truncating to 12 months.
+  const data = monthly ?? [];
   if (data.length < 2) return null;
+  const labelStep = Math.max(1, Math.ceil(data.length / 12));
   const totals = data.map((m) => Object.values(m.sports).reduce((a, b) => a + b, 0));
   const max = Math.max(...totals) || 1;
   const sports = [...new Set(data.flatMap((m) => Object.keys(m.sports)))];
@@ -56,7 +59,7 @@ export function ActivitiesMonthly({ monthly }: { monthly: ActivitiesDeep["monthl
                   <View key={s} style={{ height: `${(c / total) * 100}%`, backgroundColor: sportColor(s) }} />
                 ))}
               </View>
-              <Text variant="micro" className="text-text-muted" style={{ fontSize: 8 }}>{shortMonth(m.month)}</Text>
+              <Text variant="micro" className="text-text-muted" style={{ fontSize: 8 }}>{i % labelStep === 0 || i === data.length - 1 ? shortMonth(m.month) : ""}</Text>
             </View>
           );
         })}

--- a/universal/src/components/recovery-vitals.tsx
+++ b/universal/src/components/recovery-vitals.tsx
@@ -37,7 +37,7 @@ export function RecoveryVitals({ summary }: { summary: RecoverySummary | null | 
     ? [
         { label: "HRV", v: rdy.hrv_pct, color: "#6ad4a0" },
         { label: "Stress", v: rdy.stress_pct, color: "#e0a458" },
-        { label: "ACWR", v: rdy.acwr_pct, color: "#6aa0e0" },
+        { label: "Training Load", v: rdy.acwr_pct, color: "#6aa0e0" },
         { label: "Recovery", v: rdy.recovery_pct, color: "#c084fc" },
         { label: "Sleep hist.", v: rdy.sleep_history_pct, color: "#a5b4fc" },
         { label: "Sleep Score", v: rdy.sleep_score_pct ?? null, color: "#77c8d1" },

--- a/universal/src/components/sleep-dashboard.tsx
+++ b/universal/src/components/sleep-dashboard.tsx
@@ -136,7 +136,7 @@ export function SleepDashboard({ summary }: { summary: SleepSummary | null | und
             chart={{ series: [{ values: scoreVals, color: "#a5b4fc", width: 2.2 }], labels: scoreLabels, refLine: { y: 80, color: "#6ad4a0" }, yMin: 0, yMax: 100, yFormat: (v) => String(Math.round(v)) }}
           >
             <Text variant="micro" className="tabular-nums text-text-muted">
-              avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"} · "Good" ≥ 80
+              avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"} · "Excellent" ≥ 80
             </Text>
             <LineChart height={120} interactive labels={scoreLabels} xTicks={4} yMin={0} yMax={100} refLine={{ y: 80, color: "#6ad4a0" }} yFormat={(v) => String(Math.round(v))} series={[{ values: scoreVals, color: "#a5b4fc", width: 2.2 }]} />
           </ExpandableChart>


### PR DESCRIPTION
fix(app): parity polish — misleading zeros, formatting, internal contradictions

From a 6-screen app↔web diff, the safe/unambiguous subset:
- overview: Steps + Active Calories show "—" for missing data instead of "0";
  Active Calories total is thousands-separated; VO2max shows one decimal (51.0).
- sleep: score-chart annotation said "Good" >= 80 but the app's own qualifier
  calls >=80 "Excellent" — fixed the contradiction.
- recovery: readiness factor "ACWR" -> "Training Load" (matches web, drops jargon).
- activities: Monthly Activity chart no longer truncates to the last 12 months
  (slice(-12)); shows the full selected range with thinned month labels.

Validated on Expo web (VO2max 51.0, thousands separators, monthly chart 2013->2026)
+ tsc clean.

Closes #599
