### PR TITLE
feat(app): nutrition compose auto-solver (#607)

### DIFF
--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -26,6 +26,7 @@
         "expo-symbols": "~57.0.1",
         "expo-system-ui": "~57.0.1",
         "expo-web-browser": "~57.0.1",
+        "macro-engine-core": "^0.1.1",
         "nativewind": "^4.2.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -7805,6 +7806,12 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
+    },
+    "node_modules/macro-engine-core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/macro-engine-core/-/macro-engine-core-0.1.1.tgz",
+      "integrity": "sha512-rCKqje5PQ0C/EtwSFccn0lgiRFdosEfTx1xk031fY5ROM7WuJEyuCObDi+JsEJ9B2v/11iCAuAK85hHlSTo3FQ==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/universal/package.json
+++ b/universal/package.json
@@ -20,6 +20,7 @@
     "expo-symbols": "~57.0.1",
     "expo-system-ui": "~57.0.1",
     "expo-web-browser": "~57.0.1",
+    "macro-engine-core": "^0.1.1",
     "nativewind": "^4.2.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -712,6 +712,7 @@ export default function NutritionScreen() {
             ingredients={ingredients}
             date={DATE}
             slot={slot}
+            slotBudget={data?.slotBudgets?.[slot]?.calories ?? 0}
             initialGrams={editMeal?.grams ?? presetSeed ?? undefined}
             editMealId={editMeal?.id ?? null}
             onTotalsChange={setComposePreview}

--- a/universal/src/components/compose-meal-view.tsx
+++ b/universal/src/components/compose-meal-view.tsx
@@ -2,10 +2,16 @@ import { useState, useMemo, useEffect } from "react";
 import { View, ScrollView, TextInput, Pressable } from "react-native";
 import { Text, Button } from "soma-style";
 import {
-  ingredientMacros, logComposedMeal, deleteMeal, savePreset,
+  logComposedMeal, deleteMeal, savePreset,
   isCountBased, countToGrams, gramsToCount, rawToCooked, cookedToRaw, hasRawCookedToggle,
   type Ingredient, type ComposeItem,
 } from "../lib/api";
