### PR TITLE
feat(app): Spotify playlist builder — pick a run → BPM-matched playlist (Phase A)

### DIFF
--- a/universal/src/app/(main)/_layout.tsx
+++ b/universal/src/app/(main)/_layout.tsx
@@ -34,6 +34,7 @@ function TabsNav() {
       <Tabs.Screen name="workouts" options={{ href: null }} />
       <Tabs.Screen name="sleep" options={{ href: null }} />
       <Tabs.Screen name="playlist" options={{ href: null }} />
+      <Tabs.Screen name="playlist-builder" options={{ href: null }} />
       <Tabs.Screen name="connections" options={{ href: null }} />
     </Tabs>
   );

--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { ScrollView, View, TextInput, Pressable, ActivityIndicator } from "react-native";
+import { router } from "expo-router";
+import { Text, Card, Button, Pill, Badge } from "soma-style";
+import {
+  BPM_DEFAULTS, TYPE_COLORS, parsedToItems, flatItems, segsForGenerate, generatePlaylist,
+  fetchGarminRuns, fetchGarminRunDetail, fetchGenres, postBlacklist,
+  type SegmentItem, type Segment, type SongData, type SSEEvent, type GarminRunMeta, type GenreBucket,
+} from "../../lib/playlist";
+import { fetchJson } from "../../lib/api";
+
+interface PanelState { songs: SongData[]; loading?: boolean; poolCount?: number; warning?: string }
+type WorkoutPlan = { id: number; name: string; sport_type: string | null; total_duration_s: number | null; source: string | null };
+
+function mmss(sec: number): string {
+  const m = Math.floor(sec / 60), s = Math.round(sec % 60);
+  return s ? `${m}m ${s}s` : `${m}m`;
+}
+function songDur(ms: number): string {
+  const t = Math.round(ms / 1000);
+  return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`;
+}
+const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+/* ---- run selector (Past runs / Saved plans) ---- */
+function RunSelector({ onPick }: { onPick: (name: string, garminId: string | null, items: SegmentItem[]) => void }) {
+  const [tab, setTab] = useState<"runs" | "plans">("runs");
+  const [q, setQ] = useState("");
+  const [runs, setRuns] = useState<GarminRunMeta[] | null>(null);
+  const [plans, setPlans] = useState<WorkoutPlan[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const t = setTimeout(() => { fetchGarminRuns(q).then((r) => alive && setRuns(r ?? [])).catch(() => alive && setRuns([])); }, 300);
+    return () => { alive = false; clearTimeout(t); };
+  }, [q]);
+  useEffect(() => { fetchJson<WorkoutPlan[]>("/api/playlist/workout-plans").then(setPlans).catch(() => setPlans([])); }, []);
+
+  async function pickRun(r: GarminRunMeta) {
+    setBusy(r.activity_id);
+    try {
+      const d = await fetchGarminRunDetail(r.activity_id);
+      onPick(d.activity_name || r.activity_name || "Run", d.activity_id, parsedToItems(d.segments ?? []));
+    } catch { /* ignore */ } finally { setBusy(null); }
+  }
+  async function pickPlan(p: WorkoutPlan) {
+    setBusy(`p${p.id}`);
+    try {
+      const d = await fetchJson<{ segments?: unknown[] }>(`/api/playlist/workout-plans/${p.id}`);
+      onPick(p.name, null, parsedToItems((d.segments as never[]) ?? []));
+    } catch { /* ignore */ } finally { setBusy(null); }
+  }
+
+  return (
+    <View className="gap-3">
+      <View className="flex-row gap-2">
+        <Pill label="Past runs" active={tab === "runs"} onPress={() => setTab("runs")} />
+        <Pill label="Saved plans" active={tab === "plans"} onPress={() => setTab("plans")} />
+      </View>
+      {tab === "runs" ? (
+        <>
+          <TextInput value={q} onChangeText={setQ} placeholder="Search runs…" placeholderTextColor="#6f8695"
+            className="rounded-lg border border-border-subtle bg-surface-subtle px-3 py-2 text-text" style={{ color: "#e6f0f4" }} />
+          {runs == null ? <ActivityIndicator color="#77c8d1" /> : runs.length === 0 ? (
+            <Text variant="micro" className="text-text-muted">No runs found.</Text>
+          ) : runs.map((r) => (
+            <Pressable key={r.activity_id} onPress={() => pickRun(r)} disabled={!!busy}
+              className="flex-row items-center justify-between border-b border-border-subtle py-2.5">
+              <View className="flex-1 pr-2">
+                <Text variant="body" className="text-text" numberOfLines={1}>{r.activity_name || "Run"}</Text>
+                <Text variant="micro" className="text-text-muted tabular-nums">
+                  {r.distance ? `${(Number(r.distance) / 1000).toFixed(1)} km` : ""}{r.duration ? ` · ${Math.round(Number(r.duration) / 60)} min` : ""}
+                  {r.start_time ? ` · ${new Date(r.start_time).toLocaleDateString()}` : ""}
+                </Text>
+              </View>
+              {busy === r.activity_id ? <ActivityIndicator color="#77c8d1" /> : <Text variant="body" className="text-teal">›</Text>}
+            </Pressable>
+          ))}
+        </>
+      ) : (
+        plans == null ? <ActivityIndicator color="#77c8d1" /> : plans.length === 0 ? (
+          <Text variant="micro" className="text-text-muted">No saved plans.</Text>
+        ) : plans.map((p) => (
+          <Pressable key={p.id} onPress={() => pickPlan(p)} disabled={!!busy}
+            className="flex-row items-center justify-between border-b border-border-subtle py-2.5">
+            <View className="flex-1 pr-2">
+              <Text variant="body" className="text-text" numberOfLines={1}>{p.name}</Text>
+              <Text variant="micro" className="text-text-muted uppercase">{p.sport_type ?? "running"}</Text>
+            </View>
+            {busy === `p${p.id}` ? <ActivityIndicator color="#77c8d1" /> : <Text variant="body" className="text-teal">›</Text>}
+          </Pressable>
+        ))
+      )}
+    </View>
+  );
+}
+
+/* ---- genre filter bar ---- */
+function GenreBar({ selected, onToggle }: { selected: string[]; onToggle: (g: string) => void }) {
+  const [buckets, setBuckets] = useState<{ genre: string; pct: number }[] | null>(null);
+  useEffect(() => {
+    fetchGenres().then(({ genres, total }) => {
+      const t = Number(total) || 1;
+      setBuckets((genres ?? []).map((g: GenreBucket) => ({ genre: g.genre, pct: (Number(g.count) || 0) / t })).filter((g) => g.pct >= 0.03));
+    }).catch(() => setBuckets([]));
+  }, []);
+  if (!buckets || buckets.length === 0) return null;
+  return (
+    <Card className="gap-2">
+      <Text variant="eyebrow">Genres {selected.length ? `· ${selected.length} on` : "· all"}</Text>
+      <View className="flex-row flex-wrap gap-2">
+        {buckets.map((b) => <Pill key={b.genre} label={b.genre} active={selected.includes(b.genre)} onPress={() => onToggle(b.genre)} />)}
+      </View>
+      <Text variant="micro" className="text-text-muted">Tap to limit picks to those genres. None selected = all.</Text>
+    </Card>
+  );
+}
+
+/* ---- one segment's songs ---- */
+function SegmentCard({ seg, index, panel, onExclude, onWiden }: {
+  seg: Segment; index: number; panel: PanelState | undefined; onExclude: (t: SongData) => void; onWiden: () => void;
+}) {
+  const color = TYPE_COLORS[seg.type] ?? "#77c8d1";
+  const songs = (panel?.songs ?? []).filter((s) => !s.is_skip);
+  const skip = (panel?.songs ?? []).find((s) => s.is_skip);
+  return (
+    <Card className="gap-2">
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center gap-2">
+          <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: color }} />
+          <Text variant="body" className="text-text">{index + 1}. {cap(seg.type)}</Text>
+        </View>
+        <Text variant="micro" className="text-text-muted tabular-nums">{mmss(seg.duration_s)} · {seg.bpm_min}–{seg.bpm_max} bpm</Text>
+      </View>
+      {!panel?.loading && panel?.poolCount != null ? (
+        <Text variant="micro" className="text-text-muted tabular-nums">{songs.length} of {panel.poolCount} matching in pool</Text>
+      ) : null}
+      {panel?.loading ? (
+        <View className="flex-row items-center gap-2 py-2"><ActivityIndicator color={color} /><Text variant="micro" className="text-text-muted">Matching songs…</Text></View>
+      ) : (
+        <>
+          {panel?.warning ? <Text variant="micro" style={{ color: "#e0a458" }}>{panel.warning}</Text> : null}
+          {songs.map((s, i) => (
+            <View key={`${s.track_id}-${i}`} className="flex-row items-center gap-2 border-t border-border-subtle py-1.5">
+              <View className="flex-1">
+                <Text variant="caption" className="text-text" numberOfLines={1}>{s.name}</Text>
+                <Text variant="micro" className="text-text-muted" numberOfLines={1}>
+                  {s.artist_name}{s.tempo ? ` · ${Math.round(s.tempo)} bpm` : ""}{s.is_half_time ? " ·½" : ""} · {songDur(s.duration_ms)}
+                </Text>
+              </View>
+              <Pressable onPress={() => onExclude(s)} hitSlop={8} className="h-6 w-6 items-center justify-center rounded-md active:bg-surface-elevated">
+                <Text variant="micro" className="text-text-muted">✕</Text>
+              </Pressable>
+            </View>
+          ))}
+          {skip ? <Text variant="micro" className="text-text-muted">↪ transition: {skip.name} · {skip.artist_name}</Text> : null}
+          {songs.length === 0 && !panel?.loading ? <Text variant="micro" className="text-text-muted">No songs — try widening the BPM or clearing genres.</Text> : null}
+          <Pressable onPress={onWiden} className="self-start pt-1"><Text variant="micro" className="text-teal">Widen BPM (+15)</Text></Pressable>
+        </>
+      )}
+    </Card>
+  );
+}
+
+export default function PlaylistBuilderScreen() {
+  const [items, setItems] = useState<SegmentItem[] | null>(null);
+  const [workoutName, setWorkoutName] = useState("Run");
+  const [garminId, setGarminId] = useState<string | null>(null);
+  const [assignments, setAssignments] = useState<Record<number, PanelState>>({});
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [genres, setGenres] = useState<string[]>([]);
+  const [sessionId, setSessionId] = useState<string | number | null>(null);
+  const [genErr, setGenErr] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const flat = items ? flatItems(items) : [];
+
+  // Always regenerate ALL segments (matching the web builder, whose POST creates
+  // one session per generate). segsForGenerate bundles repeat groups; flatIndexMap
+  // fans each API segment's result back onto every flat panel it covers.
+  const runGenerate = useCallback((its: SegmentItem[], gsel: string[], excl: Set<string>, gid: string | null) => {
+    const { segments, flatIndexMap } = segsForGenerate(its);
+    const remap = (apiIdx: number) => flatIndexMap[apiIdx] ?? [apiIdx];
+    setAssignments((prev) => {
+      const next = { ...prev };
+      segments.forEach((_, api) => { for (const fi of remap(api)) next[fi] = { songs: next[fi]?.songs ?? [], loading: true }; });
+      return next;
+    });
+    setGenErr(null);
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+    const body = {
+      segments: segments.map((s) => ({ type: s.type, duration_s: s.duration_s, bpm_min: s.bpm_min, bpm_max: s.bpm_max, bpm_tolerance: s.bpm_tolerance, valence_min: s.valence_min, valence_max: s.valence_max })),
+      excluded_track_ids: [...excl], genre_selection: gsel, genre_threshold: 0.03, source_playlist_ids: [], garmin_activity_id: gid,
+    };
+    generatePlaylist(body, (e: SSEEvent) => {
+      if (e.type === "segment_done") {
+        // Spread the existing panel so a segment_warning that arrived first isn't wiped.
+        setAssignments((prev) => { const n = { ...prev }; for (const fi of remap(e.index)) n[fi] = { ...n[fi], songs: e.songs, loading: false, poolCount: e.pool_count }; return n; });
+      } else if (e.type === "segment_warning") {
+        setAssignments((prev) => { const n = { ...prev }; for (const fi of remap(e.index)) n[fi] = { ...n[fi], loading: false, warning: e.message }; return n; });
+      } else if (e.type === "done") {
+        setSessionId(e.session_id);
+      } else if (e.type === "error") {
+        setGenErr(e.message);
+        setAssignments((prev) => { const n = { ...prev }; for (const k in n) if (n[k].loading) n[k] = { ...n[k], loading: false }; return n; });
+      }
+    }, ac.signal).catch((err) => { if (!ac.signal.aborted) { setGenErr(String(err?.message ?? err)); setAssignments((prev) => { const n = { ...prev }; for (const k in n) if (n[k].loading) n[k] = { ...n[k], loading: false }; return n; }); } });
+  }, []);
+
+  function onPick(name: string, gid: string | null, its: SegmentItem[]) {
+    setWorkoutName(name); setGarminId(gid); setItems(its); setAssignments({}); setSessionId(null); setExcluded(new Set()); setGenres([]);
+    runGenerate(its, [], new Set(), gid);
+  }
+  function toggleGenre(g: string) {
+    const next = genres.includes(g) ? genres.filter((x) => x !== g) : [...genres, g];
+    setGenres(next);
+    if (items) runGenerate(items, next, excluded, garminId);
+  }
+  function exclude(t: SongData) {
+    const next = new Set(excluded); next.add(t.track_id); setExcluded(next);
+    setAssignments((prev) => { const n = { ...prev }; for (const k in n) n[k] = { ...n[k], songs: n[k].songs.filter((s) => s.track_id !== t.track_id) }; return n; });
+    void postBlacklist(t.track_id);
+  }
+  // Widen a segment: bump its BPM tolerance (+15, cap 30) on the item itself, then regenerate.
+  function widen(flatIdx: number) {
+    if (!items) return;
+    const target = flat[flatIdx];
+    if (!target) return;
+    const newTol = Math.min(30, (target.bpm_tolerance ?? 8) + 15);
+    const bump = (s: Segment) => (s.id === target.id ? { ...s, bpm_tolerance: newTol } : s);
+    const nextItems: SegmentItem[] = items.map((it) =>
+      it.type === "repeat" ? { ...it, children: it.children.map(bump) } : bump(it as Segment),
+    );
+    setItems(nextItems);
+    runGenerate(nextItems, genres, excluded, garminId);
+  }
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const totalSongs = Object.values(assignments).reduce((s, p) => s + (p.songs?.filter((x) => !x.is_skip).length ?? 0), 0);
+
+  return (
+    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+      <View className="w-full max-w-2xl gap-4">
+        <View className="flex-row items-center justify-between">
+          <Text variant="headline">{items ? workoutName : "New playlist"}</Text>
+          <Pressable onPress={() => (items ? (abortRef.current?.abort(), setItems(null), setAssignments({}), setSessionId(null)) : router.back())}>
+            <Text variant="caption" className="text-teal">{items ? "Change run" : "Close"}</Text>
+          </Pressable>
+        </View>
+
+        {!items ? (
+          <>
+            <Text variant="caption" className="text-text-secondary">Pick a run or plan — songs are BPM-matched to each segment.</Text>
+            <Card><RunSelector onPick={onPick} /></Card>
+          </>
+        ) : (
+          <>
+            <View className="flex-row items-center gap-2">
+              <Text variant="micro" className="text-text-muted tabular-nums">{flat.length} segments · {totalSongs} songs</Text>
+              {sessionId ? <Badge label="Generated" tone="success" /> : null}
+            </View>
+            {genErr ? <Card><Text variant="micro" className="text-danger">Generation error: {genErr}</Text></Card> : null}
+            <GenreBar selected={genres} onToggle={toggleGenre} />
+            {flat.map((seg, i) => (
+              <SegmentCard key={seg.id} seg={seg} index={i} panel={assignments[i]} onExclude={exclude} onWiden={() => widen(i)} />
+            ))}
+          </>
+        )}
+      </View>
+    </ScrollView>
+  );
+}

--- a/universal/src/app/(main)/playlist.tsx
+++ b/universal/src/app/(main)/playlist.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
-import { Text, Card, Badge, ProgressBar, SegmentedControl } from "soma-style";
+import { Text, Card, Badge, ProgressBar, SegmentedControl, Button } from "soma-style";
+import { router } from "expo-router";
 import { fetchJson } from "../../lib/api";
 
 /** Library analysis status — how much of the Spotify library has BPM data. */
@@ -212,6 +213,13 @@ export default function PlaylistScreen() {
               : "Connect Spotify and analyse your library on the web app to enable playlist building."}
           </Text>
         </Card>
+
+        <Button
+          label="Build a new playlist"
+          variant="primary"
+          disabled={!analysed}
+          onPress={() => router.push("/playlist-builder")}
+        />
 
         <SegmentedControl
           options={["Playlists", "Plans"] as const}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -5,7 +5,7 @@ export const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:345
 /** Personal API token for prod (soma.gkos.dev gates /api/* behind a session;
     the token bypasses that for this native client). Empty in local dev. */
 const API_TOKEN = process.env.EXPO_PUBLIC_API_TOKEN;
-const AUTH_HEADERS: Record<string, string> = API_TOKEN ? { Authorization: `Bearer ${API_TOKEN}` } : {};
+export const AUTH_HEADERS: Record<string, string> = API_TOKEN ? { Authorization: `Bearer ${API_TOKEN}` } : {};
 
 /** Image source for an activity's generated share card. Includes the auth
  *  header (React Native <Image> forwards `headers` on native; prod gates /api/*). */

--- a/universal/src/lib/playlist.ts
+++ b/universal/src/lib/playlist.ts
@@ -1,0 +1,196 @@
+/**
+ * Playlist builder core — ported faithfully from the web `playlist-builder.tsx`
+ * + `segment-editor.tsx`. All song scoring happens server-side in
+ * POST /api/playlist/sessions (which streams SSE); this file only builds the
+ * segment payload, runs the stream (via expo/fetch, whose FetchResponse.body is
+ * a real ReadableStream unlike RN's global fetch), and exposes GET helpers.
+ */
+import { fetch as streamFetch } from "expo/fetch";
+import { API_BASE, AUTH_HEADERS, fetchJson } from "./api";
+
+export type SegmentType =
+  | "warmup" | "easy" | "aerobic" | "tempo" | "interval"
+  | "vo2max" | "recovery" | "rest" | "strides" | "cooldown";
+
+export interface Segment {
+  id: string; type: SegmentType; duration_s: number;
+  bpm_min: number; bpm_max: number; bpm_tolerance: number;
+  sync_mode: "sync" | "async" | "auto";
+  valence_min: number; valence_max: number;
+}
+export interface RepeatGroup {
+  id: string; type: "repeat"; repeat_count: number; template_size: number; children: Segment[];
+}
+export type SegmentItem = Segment | RepeatGroup;
+export type ParsedStep =
+  | { type?: string; duration_s?: number }
+  | { type: "repeat"; repeat_count: number; children: ParsedStep[] };
+
+export interface SongData {
+  track_id: string; name: string; artist_name: string; artist_id?: string;
+  duration_ms: number; tempo?: number; energy?: number; valence?: number;
+  quality_score?: number; genres?: string[]; is_skip?: boolean; is_half_time?: boolean;
+}
+export interface GarminRunMeta {
+  activity_id: string; activity_name: string | null;
+  start_time?: string | null; distance?: number | null; duration?: number | null;
+}
+export interface GarminRunDetail {
+  activity_id: string; activity_name: string | null; start_time?: string | null;
+  segments: ParsedStep[]; hasSplits: boolean; isTreadmill: boolean;
+}
+export interface GenreBucket { genre: string; count: number | string }
+
+/** Per-segment-type BPM + valence defaults — verbatim from web segment-editor.tsx. */
+export const BPM_DEFAULTS: Record<SegmentType, { min: number; max: number; valence_min: number; valence_max: number }> = {
+  warmup: { min: 100, max: 140, valence_min: 0.3, valence_max: 0.7 },
+  easy: { min: 125, max: 145, valence_min: 0.3, valence_max: 0.7 },
+  aerobic: { min: 125, max: 145, valence_min: 0.3, valence_max: 0.7 },
+  tempo: { min: 160, max: 180, valence_min: 0.1, valence_max: 0.5 },
+  interval: { min: 175, max: 195, valence_min: 0.0, valence_max: 0.4 },
+  vo2max: { min: 175, max: 195, valence_min: 0.0, valence_max: 0.4 },
+  recovery: { min: 125, max: 145, valence_min: 0.3, valence_max: 0.7 },
+  rest: { min: 80, max: 110, valence_min: 0.3, valence_max: 0.7 },
+  strides: { min: 160, max: 180, valence_min: 0.1, valence_max: 0.5 },
+  cooldown: { min: 60, max: 90, valence_min: 0.6, valence_max: 1.0 },
+};
+export const TYPE_COLORS: Record<SegmentType, string> = {
+  warmup: "#77c8d1", easy: "#6ad4a0", aerobic: "#6ad4a0", tempo: "#e0c458",
+  interval: "#e0a458", vo2max: "#e06060", recovery: "#8aa0ac", rest: "#5a7a8a",
+  strides: "#e0c458", cooldown: "#6366b0",
+};
+
+let _seq = 0;
+const nid = () => `s${Date.now().toString(36)}${(_seq++).toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+
+export function makeSegment(p: { type?: string; duration_s?: number }): Segment {
+  const type = (p.type && (p.type as SegmentType) in BPM_DEFAULTS ? p.type : "easy") as SegmentType;
+  const bpm = BPM_DEFAULTS[type] ?? BPM_DEFAULTS.easy;
+  return { id: nid(), type, duration_s: p.duration_s ?? 600, bpm_min: bpm.min, bpm_max: bpm.max, bpm_tolerance: 8, sync_mode: "auto", valence_min: bpm.valence_min, valence_max: bpm.valence_max };
+}
+
+export function parsedToItems(parsed: ParsedStep[]): SegmentItem[] {
+  return parsed.map((p) => {
+    if ((p as { type?: string }).type === "repeat" && "children" in p) {
+      const repeatCount = (p as { repeat_count: number }).repeat_count ?? 1;
+      const templateSegs = (p as { children: ParsedStep[] }).children
+        .filter((c) => (c as { type?: string }).type !== "repeat")
+        .map((c) => makeSegment(c as { type?: string; duration_s?: number }));
+      if (!templateSegs.length) return makeSegment({ type: "easy", duration_s: 600 });
+      const allChildren: Segment[] = [];
+      for (let i = 0; i < repeatCount; i++) for (const seg of templateSegs) allChildren.push(i === 0 ? seg : { ...seg, id: nid() });
+      return { id: nid(), type: "repeat" as const, repeat_count: repeatCount, template_size: templateSegs.length, children: allChildren };
+    }
+    return makeSegment(p as { type?: string; duration_s?: number });
+  });
+}
+
+export function flatItems(items: SegmentItem[]): Segment[] {
+  return items.flatMap((item) => (item.type === "repeat" ? item.children : [item as Segment]));
+}
+
+/** Bundle segments for generation: short repeat groups collapse to one music block,
+ *  long ones bundle by template step type; regular segments are 1-to-1. Verbatim from web. */
+export function segsForGenerate(items: SegmentItem[]): { segments: Segment[]; flatIndexMap: number[][] } {
+  const segments: Segment[] = [];
+  const flatIndexMap: number[][] = [];
+  let flatIdx = 0;
+  for (const item of items) {
+    if (item.type === "repeat") {
+      const group = item;
+      const template = group.children.slice(0, group.template_size);
+      const allShort = template.every((s) => s.duration_s <= 120);
+      if (allShort) {
+        const dominant = template.find((s) => s.type !== "recovery" && s.type !== "rest") ?? template[0];
+        const totalDuration = group.children.reduce((s, c) => s + c.duration_s, 0);
+        segments.push({ ...dominant, id: nid(), duration_s: totalDuration });
+        flatIndexMap.push(Array.from({ length: group.children.length }, (_, i) => flatIdx + i));
+        flatIdx += group.children.length;
+      } else {
+        for (let t = 0; t < template.length; t++) {
+          segments.push({ ...template[t], id: nid(), duration_s: template[t].duration_s * group.repeat_count });
+          const indices: number[] = [];
+          for (let r = 0; r < group.repeat_count; r++) indices.push(flatIdx + r * group.template_size + t);
+          flatIndexMap.push(indices);
+        }
+        flatIdx += group.children.length;
+      }
+    } else {
+      segments.push(item);
+      flatIndexMap.push([flatIdx]);
+      flatIdx++;
+    }
+  }
+  return { segments, flatIndexMap };
+}
+
+/* ---- SSE generation (POST /api/playlist/sessions streams text/event-stream) ---- */
+export type SSEEvent =
+  | { type: "segment_start"; index: number }
+  | { type: "segment_done"; index: number; songs: SongData[]; pool_count: number }
+  | { type: "segment_warning"; index: number; message: string; pool_count?: number }
+  | { type: "error"; message: string }
+  | { type: "done"; session_id: string | number };
+
+export interface GenerateBody {
+  segments: Omit<Segment, "id" | "sync_mode">[] | Segment[];
+  excluded_track_ids: string[];
+  genre_selection: string[];
+  genre_threshold: number;
+  source_playlist_ids: string[];
+  garmin_activity_id: string | null;
+}
+
+/** Stream the generation, emitting each parsed SSE event to `onEvent`. Uses
+ *  expo/fetch so `res.body` is a real ReadableStream on native. */
+export async function generatePlaylist(body: GenerateBody, onEvent: (e: SSEEvent) => void, signal?: AbortSignal): Promise<void> {
+  const res = await streamFetch(`${API_BASE}/api/playlist/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!res.body) return;
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      try { onEvent(JSON.parse(line.slice(6)) as SSEEvent); } catch { /* ignore keep-alive/partial */ }
+    }
+  }
+}
+
+/* ---- GET helpers (all OAuth-free — DB reads) ---- */
+export const fetchGarminRuns = (q = "") =>
+  fetchJson<GarminRunMeta[]>(`/api/playlist/garmin-runs?limit=50${q.trim() ? `&q=${encodeURIComponent(q.trim())}` : ""}`);
+export const fetchGarminRunDetail = (id: string) =>
+  fetchJson<GarminRunDetail>(`/api/playlist/garmin-runs?id=${encodeURIComponent(id)}`);
+export const fetchGenres = () =>
+  fetchJson<{ genres: GenreBucket[]; total: number }>(`/api/playlist/genres`);
+
+/* ---- Track exclusion / blacklist ---- */
+export async function postBlacklist(trackId: string): Promise<number> {
+  try {
+    const r = await fetch(`${API_BASE}/api/playlist/blacklist`, {
+      method: "POST", headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({ track_id: trackId }),
+    });
+    const j = (await r.json().catch(() => ({}))) as { count?: number };
+    return Number(j.count) || 0;
+  } catch { return 0; }
+}
+export async function confirmBlacklist(trackId: string, name: string, artistName: string): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/api/playlist/blacklist/confirm`, {
+      method: "POST", headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({ track_id: trackId, name, artist_name: artistName }),
+    });
+  } catch { /* best effort */ }
+}


### PR DESCRIPTION
## Spotify playlist builder in the app (Phase A)

The web app can build a BPM-matched running playlist from a Garmin run; the native app only had a **read-only** playlist screen. This adds the **builder** so a run playlist can be created on the phone, matching the web builder.

### What's here
- **`universal/src/lib/playlist.ts`** — builder core: segment types, `BPM_DEFAULTS`/`TYPE_COLORS`, `makeSegment`/`parsedToItems`/`flatItems`/`segsForGenerate` (repeat-group bundling, verbatim from web), `generatePlaylist` (POST `/api/playlist/sessions` SSE via `expo/fetch`, whose `body` is a real `ReadableStream` on native), GET helpers (garmin-runs, run detail, genres) + blacklist.
- **`universal/src/app/(main)/playlist-builder.tsx`** — the builder screen: run/plan selector → generate → per-segment song cards (name/artist/tempo, half-time ½ flag, duration, end-of-segment transition song, match-pool count, low-pool warning), per-song exclude (blacklist), genre filter, Widen BPM (+15).
- **`universal/src/app/(main)/playlist.tsx`** — "Build a new playlist" CTA (gated on library analysed).
- **`universal/src/app/(main)/_layout.tsx`** — hidden `playlist-builder` route.
- **`universal/src/lib/api.ts`** — export `AUTH_HEADERS` for the builder lib.

Song scoring stays 100% server-side. Phase A is OAuth-free. Spotify **create** and **Live DJ** are later phases.

### Verified
- `npx tsc --noEmit` clean.
- Playwright on Expo web, end-to-end with a **real SSE stream** through `expo/fetch` (the demo `:3456` server is read-only, so generation was streamed via a local proxy speaking the exact server event protocol; the request/response contract was verified field-for-field against `web/app/api/playlist/sessions/route.ts`):
  - Run selector lists real Garmin runs (distance/duration/date).
  - Segments stream songs in; half-time ½ flag, transition song ("↪ transition: …"), "N of M matching in pool", and "Only N songs found" warning all render.
  - Genre filter toggles ("GENRES · 1 ON", pill active) and regenerates.
  - "Generated" badge on the `done` event.

Closes #609
Closes #610
Closes #611
Closes #612
