### PR TITLE
fix(gate): never take over a phone that is in use

### DIFF
--- a/universal/scripts/verify-device.sh
+++ b/universal/scripts/verify-device.sh
@@ -74,6 +74,16 @@ if [ "$DRY" != 1 ]; then
   fi
 fi
 
+# 1c. Never hijack a phone that is in use. If a third-party app is in the foreground (not soma,
+# not the launcher, not the lockscreen) the owner is using it — e.g. Maps while driving — and a
+# deep link would pull soma over it. That is a harness error, and it says why.
+if [ "$DRY" != 1 ]; then
+  FG="$($ADB -s "$DEV" shell dumpsys window 2>/dev/null | grep -oE 'mCurrentFocus=Window\{[^}]*\}' | head -1 | sed -E 's/.* ([a-zA-Z0-9_.]+)\/.*/\1/')"
+  case "$FG" in ""|dev.gkos.soma|*launcher*|*Launcher*|*nexuslauncher*|*home*) ;;
+    *) echo "HARNESS ERROR $SCREEN (not a verification result): $DEV is in use ($FG is in the foreground) — not taking it over; re-run when the phone is free"; exit 2;;
+  esac
+fi
+
 # 2. The marker: a value the screen must render, fetched LIVE from the real API.
 api() { curl -sf -m 30 -H "Authorization: Bearer $EXPO_PUBLIC_API_TOKEN" "$EXPO_PUBLIC_API_URL$1"; }
 # One marker per screen, formatted EXACTLY as the screen formats it (JS toFixed = round


### PR DESCRIPTION
## The sentence
For `device://phone`, soma knows `in_use := true|false` (observed from the foreground window), and can do `verify_screen` only when `in_use = false` (tier none; executor script; reversible; exclusive with the owner's own use; interactive), producing `soma.screen.verified` or `harness.refused` (observed), so that `screen_at_parity` is never derived from a run that hijacked the device, rendered at the harness output, governed by policy a-person-using-the-phone-always-wins.

## Done is an observation, not a claim
```
emulator-5554: VERIFIED more: 'BPM-matched running playlists' visible      # guard does not trip on a free device
```
The refusing path is not exercised on purpose: it would require using the owner's phone while it is in use. The check is a read of the foreground window before any action.
- [x] Reads real; no external writes.

## Guardrails
- [x] Sync pipeline untouched. - [x] hevy2garmin untouched. - [x] Nutrition untouched. - [x] Garmin token store untouched. - [x] No web-only feature introduced or dropped.

Closes #675
