### PR TITLE
chore(sync): run health sync hourly instead of every 30 min to cut Neon compute

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync Health Data
 
 on:
   schedule:
-    - cron: '0,30 0-3,10-23 * * *'  # Every 30min, 6am-midnight EDT (UTC-4)
+    - cron: '0 0-3,10-23 * * *'    # Hourly, 6am-midnight EDT (UTC-4)
     - cron: '0 4 * * *'           # Midnight EDT
   workflow_dispatch: {}  # Manual trigger from GitHub UI
   repository_dispatch:


### PR DESCRIPTION
## What

Change the health-sync schedule from every 30 minutes to hourly, during the same 6am-midnight EDT window.

`cron: '0,30 0-3,10-23 * * *'` becomes `cron: '0 0-3,10-23 * * *'`.

## Why

The org was downgraded from Neon Launch back to Free (100 CU-hour/month cap). The sync workflow waking the database ~39 times a day is the main compute driver, so halving the runs keeps compute comfortably under the cap and avoids a mid-month compute suspension.

## Notes

- `workflow_dispatch` and `repository_dispatch` are unchanged, so on-demand and API-triggered syncs still work immediately.
- Tradeoff: a finished workout may wait up to an hour for the scheduled run instead of 30 minutes.

Closes #696
