### PR TITLE
feat(app): daemon base URL for the Live DJ + daemon host on screen; flows cold-open via deep link (T2.2)

### DIFF
--- a/universal/.maestro/verify-builder-save.yaml
+++ b/universal/.maestro/verify-builder-save.yaml
@@ -10,9 +10,9 @@ tags:
   - verify
   - mutation
 ---
-- launchApp
-- waitForAnimationToEnd:
-    timeout: 10000
+# No launchApp: Maestro's launch hangs forever on ColorOS (the OPPO), while a deep link
+# starts the app instantly everywhere. stopApp first so every run is a cold open.
+- stopApp
 - openLink: ${ROUTE}
 - waitForAnimationToEnd:
     timeout: 10000

--- a/universal/.maestro/verify-screen.yaml
+++ b/universal/.maestro/verify-screen.yaml
@@ -16,9 +16,9 @@ name: Soma verify screen
 tags:
   - verify
 ---
-- launchApp
-- waitForAnimationToEnd:
-    timeout: 10000
+# No launchApp: Maestro's launch hangs forever on ColorOS (the OPPO), while a deep link
+# starts the app instantly everywhere. stopApp first so every run is a cold open.
+- stopApp
 - openLink: ${ROUTE}
 - waitForAnimationToEnd:
     timeout: 10000

--- a/universal/src/app/(main)/live-dj.tsx
+++ b/universal/src/app/(main)/live-dj.tsx
@@ -6,6 +6,7 @@ import {
   fetchDjStatus, fetchDjHrDefaults, startDj, stopDj, fetchGenres, fetchSpotifyPlaylists,
   type DjStatus, type DjStartBody, type GenreBucket, type SpotifyPlaylistMeta,
 } from "../../lib/playlist";
+import { DAEMON_HOST } from "../../lib/api";
 
 /* Offset modes — verbatim from web live-dj-tab.tsx. */
 type OffsetMode = "pump_up" | "normal" | "wind_down";
