### PR TITLE
test(universal): Maestro flow for the GPS route map inside an activity detail (#692)

### DIFF
--- a/universal/.maestro/verify-route-map.yaml
+++ b/universal/.maestro/verify-route-map.yaml
@@ -1,0 +1,28 @@
+# Soma verify flow: the GPS route map inside an activity detail (T1 gap: "maps unverified on
+# device"). Opens the running screen, taps the newest route thumbnail (its name is passed in as
+# TAP from the live API), and waits for the map caption the native RouteMap renders under real
+# tiles. Run via: universal/scripts/verify-device.sh running --flow .maestro/verify-route-map.yaml \
+#   --marker "green start, red finish" --env TAP="<first route name>"
+appId: dev.gkos.soma
+name: Soma verify route map
+tags:
+  - verify
+---
+- stopApp
+- openLink: ${ROUTE}
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Recent routes"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+- tapOn:
+    text: "${TAP}"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- takeScreenshot: verify-${SCREEN}


### PR DESCRIPTION
Adds `universal/.maestro/verify-route-map.yaml`: open running, scroll to Recent routes, tap the newest route (`TAP` from `/api/running/recent-routes`), wait for the RouteMap caption "GPS route · green start, red finish · colour = pace." under real tiles.

Verified on the emulator (release APK, live API): `verify-device.sh running --flow .maestro/verify-route-map.yaml --marker "green start, red finish" --env TAP="Athens Running"` → VERIFIED. The screenshot shows the Sep 2 route drawn pace-coloured over OpenFreeMap dark tiles of Pangrati, green start and red finish, and the route profile under it.

Closes #692
