### PR TITLE
chore(gate): device flows for the pump-up bank and library analysis — T1.2 verified

### DIFF
--- a/universal/.maestro/verify-builder-bank.yaml
+++ b/universal/.maestro/verify-builder-bank.yaml
@@ -1,0 +1,36 @@
+# T1.2 — a REAL mutation on device: generate from the newest run, bank the first song (⚡) into the pump-up bank.
+#   universal/scripts/verify-device.sh playlist-builder --flow .maestro/verify-builder-bank.yaml --marker "to the bank" --env "RUN=<newest run name>"
+appId: dev.gkos.soma
+name: Soma builder → bank a song
+tags: [verify, mutation]
+---
+- stopApp
+- openLink: ${ROUTE}
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${RUN}"
+    timeout: 30000
+- tapOn:
+    text: "${RUN}"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      text: "Generated"
+    timeout: 180000
+# The per-song ⚡ is the exact text "⚡"; the header "⚡ Bank" does not match an exact "⚡".
+- scrollUntilVisible:
+    element:
+      text: "⚡"
+    direction: DOWN
+    timeout: 30000
+    speed: 30
+- tapOn:
+    text: "⚡"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 15000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/.maestro/verify-library-analyse.yaml
+++ b/universal/.maestro/verify-library-analyse.yaml
@@ -1,0 +1,34 @@
+# T1.2 — a REAL long job on device: Analyse library (Spotify reads + DB writes) from the Sources modal, wait for "Done".
+#   universal/scripts/verify-device.sh playlist-builder --flow .maestro/verify-library-analyse.yaml --marker "new tracks analysed" --env "RUN=<newest run name>"
+appId: dev.gkos.soma
+name: Soma builder → analyse library
+tags: [verify, mutation, slow]
+---
+- stopApp
+- openLink: ${ROUTE}
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${RUN}"
+    timeout: 30000
+- tapOn:
+    text: "${RUN}"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      text: "Generated"
+    timeout: 180000
+- tapOn:
+    text: "Sources [(].*"
+- extendedWaitUntil:
+    visible:
+      text: "${ANALYSE}"
+    timeout: 20000
+- tapOn:
+    text: "${ANALYSE}"
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 600000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/scripts/verify-device.sh
+++ b/universal/scripts/verify-device.sh
@@ -173,9 +173,10 @@ if [ $RC -eq 0 ]; then
 fi
 # Distinguish "the harness could not run" from "the screen did not show the marker".
 # An infra failure must never masquerade as a verification result (exit 2 vs 1).
-if ! grep -qE "COMPLETED|FAILED" "$OUT/$SCREEN.maestro.log" || grep -qiE "Java 17|No devices|Unable to connect|not found|Failed to connect|maestro: command|unbound variable|syntax error" "$OUT/$SCREEN.maestro.log"; then
+# "not found" alone is NOT a harness error: Maestro's ordinary assertion failure says "Element not found".
+if ! grep -qE "COMPLETED|FAILED" "$OUT/$SCREEN.maestro.log" || grep -qiE "Java 17|No devices|Unable to connect|device .* not found|Failed to connect|maestro: command not found|unbound variable|syntax error|Parsing Failed" "$OUT/$SCREEN.maestro.log"; then
   echo "HARNESS ERROR $SCREEN (not a verification result): maestro could not run — see $OUT/$SCREEN.maestro.log"
-  grep -iE "Java 17|No devices|Unable to connect|not found|Failed to connect|unbound variable|syntax error" "$OUT/$SCREEN.maestro.log" | head -3
+  grep -iE "Java 17|No devices|Unable to connect|device .* not found|Failed to connect|maestro: command not found|unbound variable|syntax error|Parsing Failed" "$OUT/$SCREEN.maestro.log" | head -3
   exit 2
 fi
 echo "FAILED $SCREEN (maestro rc=$RC): '$MARKER' NOT seen on $DEV — see $OUT/$SCREEN.maestro.log and $OUT/$SCREEN.png"


### PR DESCRIPTION
## The sentence
For `flow://playlist-builder/{bank,analyse}`, soma knows `banked := true|false` and `library_analysed_at` (observed on the emulator with the owner's account and read back from `/api/playlist/pump-up` and `/api/playlist/spotify/library`), and can do `verify_mutation` (tier none for the bank — a row in the owner's own DB; tier none for analyse — Spotify READS + our DB; executor script; reversible; shared; batch) when the owner's standing policy allows real reads and Spotify-side writes, producing `soma.mutation.verified` (observed), so that `mutation_at_parity` = "the flow returned 0 AND the API read shows the change", rendered at the PR body, governed by policy garmin-writes-never-real-without-a-go.

## Done is an observation, not a claim
```bash
EXPO_PUBLIC_API_URL=http://127.0.0.1:3456 universal/scripts/verify-device.sh playlist-builder --flow .maestro/verify-builder-bank.yaml --marker "to the bank" --env "RUN=<newest run>"
EXPO_PUBLIC_API_URL=http://127.0.0.1:3456 universal/scripts/verify-device.sh playlist-builder --flow .maestro/verify-library-analyse.yaml --marker "new tracks analysed" --env "RUN=<newest run>" --env "ANALYSE=Analyse library.*"
```
- [x] Ran on emulator-5554 (release build against the Mac host, owner's account). Reads real; writes: one pump-up bank row and the library analysis's own rows in the owner's DB. No Garmin writes.

```
VERIFIED playlist-builder: 'to the bank' visible on emulator-5554 — evidence /tmp/soma/verify/playlist-builder.png
bank after: 2 | newest: Let The Sunshine In (Reprise) - Remastered 2000 - The 5th Dimension
VERIFIED playlist-builder: 'new tracks analysed' visible on emulator-5554 — evidence /tmp/soma/verify/playlist-builder.png
library API: before 4162 total / 2798 with BPM / last_synced 2026-02-28 → after the first device run: 4186 total / 2818 with BPM / last_synced 2026-09-03T17:21:46Z (the real analysis); the second run verified the UI reaching Done on the cached library
```

## Guardrails
- [x] Sync pipeline untouched. - [x] hevy2garmin untouched. - [x] Nutrition untouched. - [x] Garmin token store untouched. - [x] No web-only feature introduced or dropped (flows only).

Closes #652
