### PR TITLE
feat(app): meal-header emojis on nutrition (parity sweep)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -38,6 +38,10 @@ const MACROS: { key: string; label: string; color: string; tKey: string; ceiling
 
 const SLOT_ORDER = ["breakfast", "lunch", "during_workout", "dinner", "pre_sleep"];
 const slotLabel = (s: string) => s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+// Meal-slot emojis, matching web meal-card.tsx SLOT_ICONS.
+const SLOT_ICONS: Record<string, string> = {
+  breakfast: "☀️", lunch: "🌤️", dinner: "🌙", pre_sleep: "🌙", during_workout: "🏃",
+};
 
 function mealName(m: SomaMeal): string {
   const names = (m.items ?? []).map((i) => i.name).filter(Boolean) as string[];
@@ -543,7 +547,7 @@ export default function NutritionScreen() {
                 <Card key={s} className="gap-2">
                   <View className="flex-row items-center justify-between">
                     <View className="flex-row items-center gap-2">
-                      <Text variant="title">{slotLabel(s)}</Text>
+                      <Text variant="title">{SLOT_ICONS[s] ? `${SLOT_ICONS[s]} ` : ""}{slotLabel(s)}</Text>
                       {slotMeals.length > 0 && !isSkipped && !dayClosed ? (
                         <Pressable onPress={() => toggleLock(s)} hitSlop={8}>
                           <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: lockedSlots.has(s) ? "#e0a45822" : "#142530" }}>


### PR DESCRIPTION
Side-by-side nutrition parity sweep (web `nutrition-dashboard.tsx` ↔ app `nutrition.tsx`). Finding: **the app nutrition was already at ~100% parity** with the web — and the Trend tab is actually richer. The only real web element the app lacked was the meal-header emojis.

### What I compared (web :3456 ↔ app :8094, screenshots read back)
- **Day view** — at parity: energy-budget hero + current deficit, macro bars with g/kg tick tiers, Today's Activity (ad-hoc run + expected steps + gym-workout chips), burn breakdown, per-meal budgets, Copy yesterday, Close day.
- **Trend/Trajectory tab** — app is **richer**: it has all the web charts (Weight, Body Fat, Cumulative Deficit, Burn vs Eaten) with full history, plus a Body-Composition stat card and a **7-day trend table** the web doesn't show.
- **Log/Compose modal** — at parity: Presets / Quick add / Compose with the ingredient auto-solver.

### The one gap, now fixed
- **Meal-header emojis** (`meal-card.tsx` SLOT_ICONS): ☀️ Breakfast, 🌤️ Lunch, 🌙 Dinner / Pre-Sleep, 🏃 During-workout. Added to the app meal-section headers.

### Left as intentional (not regressions)
- Tab is named "Trend" (app) vs "Trajectory" (web); hero says "kcal left" vs "to goal". Wording, not missing function.
- Burn-vs-Eaten renders as a total-burn line on the app vs stacked burn-components on web; the app already shows the BMR/steps/run/gym breakdown in the Day-view "Burn breakdown" card.

### Verified
Typecheck clean; Playwright on Expo web: meal headers now show the emojis, matching the web.

Closes #636
