### PR TITLE
feat(app): song preview via Spotify embed (parity B)

### DIFF
--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -38,6 +38,7 @@
         "react-native-screens": "4.25.2",
         "react-native-svg": "15.15.4",
         "react-native-web": "~0.21.0",
+        "react-native-webview": "13.16.1",
         "react-native-worklets": "0.10.0",
         "soma-style": "^1.3.0"
       },
@@ -9682,6 +9683,20 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.1",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.1.tgz",
+      "integrity": "sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-worklets": {
       "version": "0.10.0",

--- a/universal/package.json
+++ b/universal/package.json
@@ -32,6 +32,7 @@
     "react-native-screens": "4.25.2",
     "react-native-svg": "15.15.4",
     "react-native-web": "~0.21.0",
+    "react-native-webview": "13.16.1",
     "react-native-worklets": "0.10.0",
     "soma-style": "^1.3.0"
   },

--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -9,6 +9,7 @@ import {
   type SegmentItem, type Segment, type SegmentType, type SongData, type SSEEvent, type GarminRunMeta, type GenreBucket,
 } from "../../lib/playlist";
 import { fetchJson } from "../../lib/api";
+import { SpotifyEmbed } from "../../components/spotify-embed";
 
 interface PanelState { songs: SongData[]; loading?: boolean; poolCount?: number; warning?: string }
 type WorkoutPlan = { id: number; name: string; sport_type: string | null; total_duration_s: number | null; source: string | null };
@@ -205,9 +206,10 @@ function SegmentEditor({ seg, onChange }: { seg: Segment; onChange: (s: Segment)
   );
 }
 