@@ -124,6 +125,8 @@ export default function LiveDjScreen() {
         <Text variant="caption" className="text-text-secondary">
           Polls your Garmin HR in real time and automatically queues songs that match your effort.
         </Text>
+        {/* Where the DJ actually runs (T2): the daemon host behind tailscale serve, and its live state. */}
+        <Text variant="micro" className="text-text-muted">Daemon: {DAEMON_HOST} · {status.state}</Text>
 
         {ctrlErr ? <Card><Text variant="micro" className="text-danger">{ctrlErr}</Text></Card> : null}
 

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -2,6 +2,14 @@ import { useCallback, useEffect, useState } from "react";
 
 export const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
 
+/** Daemon-class routes (Live DJ today, chat next) run on the Mac behind `tailscale serve`,
+ *  never on Vercel: the DJ is a detached process with local status files. EXPO_PUBLIC_DAEMON_URL
+ *  points the app there (e.g. https://gkos-mac.taile2630d.ts.net:8448); unset → same host as
+ *  the API, which is right for local dev and honest for prod (the call then fails visibly). */
+export const DAEMON_BASE = process.env.EXPO_PUBLIC_DAEMON_URL ?? API_BASE;
+/** Host shown on the Live DJ screen so it is never a mystery where the DJ runs. */
+export const DAEMON_HOST = DAEMON_BASE.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+
 /** Personal API token for prod (soma.gkos.dev gates /api/* behind a session;
     the token bypasses that for this native client). Empty in local dev. */
 const API_TOKEN = process.env.EXPO_PUBLIC_API_TOKEN;
@@ -24,14 +32,19 @@ export function workoutImageSource(workoutId: string) {
  * relative to API_BASE.
  */
 export async function fetchJson<T>(path: string, retries = 1): Promise<T> {
+  return fetchJsonFrom<T>(API_BASE, path, retries);
+}
+
+/** Same as fetchJson but against an explicit base (API_BASE or DAEMON_BASE). */
+export async function fetchJsonFrom<T>(base: string, path: string, retries = 1): Promise<T> {
   try {
-    const r = await fetch(`${API_BASE}${path}`, { headers: AUTH_HEADERS });
+    const r = await fetch(`${base}${path}`, { headers: AUTH_HEADERS });
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return (await r.json()) as T;
   } catch (e) {
     if (retries > 0) {
       await new Promise((res) => setTimeout(res, 600));
-      return fetchJson<T>(path, retries - 1);
+      return fetchJsonFrom<T>(base, path, retries - 1);
     }
     throw e;
   }

--- a/universal/src/lib/playlist.ts
+++ b/universal/src/lib/playlist.ts
@@ -6,7 +6,7 @@
  * a real ReadableStream unlike RN's global fetch), and exposes GET helpers.
  */
 import { fetch as streamFetch } from "expo/fetch";
-import { API_BASE, AUTH_HEADERS, fetchJson } from "./api";
+import { API_BASE, AUTH_HEADERS, fetchJson, DAEMON_BASE, fetchJsonFrom } from "./api";
 
 export const SEGMENT_TYPES = [
   "warmup", "easy", "aerobic", "tempo", "interval",
@@ -298,7 +298,8 @@ export interface DjStatus {
 export interface DjStartBody { hr_rest: number; hr_max: number; offset: number; genres: string[]; sources: string[] }
 export interface DjControlResult { ok: boolean; status: number; pid?: number; alreadyRunning?: boolean; error?: string }
 
-export const fetchDjStatus = () => fetchJson<DjStatus>(`/api/playlist/dj/status`);
+// The DJ runs on the daemon host (Mac behind tailscale serve); hr-defaults is DB-backed → API host.
+export const fetchDjStatus = () => fetchJsonFrom<DjStatus>(DAEMON_BASE, `/api/playlist/dj/status`);
 export const fetchDjHrDefaults = () => fetchJson<{ hr_rest?: number | null; hr_max?: number | null }>(`/api/playlist/dj/hr-defaults`);
 export interface SpotifyPlaylistMeta { id: string; name: string; tracks: number }
 export const fetchSpotifyPlaylists = () => fetchJson<SpotifyPlaylistMeta[]>(`/api/playlist/spotify/playlists`);
@@ -347,7 +348,7 @@ export async function analyseLibrary(sourceIds: string[], onEvent: (e: AnalyseEv
 
 async function djPost(path: string, body?: unknown): Promise<DjControlResult> {
   try {
-    const res = await fetch(`${API_BASE}${path}`, {
+    const res = await fetch(`${DAEMON_BASE}${path}`, {
       method: "POST", headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
       body: body != null ? JSON.stringify(body) : undefined,
     });


### PR DESCRIPTION
## The sentence

```
For RESOURCE      service://soma-dj on node://gkos-mac,
  soma knows PROPERTIES daemon_url := EXPO_PUBLIC_DAEMON_URL (declared at build time; shown on the Live DJ screen) and state := stopped|starting|running|error (observed by dj/status),
  and can do CAPABILITY dj.status.read; tier none; executor script; reversible; shared; interactive
  when INTENT is minted by the Live DJ screen opening,
  producing EVENTS dj.status.read; actor app; origin observed; success|failure,
  so that DERIVED STATE dj_status = the newest reading from the daemon host — no stored flag,
  rendered at TOUCHPOINTS the Live DJ screen: "Daemon: <host> · <state>" (render only),
  governed by POLICY dj-calls-go-to-the-daemon-host-never-to-vercel.
```

## Done is an observation, not a claim

`verify_cmd` (on the phone over Tailscale, the only device on the tailnet):
```bash
ANDROID_SERIAL=100.99.159.74:5555 universal/scripts/verify-device.sh live-dj --marker "Daemon: gkos-mac.taile2630d.ts.net:8448 · $(state read from the daemon)"
for s in overview nutrition running workouts sleep activities training connections playlist playlist-builder live-dj more; do ANDROID_SERIAL=100.99.159.74:5555 universal/scripts/verify-device.sh $s; done
```
- [x] Ran on the OPPO (CPH2791, Android 16) with the release build carrying EXPO_PUBLIC_DAEMON_URL, owner's account.
- [x] Reads real: the marker's state came from `GET dj/status` on the daemon over the tailnet, moments before the screen was read.
- [x] External writes: none.

```
FAILED overview (maestro rc=1): '983' NOT seen on 100.99.159.74:5555
VERIFIED nutrition: 'Copy yesterday' visible on 100.99.159.74:5555
VERIFIED running: '45 runs · 314 km' visible on 100.99.159.74:5555
VERIFIED workouts: '335 workouts logged' visible on 100.99.159.74:5555
VERIFIED sleep: '2.5h–9.6h' visible on 100.99.159.74:5555
VERIFIED activities: '21,540' visible on 100.99.159.74:5555
VERIFIED training: 'Readiness green' visible on 100.99.159.74:5555
VERIFIED connections: '411' visible on 100.99.159.74:5555
HARNESS ERROR playlist (not a verification result): maestro could not run
HARNESS ERROR playlist-builder (not a verification result): maestro could not run
HARNESS ERROR live-dj (not a verification result): maestro could not run
VERIFIED more: 'BPM-matched running playlists' visible on 100.99.159.74:5555
daemon says: host=gkos-mac.taile2630d.ts.net:8448 state=stopped
VERIFIED live-dj: 'Daemon: gkos-mac.taile2630d.ts.net:8448 · stopped' visible on 100.99.159.74:5555
VERIFIED overview: '983' visible on 100.99.159.74:5555
VERIFIED playlist: '4,162' visible on 100.99.159.74:5555
VERIFIED playlist-builder: 'Athens Running' visible on 100.99.159.74:5555
```

## Guardrails
- [x] Sync pipeline untouched. - [x] hevy2garmin untouched. - [x] Nutrition untouched. - [x] Garmin token store untouched. - [x] No web-only feature introduced or dropped (the daemon host line is app-only and additive).

Closes #667
Closes #653
