### PR TITLE
feat(app): pump-up Bank in the playlist builder (parity C)

### DIFF
--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { ScrollView, View, TextInput, Pressable, ActivityIndicator, Linking } from "react-native";
 import { router } from "expo-router";
-import { Text, Card, Button, Pill, Badge, Stepper } from "soma-style";
+import { Text, Card, Button, Pill, Badge, Stepper, Modal } from "soma-style";
 import {
   TYPE_COLORS, SEGMENT_TYPES, BPM_DEFAULTS, makeSegment, parsedToItems, flatItems, segsForGenerate,
-  generatePlaylist, saveWorkoutPlan,
+  generatePlaylist, saveWorkoutPlan, fetchPumpUp, addPumpUp, removePumpUp,
   fetchGarminRuns, fetchGarminRunDetail, fetchGenres, postBlacklist, saveSpotifyPlaylist,
-  type SegmentItem, type Segment, type SegmentType, type SongData, type SSEEvent, type GarminRunMeta, type GenreBucket,
+  type SegmentItem, type Segment, type SegmentType, type SongData, type SSEEvent, type GarminRunMeta, type GenreBucket, type PumpUpSong,
 } from "../../lib/playlist";
 import { fetchJson } from "../../lib/api";
 import { SpotifyEmbed } from "../../components/spotify-embed";
@@ -206,10 +206,10 @@ function SegmentEditor({ seg, onChange }: { seg: Segment; onChange: (s: Segment)
   );
 }
 
-function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, onMove, canUp, canDown, onPreview }: {
+function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, onMove, canUp, canDown, onPreview, onBank }: {
   seg: Segment; index: number; panel: PanelState | undefined; onExclude: (t: SongData) => void; onWiden: () => void;
   onEdit: (s: Segment) => void; onRemove: () => void; onMove: (dir: -1 | 1) => void; canUp: boolean; canDown: boolean;
-  onPreview: (s: SongData) => void;
+  onPreview: (s: SongData) => void; onBank: (s: SongData) => void;
 }) {
   const color = TYPE_COLORS[seg.type] ?? "#77c8d1";
   const [editing, setEditing] = useState(false);
@@ -247,6 +247,9 @@ function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, 
                   {s.artist_name}{s.tempo ? ` · ${Math.round(s.tempo)} bpm` : ""}{s.is_half_time ? " ·½" : ""} · {songDur(s.duration_ms)}
                 </Text>
               </Pressable>
+              <Pressable onPress={() => onBank(s)} hitSlop={8} className="h-6 w-6 items-center justify-center rounded-md active:bg-surface-elevated">
+                <Text variant="micro" style={{ color: "#e0c458" }}>⚡</Text>
+              </Pressable>
               <Pressable onPress={() => onExclude(s)} hitSlop={8} className="h-6 w-6 items-center justify-center rounded-md active:bg-surface-elevated">
                 <Text variant="micro" className="text-text-muted">✕</Text>
               </Pressable>
@@ -258,6 +261,33 @@ function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, 
         </>
       )}
     </Card>
+  );
+}
+
+/* Pump-up Bank modal (mirrors web pump-up-modal.tsx). */
+function BankModal({ visible, onClose, refreshKey }: { visible: boolean; onClose: () => void; refreshKey: number }) {
+  const [songs, setSongs] = useState<PumpUpSong[] | null>(null);
+  useEffect(() => { if (!visible) return; setSongs(null); fetchPumpUp().then(setSongs).catch(() => setSongs([])); }, [visible, refreshKey]);
+  async function remove(id: string) { setSongs((p) => (p ? p.filter((s) => s.track_id !== id) : p)); await removePumpUp(id); }
+  return (
+    <Modal visible={visible} onClose={onClose} title="⚡ Pump-up Bank">
+      <Text variant="micro" className="mb-2 text-text-muted tabular-nums">{songs?.length ?? 0}/10 songs</Text>
+      {songs == null ? <ActivityIndicator color="#77c8d1" /> : songs.length === 0 ? (
+        <Text variant="micro" className="py-6 text-center text-text-muted">Bank empty — add songs with ⚡ on any song.</Text>
+      ) : songs.map((s) => (
+        <View key={s.track_id} className="flex-row items-center gap-2 border-t border-border-subtle py-2">
+          <View className="flex-1">
+            <Text variant="caption" className="text-text" numberOfLines={1}>{s.name}</Text>
+            <Text variant="micro" className="text-text-muted" numberOfLines={1}>{s.artist_name}</Text>
+          </View>
+          {s.tempo != null ? <Text variant="micro" className="text-text-muted tabular-nums">{Math.round(s.tempo)} BPM</Text> : null}
+          <View style={{ width: 56, height: 6, borderRadius: 3, backgroundColor: "#22323a", overflow: "hidden" }}>
+            <View style={{ width: `${Math.round((s.energy ?? 0) * 100)}%`, height: "100%", backgroundColor: "#e0c458" }} />
+          </View>
+          <Pressable onPress={() => remove(s.track_id)} hitSlop={8}><Text variant="micro" className="text-text-muted">✕</Text></Pressable>
+        </View>
+      ))}
+    </Modal>
   );
 }
 
