### PR TITLE
fix(web): chat-tunnel token as an explicit middleware boundary on /api/chat*

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -31,6 +31,16 @@ function hasApiToken(req: { headers: Headers }): boolean {
   return req.headers.get("authorization") === `Bearer ${token}`;
 }
 
+/** Does the request carry the shared chat-tunnel token? The Vercel proxy sets it on every
+    forwarded /api/chat* request (chat-transport.ts). Scoped to /api/chat* only; the chat routes
+    validate it again (requireToken). Without this, the tunnel only worked while DEMO_MODE let
+    anonymous requests through — the demo gate was doing the boundary's job (soma#671). */
+function hasChatToken(req: { headers: Headers }): boolean {
+  const token = process.env.SOMA_CHAT_TOKEN?.trim();
+  if (!token) return false;
+  return req.headers.get("x-soma-chat-token") === token;
+}
+
 export default auth((req) => {
   const { pathname } = req.nextUrl;
   const isApi = pathname.startsWith("/api/");
@@ -41,6 +51,9 @@ export default auth((req) => {
 
   // Personal API token: native apps + widgets reach /api/* without a session.
   if (isApi && hasApiToken(req)) return withTokenCors(NextResponse.next());
+
+  // Chat tunnel: the shared chat token reaches /api/chat* without a session or demo mode.
+  if (isApi && pathname.startsWith("/api/chat") && hasChatToken(req)) return NextResponse.next();
 
   // Demo mode: READ-ONLY. Reads and page views need no auth, but every /api/*
   // handler runs auth-less here, so an anonymous visitor could otherwise POST/


### PR DESCRIPTION
## The sentence
For `edge://api/chat` on the Mac host, soma knows `caller := proxy|owner|anonymous` (observed from the request: X-Soma-Chat-Token = proxy, bearer/session = owner), and can do `handle_chat` (tier none; executor script; reversible; shared; realtime) only for proxy or owner, producing `chat.request` (commanded), so that `chat_reachable_via_tunnel` = "a chat-token request returns 200 while an anonymous one is redirected", rendered nowhere, governed by policy a-demo-flag-is-never-the-boundary.

## Done is an observation
```
non-demo :3457 — GET /api/chat/session: chat token -> 200 | wrong token -> 307 | none -> 307 ; GET /api/health/today with the chat token (out of scope) -> 307
```
- [x] After merge: `~/.config/soma/deploy-main.sh` updates the pinned host and `chat.gkos.dev/api/chat/session` with the chat token must return 200 (posted on the issue).

## Guardrails
- [x] Sync pipeline / hevy2garmin / nutrition / Garmin token store untouched. - [x] Scoped to /api/chat*; the personal bearer and session paths are unchanged.

Closes #689
