### PR TITLE
feat(gate): device verify harness (emulator + real account), PR template, sync-health (T0/T5)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!-- The sentence before the code (soma follows drlab's intake gate, ../drlab docs/39).
+     A slot you cannot fill is a finding about the MODEL, not a reason to code: write the
+     finding and stop. A spike/* branch never merges. -->
+
+## The sentence
+
+```
+For RESOURCE      <what this touches: e.g. ingredient://<slug>, service://soma-dj, screen://nutrition>,
+  soma knows PROPERTIES <name := value; observed by WHOM; fresh for N>,
+  and can do CAPABILITY <name; tier none|confirm|restricted; executor script|human|agent;
+                          reversible|compensable|irreversible; shared|exclusive; batch|interactive|realtime>
+  when INTENT is minted by <actor, at tier>,
+  producing EVENTS <action; actor; origin commanded|observed|inferred; outcome>,
+  or, for a human, PROCEDURE <steps; verify_cmd>,
+  so that DERIVED STATE <what answers "is it done" with no stored flag>,
+  rendered at TOUCHPOINTS <screens / endpoint / channel — render, declare, relay only>,
+  governed by POLICY <rules, or "none today">.
+```
+
+## Done is an observation, not a claim
+
+`verify_cmd` (runs on the Android emulator with the owner's account; the phone if a deviation is plausible):
+
+```bash
+universal/scripts/verify-device.sh <screen> [--marker "<live value>"]
+```
+
+- [ ] I ran it after the last commit and it exited 0 (paste the `VERIFIED …` line below).
+- [ ] Reads came from the real API (soma.gkos.dev), not a mock and not Expo web.
+- [ ] External writes: Spotify writes may be real; **Garmin writes stay mock unless the owner said go.**
+
+```
+<paste the VERIFIED line / evidence path here>
+```
+
+## Guardrails (tick each or explain)
+
+- [ ] The sync pipeline and Strava bridge are untouched, or the change is reversible and `sync_health` was read before and after.
+- [ ] hevy2garmin `main` still works for a fresh fork (fresh-fork check green) — or this PR does not touch it.
+- [ ] Nutrition logging / presets / compose solver / adjusted targets untouched, or new behaviour is behind a flag.
+- [ ] Garmin token store format untouched.
+- [ ] No web-only feature was introduced; none was silently dropped from the app.
+
+## Links
+
+Closes #<issue>
+
+https://claude.ai/code/session_017H7RibKwWqRZxuc5XrAWNF

--- a/scripts/sync-health.sh
+++ b/scripts/sync-health.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# sync-health.sh — T5 of the plan: OBSERVE the sync pipeline's health, never assume it.
+#
+# "Silence is the enemy." Exit 0 = healthy, 1 = unhealthy, 2 = could not determine.
+# Read-only: it only lists GitHub Actions runs. It never touches the pipeline.
+#
+# Thresholds derive from the OBSERVED cadence, not the declared cron (docs: GitHub drops
+# scheduled runs under load; sync.yml declares */30min but delivers ~2.5–5 h, 24/24 success
+# on 2026-09-03). Override with SYNC_MAX_AGE_H / BRIDGE_MAX_AGE_H if the cadence changes.
+set -uo pipefail
+GH=${GH:-/opt/homebrew/bin/gh}
+REPO=drkostas/soma
+SYNC_MAX_AGE_H="${SYNC_MAX_AGE_H:-6}"      # sync.yml: observed ~3 h between successes
+BRIDGE_MAX_AGE_H="${BRIDGE_MAX_AGE_H:-18}" # strava-bridge-ts.yml runs 11/15/19 UTC → the overnight gap is 16 h; 12 h false-alarmed every morning
+
+check() { # name workflow max_age_h
+  local name="$1" wf="$2" max="$3" json
+  json="$($GH run list --repo "$REPO" --workflow "$wf" --limit 8 --json status,conclusion,createdAt 2>/dev/null)" \
+    || { echo "UNKNOWN $name: gh run list failed (auth? network?)"; return 2; }
+  # JSON goes in as an ARGUMENT. Two stdin redirects once made python execute the JSON
+  # (a valid literal) as its script and exit 0 with no output — a green check over a hole.
+  python3 - "$name" "$max" "$json" <<'PY'
+import json,sys,datetime as dt
+name,max_h=sys.argv[1],float(sys.argv[2]); rows=json.loads(sys.argv[3])
+now=dt.datetime.now(dt.timezone.utc)
+ok=[r for r in rows if r["status"]=="completed" and r["conclusion"]=="success"]
+bad=[r for r in rows if r["status"]=="completed" and r["conclusion"] not in ("success",None)]
+if not rows: print(f"UNKNOWN {name}: no runs returned"); sys.exit(2)
+if not ok: print(f"UNHEALTHY {name}: no successful run in the last {len(rows)}"); sys.exit(1)
+t=dt.datetime.fromisoformat(ok[0]["createdAt"].replace("Z","+00:00")); age_h=(now-t).total_seconds()/3600
+latest=rows[0]
+if age_h>max_h:
+    print(f"UNHEALTHY {name}: last success {age_h:.1f} h ago (> {max_h:g} h); latest run {latest['status']}/{latest['conclusion']}"); sys.exit(1)
+extra=f"; {len(bad)} non-success in last {len(rows)}" if bad else ""
+print(f"OK {name}: last success {age_h:.1f} h ago (limit {max_h:g} h){extra}"); sys.exit(0)
+PY
+}
+
+rc=0
+check "sync-pipeline"  "sync.yml"             "$SYNC_MAX_AGE_H";   r=$?; [ $r -gt $rc ] && rc=$r
+check "strava-bridge"  "strava-bridge-ts.yml" "$BRIDGE_MAX_AGE_H"; r=$?; [ $r -gt $rc ] && rc=$r
+exit $rc

--- a/universal/.maestro/verify-screen.yaml
+++ b/universal/.maestro/verify-screen.yaml
@@ -1,0 +1,36 @@
+# Soma verify flow (T0 gate): open ONE screen by deep link and assert that a
+# marker fetched live from the real API is visible on the device.
+#
+# This is the "done is derived, never asserted" check from the plan: the marker
+# is a real number the screen must render (e.g. today's steps from
+# /api/health/today), passed in by universal/scripts/verify-device.sh, so a pass
+# proves the emulator/phone rendered live data from soma.gkos.dev — not a static
+# header, not a mock, not Expo web.
+#
+# Run via the script, not by hand:
+#   universal/scripts/verify-device.sh overview
+# which resolves ROUTE + MARKER and invokes:
+#   maestro --device <id> test -e ROUTE=universal://overview -e MARKER=983 .maestro/verify-screen.yaml
+appId: dev.gkos.soma
+name: Soma verify screen
+tags:
+  - verify
+---
+- launchApp
+- waitForAnimationToEnd:
+    timeout: 10000
+- openLink: ${ROUTE}
+- waitForAnimationToEnd:
+    timeout: 10000
+# The marker arrives over the network from the real API and the screen is long: the
+# card that renders it is usually BELOW the fold (Maestro sees off-screen nodes as
+# visible:false). So scroll the screen until the marker is on-screen, up to 40 s.
+# This fails honestly if the value never renders.
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+    visibilityPercentage: 60
+- takeScreenshot: verify-${SCREEN}

--- a/universal/scripts/verify-device.sh
+++ b/universal/scripts/verify-device.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# verify-device.sh — the T0 gate: is <screen> rendering REAL data from the real
+# API on a real device (the Android emulator with the owner's account, or the phone)?
+#
+# "Done is derived, never asserted." This script IS the observation. Exit 0 only
+# when the device shows a marker value fetched live from the API right now.
+#
+# Usage:
+#   universal/scripts/verify-device.sh overview            # auto marker: today's steps
+#   universal/scripts/verify-device.sh overview --activities   # auto marker: lifetime activity count
+#   universal/scripts/verify-device.sh running --marker "202 runs"   # explicit marker
+#   ANDROID_SERIAL=100.99.159.74:5555 universal/scripts/verify-device.sh overview   # the phone
+#
+# Needs: ~/.config/soma/app.env (EXPO_PUBLIC_API_URL + EXPO_PUBLIC_API_TOKEN, chmod 600,
+#        NEVER committed), the app (dev.gkos.soma) built against that URL and installed,
+#        Android SDK platform-tools, Maestro (~/.maestro/bin/maestro).
+set -euo pipefail
+
+SCREEN="${1:-overview}"; shift || true
+MODE="auto"; MARKER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --marker) MARKER="$2"; MODE="explicit"; shift 2;;
+    --activities) MODE="activities"; shift;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+DEV="${ANDROID_SERIAL:-emulator-5554}"
+ENVF="$HOME/.config/soma/app.env"
+ADB="$HOME/Library/Android/sdk/platform-tools/adb"
+MAESTRO="$HOME/.maestro/bin/maestro"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"          # universal/
+FLOW="$HERE/.maestro/verify-screen.yaml"
+OUT="/tmp/soma/verify"; mkdir -p "$OUT"
+
+[ -f "$ENVF" ] || { echo "FAIL: missing $ENVF (API url + token by reference)"; exit 2; }
+set -a; . "$ENVF"; set +a
+: "${EXPO_PUBLIC_API_URL:?}"; : "${EXPO_PUBLIC_API_TOKEN:?}"
+[ -x "$ADB" ] || { echo "FAIL: adb not at $ADB"; exit 2; }
+[ -x "$MAESTRO" ] || { echo "FAIL: maestro not at $MAESTRO"; exit 2; }
+# Maestro 2.x needs Java 17+. A non-interactive shell on this Mac defaults to JDK 8
+# (drlab gotcha), so pin it here rather than trusting the caller's environment.
+export JAVA_HOME="${JAVA_HOME_17:-/opt/homebrew/opt/openjdk@17}"
+export PATH="$JAVA_HOME/bin:$PATH"
+"$JAVA_HOME/bin/java" -version 2>&1 | grep -qE 'version "(1[7-9]|[2-9][0-9])' \
+  || { echo "FAIL: Java 17+ not found at $JAVA_HOME (maestro cannot run)"; exit 2; }
+
+# 1. Device up, app installed.
+STATE="$($ADB -s "$DEV" get-state 2>/dev/null || true)"
+[ "$STATE" = "device" ] || { echo "FAIL: $DEV state='$STATE' (not up)"; exit 2; }
+$ADB -s "$DEV" shell pm list packages 2>/dev/null | grep -q "dev.gkos.soma" \
+  || { echo "FAIL: dev.gkos.soma not installed on $DEV"; exit 2; }
+
+# 2. The marker: a value the screen must render, fetched LIVE from the real API.
+api() { curl -sf -H "Authorization: Bearer $EXPO_PUBLIC_API_TOKEN" "$EXPO_PUBLIC_API_URL$1"; }
+case "$MODE" in
+  auto)
+    case "$SCREEN" in
+      overview)
+        MARKER="$(api /api/health/today | python3 -c 'import json,sys;v=json.load(sys.stdin).get("total_steps");print(f"{int(v):,}" if v is not None else "")')";;
+      *) echo "FAIL: no auto marker for '$SCREEN' — pass --marker TEXT"; exit 2;;
+    esac;;
+  activities)
+    MARKER="$(api /api/overview/fitness | python3 -c 'import json,sys;v=json.load(sys.stdin).get("total_activities");print(f"{int(v):,}" if v is not None else "")')";;
+  explicit) ;;
+esac
+[ -n "$MARKER" ] || { echo "FAIL: could not resolve a marker from the API for '$SCREEN'"; exit 2; }
+echo "verify $SCREEN on $DEV — expecting live marker: '$MARKER'  (from $EXPO_PUBLIC_API_URL)"
+
+# 3. Drive the device: open the screen, wait for the marker to be visible.
+set +e
+( cd "$HERE" && "$MAESTRO" --device "$DEV" test \
+    -e ROUTE="universal://$SCREEN" -e MARKER="$MARKER" -e SCREEN="$SCREEN" \
+    "$FLOW" ) > "$OUT/$SCREEN.maestro.log" 2>&1
+RC=$?
+set -e
+
+# 4. Keep the evidence regardless of outcome.
+$ADB -s "$DEV" exec-out screencap -p > "$OUT/$SCREEN.png" 2>/dev/null || true
+if [ $RC -eq 0 ]; then
+  echo "VERIFIED $SCREEN: '$MARKER' visible on $DEV — evidence $OUT/$SCREEN.png"
+  exit 0
+fi
+# Distinguish "the harness could not run" from "the screen did not show the marker".
+# An infra failure must never masquerade as a verification result (exit 2 vs 1).
+if grep -qiE "Java 17|No devices|Unable to connect|not found|Failed to connect|maestro: command" "$OUT/$SCREEN.maestro.log"; then
+  echo "HARNESS ERROR $SCREEN (not a verification result): maestro could not run — see $OUT/$SCREEN.maestro.log"
+  grep -iE "Java 17|No devices|Unable to connect|not found|Failed to connect" "$OUT/$SCREEN.maestro.log" | head -3
+  exit 2
+fi
+echo "FAILED $SCREEN (maestro rc=$RC): '$MARKER' NOT seen on $DEV — see $OUT/$SCREEN.maestro.log and $OUT/$SCREEN.png"
+tail -15 "$OUT/$SCREEN.maestro.log"
+exit 1


