### PR TITLE
fix(running): scope headline stats to range (#605)

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -107,19 +107,19 @@ interface RunningPayload {
 /* Data hook — inline useEffect+fetch, matching useToday/useTraining   */
 /* ------------------------------------------------------------------ */
 
-function useRunning() {
+function useRunning(range: string) {
   const [data, setData] = useState<RunningPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
-    fetchJson<RunningPayload>("/api/running/stats")
+    fetchJson<RunningPayload>(`/api/running/stats?range=${range}`)
       .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => {
       alive = false;
     };
-  }, [reload]);
+  }, [reload, range]);
   return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
@@ -170,9 +170,10 @@ const ZONE_HEX = ["#77c8d1", "#6ad4a0", "#e0c458", "#e0a458", "#e06060"];
 /* ------------------------------------------------------------------ */
 
 export default function RunningScreen() {
-  const { data, error, refetch } = useRunning();
-  // Range drives the trend sections (all four endpoints accept 90d/1y/2y).
+  // Range drives the whole screen — headline stats + trends — matching web, where
+  // the top-level selector scopes the entire running page.
   const [range, setRange] = useRangePref();
+  const { data, error, refetch } = useRunning(range);
   const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
   const { data: runTrends } = useRunningTrends(range);
   const { data: fitScores } = useFitnessScores(range);
@@ -247,14 +248,15 @@ export default function RunningScreen() {
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" colors={["#77c8d1"]} />}
     >
       <View className="w-full max-w-2xl gap-4">
-        {/* Header */}
-        <View className="gap-1">
+        {/* Header — the range selector scopes the WHOLE screen (web parity). */}
+        <View className="gap-2">
           <Text variant="headline">Running</Text>
           <Text variant="caption" className="text-text-secondary">
             {stats?.total_runs
-              ? `${num(stats.total_runs)} runs tracked · ${num(stats.total_km).toFixed(0)} km total`
-              : "No runs tracked yet."}
+              ? `${num(stats.total_runs)} runs · ${num(stats.total_km).toFixed(0)} km · last ${rangeLabel(range)}`
+              : "No runs in this range."}
           </Text>
+          <TimeRangeSelector value={range} onChange={setRange} />
         </View>
 
         {error ? (
@@ -374,10 +376,9 @@ export default function RunningScreen() {
         {/* Route heatmap — all recent GPS paths overlaid (new /api/running/heatmap) */}
         <RunHeatmap routes={heatRoutes} />
 
-        {/* Range governs the trend charts below (stats above are all-time). */}
+        {/* Section divider — the range selector at the top governs everything. */}
         <View className="gap-1">
           <Text variant="eyebrow" className="text-text-muted">Trends — last {rangeLabel(range)}</Text>
-          <TimeRangeSelector value={range} onChange={setRange} />
         </View>
 
         {/* Training load/ACWR + cadence trends (new /api/running/trends) */}

--- a/web/app/api/running/stats/route.ts
+++ b/web/app/api/running/stats/route.ts
@@ -1,19 +1,21 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { rangeToDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
 export const revalidate = 300;
 
-/* All-time running summary for the universal (React Native) app. Mirrors the data
-   the web /running server component renders (stats, training status, HR zone
-   distribution, personal records, shoe mileage, recent runs), returned as one JSON
-   payload the RN screen consumes over fetch. All-time — the RN screen has no range
-   selector — so the cutoff is an early epoch date. */
+/* Running summary for the universal (React Native) app. Mirrors the data the web
+   /running server component renders. Match web exactly: the summary stats, HR-zone
+   distribution, recent runs, and the pace / VO2max / monthly-mileage trend series
+   scope to the selected range (rangeToDays); personal records, shoe mileage, and
+   training status stay all-time, as on web. */
 
-const ALL_TIME = "2000-01-01";
-
-export async function GET() {
+export async function GET(request: Request) {
   const sql = getDb();
+  // Match web: scope summary/HR-dist/recent-runs and the pace/VO2max/mileage trend
+  // series to the selected range; PRs, shoe mileage and training status stay all-time.
+  const days = rangeToDays(new URL(request.url).searchParams.get("range") || undefined);
 
   try {
     const [statsRows, trainingRows, hrRows, recentRows, shoeRows, paceRows, vo2Rows, mileageRows, ...records] =
@@ -30,6 +32,7 @@ export async function GET() {
         FROM garmin_activity_raw
         WHERE endpoint_name = 'summary'
           AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+          AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
       `,
       // Training status (nested under a dynamic device-id key)
       sql`
@@ -80,6 +83,7 @@ export async function GET() {
           AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
           AND raw_json->>'averageHR' IS NOT NULL
           AND (raw_json->>'distance')::float > 1000
+          AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
         GROUP BY zone, sort_order
         ORDER BY sort_order ASC
       `,
@@ -101,6 +105,7 @@ export async function GET() {
         LEFT JOIN garmin_activity_raw w ON w.activity_id = s.activity_id AND w.endpoint_name = 'weather'
         WHERE s.endpoint_name = 'summary'
           AND s.raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+          AND (s.raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
         ORDER BY (s.raw_json->>'startTimeLocal')::text DESC
         LIMIT 20
       `,
@@ -142,6 +147,7 @@ export async function GET() {
         WHERE endpoint_name = 'summary'
           AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
           AND (raw_json->>'distance')::float > 1000
+          AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
         ORDER BY (raw_json->>'startTimeLocal')::text DESC LIMIT 40
       `,
       sql`
@@ -153,6 +159,7 @@ export async function GET() {
           WHERE endpoint_name = 'summary'
             AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
             AND raw_json->>'vO2MaxValue' IS NOT NULL
+            AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
           ORDER BY LEFT((raw_json->>'startTimeLocal')::text, 10) DESC
           LIMIT 40
         ) t ORDER BY d ASC
@@ -165,6 +172,7 @@ export async function GET() {
           FROM garmin_activity_raw
           WHERE endpoint_name = 'summary'
             AND raw_json->'activityType'->>'typeKey' IN ('running', 'treadmill_running')
+            AND (raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - ${days}::int
           GROUP BY m ORDER BY m DESC LIMIT 12
         ) t ORDER BY m ASC
       `,


### PR DESCRIPTION
fix(running): scope headline stats to the selected range (web parity)

The running-screen headline (total distance/runs, avg pace, avg HR, training
intensity) and the pace/VO2max/monthly-mileage trend series came from
/api/running/stats with no cutoff — all-time — so the app showed lifetime totals
where web scopes to the range, and the selector only governed the trend charts.

- stats/route.ts: add a range param; scope the 6 queries web scopes (summary,
  HR-zone distribution, recent runs, pace/VO2max/mileage trends) with
  >= CURRENT_DATE - rangeToDays(range). PRs, shoe mileage, training status stay
  all-time. Cutoff inlined as a scalar param (Neon driver has no sql fragments).
- running.tsx: useRunning(range) passes the range; moved the selector to the top
  so it scopes the whole screen; header now "N runs · X km · last {range}".

Validated live: stats scale 1m->19/4, 6m->315/46, 1y->561/86, all->3270/506; and
on Expo web the headline re-scopes on range change (6M -> 46 runs/315 km, peak
VO2max 54.0 vs 57.0 all-time). web + universal tsc clean.

Closes #605
Follows #603.
