### PR TITLE
feat(app): Save to Spotify from the playlist builder (Phase B)

### DIFF
--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import { ScrollView, View, TextInput, Pressable, ActivityIndicator } from "react-native";
+import { ScrollView, View, TextInput, Pressable, ActivityIndicator, Linking } from "react-native";
 import { router } from "expo-router";
 import { Text, Card, Button, Pill, Badge } from "soma-style";
 import {
-  BPM_DEFAULTS, TYPE_COLORS, parsedToItems, flatItems, segsForGenerate, generatePlaylist,
-  fetchGarminRuns, fetchGarminRunDetail, fetchGenres, postBlacklist,
+  TYPE_COLORS, parsedToItems, flatItems, segsForGenerate, generatePlaylist,
+  fetchGarminRuns, fetchGarminRunDetail, fetchGenres, postBlacklist, saveSpotifyPlaylist,
   type SegmentItem, type Segment, type SongData, type SSEEvent, type GarminRunMeta, type GenreBucket,
 } from "../../lib/playlist";
 import { fetchJson } from "../../lib/api";
@@ -172,6 +172,10 @@ export default function PlaylistBuilderScreen() {
   const [genres, setGenres] = useState<string[]>([]);
   const [sessionId, setSessionId] = useState<string | number | null>(null);
   const [genErr, setGenErr] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [savedUrl, setSavedUrl] = useState<string | null>(null);
+  const [spotifyPlaylistId, setSpotifyPlaylistId] = useState<string | null>(null);
+  const [saveErr, setSaveErr] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const flat = items ? flatItems(items) : [];
 
@@ -211,7 +215,32 @@ export default function PlaylistBuilderScreen() {
 
   function onPick(name: string, gid: string | null, its: SegmentItem[]) {
     setWorkoutName(name); setGarminId(gid); setItems(its); setAssignments({}); setSessionId(null); setExcluded(new Set()); setGenres([]);
+    setSavedUrl(null); setSpotifyPlaylistId(null); setSaveErr(null);
     runGenerate(its, [], new Set(), gid);
+  }
+
+  // Save the generated session to Spotify (POST create, or PUT update if already saved).
+  // track_ids = unique non-excluded songs across all segments (incl. transitions), matching web.
+  async function saveToSpotify() {
+    if (sessionId == null) return;
+    setSaving(true); setSaveErr(null);
+    const track_ids = [...new Set(Object.values(assignments).flatMap((p) => p.songs.filter((s) => !excluded.has(s.track_id)).map((s) => s.track_id)))];
+    const song_assignments: Record<number, SongData[]> = {};
+    for (const k in assignments) song_assignments[Number(k)] = assignments[k].songs;
+    const r = await saveSpotifyPlaylist({
+      session_id: sessionId,
+      name: `Soma: ${workoutName} · ${new Date().toLocaleDateString()}`,
+      track_ids, song_assignments, playlist_id: spotifyPlaylistId,
+    });
+    setSaving(false);
+    if (r.ok) {
+      setSavedUrl(r.playlist_url ?? null);
+      if (r.playlist_id) setSpotifyPlaylistId(r.playlist_id);
+    } else if (r.status === 401) {
+      setSaveErr("Spotify isn't connected. Connect it on the web app (Sources) to save playlists.");
+    } else {
+      setSaveErr(r.error || `Save failed (${r.status})`);
+    }
   }
   function toggleGenre(g: string) {
     const next = genres.includes(g) ? genres.filter((x) => x !== g) : [...genres, g];
@@ -267,6 +296,22 @@ export default function PlaylistBuilderScreen() {
             {flat.map((seg, i) => (
               <SegmentCard key={seg.id} seg={seg} index={i} panel={assignments[i]} onExclude={exclude} onWiden={() => widen(i)} />
             ))}
+            <Card className="gap-2">
+              {savedUrl ? (
+                <>
+                  <View className="flex-row items-center gap-2">
+                    <Badge label="On Spotify" tone="success" />
+                    <Text variant="caption" className="text-text-secondary">Saved to your Spotify.</Text>
+                  </View>
+                  <Button label="Open in Spotify" variant="secondary" onPress={() => Linking.openURL(savedUrl)} />
+                  <Button label={saving ? "Updating…" : "Update on Spotify"} variant="ghost" disabled={saving} onPress={saveToSpotify} />
+                </>
+              ) : (
+                <Button label={saving ? "Saving…" : "Save to Spotify"} variant="primary" disabled={saving || sessionId == null} onPress={saveToSpotify} />
+              )}
+              {saveErr ? <Text variant="micro" className="text-danger">{saveErr}</Text> : null}
+              {sessionId == null && !savedUrl ? <Text variant="micro" className="text-text-muted">Songs are still loading — save once generation completes.</Text> : null}
+            </Card>
           </>
         )}
       </View>

--- a/universal/src/lib/playlist.ts
+++ b/universal/src/lib/playlist.ts
@@ -175,6 +175,40 @@ export const fetchGarminRunDetail = (id: string) =>
 export const fetchGenres = () =>
   fetchJson<{ genres: GenreBucket[]; total: number }>(`/api/playlist/genres`);
 
+/* ---- Save to Spotify (POST create / PUT update, mirrors web handleSave) ---- */
+export interface SpotifySaveBody {
+  session_id: string | number;
+  name?: string;
+  track_ids: string[];
+  song_assignments: Record<number, SongData[]>;
+  playlist_id?: string | null;
+}
+export interface SpotifySaveResult {
+  ok: boolean;
+  status: number;
+  playlist_id?: string;
+  playlist_url?: string;
+  error?: string;
+}
+
+/** Create (POST) or update (PUT, when `playlist_id` is set) the Spotify playlist
+ *  for a generated session. Returns status so the UI can special-case 401
+ *  ("Spotify not connected") vs other failures. Needs a server-side Spotify token. */
+export async function saveSpotifyPlaylist(body: SpotifySaveBody): Promise<SpotifySaveResult> {
+  const isUpdate = !!body.playlist_id;
+  try {
+    const res = await fetch(`${API_BASE}/api/playlist/spotify/create`, {
+      method: isUpdate ? "PUT" : "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify(body),
+    });
+    const data = (await res.json().catch(() => ({}))) as { playlist_id?: string; playlist_url?: string; error?: string };
+    return { ok: res.ok, status: res.status, playlist_id: data.playlist_id, playlist_url: data.playlist_url, error: data.error };
+  } catch (err) {
+    return { ok: false, status: 0, error: String((err as Error)?.message ?? err) };
+  }
+}
+
 /* ---- Track exclusion / blacklist ---- */
 export async function postBlacklist(trackId: string): Promise<number> {
   try {


### PR DESCRIPTION
## Save to Spotify from the app playlist builder (Phase B)

Builds on Phase A (#609 / PR #613). After generating a BPM-matched playlist in the app, save it to Spotify — matching the web builder's `handleSave`.

### What's here
- **`universal/src/lib/playlist.ts`** — `saveSpotifyPlaylist(body)`: POST `/api/playlist/spotify/create` to **create**, or PUT to **update** when a `playlist_id` already exists. Returns `{ ok, status, playlist_id, playlist_url, error }` so the UI can special-case 401.
- **`universal/src/app/(main)/playlist-builder.tsx`** — Save-to-Spotify card: enabled once generation completes (`session_id` set). Collects `track_ids` = unique non-excluded songs across all segments (incl. transition songs, exactly like web) + the `song_assignments` map, and sends `name = "Soma: {run} · {date}"`.
  - **401 (not connected):** shows "Spotify isn't connected. Connect it on the web app (Sources) to save playlists." — OAuth stays a web-only action.
  - **Success:** "On Spotify" badge, "Open in Spotify" (`Linking.openURL`), and "Update on Spotify" (PUT, replace tracks in place).

The Spotify write stays server-side (`web/app/api/playlist/spotify/create/route.ts`). Live DJ (Phase C) is deferred (local-daemon blocker).

### Verified
- `npx tsc --noEmit` clean.
- Playwright on Expo web against a local proxy speaking the exact create/update contract (the demo `:3456` server is read-only, so the mutation can't run there; request/response shape verified field-for-field against the web create route + web `handleSave`):
  - **401 not-connected** → the connect message renders under the button.
  - **POST create** → flips to the "On Spotify" success state with the open link.
  - **PUT update** → stays successful, no error.

Closes #614
Closes #615
Closes #616
