### PR TITLE
Coverage guard: absent days stop feeding adaptive TDEE, deficit streak and adherence

### DIFF
--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -5,6 +5,7 @@ import type { Mode } from "@/lib/mode-engine";
 import type { SlotBudgets } from "@/lib/nutrition-types";
 import { computeAdaptiveContext } from "@/lib/adaptive-tdee";
 import { computeWeeklyAdherence } from "@/lib/adherence";
+import { meetsCoverageFloor } from "@/lib/coverage";
 import { computeAlcoholDisplacement } from "macro-engine-core";
 
 export const runtime = "edge";
@@ -473,18 +474,31 @@ export async function GET(req: NextRequest) {
   }
 
   // ── 7-day rolling trend ──
+  // `coverage` = (distinct slots with logged kcal ∪ explicitly skipped) / 4,
+  // the same definition lib/adaptive-tdee uses, so a closed-but-empty day is
+  // treated identically everywhere (#699).
   const trendRows = await sql`
     SELECT
-      date::text AS date,
-      target_calories,
-      actual_calories,
-      status,
-      manual_override,
-      deficit_used
-    FROM nutrition_day
-    WHERE date >= ${date}::date - interval '6 days'
-      AND date <= ${date}::date
-    ORDER BY date
+      n.date::text AS date,
+      n.target_calories,
+      n.actual_calories,
+      n.status,
+      n.manual_override,
+      n.deficit_used,
+      (
+        SELECT COUNT(DISTINCT s)::float / 4
+        FROM (
+          SELECT m.meal_slot AS s FROM meal_log m
+           WHERE m.date = n.date AND m.calories > 0
+          UNION
+          SELECT unnest(COALESCE(n.skipped_slots, ARRAY[]::text[]))
+        ) u
+        WHERE u.s IN ('breakfast', 'lunch', 'dinner', 'pre_sleep')
+      ) AS coverage
+    FROM nutrition_day n
+    WHERE n.date >= ${date}::date - interval '6 days'
+      AND n.date <= ${date}::date
+    ORDER BY n.date
   `;
 
   // Goal deficit from profile (the user's real target, e.g. 800/day)
@@ -503,6 +517,14 @@ export async function GET(req: NextRequest) {
     return target + defUsed;
   };
 
