### PR TITLE
test(universal): song-row test ids + Maestro flow for the Spotify embed preview (#694)

### DIFF
--- a/universal/.maestro/verify-builder-preview.yaml
+++ b/universal/.maestro/verify-builder-preview.yaml
@@ -1,0 +1,44 @@
+# Soma verify flow: the Spotify embed (a WebView) inside the playlist builder — the last surface
+# the T1 audit listed as unverified on device. Generates a playlist for the newest run (RUN from
+# the live API, real Spotify reads), taps the first song of the first segment (testID song-0-0),
+# and waits for the "Preview" caption the app renders above the embed. The embed itself is a
+# WebView, so its contents are evidence in the screenshot, not in the accessibility tree.
+# Run via: universal/scripts/verify-device.sh playlist-builder --flow .maestro/verify-builder-preview.yaml \
+#   --marker "Preview" --env RUN="<newest run name>"
+appId: dev.gkos.soma
+name: Soma builder song preview (Spotify embed)
+tags:
+  - verify
+---
+- stopApp
+- openLink: ${ROUTE}
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${RUN}"
+    timeout: 30000
+- tapOn:
+    text: "${RUN}"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      text: "Generated"
+    timeout: 180000
+- scrollUntilVisible:
+    element:
+      id: "song-0-0"
+    direction: DOWN
+    timeout: 30000
+    speed: 40
+- tapOn:
+    id: "song-0-0"
+# The preview card sits below every segment card and the save row, so it is off-screen after
+# the tap (Maestro reads off-screen nodes as not visible): scroll to it rather than wait.
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -242,7 +242,7 @@ function SegmentCard({ seg, index, panel, onExclude, onWiden, onEdit, onRemove, 
           {panel?.warning ? <Text variant="micro" style={{ color: "#e0a458" }}>{panel.warning}</Text> : null}
           {songs.map((s, i) => (
             <View key={`${s.track_id}-${i}`} className="flex-row items-center gap-2 border-t border-border-subtle py-1.5">
-              <Pressable className="flex-1" onPress={() => onPreview(s)}>
+              <Pressable className="flex-1" onPress={() => onPreview(s)} testID={`song-${index}-${i}`}>
                 <Text variant="caption" className="text-text" numberOfLines={1}>{s.name}</Text>
                 <Text variant="micro" className="text-text-muted" numberOfLines={1}>
                   {s.artist_name}{s.tempo ? ` · ${Math.round(s.tempo)} bpm` : ""}{s.is_half_time ? " ·½" : ""} · {songDur(s.duration_ms)}


### PR DESCRIPTION
- `universal/src/app/(main)/playlist-builder.tsx`: song rows carry `testID="song-<segment>-<row>"` (no visual change).
- `universal/.maestro/verify-builder-preview.yaml`: open the builder, tap the newest run (`RUN` from `/api/playlist/garmin-runs`), wait for "Generated", tap `song-0-0`, scroll to the Preview card (it sits below every segment card, so an off-screen wait would never pass), screenshot.

Verified on the emulator (release APK, live API, real Spotify reads): `verify-device.sh playlist-builder --flow .maestro/verify-builder-preview.yaml --marker "Preview" --env RUN="Athens Running"` → VERIFIED; the screenshot shows the Spotify embed rendered inside the Preview card under the tapped song.

Closes #694
