### PR TITLE
fix(api): running trend endpoints use rangeToDays (#603)

### DIFF
--- a/web/app/api/running/fitness-scores/route.ts
+++ b/web/app/api/running/fitness-scores/route.ts
@@ -8,10 +8,10 @@ export const runtime = "edge";
  * reads garmin_raw_data server-side). Mirrors getFitnessScores in
  * app/running/page.tsx.
  */
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const range = searchParams.get("range") || "1y";
-  const days = range === "90d" ? 90 : range === "6m" ? 182 : range === "2y" ? 730 : 365;
+export async function GET() {
+  // Match web exactly: getFitnessScores uses a fixed 12-month window and ignores
+  // the range selector, so the app must too (else its scores diverge from web).
+  const days = 365;
 
   const sql = getDb();
 

--- a/web/app/api/running/hr-pace/route.ts
+++ b/web/app/api/running/hr-pace/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { rangeToDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
 
@@ -10,8 +11,8 @@ export const runtime = "edge";
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const range = searchParams.get("range") || "1y";
-  const days = range === "90d" ? 90 : range === "6m" ? 182 : range === "2y" ? 730 : 365;
+  // Match web exactly: map the app's 10 range tokens via web's rangeToDays.
+  const days = rangeToDays(searchParams.get("range") || undefined);
 
   const sql = getDb();
   const points = (await sql`

--- a/web/app/api/running/splits/route.ts
+++ b/web/app/api/running/splits/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { rangeToDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
 
@@ -10,8 +11,8 @@ export const runtime = "edge";
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const range = searchParams.get("range") || "1y";
-  const days = range === "90d" ? 90 : range === "6m" ? 182 : range === "2y" ? 730 : 365;
+  // Match web exactly: map the app's 10 range tokens via web's rangeToDays.
+  const days = rangeToDays(searchParams.get("range") || undefined);
 
   const sql = getDb();
 

--- a/web/app/api/running/trends/route.ts
+++ b/web/app/api/running/trends/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { rangeToDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
 
@@ -10,8 +11,9 @@ export const runtime = "edge";
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const range = searchParams.get("range") || "180d";
-  const days = range === "30d" ? 30 : range === "90d" ? 90 : range === "1y" ? 365 : range === "2y" ? 730 : 180;
+  // Match web exactly: the app sends the 10 range tokens (1w..all); map each to
+  // the same day count web's rangeToDays uses (1m=30, 3m=90, all=3650, …).
+  const days = rangeToDays(searchParams.get("range") || undefined);
 
   const sql = getDb();
 


### PR DESCRIPTION
fix(api): running trend endpoints map range tokens via rangeToDays (web parity)

/api/running/{trends,splits,hr-pace} hand-rolled a crude token map that only knew
90d/30d/6m/2y, so the app's 3m/1m/9m/3y/all tokens fell through to 365 or 180 —
3M showed a year, 1M showed a year, All showed 6 months. Now use web's canonical
rangeToDays (1w=7 … 3m=90 … all=3650), removing the 6m=182 vs 180 drift too.

fitness-scores now uses a fixed 12-month window ignoring range, matching web's
getFitnessScores() (INTERVAL '12 months'), so app scores don't diverge from web.

Web bypasses these routes (queries the DB directly), so only the app's data is
affected. Validated live: hr-pace point count scales 1m->4, 3m->8, 6m->46,
1y->85, all->414 (previously 1m/3m/all were wrong). web tsc clean.

Closes #603
