### PR TITLE
feat(app): playlist builder + Live DJ web-parity pass (side-by-side)

### DIFF
--- a/universal/src/app/(main)/live-dj.tsx
+++ b/universal/src/app/(main)/live-dj.tsx
@@ -1,88 +1,77 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { ScrollView, View, Pressable } from "react-native";
 import { router } from "expo-router";
-import { Text, Card, Button, Pill, Badge, SegmentedControl, Stepper } from "soma-style";
+import { Text, Card, Button, Pill, Stepper } from "soma-style";
 import {
-  fetchDjStatus, fetchDjHrDefaults, startDj, stopDj, fetchGenres,
-  type DjStatus, type DjStartBody, type GenreBucket,
+  fetchDjStatus, fetchDjHrDefaults, startDj, stopDj, fetchGenres, fetchSpotifyPlaylists,
+  type DjStatus, type DjStartBody, type GenreBucket, type SpotifyPlaylistMeta,
 } from "../../lib/playlist";
 
-type OffsetMode = "Wind down" | "Steady" | "Pump up";
-const OFFSETS: Record<OffsetMode, number> = { "Wind down": -12, Steady: 0, "Pump up": 12 };
-type SourceMode = "Whole library" | "Auto-detect";
+/* Offset modes — verbatim from web live-dj-tab.tsx. */
+type OffsetMode = "pump_up" | "normal" | "wind_down";
+const DEFAULT_OFFSETS: Record<OffsetMode, number> = { pump_up: 12, normal: 0, wind_down: -12 };
+const OFFSET_ICONS: Record<OffsetMode, string> = { pump_up: "⬆", normal: "●", wind_down: "⬇" };
+const OFFSET_NAMES: Record<OffsetMode, string> = { pump_up: "Pump up", normal: "Normal", wind_down: "Wind down" };
+const OFFSET_RANGE: Record<OffsetMode, [number, number]> = { pump_up: [0, 30], normal: [-15, 15], wind_down: [-30, 0] };
+type SourceMode = "auto" | "manual";
 