+  // A day feeds the cumulative deficit and weekly adherence only when it is
+  // closed AND its logging coverage clears the floor. A closed day with one
+  // meal logged is absent data, not a 600-kcal day; counting it is how the
+  // week reads as a huge deficit the user never had (#699).
+  const counts = (r: Record<string, unknown>) =>
+    r.status === "closed" && meetsCoverageFloor(r.coverage as number | null);
+  const counted = trendRows.filter(counts);
+
   const trend7d = {
     goalDeficit,
     days: trendRows.map((r: Record<string, unknown>) => {
@@ -516,31 +538,30 @@ export async function GET(req: NextRequest) {
         burn,
         deficit,
         closed: r.status === "closed",
+        // Surfaced so the UI can distinguish "closed and complete" from
+        // "closed but barely logged" instead of painting both the same.
+        coverage: typeof r.coverage === "number" ? r.coverage : null,
+        counted: counts(r),
         isToday: isCurrentDay,
       };
     }),
-    // Cumulative deficit: sum of (ate - burn) for closed days only
-    totalDeficit: trendRows
-      .filter((r: Record<string, unknown>) => r.status === "closed")
-      .reduce((sum: number, r: Record<string, unknown>) => {
-        const ate = Number(r.actual_calories) || 0;
-        const burn = Math.round(computeBurn(r, false));
-        return sum + (ate - burn);
-      }, 0),
-    closedDays: trendRows.filter((r: Record<string, unknown>) => r.status === "closed").length,
-    goalExpectedDeficit: trendRows
-      .filter((r: Record<string, unknown>) => r.status === "closed")
-      .length * goalDeficit,
+    // Cumulative deficit: sum of (ate - burn) over counted days only
+    totalDeficit: counted.reduce((sum: number, r: Record<string, unknown>) => {
+      const ate = Number(r.actual_calories) || 0;
+      const burn = Math.round(computeBurn(r, false));
+      return sum + (ate - burn);
+    }, 0),
+    closedDays: counted.length,
+    goalExpectedDeficit: counted.length * goalDeficit,
     // Weekly adherence (±10% band). Achieved deficit = burn − ate, summed over
-    // closed days (positive = in deficit); goal = closed days × goal/day.
+    // counted days (positive = in deficit); goal = counted days × goal/day.
     adherence: (() => {
-      const closed = trendRows.filter((r: Record<string, unknown>) => r.status === "closed");
-      const weeklyActual = closed.reduce((s: number, r: Record<string, unknown>) => {
+      const weeklyActual = counted.reduce((s: number, r: Record<string, unknown>) => {
         const ate = Number(r.actual_calories) || 0;
         const burn = Math.round(computeBurn(r, false));
         return s + (burn - ate);
       }, 0);
-      return computeWeeklyAdherence(weeklyActual, closed.length * goalDeficit);
+      return computeWeeklyAdherence(weeklyActual, counted.length * goalDeficit);
     })(),
   };
 

--- a/web/lib/adaptive-tdee.test.ts
+++ b/web/lib/adaptive-tdee.test.ts
@@ -13,9 +13,83 @@ function day(date: string, o: Partial<Row> = {}): Row {
     is_diet_break: false,
     is_refeed: false,
     status: "closed",
+    coverage: 1,
     ...o,
   } as Row;
 }
+
+describe("countDeficitDuration — coverage guard and gap rule (#699)", () => {
+  // Each case: rows oldest→newest, expected streak. Days are consecutive
+  // unless a gap is spelled out in the name.
+  const cases: [string, Row[], number][] = [
+    [
+      "a closed day below the coverage floor does not count",
+      [day("2026-07-10"), day("2026-07-11", { coverage: 0.25 }), day("2026-07-12")],
+      2,
+    ],
+    [
+      "a closed day with NULL coverage is unknown and does not count",
+      [day("2026-07-10"), day("2026-07-11", { coverage: null }), day("2026-07-12")],
+      2,
+    ],
+    [
+      "exactly at the floor counts",
+      [day("2026-07-11", { coverage: 0.75 }), day("2026-07-12")],
+      2,
+    ],
+    [
+      "the May-Jun poison: closed, deficit_used>0, zero coverage → contributes nothing",
+      [day("2026-05-01", { coverage: 0 }), day("2026-05-02", { coverage: 0 }), day("2026-05-03", { coverage: 0 })],
+      0,
+    ],
+    [
+      "a real April streak followed by four empty months is NOT the current phase (gap rule)",
+      [
+        day("2026-04-28"), day("2026-04-29"), day("2026-04-30"),
+        day("2026-06-15", { coverage: 0 }), day("2026-09-05", { status: "active", coverage: 0 }),
+        day("2026-09-06", { status: "active", coverage: 0 }),
+      ],
+      0,
+    ],
+    [
+      "a gap of exactly the max is still consecutive",
+      [day("2026-07-05"), day("2026-07-12")],
+      2,
+    ],
+    [
+      "a gap one day over the max breaks the streak at the newer day",
+      [day("2026-07-04"), day("2026-07-12")],
+      1,
+    ],
+    [
+      "unclosed days inside the window are skipped without breaking",
+      [day("2026-07-10"), day("2026-07-11", { status: "active" }), day("2026-07-12")],
+      2,
+    ],
+  ];
+  for (const [name, rows, want] of cases) {
+    it(name, () => {
+      expect(countDeficitDuration(rows)).toBe(want);
+    });
+  }
+});
+
+describe("buildDayPoints — coverage guard (#699)", () => {
+  const w = [{ date: "2026-07-09", weightKg: 80 }];
+  it("a breakfast-only closed day is excluded even though it has intake", () => {
+    const rows = [day("2026-07-10", { actual_calories: 600, coverage: 0.25 }), day("2026-07-11")];
+    const pts = buildDayPoints(rows, w);
+    expect(pts.map((p) => p.intakeKcal)).toEqual([2000]);
+  });
+  it("a day with all-but-one slot explicitly skipped is complete and included", () => {
+    const rows = [day("2026-07-10", { actual_calories: 600, coverage: 1 })];
+    expect(buildDayPoints(rows, w)).toHaveLength(1);
+  });
+  it("null coverage is excluded", () => {
+    const rows = [day("2026-07-10", { coverage: null })];
+    expect(buildDayPoints(rows, w)).toHaveLength(0);
+  });
+});
 
 describe("countDeficitDuration", () => {
   it("counts consecutive closed deficit days from the end", () => {

--- a/web/lib/adaptive-tdee.ts
+++ b/web/lib/adaptive-tdee.ts
@@ -10,6 +10,7 @@
  */
 import { computeAdaptiveTdee, recommendDietBreak, type DietBreakLevel } from "macro-engine-core";
 import type { QueryFn } from "@/lib/db";
+import { meetsCoverageFloor, daysBetween, STREAK_MAX_GAP_DAYS } from "@/lib/coverage";
 
 export interface AdaptiveContext {
   effectiveTdee: number;
@@ -29,6 +30,21 @@ interface DayRow {
   is_diet_break: boolean | null;
   is_refeed: boolean | null;
   status: string | null;
+  /**
+   * Logging coverage 0..1 (see lib/coverage). A closed day below the floor is
+   * ABSENT data wearing a "closed" badge: it contributes nothing, exactly like
+   * an unclosed day. `null` means unknown and also contributes nothing.
+   */
+  coverage: number | null;
+}
+
+/**
+ * A day counts toward any inference only when it is closed AND its logging
+ * coverage clears the floor. This is the single guard behind #699: the 53
+ * May–Jun 2026 days that were closed with zero meal_log rows fail it.
+ */
+function contributes(r: DayRow): boolean {
+  return r.status === "closed" && meetsCoverageFloor(r.coverage);
 }
 
 // How far back to look. 130 days covers the diet-break ceiling (112) for the
@@ -42,12 +58,22 @@ const LOOKBACK_DAYS = 130;
  */
 export function countDeficitDuration(rows: DayRow[]): number {
   let n = 0;
+  let lastCounted: string | null = null;
+  const latest = rows.length ? rows[rows.length - 1].date : null;
   for (let i = rows.length - 1; i >= 0; i--) {
     const r = rows[i];
-    if (r.status !== "closed") continue; // ignore not-yet-closed days without breaking the streak
+    // Unclosed AND low-coverage days are both absent data: skip without
+    // breaking, but they still consume calendar distance (see gap rule).
+    if (!contributes(r)) continue;
+    // Gap rule: a "consecutive" phase cannot span more than STREAK_MAX_GAP_DAYS
+    // of absent data. Without it the walk-back crosses four empty months and
+    // reports last spring's deficit as the current phase.
+    const anchor = lastCounted ?? latest;
+    if (anchor && daysBetween(r.date, anchor) > STREAK_MAX_GAP_DAYS) break;
     if (r.is_diet_break || r.is_refeed) break;
     if ((Number(r.deficit_used) || 0) <= 0) break;
     n++;
+    lastCounted = r.date;
   }
   return n;
 }
@@ -76,7 +102,7 @@ export function buildDayPoints(
       if (weights[wi].weightKg > 0) lastWeight = weights[wi].weightKg;
       wi++;
     }
-    if (r.status !== "closed") continue;
+    if (!contributes(r)) continue;
     const intake = Number(r.actual_calories) || 0;
     if (intake <= 0) continue;
     if (lastWeight <= 0) continue; // no weigh-in yet — skip until we have one
@@ -89,12 +115,26 @@ export function buildDayPoints(
 }
 
 export async function computeAdaptiveContext(sql: QueryFn): Promise<AdaptiveContext | null> {
+  // Coverage = (distinct slots with logged kcal ∪ explicitly skipped slots) / 4.
+  // Computed in SQL so every consumer of these rows sees the same number.
+  // Only the four canonical slots count; a slot both logged and skipped
+  // counts once (the UNION dedupes).
   const rows = (await sql`
-    SELECT date::text AS date, actual_calories, tdee_used, target_calories,
-           deficit_used, is_diet_break, is_refeed, status
-    FROM nutrition_day
-    WHERE date >= CURRENT_DATE - ${`${LOOKBACK_DAYS} days`}::interval
-    ORDER BY date
+    SELECT n.date::text AS date, n.actual_calories, n.tdee_used, n.target_calories,
+           n.deficit_used, n.is_diet_break, n.is_refeed, n.status,
+           (
+             SELECT COUNT(DISTINCT s)::float / 4
+             FROM (
+               SELECT m.meal_slot AS s FROM meal_log m
+                WHERE m.date = n.date AND m.calories > 0
+               UNION
+               SELECT unnest(COALESCE(n.skipped_slots, ARRAY[]::text[]))
+             ) u
+             WHERE u.s IN ('breakfast', 'lunch', 'dinner', 'pre_sleep')
+           ) AS coverage
+    FROM nutrition_day n
+    WHERE n.date >= CURRENT_DATE - ${`${LOOKBACK_DAYS} days`}::interval
+    ORDER BY n.date
   `) as unknown as DayRow[];
   if (!rows.length) return null;
 

--- a/web/lib/coverage.test.ts
+++ b/web/lib/coverage.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { slotCoverage, meetsCoverageFloor, daysBetween, COVERAGE_FLOOR } from "./coverage";
+
+describe("slotCoverage", () => {
+  const cases: [string, string[], string[], number][] = [
+    ["nothing logged, nothing skipped", [], [], 0],
+    ["breakfast only", ["breakfast"], [], 0.25],
+    ["breakfast + lunch", ["breakfast", "lunch"], [], 0.5],
+    ["three slots logged", ["breakfast", "lunch", "dinner"], [], 0.75],
+    ["all four logged", ["breakfast", "lunch", "dinner", "pre_sleep"], [], 1],
+    ["breakfast logged, rest explicitly skipped = complete", ["breakfast"], ["lunch", "dinner", "pre_sleep"], 1],
+    ["all skipped = complete (a deliberate fast is real information)", [], ["breakfast", "lunch", "dinner", "pre_sleep"], 1],
+    ["logged AND skipped same slot counts once", ["lunch"], ["lunch"], 0.25],
+    ["unknown slot names are ignored, not counted", ["breakfast", "during_workout", "snack"], [], 0.25],
+    ["null inputs behave as empty", null as unknown as string[], undefined as unknown as string[], 0],
+  ];
+  for (const [name, logged, skipped, want] of cases) {
+    it(name, () => {
+      expect(slotCoverage(logged, skipped)).toBeCloseTo(want, 6);
+    });
+  }
+});
+
+describe("meetsCoverageFloor", () => {
+  it("floor is 3 of 4, calibrated from the Mar-Apr 2026 active period (#698)", () => {
+    expect(COVERAGE_FLOOR).toBe(0.75);
+  });
+  const cases: [string, number | null | undefined, boolean][] = [
+    ["exactly at the floor passes", 0.75, true],
+    ["full coverage passes", 1, true],
+    ["half coverage fails", 0.5, false],
+    ["breakfast-only fails", 0.25, false],
+    ["zero fails", 0, false],
+    ["null is unknown, not zero, and fails", null, false],
+    ["undefined fails", undefined, false],
+    ["NaN fails", Number.NaN, false],
+  ];
+  for (const [name, cov, want] of cases) {
+    it(name, () => {
+      expect(meetsCoverageFloor(cov)).toBe(want);
+    });
+  }
+});
+
+describe("daysBetween", () => {
+  const cases: [string, string, string, number][] = [
+    ["same day", "2026-05-01", "2026-05-01", 0],
+    ["next day", "2026-05-01", "2026-05-02", 1],
+    ["across a month end", "2026-04-30", "2026-05-01", 1],
+    ["a week", "2026-05-01", "2026-05-08", 7],
+    ["the four-month poison gap, Apr 30 to Sep 6", "2026-04-30", "2026-09-06", 129],
+    ["negative when reversed", "2026-05-08", "2026-05-01", -7],
+  ];
+  for (const [name, a, b, want] of cases) {
+    it(name, () => {
+      expect(daysBetween(a, b)).toBe(want);
+    });
+  }
+});

--- a/web/lib/coverage.ts
+++ b/web/lib/coverage.ts
@@ -1,0 +1,55 @@
+/**
+ * Logging coverage for a nutrition day — how much of the day was actually
+ * observed, as opposed to assumed.
+ *
+ * A day has four slots. A slot is COVERED when the user either logged food
+ * with calories in it, or explicitly skipped it (skip-slot is the "I did not
+ * eat this" assertion, which is real information). A slot that is neither is
+ * ABSENT: not zero, unknown. Treating absent as zero is how a breakfast-only
+ * day turns into a fake 600-kcal "intake" and poisons the adaptive TDEE.
+ *
+ * The floor is calibrated from the user's own history, not guessed: during the
+ * Mar–Apr 2026 active period, 33 of 48 closed days covered 3+ of 4 slots
+ * (#698). Below the floor a closed day is treated exactly like an unclosed
+ * one: it contributes nothing, and it does not pretend to.
+ */
+
+export const ALL_SLOTS = ["breakfast", "lunch", "dinner", "pre_sleep"] as const;
+export type Slot = (typeof ALL_SLOTS)[number];
+
+/** Minimum coverage for a closed day to feed any inference. 3 of 4 slots. */
+export const COVERAGE_FLOOR = 0.75;
+
+/**
+ * Max gap, in days, between two counted days before a "consecutive" deficit
+ * streak is considered broken. Without this, a streak walks straight across
+ * months of absent data and reports last spring's deficit as the current phase.
+ */
+export const STREAK_MAX_GAP_DAYS = 7;
+
+/**
+ * Fraction of the four slots that were covered. Slots outside ALL_SLOTS (for
+ * example "during_workout") are ignored rather than inflating the count, and
+ * a slot that is both logged and skipped counts once.
+ */
+export function slotCoverage(
+  loggedSlots: readonly string[] | null | undefined,
+  skippedSlots: readonly string[] | null | undefined,
+): number {
+  const covered = new Set<string>();
+  for (const s of loggedSlots ?? []) if ((ALL_SLOTS as readonly string[]).includes(s)) covered.add(s);
+  for (const s of skippedSlots ?? []) if ((ALL_SLOTS as readonly string[]).includes(s)) covered.add(s);
+  return covered.size / ALL_SLOTS.length;
+}
+
+/** True when a day's coverage clears the floor. `null` coverage is unknown → false. */
+export function meetsCoverageFloor(coverage: number | null | undefined): boolean {
+  return typeof coverage === "number" && Number.isFinite(coverage) && coverage >= COVERAGE_FLOOR;
+}
+
+/** Whole days between two ISO dates (b − a). Both are date-only strings. */
+export function daysBetween(a: string, b: string): number {
+  const ms = Date.UTC(+b.slice(0, 4), +b.slice(5, 7) - 1, +b.slice(8, 10)) -
+    Date.UTC(+a.slice(0, 4), +a.slice(5, 7) - 1, +a.slice(8, 10));
+  return Math.round(ms / 86_400_000);
+}


### PR DESCRIPTION
Closes #699. Part of #698.

A closed day now feeds adaptive TDEE, the deficit streak and weekly adherence only when its logging coverage clears a floor. Coverage = (distinct slots with logged kcal ∪ explicitly skipped slots) / 4, computed once in SQL so every consumer sees the same number.

**The floor is 3 of 4, from your own history rather than a guess.** During the Mar–Apr 2026 active period, 33 of 48 closed days met it.

## What it fixes

Absent data was being treated as zero. 61 days in May–Jun 2026 were closed with, in 53 cases, no `meal_log` row at all, and `countDeficitDuration` counted them as deficit days via `deficit_used`. A breakfast-only closed day fed the adaptive engine as a 600 kcal intake. Same error as the readiness bug that fabricated a green from stale sleep.

## One thing the issue did not anticipate

With only the guard, `countDeficitDuration` skips Sep→May as non-contributing and lands on April's real deficit days, reporting them as the **current** phase. A consecutive streak cannot span four empty months, so the walk-back now also breaks at a gap over 7 days. There is a test for exactly that shape.

## Verified against real data, not only types

| day | status | kcal | coverage | counted |
|---|---|---|---|---|
| 2026-04-15 (active period, 2 slots) | closed | 1269 | 0.5 | no |
| 2026-05-10 (poison) | closed | 0 | 0 | no |
| 2026-06-10 (poison) | closed | 0 | 0 | no |

`plan/route.ts` collapses its four repeated `status === "closed"` filters into one `counts()` predicate, and each trend day now exposes `coverage` and `counted` so P5 can render a partial day differently from a complete one.

tsc clean, vitest 218/218 across 34 files. No UI change in this PR.
