### PR TITLE
fix(app): high-value accuracy — nutrition/gym/weight (#601)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -135,7 +135,7 @@ export default function NutritionScreen() {
   const dayClosed = closeStatus === "closed" || plan?.status === "closed";
   const manualOverride = (bd?.manualOverride ?? false) && !dayClosed;
   const caloriesTrend = useCaloriesTrend();
-  const targetCal = plan?.target_calories ?? 0;
+  const targetCal = bd?.adjustedTargets?.calories ?? (Number(plan?.target_calories) || 0);
 
   const availSlots = SLOT_ORDER.filter((s) => data?.slotBudgets?.[s] != null);
   const slots = availSlots.length ? availSlots : SLOT_ORDER.filter((s) => s !== "during_workout");
@@ -302,10 +302,10 @@ export default function NutritionScreen() {
   // research goalposts (kcal bar adds a goal soft-ceiling + burn hard-ceiling).
   const renderDayStrip = (preview: { calories: number; protein: number; carbs: number; fat: number; fiber: number }) => {
     const t = {
-      protein: Number(plan?.target_protein) || 0,
-      carbs: Number(plan?.target_carbs) || 0,
-      fat: Number(plan?.target_fat) || 0,
-      fiber: Number(plan?.target_fiber) || 0,
+      protein: bd?.adjustedTargets?.protein ?? (Number(plan?.target_protein) || 0),
+      carbs: bd?.adjustedTargets?.carbs ?? (Number(plan?.target_carbs) || 0),
+      fat: bd?.adjustedTargets?.fat ?? (Number(plan?.target_fat) || 0),
+      fiber: bd?.adjustedTargets?.fiber ?? (Number(plan?.target_fiber) || 0),
     };
     const marks = buildMacroMarkers(Number(bd?.weightKg) || 0, t);
     const kcalMarkers: MacroMarker[] = [];
@@ -326,10 +326,10 @@ export default function NutritionScreen() {
   // Render the 4 macro goal bars; `extra` folds an in-progress meal's macros in.
   const renderMacroBars = (extra?: { protein: number; carbs: number; fat: number; fiber: number } | null) => {
     const t = {
-      protein: Number(plan?.target_protein) || 0,
-      carbs: Number(plan?.target_carbs) || 0,
-      fat: Number(plan?.target_fat) || 0,
-      fiber: Number(plan?.target_fiber) || 0,
+      protein: bd?.adjustedTargets?.protein ?? (Number(plan?.target_protein) || 0),
+      carbs: bd?.adjustedTargets?.carbs ?? (Number(plan?.target_carbs) || 0),
+      fat: bd?.adjustedTargets?.fat ?? (Number(plan?.target_fat) || 0),
+      fiber: bd?.adjustedTargets?.fiber ?? (Number(plan?.target_fiber) || 0),
     };
     const marks = buildMacroMarkers(Number(bd?.weightKg) || 0, t);
     return MACROS.map((m) => {

--- a/universal/src/components/body-comp-chart.tsx
+++ b/universal/src/components/body-comp-chart.tsx
@@ -55,13 +55,20 @@ function kg(v: number | null | undefined): string {
 function StatusCard({ p }: { p: BodyComp["profile"] }) {
   const slope = p.trendSlope ?? 0;
   const losing = slope < 0;
+  // Trend-based verdict (web parity): actual weekly-loss rate vs goal rate, not
+  // the API's deficit-budget onTrack — those can disagree for the same weight data.
+  const rateRatio = (p.weeklyRate ?? 0) > 0 ? Math.abs(slope) / (p.weeklyRate as number) : 0;
+  const onTrack = slope < 0 && rateRatio >= 0.8;
+  const behind = slope < 0 && rateRatio >= 0.3 && rateRatio < 0.8;
+  const verdict = p.targetDatePassed ? { label: "Reset goal", tone: "danger" as const }
+    : onTrack ? { label: "On track", tone: "success" as const }
+    : behind ? { label: "Behind pace", tone: "warm" as const }
+    : { label: "Off pace", tone: "danger" as const };
   return (
     <Card className="gap-2">
       <View className="flex-row items-center justify-between">
         <Text variant="eyebrow">Body composition</Text>
-        {p.onTrack != null ? (
-          <Badge label={p.onTrack ? "On track" : "Behind pace"} tone={p.onTrack ? "success" : "warm"} />
-        ) : null}
+        {p.trendSlope != null ? <Badge label={verdict.label} tone={verdict.tone} /> : null}
       </View>
       <View className="flex-row items-end gap-2">
         <Text variant="display" className="tabular-nums">{kg(p.latestActualWeight ?? p.currentWeight)}</Text>

--- a/universal/src/components/workout-detail-modal.tsx
+++ b/universal/src/components/workout-detail-modal.tsx
@@ -151,14 +151,15 @@ export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | 
 
             <View className="gap-2">
               {exercises.map((ex, ei) => {
-                let exVol = 0, topIdx = -1, topVol = 0;
-                ex.sets.forEach((s, i) => {
-                  if (s.weight_kg != null && s.reps != null) {
-                    const v = s.weight_kg * s.reps;
-                    exVol += v;
-                    if (v > topVol) { topVol = v; topIdx = i; }
-                  }
-                });
+                // Top set = heaviest WEIGHT among working sets (web parity); mark every
+                // set at that weight, and suppress when all working sets already match.
+                let exVol = 0;
+                const workWeights = ex.sets.filter((s) => s.type !== "warmup" && s.weight_kg != null && s.weight_kg > 0).map((s) => s.weight_kg as number);
+                const maxWeight = workWeights.length ? Math.max(...workWeights) : 0;
+                const normalCount = ex.sets.filter((s) => s.type !== "warmup").length;
+                const atMaxCount = ex.sets.filter((s) => s.type !== "warmup" && s.weight_kg === maxWeight).length;
+                const showTop = maxWeight > 0 && atMaxCount < normalCount;
+                ex.sets.forEach((s) => { if (s.weight_kg != null && s.reps != null) exVol += s.weight_kg * s.reps; });
                 const exVolDisp = unit === "lb" ? exVol * KG_TO_LB : exVol;
                 return (
                   <View key={ei} className="gap-1 border-t border-border-subtle pt-2">
@@ -173,13 +174,13 @@ export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | 
                     <View className="flex-row flex-wrap gap-1.5">
                       {ex.sets.map((s, si) => {
                         const badge = s.type && s.type !== "normal" ? SET_TYPE[s.type] : undefined;
-                        const isTop = si === topIdx && topVol > 0;
+                        const isTop = showTop && s.weight_kg === maxWeight && s.type !== "warmup";
                         return (
                           <View key={si} className="flex-row items-center gap-1 rounded-md bg-surface-subtle px-2 py-1" style={isTop ? { borderWidth: 1, borderColor: "#77c8d1" } : undefined}>
                             {isTop ? <Text variant="micro" style={{ color: "#77c8d1" }}>▲</Text> : null}
                             {badge ? <Text variant="micro" style={{ color: badge.color }}>{badge.label}</Text> : null}
                             <Text variant="micro" className="tabular-nums text-text-secondary">
-                              {s.weight_kg != null ? `${w(s.weight_kg)} × ` : ""}{s.reps ?? "—"}
+                              {s.weight_kg != null && s.weight_kg > 0 ? `${w(s.weight_kg)} × ` : (s.reps != null ? "BW × " : "")}{s.reps ?? "—"}
                             </Text>
                             {s.avg_hr != null ? <Text variant="micro" className="tabular-nums" style={{ color: "#e06060" }}>♥{Math.round(s.avg_hr)}</Text> : null}
                           </View>

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -62,6 +62,10 @@ export interface SomaBreakdown {
   gymCalories?: number; gymBreakdown?: { title: string; calories: number; predicted?: number; actual?: number }[];
   drinkCalories?: number; deficit?: number; manualOverride?: boolean;
   weightKg?: number;
+  // Dynamically recomputed targets for the day (run/gym/drink/macro-floor adjusted).
+  // Web reads these; the app must too, or it shows stale stored plan.target_* goals.
+  targetIntake?: number;
+  adjustedTargets?: { calories?: number; protein?: number; carbs?: number; fat?: number; fiber?: number };
 }
 export interface TrendDay { date: string; ate: number; burn: number; deficit: number; closed: boolean; isToday: boolean }
 export interface LoggedDrink {
@@ -1079,6 +1083,7 @@ export interface BodyCompProfile {
   trendSlope?: number; daysRemaining?: number; weeklyRate?: number;
   totalActualDeficit?: number; realisticDate?: string | null;
   fatToLose?: number; requiredDeficit?: number; avgActualDeficit?: number;
+  targetDatePassed?: boolean;
 }
 export interface BodyComp {
   profile: BodyCompProfile;


### PR DESCRIPTION
fix(app): high-value accuracy — nutrition adjusted targets, gym top-set, weight verdict

From a 4-agent app↔web accuracy diff of the must-be-accurate screens:

- nutrition: read breakdown.adjustedTargets.* (?? plan.target_*) for the energy
  goal + carb/fat/fiber markers, matching web. The app was showing stale stored
  plan.target_* goals on manual-override/past days and right after a run/gym
  toggle or drink log, disagreeing with web (and with its own adjusted hero).
- gym: top-set = heaviest WEIGHT (all sets at max, suppressed when all working
  sets match, warmups excluded) — a direct port of web's algorithm, replacing the
  max-volume selection that flagged the wrong set. Show "BW" for bodyweight sets.
- weight: on-track verdict from the trend slope vs goal rate (web parity) instead
  of the API's deficit-budget onTrack, which could read the opposite of web.

Verified byte-identical (unchanged): onboarding BF%/target math, protein g/kg
tiers, consumed, slot handling, body-comp trend/smoothing.

Validated on Expo web (nutrition + body-comp render; gym top-set correct on real
data: Seated Cable Row 52kg->65kg, Lat Pulldown both 59kg, Bicep Curl suppressed).

Closes #601