### PR DESCRIPTION
## The sentence

```
For RESOURCE      project://soma,
  soma knows PROPERTIES verification_target := android-emulator + owner's real account (declared by the owner),
  and can do CAPABILITY verify_task; tier none; executor script; reversible; shared; batch
  when INTENT is minted by a pull request,
  producing EVENTS soma.task.verified; actor script; origin observed; success|failure,
  so that DERIVED STATE task_done = "the last verify_cmd run returned 0" — no stored flag,
  rendered at TOUCHPOINTS the PR template (render, declare, relay only),
  governed by POLICY no-merge-without-verify_cmd.
```

## Done is an observation, not a claim

`verify_cmd`:
```bash
universal/scripts/verify-device.sh overview
universal/scripts/verify-device.sh overview --activities
scripts/sync-health.sh
```

- [x] Ran after the last commit, exit 0 (release APK built against prod, installed on emulator-5554 / Pixel_3a_API_34):
- [x] Reads came from the real API (soma.gkos.dev), not a mock and not Expo web.
- [x] External writes: none in this PR.

```
VERIFIED overview: '983' visible on emulator-5554 — evidence /tmp/soma/verify/overview.png
VERIFIED overview: '1,096' visible on emulator-5554 — evidence /tmp/soma/verify/overview.png
OK sync-pipeline: last success 0.6 h ago (limit 6 h)
OK strava-bridge: last success 11.7 h ago (limit 18 h)
```
Screenshot read back: live Steps 983 / Active Cal 40 / RHR 49 / VO₂max 51.0 / HRV 71 / 1,096 activities; react-native-svg sparklines and the native tab bar render on device.

## Guardrails

- [x] Sync pipeline / Strava bridge untouched (sync-health.sh is read-only: `gh run list`).
- [x] hevy2garmin not touched.
- [x] Nutrition logging untouched.
- [x] Garmin token store untouched. The API token lives in `~/.config/soma/app.env` (chmod 600), by reference, never committed.
- [x] No web-only feature introduced or dropped.

## Gotchas learned (also in the plan)
`expo run:android --device` wants the AVD name, not the adb serial · Maestro 2 needs `JAVA_HOME`=openjdk@17 (a non-interactive shell here defaults to JDK 8) · below-fold markers need `scrollUntilVisible` · two stdin redirects made a python check exit 0 with no output (a green check over a hole) — fixed by passing JSON as an argument.

Closes #638
Closes #639
Closes #640
Closes #641