-function mmss(ms: number): string {
-  const t = Math.max(0, Math.round(ms / 1000));
-  return `${Math.floor(t / 60)}:${String(t % 60).padStart(2, "0")}`;
+function msToMinSec(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
 }
-const cap = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
-
-/** Compact genre picker (same 3% threshold as the builder). */
-function GenrePicker({ selected, onToggle }: { selected: string[]; onToggle: (g: string) => void }) {
-  const [buckets, setBuckets] = useState<string[] | null>(null);
-  useEffect(() => {
-    fetchGenres().then(({ genres, total }) => {
-      const t = Number(total) || 1;
-      setBuckets((genres ?? []).filter((g: GenreBucket) => (Number(g.count) || 0) / t >= 0.03).map((g) => g.genre));
-    }).catch(() => setBuckets([]));
-  }, []);
-  if (!buckets || buckets.length === 0) return null;
-  return (
-    <View className="gap-2">
-      <Text variant="eyebrow">Genres {selected.length ? `· ${selected.length}` : "· all"}</Text>
-      <View className="flex-row flex-wrap gap-2">
-        {buckets.map((g) => <Pill key={g} label={g} active={selected.includes(g)} onPress={() => onToggle(g)} />)}
-      </View>
-    </View>
-  );
+function formatElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  return m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
 }
+function hrAgeLabel(sec: number): string {
+  if (sec < 120) return "just now";
+  if (sec < 3600) return `${Math.round(sec / 60)}m ago`;
+  return `${Math.round(sec / 3600)}h ago — stale`;
+}
+const formatReason = (r: string) => r.replace(/_/g, " ");
 
 export default function LiveDjScreen() {
   const [hrRest, setHrRest] = useState(60);
   const [hrMax, setHrMax] = useState(190);
   const [hrFromGarmin, setHrFromGarmin] = useState(false);
-  const [offsetMode, setOffsetMode] = useState<OffsetMode>("Steady");
-  const [sourceMode, setSourceMode] = useState<SourceMode>("Whole library");
+  const [offsetMode, setOffsetMode] = useState<OffsetMode>("normal");
+  const [offsetValues, setOffsetValues] = useState<Record<OffsetMode, number>>({ ...DEFAULT_OFFSETS });
+  const [sourceMode, setSourceMode] = useState<SourceMode>("auto");
+  const [sources, setSources] = useState<string[]>(["liked"]);
   const [genres, setGenres] = useState<string[]>([]);
   const [status, setStatus] = useState<DjStatus>({ state: "stopped" });
   const [busy, setBusy] = useState(false);
   const [ctrlErr, setCtrlErr] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  // Local ms countdown between polls, for a smooth "time left" readout.
-  const [tick, setTick] = useState(0);
-  const lastPollRef = useRef<number>(Date.now());
+  const sessionStartRef = useRef<number | null>(null);
+  const [, setTick] = useState(0);
 
-  const isLive = status.state === "running" || status.state === "starting";
+  const isRunning = status.state === "running";
+  const isLive = status.state !== "stopped";
 
   const poll = useCallback(async () => {
     try {
       const s = await fetchDjStatus();
       setStatus(s);
-      lastPollRef.current = Date.now();
+      if (s.state === "running" || s.state === "starting") { if (sessionStartRef.current === null) sessionStartRef.current = Date.now(); }
+      else sessionStartRef.current = null;
       if (s.state === "stopped" && pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
-    } catch { /* keep last status */ }
+    } catch { /* keep last */ }
   }, []);
+  const startPolling = useCallback(() => { if (!pollRef.current) pollRef.current = setInterval(poll, 5000); }, [poll]);
 
-  const startPolling = useCallback(() => {
-    if (pollRef.current) return;
-    pollRef.current = setInterval(poll, 5000);
-  }, [poll]);
-
-  // Prefill HR from Garmin, and adopt an already-running daemon on mount.
   useEffect(() => {
     fetchDjHrDefaults().then((d) => {
       if (d.hr_rest) setHrRest(d.hr_rest);
       if (d.hr_max) setHrMax(d.hr_max);
       if (d.hr_rest || d.hr_max) setHrFromGarmin(true);
     }).catch(() => {});
-    fetchDjStatus().then((s) => {
-      setStatus(s);
-      if (s.state === "running" || s.state === "starting") startPolling();
-    }).catch(() => {});
+    fetchDjStatus().then((s) => { setStatus(s); if (s.state === "running" || s.state === "starting") startPolling(); }).catch(() => {});
     return () => { if (pollRef.current) clearInterval(pollRef.current); };
   }, [startPolling]);
 
-  // 1s ticker (only while live) to animate the countdown between 5s polls.
+  // 1s ticker while live — animates "Session:", "polled Ns ago", and the countdown.
   useEffect(() => {
     if (!isLive) return;
     const id = setInterval(() => setTick((t) => t + 1), 1000);
@@ -92,42 +81,38 @@ export default function LiveDjScreen() {
   async function onStart() {
     setBusy(true); setCtrlErr(null);
     const body: DjStartBody = {
-      hr_rest: hrRest, hr_max: hrMax, offset: OFFSETS[offsetMode],
-      genres: sourceMode === "Auto-detect" ? [] : genres,
-      sources: sourceMode === "Auto-detect" ? ["auto"] : ["liked"],
+      hr_rest: hrRest, hr_max: hrMax, offset: offsetValues[offsetMode],
+      genres: sourceMode === "auto" ? [] : genres,
+      sources: sourceMode === "auto" ? ["auto"] : sources,
     };
     const r = await startDj(body);
     setBusy(false);
-    if (r.ok) {
-      setStatus({ state: "starting" });
-      startPolling();
-      void poll();
-    } else if (r.status === 403) {
-      setCtrlErr("This server is read-only (demo mode) — start the DJ from your own soma instance.");
-    } else if (r.status === 401) {
-      setCtrlErr("Not authorized. Connect Spotify + Garmin on the web app first.");
-    } else {
-      setCtrlErr(r.error || `Couldn't start the DJ (${r.status}).`);
-    }
+    if (r.ok) { setStatus({ state: "starting" }); startPolling(); void poll(); }
+    else if (r.status === 403) setCtrlErr("This server is read-only (demo mode) — start the DJ from your own soma instance.");
+    else if (r.status === 401) setCtrlErr("Not authorized. Connect Spotify + Garmin on the web app first.");
+    else setCtrlErr(r.error || `Couldn't start the DJ (${r.status}).`);
   }
   async function onStop() {
     setBusy(true); setCtrlErr(null);
     const r = await stopDj();
     setBusy(false);
     if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    sessionStartRef.current = null;
     if (r.ok || r.status === 403) setStatus({ state: "stopped" });
     else setCtrlErr(r.error || `Couldn't stop the DJ (${r.status}).`);
   }
 
-  const toggleGenre = (g: string) => setGenres((cur) => (cur.includes(g) ? cur.filter((x) => x !== g) : [...cur, g]));
+  // Live-card derived stats (port of the web summary line).
+  const played = (status.play_history ?? []).filter((e) => e.status !== "queued");
+  const matchPcts = played.filter((e) => e.track_bpm && e.target_bpm).map((e) => Math.round(100 - (Math.abs((e.track_bpm as number) - (e.target_bpm as number)) / (e.target_bpm as number)) * 100));
+  const avgMatch = matchPcts.length ? Math.round(matchPcts.reduce((a, b) => a + b, 0) / matchPcts.length) : null;
+  const hrs = (status.hr_history ?? []).map((p) => p.hr).filter((h) => h > 0);
+  const hrLo = hrs.length ? Math.min(...hrs) : null;
+  const hrHi = hrs.length ? Math.max(...hrs) : null;
+  const polledAgo = status.ts ? Math.max(0, Math.floor(Date.now() / 1000 - status.ts)) : null;
 
-  // Smoothed ms remaining (decrement locally since the last poll).
-  const liveMsRemaining = status.ms_remaining != null
-    ? Math.max(0, status.ms_remaining - (Date.now() - lastPollRef.current))
-    : null;
-  void tick; // re-render dependency
-
-  const recentQueue = (status.queue_history ?? []).slice(-4).reverse();
+  const dotColor = status.state === "error" ? "#e06060" : status.state === "starting" ? "#e0c458" : "#6ad4a0";
+  const stateLabel = status.state === "error" ? "ERROR" : status.state === "starting" ? "STARTING…" : "LIVE";
 
   return (
     <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
@@ -137,108 +122,191 @@ export default function LiveDjScreen() {
           <Pressable onPress={() => router.back()}><Text variant="caption" className="text-teal">Close</Text></Pressable>
         </View>
         <Text variant="caption" className="text-text-secondary">
-          Auto-queues BPM-matched songs to your live heart rate. Runs on your soma host; control it from here.
+          Polls your Garmin HR in real time and automatically queues songs that match your effort.
         </Text>
 
         {ctrlErr ? <Card><Text variant="micro" className="text-danger">{ctrlErr}</Text></Card> : null}
 
+        {/* Controls (disabled while running, like web) */}
+        <Card className="gap-4">
+          <View className="flex-row gap-6">
+            <View className="gap-1">
+              <View className="flex-row items-center gap-1.5">
+                <Text variant="eyebrow">Resting HR</Text>
+                {hrFromGarmin ? <Text variant="micro" className="italic text-text-muted">Garmin</Text> : null}
+              </View>
+              <Stepper value={hrRest} onChange={setHrRest} step={1} min={30} max={100} />
+            </View>
+            <View className="gap-1">
+              <View className="flex-row items-center gap-1.5">
+                <Text variant="eyebrow">Max HR</Text>
+                {hrFromGarmin ? <Text variant="micro" className="italic text-text-muted">Garmin</Text> : null}
+              </View>
+              <Stepper value={hrMax} onChange={setHrMax} step={1} min={140} max={220} />
+            </View>
+          </View>
+
+          {/* Mode cards */}
+          <View className="gap-1.5">
+            <Text variant="eyebrow">Mode</Text>
+            <View className="flex-row gap-1">
+              {(["pump_up", "normal", "wind_down"] as OffsetMode[]).map((mode) => {
+                const val = offsetValues[mode];
+                const active = offsetMode === mode;
+                return (
+                  <Pressable key={mode} disabled={isRunning} onPress={() => setOffsetMode(mode)}
+                    className={`flex-1 items-center gap-0.5 rounded-lg border py-2 ${active ? "border-teal bg-teal-bg" : "border-border-glow active:bg-surface-hover"} ${isRunning ? "opacity-50" : ""}`}>
+                    <Text variant="caption" className={`font-semibold ${active ? "text-teal" : "text-text-muted"}`}>{OFFSET_ICONS[mode]} {OFFSET_NAMES[mode]}</Text>
+                    <Text variant="micro" className="text-text-muted tabular-nums">{val > 0 ? "+" : ""}{val} BPM</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            {!isRunning ? (
+              <View className="flex-row items-center gap-2">
+                <Text variant="micro" className="w-24 text-text-muted">{OFFSET_NAMES[offsetMode]} offset</Text>
+                <View className="flex-1 items-center">
+                  <Stepper value={offsetValues[offsetMode]} onChange={(v) => setOffsetValues((p) => ({ ...p, [offsetMode]: v }))} step={1} min={OFFSET_RANGE[offsetMode][0]} max={OFFSET_RANGE[offsetMode][1]} />
+                </View>
+                <Pressable onPress={() => setOffsetValues((p) => ({ ...p, [offsetMode]: DEFAULT_OFFSETS[offsetMode] }))} hitSlop={8}>
+                  <Text variant="body" className="text-text-muted">↺</Text>
+                </Pressable>
+              </View>
+            ) : null}
+          </View>
+
+          {/* Source mode */}
+          <View className="gap-1">
+            <Text variant="eyebrow">Source</Text>
+            <View className="flex-row gap-1">
+              {(["auto", "manual"] as SourceMode[]).map((mode) => {
+                const active = sourceMode === mode;
+                return (
+                  <Pressable key={mode} disabled={isRunning} onPress={() => setSourceMode(mode)}
+                    className={`flex-1 items-center rounded-lg border py-2 ${active ? "border-teal bg-teal-bg" : "border-border-glow active:bg-surface-hover"} ${isRunning ? "opacity-50" : ""}`}>
+                    <Text variant="caption" className={`font-semibold ${active ? "text-teal" : "text-text-muted"}`}>{mode === "auto" ? "⟳ Auto (from Spotify)" : "▤ Manual"}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            {sourceMode === "auto" && !isRunning ? (
+              <Text variant="micro" className="text-text-muted">Play any playlist or album on Spotify — DJ will match songs from it.</Text>
+            ) : null}
+          </View>
+
+          {sourceMode === "manual" && !isRunning ? (
+            <ManualPickers sources={sources} onSources={setSources} genres={genres} onGenres={setGenres} />
+          ) : null}
+        </Card>
+
+        {isRunning ? (
+          <Button label={busy ? "Stopping…" : "■ Stop Live DJ"} variant="warm" disabled={busy} onPress={onStop} />
+        ) : (
+          <Button label={busy ? "Starting…" : "▶ Start Live DJ"} variant="primary" disabled={busy} onPress={onStart} />
+        )}
+
+        {/* LIVE card */}
         {isLive ? (
-          <>
-            {/* Live status */}
-            <Card className="gap-3">
-              <View className="flex-row items-center justify-between">
-                <Badge label={status.state === "starting" ? "Starting" : "Running"} tone={status.state === "starting" ? "warm" : "success"} />
-                <Text variant="micro" className="text-text-muted tabular-nums">
-                  {status.session_played_count != null ? `${status.session_played_count} played` : ""}
-                  {status.auto_detect && status.context_name ? ` · ${status.context_name}` : status.allowed_track_count != null ? ` · ${status.allowed_track_count} in pool` : ""}
-                </Text>
+          <Card className="gap-2">
+            <View className="flex-row items-center gap-2">
+              <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: dotColor }} />
+              <Text variant="caption" className="font-semibold" style={{ color: dotColor }}>{stateLabel}</Text>
+              <View className="ml-auto flex-row items-center gap-2">
+                {sessionStartRef.current !== null ? <Text variant="micro" className="text-text-muted">Session: {formatElapsed(Date.now() - sessionStartRef.current)}</Text> : null}
+                {polledAgo != null ? <Text variant="micro" className="text-text-muted">polled {polledAgo < 60 ? `${polledAgo}s ago` : `${Math.floor(polledAgo / 60)}m ago`}</Text> : null}
               </View>
-              <View className="flex-row gap-3">
-                <View className="flex-1 gap-1">
-                  <Text variant="headline" className="text-warm tabular-nums">{status.hr != null ? status.hr : "—"}</Text>
-                  <Text variant="micro">bpm heart rate{status.hr_age_s != null && status.hr_age_s > 120 ? ` · ${Math.round(status.hr_age_s / 60)}m old` : ""}</Text>
-                </View>
-                <View className="flex-1 gap-1">
-                  <Text variant="headline" className="text-teal tabular-nums">{status.target_bpm != null ? status.target_bpm : "—"}</Text>
-                  <Text variant="micro">target song bpm{status.offset ? ` · ${status.offset > 0 ? "+" : ""}${status.offset}` : ""}</Text>
-                </View>
-              </View>
-            </Card>
+            </View>
 
-            {/* Now playing / up next */}
-            <Card className="gap-2">
-              <Text variant="eyebrow">Now playing</Text>
-              {status.current_track ? (
-                <View className="flex-row items-center justify-between">
-                  <Text variant="body" className="text-text flex-1 pr-2" numberOfLines={1}>{status.current_track}</Text>
-                  {liveMsRemaining != null ? <Text variant="micro" className="text-text-muted tabular-nums">{mmss(liveMsRemaining)} left</Text> : null}
-                </View>
-              ) : <Text variant="micro" className="text-text-muted">Nothing playing — start playback on Spotify.</Text>}
-              {status.queued_track ? (
-                <View className="border-t border-border-subtle pt-2">
-                  <Text variant="eyebrow">Up next</Text>
-                  <Text variant="caption" className="text-text-secondary" numberOfLines={1}>↪ {status.queued_track}</Text>
-                </View>
-              ) : status.no_queue_reason ? (
-                <Text variant="micro" className="text-text-muted">Waiting to queue ({status.no_queue_reason.replace(/_/g, " ")}).</Text>
-              ) : null}
-            </Card>
-
-            {recentQueue.length ? (
-              <Card className="gap-1">
-                <Text variant="eyebrow">Recently queued</Text>
-                {recentQueue.map((q, i) => (
-                  <View key={`${q.ts}-${i}`} className="flex-row items-center justify-between border-t border-border-subtle py-1.5">
-                    <View className="flex-1 pr-2">
-                      <Text variant="caption" className="text-text" numberOfLines={1}>{q.name}</Text>
-                      <Text variant="micro" className="text-text-muted" numberOfLines={1}>{q.artist}{q.track_bpm ? ` · ${q.track_bpm} bpm` : ""}</Text>
-                    </View>
-                    <Text variant="micro" className="text-text-muted tabular-nums">→{q.target_bpm ?? "—"}</Text>
-                  </View>
-                ))}
-              </Card>
+            {played.length ? (
+              <Text variant="micro" className="text-text-muted">
+                {played.length} song{played.length !== 1 ? "s" : ""}{avgMatch != null ? ` · avg match: ${avgMatch}%` : ""}{hrLo != null && hrHi != null ? ` · HR range: ${hrLo}–${hrHi}` : ""}
+              </Text>
             ) : null}
 
-            <Button label={busy ? "Stopping…" : "Stop DJ"} variant="warm" disabled={busy} onPress={onStop} />
-          </>
-        ) : (
-          <>
-            {/* Setup */}
-            <Card className="gap-4">
-              <View className="gap-2">
-                <View className="flex-row items-center justify-between">
-                  <Text variant="eyebrow">Resting HR</Text>
-                  <Stepper value={hrRest} onChange={setHrRest} step={1} min={20} max={120} />
-                </View>
-                <View className="flex-row items-center justify-between">
-                  <Text variant="eyebrow">Max HR</Text>
-                  <Stepper value={hrMax} onChange={setHrMax} step={1} min={140} max={230} />
-                </View>
-                {hrFromGarmin ? <Text variant="micro" className="text-text-muted">Prefilled from your Garmin history.</Text> : null}
+            {status.state === "error" && status.error ? <Text variant="micro" className="text-danger">{status.error}</Text> : null}
+
+            <View className="flex-row items-center gap-3">
+              {status.hr ? (
+                <Text variant="caption" className="text-text-secondary">HR <Text variant="caption" className="text-text">{status.hr} bpm</Text>{status.hr_age_s != null ? ` (${hrAgeLabel(status.hr_age_s)})` : ""}</Text>
+              ) : <Text variant="caption" className="italic text-text-muted">Waiting for Garmin HR…</Text>}
+              {status.target_bpm ? <Text variant="caption" className="text-text-secondary">→ target <Text variant="caption" className="text-teal">{status.target_bpm} BPM</Text></Text> : null}
+            </View>
+
+            {status.no_queue_reason && status.no_queue_reason !== "already_queued" ? (
+              <Text variant="micro" style={{ color: "#e0a458" }}>
+                {status.no_queue_reason === "no_hr" ? "⚠ No HR data — will queue once Garmin syncs"
+                  : status.no_queue_reason === "no_candidates" ? `⚠ No tracks match ${status.target_bpm ?? "?"} BPM — widen genres or sources`
+                  : `⚠ ${formatReason(status.no_queue_reason)}`}
+              </Text>
+            ) : null}
+
+            {status.current_track ? (
+              <Text variant="caption" className="text-text-secondary" numberOfLines={1}>▶ <Text variant="caption" className="text-text">{status.current_track}</Text>{status.ms_remaining != null ? ` (${msToMinSec(status.ms_remaining)} left)` : ""}</Text>
+            ) : status.state === "running" ? <Text variant="micro" className="italic text-text-muted">Nothing playing on Spotify</Text> : null}
+
+            {status.queued_track ? <Text variant="caption" className="text-text-secondary" numberOfLines={1}>⏭ <Text variant="caption" className="text-text">{status.queued_track}</Text> (queued)</Text> : null}
+
+            {status.auto_detect ? (
+              <Text variant="micro" className="text-text-muted">
+                {status.context_name ? `Auto: sourcing from ${status.context_name}${status.allowed_track_count != null ? ` (${status.allowed_track_count} tracks)` : ""}` : "Auto-detect: play something on Spotify to set source"}
+              </Text>
+            ) : status.allowed_track_count != null ? <Text variant="micro" className="text-text-muted">Pool: {status.allowed_track_count} tracks from selected source</Text> : null}
+
+            {(status.queue_history ?? []).length ? (
+              <View className="gap-1 border-t border-border-subtle pt-2">
+                <Text variant="eyebrow">Queued this session</Text>
+                {[...(status.queue_history ?? [])].reverse().slice(0, 10).map((e, i) => (
+                  <View key={i} className="flex-row items-baseline gap-1.5">
+                    <Text variant="micro" className="flex-1 text-text" numberOfLines={1}>{e.name}</Text>
+                    <Text variant="micro" className="text-text-muted" numberOfLines={1}>{e.artist}</Text>
+                    <Text variant="micro" className="text-text-secondary tabular-nums">{e.track_bpm} BPM</Text>
+                    <Text variant="micro" className="text-text-muted">{formatReason(e.reason)}</Text>
+                  </View>
+                ))}
               </View>
+            ) : null}
+          </Card>
+        ) : null}
 
-              <View className="gap-2">
-                <Text variant="eyebrow">Energy</Text>
-                <SegmentedControl options={["Wind down", "Steady", "Pump up"] as const} value={offsetMode} onChange={setOffsetMode} />
-                <Text variant="micro" className="text-text-muted">Shifts target BPM {OFFSETS[offsetMode] > 0 ? "+" : ""}{OFFSETS[offsetMode]} for the whole session.</Text>
-              </View>
-
-              <View className="gap-2">
-                <Text variant="eyebrow">Song source</Text>
-                <SegmentedControl options={["Whole library", "Auto-detect"] as const} value={sourceMode} onChange={setSourceMode} />
-                <Text variant="micro" className="text-text-muted">
-                  {sourceMode === "Auto-detect" ? "Match within whatever playlist/album you're already playing." : "Pull from your whole liked library, optionally by genre."}
-                </Text>
-              </View>
-
-              {sourceMode === "Whole library" ? <GenrePicker selected={genres} onToggle={toggleGenre} /> : null}
-            </Card>
-
-            <Button label={busy ? "Starting…" : "Start DJ"} variant="primary" disabled={busy} onPress={onStart} />
-            <Text variant="micro" className="text-text-muted">Play any song on Spotify first, then start — the DJ takes over the queue.</Text>
-          </>
-        )}
+        <Text variant="micro" className="text-text-muted">Play any song on Spotify first, then start — the DJ takes over the queue.</Text>
       </View>
     </ScrollView>
+  );
+}
+
+/* Manual source + genre pickers (mobile inline form of the web popovers). */
+function ManualPickers({ sources, onSources, genres, onGenres }: {
+  sources: string[]; onSources: (v: string[]) => void; genres: string[]; onGenres: (v: string[]) => void;
+}) {
+  const [playlists, setPlaylists] = useState<SpotifyPlaylistMeta[] | null>(null);
+  const [genreBuckets, setGenreBuckets] = useState<string[] | null>(null);
+  useEffect(() => {
+    fetchSpotifyPlaylists().then(setPlaylists).catch(() => setPlaylists([]));
+    fetchGenres().then(({ genres: g, total }) => {
+      const t = Number(total) || 1;
+      setGenreBuckets((g ?? []).filter((b: GenreBucket) => (Number(b.count) || 0) / t >= 0.03).map((b) => b.genre));
+    }).catch(() => setGenreBuckets([]));
+  }, []);
+  const toggle = (arr: string[], v: string, set: (x: string[]) => void) => set(arr.includes(v) ? arr.filter((x) => x !== v) : [...arr, v]);
+  return (
+    <View className="gap-3">
+      <View className="gap-2">
+        <Text variant="eyebrow">Sources {sources.length ? `· ${sources.length}` : ""}</Text>
+        <View className="flex-row flex-wrap gap-2">
+          <Pill label="Liked Songs" active={sources.includes("liked")} onPress={() => toggle(sources, "liked", onSources)} />
+          {(playlists ?? []).map((p) => (
+            <Pill key={p.id} label={`${p.name} (${p.tracks})`} active={sources.includes(p.id)} onPress={() => toggle(sources, p.id, onSources)} />
+          ))}
+        </View>
+      </View>
+      {genreBuckets && genreBuckets.length ? (
+        <View className="gap-2">
+          <Text variant="eyebrow">Genres {genres.length ? `· ${genres.length}` : "· any"}</Text>
+          <View className="flex-row flex-wrap gap-2">
+            {genreBuckets.map((g) => <Pill key={g} label={g} active={genres.includes(g)} onPress={() => toggle(genres, g, onGenres)} />)}
+          </View>
+        </View>
+      ) : null}
+    </View>
   );
 }

--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -22,12 +22,17 @@ function songDur(ms: number): string {
 }
 const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
-/* ---- run selector (Past runs / Saved plans) ---- */
+/* ---- run selector (Past Runs / Saved Plans / History / Manual — mirrors web) ---- */
+type SelTab = "past" | "plans" | "history" | "manual";
+interface SessionMeta { id: number; workout_name: string | null; garmin_activity_id: string | null; spotify_playlist_url: string | null; song_assignments: Record<string, unknown[]> | null; created_at: string }
+const sessTrackCount = (a: Record<string, unknown[]> | null) => a ? Object.values(a).reduce((s, v) => s + (Array.isArray(v) ? v.length : 0), 0) : 0;
+
 function RunSelector({ onPick }: { onPick: (name: string, garminId: string | null, items: SegmentItem[]) => void }) {
-  const [tab, setTab] = useState<"runs" | "plans">("runs");
+  const [tab, setTab] = useState<SelTab>("past");
   const [q, setQ] = useState("");
   const [runs, setRuns] = useState<GarminRunMeta[] | null>(null);
   const [plans, setPlans] = useState<WorkoutPlan[] | null>(null);
+  const [sessions, setSessions] = useState<SessionMeta[] | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
 
   useEffect(() => {
@@ -36,6 +41,7 @@ function RunSelector({ onPick }: { onPick: (name: string, garminId: string | nul
     return () => { alive = false; clearTimeout(t); };
   }, [q]);
   useEffect(() => { fetchJson<WorkoutPlan[]>("/api/playlist/workout-plans").then(setPlans).catch(() => setPlans([])); }, []);
+  useEffect(() => { fetchJson<SessionMeta[]>("/api/playlist/sessions").then(setSessions).catch(() => setSessions([])); }, []);
 
   async function pickRun(r: GarminRunMeta) {
     setBusy(r.activity_id);
@@ -51,14 +57,36 @@ function RunSelector({ onPick }: { onPick: (name: string, garminId: string | nul
       onPick(p.name, null, parsedToItems((d.segments as never[]) ?? []));
     } catch { /* ignore */ } finally { setBusy(null); }
   }
+  async function pickSession(s: SessionMeta) {
+    if (!s.garmin_activity_id) return;
+    setBusy(`s${s.id}`);
+    try {
+      const d = await fetchGarminRunDetail(s.garmin_activity_id);
+      onPick(s.workout_name || d.activity_name || "Run", d.activity_id, parsedToItems(d.segments ?? []));
+    } catch { /* ignore */ } finally { setBusy(null); }
+  }
+
+  // De-dup history like the read-only playlist screen (real, most-recent per name/day).
+  const historyRows = (() => {
+    const real = (sessions ?? []).filter((s) => sessTrackCount(s.song_assignments) > 0 || s.spotify_playlist_url);
+    const g = new Map<string, SessionMeta>();
+    for (const s of real) { const k = `${s.workout_name ?? "Run"}|${(s.created_at ?? "").slice(0, 10)}`; if (!g.has(k)) g.set(k, s); }
+    return [...g.values()].sort((a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime());
+  })();
+
+  const TabPill = ({ id, label, n }: { id: SelTab; label: string; n?: number }) => (
+    <Pill label={n != null ? `${label} (${n})` : label} active={tab === id} onPress={() => setTab(id)} />
+  );
 
   return (
     <View className="gap-3">
-      <View className="flex-row gap-2">
-        <Pill label="Past runs" active={tab === "runs"} onPress={() => setTab("runs")} />
-        <Pill label="Saved plans" active={tab === "plans"} onPress={() => setTab("plans")} />
+      <View className="flex-row flex-wrap gap-2">
+        <TabPill id="past" label="Past Runs" />
+        <TabPill id="plans" label="Saved Plans" n={plans?.length} />
+        <TabPill id="history" label="History" n={historyRows.length || undefined} />
+        <TabPill id="manual" label="Manual" />
       </View>
-      {tab === "runs" ? (
+      {tab === "past" ? (
         <>
           <TextInput value={q} onChangeText={setQ} placeholder="Search runs…" placeholderTextColor="#6f8695"
             className="rounded-lg border border-border-subtle bg-surface-subtle px-3 py-2 text-text" style={{ color: "#e6f0f4" }} />
@@ -78,7 +106,7 @@ function RunSelector({ onPick }: { onPick: (name: string, garminId: string | nul
             </Pressable>
           ))}
         </>
-      ) : (
+      ) : tab === "plans" ? (
         plans == null ? <ActivityIndicator color="#77c8d1" /> : plans.length === 0 ? (
           <Text variant="micro" className="text-text-muted">No saved plans.</Text>
         ) : plans.map((p) => (
@@ -91,6 +119,23 @@ function RunSelector({ onPick }: { onPick: (name: string, garminId: string | nul
             {busy === `p${p.id}` ? <ActivityIndicator color="#77c8d1" /> : <Text variant="body" className="text-teal">›</Text>}
           </Pressable>
         ))
+      ) : tab === "history" ? (
+        sessions == null ? <ActivityIndicator color="#77c8d1" /> : historyRows.length === 0 ? (
+          <Text variant="micro" className="text-text-muted">No saved playlists yet.</Text>
+        ) : historyRows.map((s) => (
+          <Pressable key={s.id} onPress={() => pickSession(s)} disabled={!!busy || !s.garmin_activity_id}
+            className="flex-row items-center justify-between border-b border-border-subtle py-2.5">
+            <View className="flex-1 pr-2">
+              <Text variant="body" className="text-text" numberOfLines={1}>{s.workout_name || "Run"}</Text>
+              <Text variant="micro" className="text-text-muted tabular-nums">
+                {sessTrackCount(s.song_assignments)} songs{s.spotify_playlist_url ? " · on Spotify" : ""}{s.created_at ? ` · ${new Date(s.created_at).toLocaleDateString()}` : ""}
+              </Text>
+            </View>
+            {busy === `s${s.id}` ? <ActivityIndicator color="#77c8d1" /> : <Text variant="body" className="text-teal">›</Text>}
+          </Pressable>
+        ))
+      ) : (
+        <Text variant="micro" className="py-4 text-center text-text-muted">Manual builder — coming soon</Text>
       )}
     </View>
   );
@@ -269,6 +314,7 @@ export default function PlaylistBuilderScreen() {
   useEffect(() => () => abortRef.current?.abort(), []);
 
   const totalSongs = Object.values(assignments).reduce((s, p) => s + (p.songs?.filter((x) => !x.is_skip).length ?? 0), 0);
+  const totalSkip = Object.values(assignments).reduce((s, p) => s + (p.songs?.filter((x) => x.is_skip).length ?? 0), 0);
 
   return (
     <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
@@ -288,7 +334,7 @@ export default function PlaylistBuilderScreen() {
         ) : (
           <>
             <View className="flex-row items-center gap-2">
-              <Text variant="micro" className="text-text-muted tabular-nums">{flat.length} segments · {totalSongs} songs</Text>
+              <Text variant="micro" className="text-text-muted tabular-nums">{flat.length} segments · {totalSongs} songs · {totalSkip} skip songs</Text>
               {sessionId ? <Badge label="Generated" tone="success" /> : null}
             </View>
             {genErr ? <Card><Text variant="micro" className="text-danger">Generation error: {genErr}</Text></Card> : null}

--- a/universal/src/lib/playlist.ts
+++ b/universal/src/lib/playlist.ts
@@ -257,6 +257,8 @@ export interface DjControlResult { ok: boolean; status: number; pid?: number; al
 
 export const fetchDjStatus = () => fetchJson<DjStatus>(`/api/playlist/dj/status`);
 export const fetchDjHrDefaults = () => fetchJson<{ hr_rest?: number | null; hr_max?: number | null }>(`/api/playlist/dj/hr-defaults`);
+export interface SpotifyPlaylistMeta { id: string; name: string; tracks: number }
+export const fetchSpotifyPlaylists = () => fetchJson<SpotifyPlaylistMeta[]>(`/api/playlist/spotify/playlists`);
 
 async function djPost(path: string, body?: unknown): Promise<DjControlResult> {
   try {


### PR DESCRIPTION
A proper side-by-side parity pass on the app's playlist builder + Live DJ, rendering the web screen and the app screen together, spotting the gaps, and closing them. The first cut of these screens (#609/#614/#618) was built from the web's source but not compared visually against the running web UI — this fixes the gaps that comparison surfaced.

### Live DJ — now matches `web/components/live-dj-tab.tsx`
- Subtitle "Polls your Garmin HR in real time and automatically queues songs that match your effort."
- Resting/Max HR with the italic **"Garmin"** annotation per field.
- **Mode cards** `Pump up / Normal / Wind down` (⬆/●/⬇ + "+12/0/-12 BPM") in the web's order, plus the per-mode **offset editor + reset ↺** (was a plain 3-way segmented control).
- Source **Auto (from Spotify) / Manual**; Manual reveals the **Sources** picker (Liked Songs + your real Spotify playlists with track counts) and the **Genres** picker (was always-on genre pills + wrong labels).
- Full **live card**: LIVE/STARTING/ERROR dot, "Session: …" + "polled …", session stats (N songs · avg match% · HR range), HR → target with staleness, no-queue reasons, ▶ current + ⏭ queued, pool/context, "Queued this session".

### Playlist builder — closer to `web/components/playlist-run-selector.tsx`
- Run selector now has the web's **4 tabs**: Past Runs / Saved Plans / History / Manual (History reopens a past session via its Garmin run; Manual is the web's "coming soon" placeholder).
- Count reads "**N songs · N skip songs**" like the web.

### Still open (deeper, desktop-centric — separate follow-ups)
Builder top-bar **Sources** picker, the **Bank** (pump-up) modal, the Spotify **preview** player, and the **segment-timeline** visualization.

### Verified
Typecheck clean; validated on Expo web with Playwright, screenshots read back **side-by-side against the web** for each state (DJ setup, DJ Manual pickers, DJ live card, builder 4-tab selector, builder History, builder count).

Closes #622
Closes #623
Closes #624
