### PR TITLE
feat(app): Analyse library trigger in the Sources picker (parity)

### DIFF
--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { ScrollView, View, TextInput, Pressable, ActivityIndicator, Linking } from "react-native";
 import { router } from "expo-router";
-import { Text, Card, Button, Pill, Badge, Stepper, Modal } from "soma-style";
+import { Text, Card, Button, Pill, Badge, Stepper, Modal, ProgressBar } from "soma-style";
 import {
   TYPE_COLORS, SEGMENT_TYPES, BPM_DEFAULTS, makeSegment, parsedToItems, flatItems, segsForGenerate,
   generatePlaylist, saveWorkoutPlan, fetchPumpUp, addPumpUp, removePumpUp, fetchSpotifyPlaylists,
+  fetchLibraryStatus, analyseLibrary,
   fetchGarminRuns, fetchGarminRunDetail, fetchGenres, postBlacklist, saveSpotifyPlaylist,
-  type SegmentItem, type Segment, type SegmentType, type SongData, type SSEEvent, type GarminRunMeta, type GenreBucket, type PumpUpSong, type SpotifyPlaylistMeta,
+  type SegmentItem, type Segment, type SegmentType, type SongData, type SSEEvent, type GarminRunMeta, type GenreBucket, type PumpUpSong, type SpotifyPlaylistMeta, type LibraryStatus,
 } from "../../lib/playlist";
 import { fetchJson } from "../../lib/api";
 import { SpotifyEmbed } from "../../components/spotify-embed";
@@ -268,23 +269,70 @@ function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, 
 function SourcesModal({ visible, onClose, selected, onChange }: { visible: boolean; onClose: () => void; selected: string[]; onChange: (v: string[]) => void }) {
   const [playlists, setPlaylists] = useState<SpotifyPlaylistMeta[] | null>(null);
   const [q, setQ] = useState("");
-  useEffect(() => { if (visible && playlists == null) fetchSpotifyPlaylists().then(setPlaylists).catch(() => setPlaylists([])); }, [visible, playlists]);
+  const [lib, setLib] = useState<LibraryStatus | null>(null);
+  const [analysing, setAnalysing] = useState(false);
+  const [progress, setProgress] = useState<{ stage: string; pct: number } | null>(null);
+  const analyseAbort = useRef<AbortController | null>(null);
+  useEffect(() => {
+    if (!visible) return;
+    if (playlists == null) fetchSpotifyPlaylists().then(setPlaylists).catch(() => setPlaylists([]));
+    fetchLibraryStatus().then(setLib).catch(() => {});
+    return () => analyseAbort.current?.abort();
+  }, [visible, playlists]);
   const toggle = (id: string) => onChange(selected.includes(id) ? selected.filter((s) => s !== id) : [...selected, id]);
   const all: { id: string; name: string; tracks?: number }[] = [{ id: "liked", name: "Liked Songs" }, ...(playlists ?? [])];
   const ql = q.trim().toLowerCase();
   const list = ql ? all.filter((s) => s.name.toLowerCase().includes(ql)) : all;
+
+  const withBpm = lib ? Number(lib.tracks_with_bpm) || 0 : 0;
+  const total = lib ? Number(lib.total_tracks) || 0 : 0;
+  const pct = total > 0 ? Math.round((withBpm / total) * 100) : 0;
+  const needsAnalysis = lib != null && withBpm === 0;
+
+  async function analyse() {
+    setAnalysing(true); setProgress({ stage: "Starting…", pct: 0 });
+    analyseAbort.current?.abort();
+    const ac = new AbortController(); analyseAbort.current = ac;
+    try {
+      await analyseLibrary(selected, (e) => {
+        if (e.type === "progress") setProgress({ stage: e.stage, pct: e.pct });
+        else if (e.type === "done") { setProgress({ stage: `Done — ${e.new} new tracks analysed`, pct: 100 }); fetchLibraryStatus().then(setLib).catch(() => {}); }
+        else if (e.type === "error") setProgress({ stage: e.message, pct: 0 });
+      }, ac.signal);
+    } catch (err) { if (!ac.signal.aborted) setProgress({ stage: String((err as Error)?.message ?? err), pct: 0 }); }
+    finally { setAnalysing(false); }
+  }
+
   return (
     <Modal visible={visible} onClose={onClose} title="Sources">
       <Text variant="micro" className="mb-2 text-text-muted">{selected.length} selected · songs are matched from these.</Text>
       <TextInput value={q} onChangeText={setQ} placeholder="Search sources…" placeholderTextColor="#6f8695"
         className="mb-2 rounded-lg border border-border-subtle bg-surface-subtle px-3 py-2" style={{ color: "#e6f0f4" }} />
       {playlists == null ? <ActivityIndicator color="#77c8d1" /> : (
-        <ScrollView style={{ maxHeight: 360 }}>
+        <ScrollView style={{ maxHeight: 300 }}>
           <View className="flex-row flex-wrap gap-2">
             {list.map((s) => <Pill key={s.id} label={s.tracks != null ? `${s.name} (${s.tracks})` : s.name} active={selected.includes(s.id)} onPress={() => toggle(s.id)} />)}
           </View>
         </ScrollView>
       )}
+      {/* Analyse library (BPM data) */}
+      <View className="mt-3 gap-2 border-t border-border-subtle pt-3">
+        <Text variant="micro" className={needsAnalysis ? "text-warm" : "text-text-muted"}>
+          {lib == null ? "Loading library status…"
+            : needsAnalysis ? "⚠ No BPM data yet — Analyse to enable song matching"
+            : `${pct}% of tracks have BPM data (${withBpm.toLocaleString()} / ${total.toLocaleString()})`}
+        </Text>
+        <Button label={analysing ? "Analysing…" : "Analyse library (fetch BPM data)"} variant="primary" disabled={analysing} onPress={analyse} />
+        {progress ? (
+          <View className="gap-1">
+            <View className="flex-row justify-between">
+              <Text variant="micro" className="flex-1 text-text-muted" numberOfLines={1}>{progress.stage}</Text>
+              {progress.pct > 0 ? <Text variant="micro" className="text-text-muted tabular-nums">{progress.pct}%</Text> : null}
+            </View>
+            {progress.pct > 0 ? <ProgressBar pct={progress.pct / 100} color="#6ad4a0" /> : null}
+          </View>
+        ) : null}
+      </View>
     </Modal>
   );
 }