+import { solvePortions, computeItemMacros, type Ingredient as MEIngredient } from "macro-engine-core";
+
+/** The app Ingredient is structurally the macro-engine-core Ingredient (only `unit`
+ *  differs by null vs undefined); cast so the app shares web's solver + macro math. */
+const mei = (ing: Ingredient): MEIngredient => ing as unknown as MEIngredient;
+const im = (ing: Ingredient, grams: number) => computeItemMacros(mei(ing), grams);
 
 const CATEGORY_LABELS: Record<string, string> = {
   protein: "Protein", carbs: "Carbs", grain: "Grain", vegetable: "Vegetable", fat: "Fat",
@@ -38,9 +44,11 @@ function autoMealName(items: { ingredient_id: string; name?: string }[]): string
  *  a max-yolks clamp, live macros + running totals + a volume-score hint, and
  *  a save-as-preset step after logging. Full parity with the web ComposeMealView. */
 export function ComposeMealView({
-  ingredients, date, slot, onLogged, initialGrams, editMealId, onTotalsChange,
+  ingredients, date, slot, slotBudget, onLogged, initialGrams, editMealId, onTotalsChange,
 }: {
   ingredients: Ingredient[]; date: string; slot: string; onLogged: () => void;
+  /** The slot's kcal budget — seeds the auto-solver so the preview ≈ budget (web parity). */
+  slotBudget?: number;
   /** Pre-select ingredients (id -> grams) — used when editing a logged meal. */
   initialGrams?: Record<string, number>;
   /** When set, saving deletes this meal after re-logging (edit = replace). */
@@ -80,7 +88,7 @@ export function ComposeMealView({
 
   const totals = selectedIds.reduce(
     (a, id) => {
-      const mm = ingredientMacros(byId.get(id)!, grams[id]);
+      const mm = im(byId.get(id)!, grams[id]);
       return { calories: a.calories + mm.calories, protein: a.protein + mm.protein, carbs: a.carbs + mm.carbs, fat: a.fat + mm.fat, fiber: a.fiber + mm.fiber };
     },
     { calories: 0, protein: 0, carbs: 0, fat: 0, fiber: 0 },
@@ -93,7 +101,20 @@ export function ComposeMealView({
     onTotalsChange?.(totals);
   }, [totals.calories, totals.protein, totals.carbs, totals.fat, totals.fiber]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const add = (id: string) => setGrams((g) => ({ ...g, [id]: g[id] && g[id] > 0 ? g[id] : 100 }));
+  // Web parity: adding an ingredient re-solves the whole selection to the slot's
+  // kcal budget (+30g MPS protein floor) via solvePortions, so the preview totals
+  // land near the budget immediately instead of dropping in a flat 100g.
+  const add = (id: string) => setGrams((g) => {
+    const ids = new Set(Object.keys(g).filter((k) => (g[k] ?? 0) > 0 && byId.has(k)));
+    ids.add(id);
+    const sel = [...ids].map((k) => byId.get(k)).filter((x): x is Ingredient => !!x);
+    if (!slotBudget || slotBudget <= 0 || sel.length === 0) {
+      return { ...g, [id]: g[id] && g[id] > 0 ? g[id] : 100 };
+    }
+    const next: Record<string, number> = {};
+    for (const p of solvePortions(sel.map(mei), { calories: slotBudget })) next[p.ingredient_id] = p.grams;
+    return next;
+  });
   const setG = (id: string, v: number) => setGrams((g) => ({ ...g, [id]: Math.max(0, Math.round(v)) }));
   const remove = (id: string) => setGrams((g) => { const n = { ...g }; delete n[id]; return n; });
   const toggleSet = (setter: React.Dispatch<React.SetStateAction<Set<string>>>) => (id: string) =>
@@ -112,7 +133,7 @@ export function ComposeMealView({
   function buildItems(): ComposeItem[] {
     return selectedIds.map((id) => {
       const ing = byId.get(id)!;
-      const m = ingredientMacros(ing, grams[id]);
+      const m = im(ing, grams[id]);
       return { ingredient_id: id, name: ing.name, grams: grams[id], calories: m.calories, protein: m.protein, carbs: m.carbs, fat: m.fat, fiber: m.fiber };
     });
   }
@@ -172,7 +193,7 @@ export function ComposeMealView({
           {selectedIds.map((id) => {
             const ing = byId.get(id)!;
             const g = grams[id];
-            const m = ingredientMacros(ing, g);
+            const m = im(ing, g);
             const asCount = isCountBased(ing) && !gramMode.has(id);
             const canCook = hasRawCookedToggle(ing);
             const asCooked = canCook && cookedMode.has(id);


### PR DESCRIPTION
feat(app): nutrition compose auto-solver (seed grams to slot budget, web parity)

The compose preview was meaningless until you hand-edited every gram — the app
dropped each ingredient in at a flat 100g, so the same selection previewed a
different kcal/macro total than web. Web seeds via solvePortions(selected,
{ calories: slotBudget }) so the preview lands on the slot's kcal budget (+30g
MPS protein floor) immediately.

- Add macro-engine-core@^0.1.1 to universal (the shared source of truth web uses;
  expo unchanged, no patch-package breakage, Metro bundles it).
- compose-meal-view.tsx: adding an ingredient re-solves the whole selection to the
  slot budget; totals/logged items use computeItemMacros so the math is
  byte-identical to web (was hand-rolled ingredientMacros, ~1-3 kcal drift).
- nutrition.tsx: pass the slot's kcal budget into the compose view.

Validated on Expo web: Chicken Breast alone -> 300g/360 kcal; adding White Rice
rebalanced to chicken 210g (252) + rice 69g (252) = 504 kcal on the ~503 Lunch
budget, protein 52g > 30g floor. tsc clean.

Closes #607
