### PR TITLE
fix(training): readiness "unknown" when last night is missing; overrides and graph use same-day inputs (#647)

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -132,6 +132,7 @@ const TL_COLOR: Record<string, string> = {
   amber: "#e0a458",
   yellow: "#e0a458",
   red: "#e06060",
+  unknown: "#9aa3ad",
 };
 
 function formDescriptor(tsb: number): string {
@@ -228,7 +229,11 @@ export default function OverviewScreen() {
                 <Badge label={readiness.traffic_light.toUpperCase()} tone={TL_TONE[readiness.traffic_light] ?? "teal"} />
               </View>
               <View className="flex-row items-end gap-2">
-                {readiness.composite_score != null && readiness.composite_score > 0 ? (
+                {readiness.traffic_light === "unknown" ? (
+                  <Text variant="caption" className="text-text-muted">
+                    No sleep data for last night — readiness unknown until the watch syncs a night.
+                  </Text>
+                ) : readiness.composite_score != null && readiness.composite_score > 0 ? (
                   <>
                     <Text variant="display" style={{ color: TL_COLOR[readiness.traffic_light] ?? "#77c8d1" }}>
                       {readinessScore(readiness.composite_score)}

--- a/web/app/api/training/breakdown/route.ts
+++ b/web/app/api/training/breakdown/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: Request) {
 
   const sql = getDb();
   const [readiness] = await sql`
-    SELECT traffic_light, composite_score, hrv_z_score, sleep_z_score, rhr_z_score, body_battery_z_score
+    SELECT traffic_light, composite_score, hrv_z_score, sleep_z_score, rhr_z_score, body_battery_z_score, flags
     FROM daily_readiness WHERE date = ${date}
   `;
   const [pmc] = await sql`
@@ -22,7 +22,11 @@ export async function GET(request: Request) {
 
   return NextResponse.json({
     date,
-    readiness: readiness || null,
+    // No row for the date = nothing to score yet: say "unknown", never nothing (#647).
+    readiness: readiness || {
+      traffic_light: "unknown", composite_score: null, hrv_z_score: null, sleep_z_score: null,
+      rhr_z_score: null, body_battery_z_score: null, flags: ["no_data"],
+    },
     pmc: pmc || null,
     fitness: fitness || null,
   });

--- a/web/app/api/training/forward-sim/route.ts
+++ b/web/app/api/training/forward-sim/route.ts
@@ -99,7 +99,7 @@ export async function GET() {
   const pmc = pmcRows[0] ?? { ctl: 0, atl: 0, tsb: 0 };
   const fitness = fitnessRows[0] ?? { vo2max: 47, vdot_adjusted: 47, weight_kg: 80.5 };
   const banister = banisterRows[0] ?? { p0: 0, k1: 0.05, k2: 0.08, tau1: 42, tau2: 7, n_anchors: 0, current_vdot: 0 };
-  const readiness = readinessRows[0] ?? { composite_score: 0, traffic_light: "green", flags: [] };
+  const readiness = readinessRows[0] ?? { composite_score: null, traffic_light: "unknown", flags: [] };
   const calib = calibRows[0] ?? { phase: 1, data_days: 0, weights: { hrv: 0.25, sleep: 0.25, rhr: 0.25, bb: 0.25 }, force_equal: false };
 
   // Race-calibrated VDOT from Banister model — no Garmin fallback

--- a/web/app/api/training/graph/route.ts
+++ b/web/app/api/training/graph/route.ts
@@ -66,6 +66,7 @@ export async function GET(request: Request) {
           (SELECT sleep_time_seconds FROM daily_health_summary WHERE date <= ${date} AND sleep_time_seconds IS NOT NULL ORDER BY date DESC LIMIT 1) as sleep_time_seconds,
           (SELECT resting_heart_rate FROM daily_health_summary WHERE date <= ${date} AND resting_heart_rate IS NOT NULL ORDER BY date DESC LIMIT 1) as resting_heart_rate,
           (SELECT date::text FROM daily_health_summary WHERE date <= ${date} ORDER BY date DESC LIMIT 1) as data_date,
+          (SELECT avg_overnight_hrv FROM daily_health_summary WHERE date = ${date}) as avg_overnight_hrv_today,
           (SELECT sleep_time_seconds FROM daily_health_summary WHERE date = ${date}) as sleep_time_seconds_today,
           (SELECT body_battery_at_wake FROM daily_health_summary WHERE date = ${date}) as body_battery_at_wake_today,
           (SELECT date::text FROM daily_health_summary WHERE date <= ${date} AND sleep_time_seconds IS NOT NULL ORDER BY date DESC LIMIT 1) as sleep_data_date
@@ -105,10 +106,11 @@ export async function GET(request: Request) {
   const sleepHours = sleepSec != null ? sleepSec / 3600 : null;
   const rhrRaw = health ? Number(health.resting_heart_rate) || null : null;
   const bbRaw = health ? Number(health.body_battery_at_wake) || null : null;
-  // Same-day inputs for the hard overrides (#647). The raw nodes above fall back to
-  // the latest non-null row for display, but a safety rule must never fire from a
-  // night that is days old. Missing today → the rule stays off and no_sleep_data
+  // Same-day inputs for the hard overrides AND the raw HRV/sleep/body-battery nodes
+  // (#647): the model computation for a date must show that date's inputs, and a
+  // safety rule must never fire from a night that is days old. Missing today → the rule stays off and no_sleep_data
   // says so instead.
+  const hrvToday = health ? Number(health.avg_overnight_hrv_today) || null : null;
   const sleepSecToday = health ? Number(health.sleep_time_seconds_today) || null : null;
   const sleepHoursToday = sleepSecToday != null ? sleepSecToday / 3600 : null;
   const bbToday = health ? Number(health.body_battery_at_wake_today) || null : null;
@@ -190,10 +192,10 @@ export async function GET(request: Request) {
 
   const nodes: GraphNode[] = [
     // Raw layer — raw values don't have a natural neutral; mirror their z-score activation
-    { id: "hrv_raw", column: "raw", label: "HRV (overnight)", value: hrvRaw, unit: "ms", color: colorForNode("hrv_z", hrvZ), normalizedValue: zNorm(hrvZ), tooltip: { ...tooltip("hrv_raw"), inputs: [] } },
-    { id: "sleep_raw", column: "raw", label: "Sleep", value: sleepHours != null ? round(sleepHours, 1) : null, unit: "h", color: colorForNode("sleep_z", sleepZ), normalizedValue: zNorm(sleepZ), tooltip: { ...tooltip("sleep_raw"), inputs: [] } },
+    { id: "hrv_raw", column: "raw", label: "HRV (overnight)", value: hrvToday, unit: "ms", color: colorForNode("hrv_z", hrvZ), normalizedValue: zNorm(hrvZ), tooltip: { ...tooltip("hrv_raw"), inputs: [] } },
+    { id: "sleep_raw", column: "raw", label: "Sleep", value: sleepHoursToday != null ? round(sleepHoursToday, 1) : null, unit: "h", color: colorForNode("sleep_z", sleepZ), normalizedValue: zNorm(sleepZ), tooltip: { ...tooltip("sleep_raw"), inputs: [] } },
     { id: "rhr_raw", column: "raw", label: "RHR", value: rhrRaw, unit: "bpm", color: colorForNode("rhr_z", rhrZ), normalizedValue: zNorm(rhrZ), tooltip: { ...tooltip("rhr_raw"), inputs: [] } },
-    { id: "bb_raw", column: "raw", label: "Body Battery", value: bbRaw, unit: "/100", color: colorForNode("bb_z", bbZ), normalizedValue: zNorm(bbZ), tooltip: { ...tooltip("bb_raw"), inputs: [] } },
+    { id: "bb_raw", column: "raw", label: "Body Battery", value: bbToday, unit: "/100", color: colorForNode("bb_z", bbZ), normalizedValue: zNorm(bbZ), tooltip: { ...tooltip("bb_raw"), inputs: [] } },
     { id: "epoc_raw", column: "raw", label: "EPOC", value: epocRaw, unit: "", color: "oklch(0.7 0.05 250)", normalizedValue: 0, tooltip: { ...tooltip("epoc_raw"), inputs: [] } },
     { id: "weight_raw", column: "raw", label: "Weight", value: weightKg != null ? round(weightKg, 1) : null, unit: "kg", color: "oklch(0.7 0.05 250)", normalizedValue: 0, tooltip: { ...tooltip("weight_raw"), inputs: [] } },
 

--- a/web/app/api/training/graph/route.ts
+++ b/web/app/api/training/graph/route.ts
@@ -65,7 +65,10 @@ export async function GET(request: Request) {
           (SELECT body_battery_max FROM daily_health_summary WHERE date <= ${date} AND body_battery_max IS NOT NULL ORDER BY date DESC LIMIT 1) as body_battery_max,
           (SELECT sleep_time_seconds FROM daily_health_summary WHERE date <= ${date} AND sleep_time_seconds IS NOT NULL ORDER BY date DESC LIMIT 1) as sleep_time_seconds,
           (SELECT resting_heart_rate FROM daily_health_summary WHERE date <= ${date} AND resting_heart_rate IS NOT NULL ORDER BY date DESC LIMIT 1) as resting_heart_rate,
-          (SELECT date::text FROM daily_health_summary WHERE date <= ${date} ORDER BY date DESC LIMIT 1) as data_date
+          (SELECT date::text FROM daily_health_summary WHERE date <= ${date} ORDER BY date DESC LIMIT 1) as data_date,
+          (SELECT sleep_time_seconds FROM daily_health_summary WHERE date = ${date}) as sleep_time_seconds_today,
+          (SELECT body_battery_at_wake FROM daily_health_summary WHERE date = ${date}) as body_battery_at_wake_today,
+          (SELECT date::text FROM daily_health_summary WHERE date <= ${date} AND sleep_time_seconds IS NOT NULL ORDER BY date DESC LIMIT 1) as sleep_data_date
       `.catch(() => []),
       sql`
         SELECT phase, data_days, weights, force_equal
@@ -102,6 +105,14 @@ export async function GET(request: Request) {
   const sleepHours = sleepSec != null ? sleepSec / 3600 : null;
   const rhrRaw = health ? Number(health.resting_heart_rate) || null : null;
   const bbRaw = health ? Number(health.body_battery_at_wake) || null : null;
+  // Same-day inputs for the hard overrides (#647). The raw nodes above fall back to
+  // the latest non-null row for display, but a safety rule must never fire from a
+  // night that is days old. Missing today → the rule stays off and no_sleep_data
+  // says so instead.
+  const sleepSecToday = health ? Number(health.sleep_time_seconds_today) || null : null;
+  const sleepHoursToday = sleepSecToday != null ? sleepSecToday / 3600 : null;
+  const bbToday = health ? Number(health.body_battery_at_wake_today) || null : null;
+  const sleepDataDate: string | null = (health as any)?.sleep_data_date ?? null;
   const epocRaw = pmc ? Number(pmc.daily_load) || null : null;
   const weightKg = fitness ? Number(fitness.weight_kg) || null : null;
 
@@ -299,18 +310,25 @@ export async function GET(request: Request) {
 
   // ─── Build overrides ──────────────────────────────────────
 
-  const flags: string[] = readiness?.flags ?? [];
+  // Flags only count when the readiness row is the requested day's (#647).
+  const flags: string[] = (readiness as any)?.data_date === date ? (readiness?.flags ?? []) : [];
   const overrides: Override[] = [
     {
+      rule: "no_sleep_data",
+      triggered: sleepHoursToday == null,
+      message: `No sleep data for ${date}${sleepDataDate ? ` (last night recorded: ${sleepDataDate})` : ""} — readiness unknown.`,
+      severity: "yellow",
+    },
+    {
       rule: "sleep_under_5h",
-      triggered: sleepHours != null && sleepHours < 5.0,
-      message: `Sleep under 5 hours (${sleepHours != null ? sleepHours.toFixed(1) : "?"}h) — forced RED.`,
+      triggered: sleepHoursToday != null && sleepHoursToday < 5.0,
+      message: `Sleep under 5 hours (${sleepHoursToday != null ? sleepHoursToday.toFixed(1) : "?"}h) — forced RED.`,
       severity: "red",
     },
     {
       rule: "body_battery_critical",
-      triggered: bbRaw != null && bbRaw < 25,
-      message: `Body Battery at wake < 25 (${bbRaw ?? "?"}) — forced RED.`,
+      triggered: bbToday != null && bbToday < 25,
+      message: `Body Battery at wake < 25 (${bbToday ?? "?"}) — forced RED.`,
       severity: "red",
     },
     {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -493,7 +493,8 @@ async function getLatestSleep() {
     SELECT
       (raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::int as total,
       (raw_json->'dailySleepDTO'->'sleepScores'->'overall'->>'value')::int as score,
-      (raw_json->'dailySleepDTO'->'sleepScores'->'overall'->>'qualifierKey') as quality
+      (raw_json->'dailySleepDTO'->'sleepScores'->'overall'->>'qualifierKey') as quality,
+      date::text as date
     FROM garmin_raw_data
     WHERE endpoint_name = 'sleep_data'
       AND (raw_json->'dailySleepDTO'->>'sleepTimeSeconds')::int > 0
@@ -873,7 +874,15 @@ export default async function HomePage({
               const secs = health?.sleep_time_seconds || latestSleep?.total;
               return secs ? `${(secs / 3600).toFixed(1)}h` : "—";
             })(),
-            subtitle: latestSleep?.score ? `Score: ${latestSleep.score}` : undefined,
+            // The value falls back to the latest recorded night; say WHEN that was
+            // once it is older than last night, instead of passing it off as today's (#647).
+            subtitle: (() => {
+              const score = latestSleep?.score ? `Score: ${latestSleep.score}` : "";
+              const yesterday = new Date(Date.now() - 86_400_000).toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+              const stale = !health?.sleep_time_seconds && latestSleep?.date && latestSleep.date < yesterday;
+              const when = stale ? `last recorded ${latestSleep.date}` : "";
+              return [score, when].filter(Boolean).join(" · ") || undefined;
+            })(),
             icon: <Moon className="h-4 w-4 text-indigo-400" />,
             info: "Total sleep time from Garmin sleep tracking. Recommended: 7-9 hours",
             trend: sleepTrendPct != null ? { value: sleepTrendPct, label: "7-day avg vs prior week" } : null,

--- a/web/app/training/page.tsx
+++ b/web/app/training/page.tsx
@@ -50,6 +50,9 @@ async function getRaceInfo() {
 
 async function getReadiness() {
   const sql = getDb();
+  // Today's row only: readiness is about last night, so an older row is not a
+  // fallback — with no row the card says "No readiness data" (#647).
+  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
   const rows = await safeQuery(
     () => sql`
       SELECT r.composite_score, r.traffic_light,
@@ -57,7 +60,7 @@ async function getReadiness() {
              h.training_readiness_level AS garmin_readiness_level
       FROM daily_readiness r
       LEFT JOIN daily_health_summary h ON r.date = h.date
-      ORDER BY r.date DESC
+      WHERE r.date = ${today}
       LIMIT 1
     `,
     [],

--- a/web/components/readiness-card.tsx
+++ b/web/components/readiness-card.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Activity } from "lucide-react";
 
 interface ReadinessData {
-  composite_score: number;
+  composite_score: number | null;
   traffic_light: string;
   hrv_z_score: number | null;
   sleep_z_score: number | null;
@@ -17,6 +17,7 @@ const lightColors: Record<string, string> = {
   green: "oklch(62% 0.17 142)",
   yellow: "oklch(80% 0.18 87)",
   red: "oklch(60% 0.22 25)",
+  unknown: "oklch(60% 0.02 250)",
 };
 
 function ZBar({ label, value }: { label: string; value: number | null }) {
@@ -92,7 +93,7 @@ export function ReadinessCard({ data, garminScore, garminLevel }: ReadinessCardP
     );
   }
 
-  const color = lightColors[data.traffic_light] || lightColors.green;
+  const color = lightColors[data.traffic_light] || lightColors.unknown;
   const flags = typeof data.flags === "string" ? JSON.parse(data.flags) : data.flags || [];
 
   return (
@@ -110,16 +111,17 @@ export function ReadinessCard({ data, garminScore, garminLevel }: ReadinessCardP
             style={{ backgroundColor: color }}
           >
             <span className="text-xs font-bold text-white uppercase">
-              {data.traffic_light === "green" ? "GO" : data.traffic_light === "yellow" ? "EZ" : "X"}
+              {data.traffic_light === "green" ? "GO" : data.traffic_light === "yellow" ? "EZ" : data.traffic_light === "red" ? "X" : "?"}
             </span>
           </div>
           <div>
             <div className="text-lg font-semibold tabular-nums">
-              {data.composite_score >= 0 ? "+" : ""}
-              {Number(data.composite_score).toFixed(2)}
+              {data.composite_score == null
+                ? "—"
+                : `${data.composite_score >= 0 ? "+" : ""}${Number(data.composite_score).toFixed(2)}`}
             </div>
             <div className="text-[10px] text-muted-foreground capitalize">
-              {data.traffic_light} — {data.traffic_light === "green" ? "train as planned" : data.traffic_light === "yellow" ? "reduce intensity" : "rest or easy only"}
+              {data.traffic_light} — {data.traffic_light === "green" ? "train as planned" : data.traffic_light === "yellow" ? "reduce intensity" : data.traffic_light === "red" ? "rest or easy only" : "no sleep data for last night"}
             </div>
           </div>
         </div>

--- a/web/components/todays-recommendation.tsx
+++ b/web/components/todays-recommendation.tsx
@@ -59,6 +59,10 @@ export function TodaysRecommendation({
   } else if (trafficLight === "yellow") {
     detail = `Readiness YELLOW — keep it easy. ${adjustedPace ? `Target ${formatPace(adjustedPace)}/km` : ""}`;
     bgClass = "bg-yellow-500/5 border-yellow-500/20";
+  } else if (trafficLight === "unknown") {
+    icon = <AlertTriangle className="h-5 w-5 text-muted-foreground" />;
+    detail = "Readiness unknown — no sleep data for last night. Train by feel and keep hard sessions honest.";
+    bgClass = "bg-muted/30 border-muted";
   } else {
     // Green
     if (isHard) {

--- a/web/lib/readiness-stream.test.ts
+++ b/web/lib/readiness-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { zScore, computeReadiness } from "./readiness-stream";
+import { zScore, computeReadiness, computeDailyReadiness } from "./readiness-stream";
+import type { QueryFn } from "./db";
 import golden from "./readiness-stream.golden.json";
 
 const g = golden as any;
@@ -18,5 +19,62 @@ describe("readiness stream — Python parity", () => {
       expect(out.hrv_z_score).toBe(c.v.hrv_z_score);
       expect(out.rhr_z_score).toBe(c.v.rhr_z_score);
     }
+  });
+});
+
+// #647 — a missing night is "unknown", never green; stale nights never fire overrides.
+describe("readiness — missing last night (#647)", () => {
+  it("null sleep_hours → unknown, no_sleep_data, composite null (resting HR alone is not a light)", () => {
+    const out = computeReadiness({ hrv_z: null, sleep_z: null, rhr_z: 1.2, bb_z: null, sleep_hours: null, body_battery_morning: null });
+    expect(out.traffic_light).toBe("unknown");
+    expect(out.flags).toEqual(["no_sleep_data"]);
+    expect(out.composite_score).toBeNull();
+  });
+
+  it("body battery critical still forces red without a night", () => {
+    const out = computeReadiness({ hrv_z: null, sleep_z: null, rhr_z: 0, bb_z: -2, sleep_hours: null, body_battery_morning: 20 });
+    expect(out.traffic_light).toBe("red");
+    expect(out.flags).toEqual(["no_sleep_data", "body_battery_critical"]);
+  });
+
+  it("2-of-4 never downgrades unknown to yellow", () => {
+    const out = computeReadiness({ hrv_z: -1.5, sleep_z: null, rhr_z: -1.5, bb_z: null, sleep_hours: null, body_battery_morning: null });
+    expect(out.traffic_light).toBe("unknown");
+    expect(out.flags).toEqual(["no_sleep_data", "hrv_below_swc"]); // 2_of_4 only ever moves green → yellow
+  });
+
+  it("computeDailyReadiness: an 11-day-old 3.7 h night never triggers sleep_under_5h; a night-less target → unknown", async () => {
+    // Baseline with proper nights up to 08-23 (3.7 h that night), then RHR-only rows,
+    // exactly the shape Garmin produced from 2026-08-24 on.
+    const rows: Record<string, unknown>[] = [];
+    for (let d = 1; d <= 23; d++) {
+      rows.push({ date: `2026-08-${String(d).padStart(2, "0")}`, avg_overnight_hrv: 70, sleep_time_seconds: d === 23 ? 13380 : 25200, resting_heart_rate: 50, body_battery_at_wake: 70 });
+    }
+    for (let d = 24; d <= 31; d++) rows.push({ date: `2026-08-${d}`, avg_overnight_hrv: null, sleep_time_seconds: null, resting_heart_rate: 50, body_battery_at_wake: null });
+    for (let d = 1; d <= 4; d++) rows.push({ date: `2026-09-0${d}`, avg_overnight_hrv: null, sleep_time_seconds: null, resting_heart_rate: 46, body_battery_at_wake: null });
+    const writes: unknown[][] = [];
+    const sql = (async (strings: TemplateStringsArray, ...vals: unknown[]) => {
+      if (strings[0].includes("INSERT INTO daily_readiness")) { writes.push(vals); return []; }
+      return rows;
+    }) as unknown as QueryFn;
+    const out = await computeDailyReadiness(sql, "2026-09-04");
+    expect(out.traffic_light).toBe("unknown");
+    expect(out.flags).toEqual(["no_sleep_data"]);
+    expect(out.composite_score).toBeNull();
+    expect(out.rhr_z_score).not.toBeNull(); // the signal that exists is still scored
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain("unknown"); // what gets persisted is the unknown light
+  });
+
+  it("computeDailyReadiness: no row for the date → unknown / no_target_data, nothing green persisted", async () => {
+    const writes: unknown[][] = [];
+    const sql = (async (strings: TemplateStringsArray, ...vals: unknown[]) => {
+      if (strings[0].includes("INSERT INTO daily_readiness")) { writes.push(vals); return []; }
+      return [{ date: "2026-09-01", avg_overnight_hrv: 70, sleep_time_seconds: 25200, resting_heart_rate: 50, body_battery_at_wake: 70 }];
+    }) as unknown as QueryFn;
+    const out = await computeDailyReadiness(sql, "2026-09-04");
+    expect(out.traffic_light).toBe("unknown");
+    expect(out.flags).toEqual(["no_target_data"]);
+    expect(writes).toHaveLength(0);
   });
 });

--- a/web/lib/readiness-stream.ts
+++ b/web/lib/readiness-stream.ts
@@ -25,17 +25,22 @@ export interface ReadinessSignals {
   sleep_z: number | null;
   rhr_z: number | null;
   bb_z: number | null;
-  sleep_hours: number;
+  /** Last night's sleep in hours; null when the night is missing (#647). */
+  sleep_hours: number | null;
   body_battery_morning?: number | null;
 }
+
+/** "unknown" = last night is missing; never rendered as green. */
+export type TrafficLight = "green" | "yellow" | "red" | "unknown";
 
 export interface Readiness {
   hrv_z_score: number | null;
   sleep_z_score: number | null;
   rhr_z_score: number | null;
   body_battery_z_score: number | null;
-  composite_score: number;
-  traffic_light: "green" | "yellow" | "red";
+  /** null when the light is unknown (no last-night inputs to score). */
+  composite_score: number | null;
+  traffic_light: TrafficLight;
   flags: string[];
 }
 
@@ -49,22 +54,27 @@ export function computeReadiness(signals: ReadinessSignals): Readiness {
   const composite = zValues.length ? zValues.reduce((a, b) => a + b, 0) / zValues.length : 0.0;
 
   const flags: string[] = [];
-  let trafficLight: "green" | "yellow" | "red" = "green";
+  // Last night is the anchor of a readiness call. Without it (watch not worn, sleep
+  // not synced) the light is "unknown" — never green by default (#647). Hard safety
+  // overrides below can still force RED from the inputs that do exist.
+  const unknown = sleep_hours === null || sleep_hours === undefined;
+  let trafficLight: TrafficLight = unknown ? "unknown" : "green";
 
-  if (sleep_hours < 5.0) { flags.push("sleep_under_5h"); trafficLight = "red"; }
+  if (unknown) flags.push("no_sleep_data");
+  else if (sleep_hours < 5.0) { flags.push("sleep_under_5h"); trafficLight = "red"; }
   if (bodyBatteryMorning !== null && bodyBatteryMorning < 25) { flags.push("body_battery_critical"); trafficLight = "red"; }
   if (hrv_z !== null && hrv_z !== undefined && hrv_z < -0.5) flags.push("hrv_below_swc");
 
   const flaggedCount = zValues.filter((z) => z < -1.0).length;
   if (flaggedCount >= 3) { flags.push("3_of_4_flagged"); trafficLight = "red"; }
-  else if (flaggedCount >= 2 && trafficLight !== "red") { flags.push("2_of_4_flagged"); trafficLight = "yellow"; }
+  else if (flaggedCount >= 2 && trafficLight === "green") { flags.push("2_of_4_flagged"); trafficLight = "yellow"; }
 
   return {
     hrv_z_score: hrv_z,
     sleep_z_score: sleep_z,
     rhr_z_score: rhr_z,
     body_battery_z_score: bb_z,
-    composite_score: r(composite, 4),
+    composite_score: trafficLight === "unknown" ? null : r(composite, 4),
     traffic_light: trafficLight,
     flags,
   };
@@ -87,7 +97,7 @@ export async function computeDailyReadiness(sql: QueryFn, targetDate: string): P
 
   const noData = (flag: string): Readiness => ({
     hrv_z_score: null, sleep_z_score: null, rhr_z_score: null, body_battery_z_score: null,
-    composite_score: 0.0, traffic_light: "green", flags: [flag],
+    composite_score: null, traffic_light: "unknown", flags: [flag],
   });
   if (!rows.length) return noData("no_data");
 
@@ -110,7 +120,9 @@ export async function computeDailyReadiness(sql: QueryFn, targetDate: string): P
   const rhrZ = rhrRaw !== null ? -rhrRaw : null; // inverted
   const bbZ = todayBb !== null ? zScore(todayBb, baseline("body_battery_at_wake")) : null;
 
-  const sleepHours = todaySleep !== null ? todaySleep / 3600.0 : 8.0;
+  // No default night: a missing sleep_time_seconds stays null and yields "unknown"
+  // (the old 8.0 h stand-in produced a green light from resting HR alone; #647).
+  const sleepHours = todaySleep !== null ? todaySleep / 3600.0 : null;
 
   const result = computeReadiness({
     hrv_z: hrvZ, sleep_z: sleepZ, rhr_z: rhrZ, bb_z: bbZ,

--- a/web/scripts/readiness-recompute.mts
+++ b/web/scripts/readiness-recompute.mts
@@ -1,0 +1,25 @@
+/**
+ * Recompute daily_readiness for a date range with the current rules (#647).
+ *
+ *   cd web && set -a && . ./.env.local && set +a && \
+ *   npx tsx scripts/readiness-recompute.mts 2026-08-22 2026-09-04
+ *
+ * Idempotent upsert — the same write garmin-ingest does for today after every
+ * sync. Use it after a rule change so stored lights match the code.
+ */
+import { getDb } from "../lib/db";
+import { computeDailyReadiness } from "../lib/readiness-stream";
+
+const [from, to] = process.argv.slice(2);
+const isDate = (s: string | undefined) => !!s && /^\d{4}-\d{2}-\d{2}$/.test(s);
+if (!isDate(from) || !isDate(to)) {
+  console.error("usage: readiness-recompute.mts YYYY-MM-DD YYYY-MM-DD");
+  process.exit(2);
+}
+const sql = getDb();
+for (let t = Date.parse(from + "T00:00:00Z"); t <= Date.parse(to + "T00:00:00Z"); t += 86_400_000) {
+  const d = new Date(t).toISOString().slice(0, 10);
+  const r = await computeDailyReadiness(sql, d);
+  console.log(`${d} ${r.traffic_light} composite=${r.composite_score} flags=${JSON.stringify(r.flags)}`);
+}
+process.exit(0);

--- a/web/scripts/verify-web-readiness.mjs
+++ b/web/scripts/verify-web-readiness.mjs
@@ -1,0 +1,18 @@
+// #647 web verification: the training page renders readiness "unknown" (grey "?" card, no stale forced-RED banner,
+// a "No sleep data for <date>" note) against the working-tree server with the API bearer. Prints what it saw.
+import { chromium } from "@playwright/test";
+const base = process.env.BASE || "http://127.0.0.1:3457";
+const browser = await chromium.launch(); const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 }, extraHTTPHeaders: { Authorization: `Bearer ${process.env.SOMA_TOKEN}` } });
+const page = await ctx.newPage();
+try {
+  await page.goto(`${base}/training`, { waitUntil: "networkidle", timeout: 90000 });
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: "/tmp/soma/verify/web-training-647.png", fullPage: false });
+  const body = await page.locator("body").innerText();
+  const pick = (re) => { const m = body.match(re); return m ? m[0] : "(not found)"; };
+  console.log("readiness card:", pick(/Today.s Readiness[\s\S]{0,160}/));
+  console.log("no_sleep banner:", pick(/No sleep data for [^\n]{0,120}/));
+  console.log("forced RED present:", /forced RED/.test(body));
+  console.log("recommendation:", pick(/Readiness unknown[^\n]{0,120}/));
+} catch (e) { console.log("FAILED:", e.message.split("\n")[0]); process.exitCode = 1; }
+finally { await browser.close(); }

--- a/web/scripts/verify-web-readiness.mjs
+++ b/web/scripts/verify-web-readiness.mjs
@@ -1,13 +1,13 @@
 // #647 web verification: the training page renders readiness "unknown" (grey "?" card, no stale forced-RED banner,
 // a "No sleep data for <date>" note) against the working-tree server with the API bearer. Prints what it saw.
 import { chromium } from "@playwright/test";
-const base = process.env.BASE || "http://127.0.0.1:3457";
+const base = process.env.BASE || "http://127.0.0.1:3457", route = process.env.ROUTE || "/training", tag = route.replace(/\W+/g, "") || "overview";
 const browser = await chromium.launch(); const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 }, extraHTTPHeaders: { Authorization: `Bearer ${process.env.SOMA_TOKEN}` } });
 const page = await ctx.newPage();
 try {
-  await page.goto(`${base}/training`, { waitUntil: "networkidle", timeout: 90000 });
+  await page.goto(`${base}${route}`, { waitUntil: "networkidle", timeout: 90000 });
   await page.waitForTimeout(1500);
-  await page.screenshot({ path: "/tmp/soma/verify/web-training-647.png", fullPage: false });
+  await page.screenshot({ path: `/tmp/soma/verify/web-${tag}-647.png`, fullPage: false });
   const body = await page.locator("body").innerText();
   const pick = (re) => { const m = body.match(re); return m ? m[0] : "(not found)"; };
   console.log("readiness card:", pick(/Today.s Readiness[\s\S]{0,160}/));


### PR DESCRIPTION
## Sentence

The owner needs the Training and Overview screens (app + web) to say readiness is **unknown** when last night is missing, instead of a green light next to a "forced RED" banner from an eleven-day-old night, verified by `universal/scripts/verify-device.sh training` rendering `Readiness unknown` from the live API on the emulator, with the risk that other consumers of the three-value light treat `unknown` as green.

## What was wrong

Since 2026-08-24 the watch delivered resting HR only (no sleep, HRV or body battery). Readiness scored that one signal, defaulted the missing night to 8 h and stored a **green** light. The graph route fired `sleep_under_5h` from the latest non-null sleep row (2026-08-23, 3.7 h). Both were persisted/served, so the app showed "Readiness green" under "Sleep under 5 hours (3.7h) — forced RED."

## Changes

- `lib/readiness-stream.ts`: `sleep_hours` is nullable; a missing night yields `traffic_light: "unknown"` with flag `no_sleep_data` and a null composite. Hard overrides (body battery critical, 3-of-4) still force red; 2-of-4 only ever moves green to yellow. No-data fallbacks are unknown, never green.
- `/api/training/breakdown`: no row for the date returns an unknown object, not `null`.
- `/api/training/graph`: `sleep_under_5h` and `body_battery_critical` read the requested day's row only; readiness flags count only when the stored row is that day's; a yellow `no_sleep_data` override names the last recorded night. The raw HRV / Sleep / Body Battery nodes show the requested day's values (empty when missing).
- `/api/training/forward-sim`: default readiness is unknown.
- App overview: grey `UNKNOWN` badge and "No sleep data for last night — readiness unknown until the watch syncs a night." Training badge renders `Readiness unknown`.
- Web: readiness card ("?" / "no sleep data for last night"), today's recommendation gets an unknown branch, the training page reads today's row, the overview Sleep stat appends "last recorded <date>" once the fallback night is older than last night.
- `scripts/readiness-recompute.mts` rewrites stored rows for a date range with the current rules. Run for 2026-08-20..2026-09-04: 08-22 and 08-24..09-04 are now `unknown`; the three real sub-5 h nights (08-20, 08-21, 08-23) stay red.
- Tests: five additive cases (Python golden untouched), including an 11-day-old 3.7 h night that never triggers the override.

## Verified

- `npx tsc --noEmit` clean (web + universal); `vitest lib/readiness-stream.test.ts` 7/7.
- Working-tree server: breakdown today → `unknown` / `no_sleep_data`; graph today → `no_sleep_data` triggered (yellow), `sleep_under_5h` not triggered; raw sleep/bb nodes null.
- Emulator (release APK, live DB): `verify-device.sh training` → `Readiness unknown` visible; `verify-device.sh overview --marker "readiness unknown until"` → visible.
- Web (demo-mode worktree server): training page shows the yellow "No sleep data for 2026-09-04 (last night recorded: 2026-08-23)" note and no forced-RED text.

Closes #647
Closes #648
Closes #649
