### PR TITLE
fix(app): Research… row above the compose picker list

### DIFF
--- a/universal/src/components/compose-meal-view.tsx
+++ b/universal/src/components/compose-meal-view.tsx
@@ -295,6 +295,11 @@ export function ComposeMealView({
         onChangeText={setSearch}
         className="rounded-md border border-border-subtle px-3 py-2 text-text"
       />
+      {/* T3a: the catalog is not the world. Research a food from USDA / Open Food Facts and confirm it — above the
+          list so it is reachable without scrolling 80+ rows (a person or a Maestro flow). */}
+      <Pressable testID="research-row" onPress={() => setResearchOpen(true)} className="flex-row items-center gap-2 py-1">
+        <Text variant="caption" className="text-teal">{search.trim() ? `Not finding it? Research “${search.trim()}”…` : "Not finding it? Research an ingredient…"}</Text>
+      </Pressable>
       <ScrollView className="max-h-72" keyboardShouldPersistTaps="handled">
         {groups.length === 0 ? (
           <Text variant="caption" className="text-text-muted">No ingredients match.</Text>
@@ -312,10 +317,6 @@ export function ComposeMealView({
             })}
           </View>
         ))}
-        {/* T3a: the catalog is not the world. Research a food from USDA / Open Food Facts and confirm it. */}
-        <Pressable testID="research-row" onPress={() => setResearchOpen(true)} className="mt-1 flex-row items-center gap-2 py-2">
-          <Text variant="caption" className="text-teal">{search.trim() ? `Not finding it? Research “${search.trim()}”…` : "Not finding it? Research an ingredient…"}</Text>
-        </Pressable>
       </ScrollView>
       <IngredientResearchSheet
         visible={researchOpen}


### PR DESCRIPTION
## The sentence
For `screen://nutrition/compose`, the research affordance is rendered ABOVE the ingredient list (declared here; observed by the device flow `.maestro/verify-ingredient-research.yaml`, which taps it without scrolling), so that `screen_at_parity` for #685 is derived from the layout that was verified.

## Done is an observation
- [x] The device runs of #685 (halloumi, tahini) executed with this exact file; #685 merged the earlier position by my omission (uncommitted working-tree change).
- [x] `cd universal && npx tsc --noEmit` clean.

## Guardrails
- [x] Sync / hevy2garmin / nutrition logging / Garmin token store untouched. - [x] App-only layout tweak; the web picker already places its link outside the list.

Closes #686