--- a/universal/src/lib/playlist.ts
+++ b/universal/src/lib/playlist.ts
@@ -303,6 +303,48 @@ export const fetchDjHrDefaults = () => fetchJson<{ hr_rest?: number | null; hr_m
 export interface SpotifyPlaylistMeta { id: string; name: string; tracks: number }
 export const fetchSpotifyPlaylists = () => fetchJson<SpotifyPlaylistMeta[]>(`/api/playlist/spotify/playlists`);
 
+/* ---- Library BPM analysis (POST /api/playlist/spotify/library streams
+ *      `event: progress|done|error` SSE; GET returns coverage status). ---- */
+export interface LibraryStatus { total_tracks: number | string; tracks_with_bpm: number | string }
+export const fetchLibraryStatus = () => fetchJson<LibraryStatus>(`/api/playlist/spotify/library`);
+export type AnalyseEvent =
+  | { type: "progress"; stage: string; pct: number }
+  | { type: "done"; new: number }
+  | { type: "error"; message: string };
+
+/** Analyse the Spotify library for BPM data, emitting SSE progress. Uses the
+ *  `event:`/`data:` SSE shape (differs from the generation stream's bare data). */
+export async function analyseLibrary(sourceIds: string[], onEvent: (e: AnalyseEvent) => void, signal?: AbortSignal): Promise<void> {
+  const res = await streamFetch(`${API_BASE}/api/playlist/spotify/library`, {
+    method: "POST", headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify({ source_ids: sourceIds }), signal,
+  });
+  if (!res.ok) { const t = await res.text().catch(() => ""); onEvent({ type: "error", message: `${res.status} ${t.slice(0, 120)}` }); return; }
+  if (!res.body) return;
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const parts = buffer.split("\n\n");
+    buffer = parts.pop() ?? "";
+    for (const part of parts) {
+      const lines = part.trim().split("\n");
+      const evtLine = lines.find((l) => l.startsWith("event: "));
+      const dataLine = lines.find((l) => l.startsWith("data: "));
+      if (!evtLine || !dataLine) continue;
+      const evt = evtLine.slice(7).trim();
+      let data: { stage?: string; pct?: number; new?: number; message?: string } = {};
+      try { data = JSON.parse(dataLine.slice(6)); } catch { continue; }
+      if (evt === "progress") onEvent({ type: "progress", stage: data.stage ?? "", pct: data.pct ?? 0 });
+      else if (evt === "done") onEvent({ type: "done", new: data.new ?? 0 });
+      else if (evt === "error") onEvent({ type: "error", message: data.message ?? "error" });
+    }
+  }
+}
+
 async function djPost(path: string, body?: unknown): Promise<DjControlResult> {
   try {
     const res = await fetch(`${API_BASE}${path}`, {


### PR DESCRIPTION
The last web-only item: the **Analyse library** trigger inside the Sources picker (`playlist-source-picker.tsx` handleAnalyse). The app could show BPM-coverage status read-only but couldn't start an analysis; now it can, so nothing in the builder is web-only.

### What's here
- In the builder's **Sources** modal: a BPM-coverage line ("N% of tracks have BPM data (X / Y)", or "⚠ No BPM data yet — Analyse to enable song matching"), an **Analyse library (fetch BPM data)** button, and a live **progress** readout (stage + % + bar).
- `playlist.ts`: `fetchLibraryStatus` + `analyseLibrary(sourceIds, onEvent)` — streams the `event: progress|done|error` SSE (a different SSE shape than the generation stream) over `expo/fetch`; on done it re-reads the coverage status.

Hits `/api`, so it's remote-available like the rest.

### Verified
Typecheck clean; Playwright on Expo web: opened Sources, saw "67% of tracks have BPM data (2,798 / 4,162)", clicked Analyse → SSE progressed to "Done — 42 new tracks analysed" at 100% with a full progress bar — matching the web flow.

### The parity push is now complete
Builder: editable timeline (#627), preview (#629), Bank (#631), Sources (#633), **Analyse (this)**. Live DJ: #625. The app builder + Live DJ now mirror the web feature-for-feature — nothing web-only.

Closes #634