-function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, onMove, canUp, canDown }: {
+function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, onMove, canUp, canDown, onPreview }: {
   seg: Segment; index: number; panel: PanelState | undefined; onExclude: (t: SongData) => void; onWiden: () => void;
   onEdit: (s: Segment) => void; onRemove: () => void; onMove: (dir: -1 | 1) => void; canUp: boolean; canDown: boolean;
+  onPreview: (s: SongData) => void;
 }) {
   const color = TYPE_COLORS[seg.type] ?? "#77c8d1";
   const [editing, setEditing] = useState(false);
@@ -239,12 +241,12 @@ function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, 
           {panel?.warning ? <Text variant="micro" style={{ color: "#e0a458" }}>{panel.warning}</Text> : null}
           {songs.map((s, i) => (
             <View key={`${s.track_id}-${i}`} className="flex-row items-center gap-2 border-t border-border-subtle py-1.5">
-              <View className="flex-1">
+              <Pressable className="flex-1" onPress={() => onPreview(s)}>
                 <Text variant="caption" className="text-text" numberOfLines={1}>{s.name}</Text>
                 <Text variant="micro" className="text-text-muted" numberOfLines={1}>
                   {s.artist_name}{s.tempo ? ` · ${Math.round(s.tempo)} bpm` : ""}{s.is_half_time ? " ·½" : ""} · {songDur(s.duration_ms)}
                 </Text>
-              </View>
+              </Pressable>
               <Pressable onPress={() => onExclude(s)} hitSlop={8} className="h-6 w-6 items-center justify-center rounded-md active:bg-surface-elevated">
                 <Text variant="micro" className="text-text-muted">✕</Text>
               </Pressable>
@@ -277,6 +279,7 @@ export default function PlaylistBuilderScreen() {
   const [planName, setPlanName] = useState("");
   const [planSaving, setPlanSaving] = useState(false);
   const [planSaved, setPlanSaved] = useState(false);
+  const [previewSong, setPreviewSong] = useState<SongData | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const flat = items ? flatItems(items) : [];
 
@@ -420,7 +423,8 @@ export default function PlaylistBuilderScreen() {
             <GenreBar selected={genres} onToggle={toggleGenre} />
             {flat.map((seg, i) => (
               <SegmentCard key={seg.id} seg={seg} index={i} panel={assignments[i]} onExclude={exclude} onWiden={() => widen(i)}
-                onEdit={(s) => editSeg(i, s)} onRemove={() => removeSeg(i)} onMove={(d) => moveSeg(i, d)} canUp={i > 0} canDown={i < flat.length - 1} />
+                onEdit={(s) => editSeg(i, s)} onRemove={() => removeSeg(i)} onMove={(d) => moveSeg(i, d)} canUp={i > 0} canDown={i < flat.length - 1}
+                onPreview={setPreviewSong} />
             ))}
             {/* Timeline footer: add / save-plan / total */}
             <Card className="gap-2">
@@ -437,6 +441,20 @@ export default function PlaylistBuilderScreen() {
                 </View>
               ) : (
                 <Pressable onPress={() => setPlanInput(true)} className="self-start"><Text variant="caption" className="text-teal">{planSaved ? "✓ Saved!" : "＋ Save as plan"}</Text></Pressable>
+              )}
+            </Card>
+            {/* Preview player (tap any song) — Spotify embed, mirrors web SpotifyPlayer */}
+            <Card className="gap-2">
+              {previewSong ? (
+                <>
+                  <View className="flex-row items-center justify-between">
+                    <Text variant="eyebrow">Preview</Text>
+                    <Pressable onPress={() => setPreviewSong(null)} hitSlop={8}><Text variant="micro" className="text-text-muted">✕ close</Text></Pressable>
+                  </View>
+                  <SpotifyEmbed key={previewSong.track_id} trackId={previewSong.track_id} />
+                </>
+              ) : (
+                <Text variant="micro" className="text-center text-text-muted">Tap a song to preview it.</Text>
               )}
             </Card>
             <Card className="gap-2">

--- a/universal/src/components/spotify-embed.d.ts
+++ b/universal/src/components/spotify-embed.d.ts
@@ -1,0 +1,3 @@
+import type { ReactElement } from "react";
+/** Platform-split (spotify-embed.web.tsx / spotify-embed.native.tsx). */
+export declare function SpotifyEmbed(props: { trackId: string }): ReactElement;

--- a/universal/src/components/spotify-embed.native.tsx
+++ b/universal/src/components/spotify-embed.native.tsx
@@ -1,0 +1,15 @@
+import { WebView } from "react-native-webview";
+
+/** Spotify preview on native — the official embed in a WebView (30s for free
+ *  users, full for Premium). Mirrors the web spotify-player.tsx iframe. */
+export function SpotifyEmbed({ trackId }: { trackId: string }) {
+  return (
+    <WebView
+      source={{ uri: `https://open.spotify.com/embed/track/${trackId}?utm_source=generator&theme=0&autoplay=1` }}
+      style={{ height: 80, backgroundColor: "transparent" }}
+      allowsInlineMediaPlayback
+      mediaPlaybackRequiresUserAction={false}
+      scrollEnabled={false}
+    />
+  );
+}

--- a/universal/src/components/spotify-embed.web.tsx
+++ b/universal/src/components/spotify-embed.web.tsx
@@ -1,0 +1,15 @@
+import { createElement } from "react";
+
+/** Spotify preview on web — the official embed iframe (30s for free users, full
+ *  for Premium). No SDK, no server calls; mirrors web spotify-player.tsx. */
+export function SpotifyEmbed({ trackId }: { trackId: string }) {
+  return createElement("iframe", {
+    src: `https://open.spotify.com/embed/track/${trackId}?utm_source=generator&theme=0&autoplay=1`,
+    width: "100%",
+    height: 80,
+    frameBorder: "0",
+    allow: "autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture",
+    loading: "eager",
+    style: { border: 0, display: "block", borderRadius: 8 },
+  });
+}


### PR DESCRIPTION
Parity part B: port the web builder's **song preview** (`spotify-player.tsx`). Tap any song in the builder to hear it — the same Spotify embed the web uses (30s for free users, full for Premium; no SDK, no server calls).

### What's here
- **`spotify-embed.web.tsx` / `spotify-embed.native.tsx`** (+ `.d.ts`) — platform split: an `<iframe>` on web, a `react-native-webview` `WebView` on native, both loading `open.spotify.com/embed/track/{id}?autoplay=1`.
- Builder: tapping a song sets the preview; a persistent **Preview** card at the bottom shows the player (with ✕ close), else "Tap a song to preview it." — mirrors the web's bottom player + "Click a song to preview".
- Added the `react-native-webview` dependency via `expo install` (@expo untouched at 57.0.6).

Loads from Spotify's CDN, so it works wherever the app runs (remote-available).

### Verified
Typecheck clean; Playwright on Expo web: tapping a song renders the Spotify embed; with a real track id the player shows album art, title/artist, a Preview badge and a ▶ play button (identical chrome to the web player).

### Next
C — Pump-up Bank; D — Sources picker on the builder top bar.

Closes #628