@@ -280,6 +310,9 @@ export default function PlaylistBuilderScreen() {
   const [planSaving, setPlanSaving] = useState(false);
   const [planSaved, setPlanSaved] = useState(false);
   const [previewSong, setPreviewSong] = useState<SongData | null>(null);
+  const [bankOpen, setBankOpen] = useState(false);
+  const [bankRefresh, setBankRefresh] = useState(0);
+  const [bankToast, setBankToast] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const flat = items ? flatItems(items) : [];
 
@@ -335,6 +368,12 @@ export default function PlaylistBuilderScreen() {
   }
   function addSeg() { setItems((prev) => [...(prev ?? []), makeSegment({ type: "easy", duration_s: 600 })]); setDirty(true); }
   function regenerate() { if (items) { runGenerate(items, genres, excluded, garminId); setDirty(false); } }
+  async function bankSong(s: SongData) {
+    const r = await addPumpUp({ track_id: s.track_id, name: s.name, artist_name: s.artist_name, tempo: s.tempo, energy: s.energy });
+    setBankRefresh((k) => k + 1);
+    setBankToast(r.ok ? `Added “${s.name}” to the bank` : r.error || "Couldn't add to bank");
+    setTimeout(() => setBankToast(null), 2500);
+  }
   async function savePlan() {
     const name = planName.trim();
     if (!name || !items) return;
@@ -401,10 +440,15 @@ export default function PlaylistBuilderScreen() {
       <View className="w-full max-w-2xl gap-4">
         <View className="flex-row items-center justify-between">
           <Text variant="headline">{items ? workoutName : "New playlist"}</Text>
-          <Pressable onPress={() => (items ? (abortRef.current?.abort(), setItems(null), setAssignments({}), setSessionId(null)) : router.back())}>
-            <Text variant="caption" className="text-teal">{items ? "Change run" : "Close"}</Text>
-          </Pressable>
+          <View className="flex-row items-center gap-3">
+            {items ? <Pressable onPress={() => setBankOpen(true)}><Text variant="caption" style={{ color: "#e0c458" }}>⚡ Bank</Text></Pressable> : null}
+            <Pressable onPress={() => (items ? (abortRef.current?.abort(), setItems(null), setAssignments({}), setSessionId(null)) : router.back())}>
+              <Text variant="caption" className="text-teal">{items ? "Change run" : "Close"}</Text>
+            </Pressable>
+          </View>
         </View>
+        <BankModal visible={bankOpen} onClose={() => setBankOpen(false)} refreshKey={bankRefresh} />
+        {bankToast ? <Card className="border-teal-dim"><Text variant="micro" className="text-teal">{bankToast}</Text></Card> : null}
 
         {!items ? (
           <>
@@ -424,7 +468,7 @@ export default function PlaylistBuilderScreen() {
             {flat.map((seg, i) => (
               <SegmentCard key={seg.id} seg={seg} index={i} panel={assignments[i]} onExclude={exclude} onWiden={() => widen(i)}
                 onEdit={(s) => editSeg(i, s)} onRemove={() => removeSeg(i)} onMove={(d) => moveSeg(i, d)} canUp={i > 0} canDown={i < flat.length - 1}
-                onPreview={setPreviewSong} />
+                onPreview={setPreviewSong} onBank={bankSong} />
             ))}
             {/* Timeline footer: add / save-plan / total */}
             <Card className="gap-2">

--- a/universal/src/lib/playlist.ts
+++ b/universal/src/lib/playlist.ts
@@ -232,6 +232,26 @@ export async function saveSpotifyPlaylist(body: SpotifySaveBody): Promise<Spotif
   }
 }
 
+/* ---- Pump-up Bank (max 10 saved pump-up songs; mirrors web pump-up-modal) ---- */
+export interface PumpUpSong { track_id: string; name: string; artist_name: string; tempo: number | null; energy: number | null; added_at?: string }
+export const fetchPumpUp = () => fetchJson<PumpUpSong[]>(`/api/playlist/pump-up`);
+export async function addPumpUp(s: { track_id: string; name: string; artist_name: string; tempo?: number; energy?: number }): Promise<{ ok: boolean; status: number; error?: string }> {
+  try {
+    const res = await fetch(`${API_BASE}/api/playlist/pump-up`, {
+      method: "POST", headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({ track_id: s.track_id, name: s.name, artist_name: s.artist_name, tempo: s.tempo, energy: s.energy }),
+    });
+    const j = (await res.json().catch(() => ({}))) as { error?: string };
+    return { ok: res.ok, status: res.status, error: j.error };
+  } catch (err) { return { ok: false, status: 0, error: String((err as Error)?.message ?? err) }; }
+}
+export async function removePumpUp(trackId: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/playlist/pump-up/${encodeURIComponent(trackId)}`, { method: "DELETE", headers: { ...AUTH_HEADERS } });
+    return res.ok;
+  } catch { return false; }
+}
+
 /* ---- Track exclusion / blacklist ---- */
 export async function postBlacklist(trackId: string): Promise<number> {
   try {


### PR DESCRIPTION
Parity part C: port the web builder's **Pump-up Bank** (`pump-up-modal.tsx` + the ⚡ on song cards). A saved bank of up to 10 pump-up songs.

### What's here
- **⚡ on every song row** adds it to the bank (POST `/api/playlist/pump-up`; max 10; a short confirmation shows).
- **⚡ Bank** button in the builder header opens the **Pump-up Bank** modal: "N/10 songs", each song with artist, BPM, an energy bar, and a remove ✕ (DELETE `/api/playlist/pump-up/{id}`); empty-state hint.
- `playlist.ts`: `fetchPumpUp` / `addPumpUp` / `removePumpUp` helpers.

Hits `/api`, so remote-available.

### Verified
Typecheck clean; Playwright on Expo web: ⚡ on a song adds it (bank went 1→2), the Bank modal shows both songs with BPM + energy bars + remove and the "2/10 songs" count — matching the web modal.

### Next
D — Sources picker on the builder top bar (final piece).

Closes #630
