### PR TITLE
lib/engagement: nutritionEngagement and trainingEngagement, pure and table-tested

### DIFF
--- a/web/lib/engagement.test.ts
+++ b/web/lib/engagement.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import {
+  nutritionDayState,
+  nutritionEngagement,
+  trainingEngagement,
+  WEEK_ENGAGEMENT_FLOOR_DAYS,
+  PLAN_COMPLETION_FLOOR,
+  PLAN_LIVE_WINDOW_DAYS,
+  type NutritionDayInput,
+  type PlanDayInput,
+} from "./engagement";
+
+const TODAY = "2026-09-06";
+
+function nd(date: string, o: Partial<NutritionDayInput> = {}): NutritionDayInput {
+  return { date, status: "closed", coverage: 1, ...o };
+}
+
+describe("nutritionDayState", () => {
+  const cases: [string, NutritionDayInput, string][] = [
+    ["closed at full coverage is complete", nd("2026-09-06"), "complete"],
+    ["closed exactly at the floor is complete", nd("2026-09-06", { coverage: 0.75 }), "complete"],
+    ["closed below the floor is partial, not complete", nd("2026-09-06", { coverage: 0.5 }), "partial"],
+    ["open with something logged is partial", nd("2026-09-06", { status: "active", coverage: 0.25 }), "partial"],
+    ["open with nothing logged is absent", nd("2026-09-06", { status: "active", coverage: 0 }), "absent"],
+    ["closed with ZERO coverage is absent — the May-Jun poison", nd("2026-09-06", { coverage: 0 }), "absent"],
+    ["null coverage is absent, never complete", nd("2026-09-06", { coverage: null }), "absent"],
+  ];
+  for (const [name, d, want] of cases) it(name, () => expect(nutritionDayState(d)).toBe(want));
+});
+
+describe("nutritionEngagement (week ending today)", () => {
+  it("floor is 3 of 7, calibrated from Mar-Apr 2026 (#698)", () => {
+    expect(WEEK_ENGAGEMENT_FLOOR_DAYS).toBe(3);
+  });
+
+  const cases: [string, NutritionDayInput[], string, number][] = [
+    ["no rows at all is absent", [], "absent", 0],
+    [
+      "the user's actual recent state: a few open rows, nothing logged → absent",
+      [nd("2026-09-04", { status: "active", coverage: 0 }), nd("2026-09-05", { status: "active", coverage: 0 }), nd("2026-09-06", { status: "active", coverage: 0 })],
+      "absent",
+      0,
+    ],
+    [
+      "breakfast only on two days is partial",
+      [nd("2026-09-05", { status: "active", coverage: 0.25 }), nd("2026-09-06", { status: "active", coverage: 0.25 })],
+      "partial",
+      0,
+    ],
+    [
+      "two full days is still partial (below the floor)",
+      [nd("2026-09-05"), nd("2026-09-06")],
+      "partial",
+      2 / 7,
+    ],
+    [
+      "three full days is complete",
+      [nd("2026-09-04"), nd("2026-09-05"), nd("2026-09-06")],
+      "complete",
+      3 / 7,
+    ],
+    [
+      "seven full days is complete at coverage 1",
+      ["2026-08-31", "2026-09-01", "2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05", "2026-09-06"].map((d) => nd(d)),
+      "complete",
+      1,
+    ],
+    [
+      "full days OUTSIDE the window do not count (an April streak is not this week)",
+      [nd("2026-04-10"), nd("2026-04-11"), nd("2026-04-12"), nd("2026-09-06", { status: "active", coverage: 0 })],
+      "absent",
+      0,
+    ],
+    [
+      "the poison: closed-with-zero days are absent even inside the window",
+      [nd("2026-09-03", { coverage: 0 }), nd("2026-09-04", { coverage: 0 }), nd("2026-09-05", { coverage: 0 }), nd("2026-09-06", { coverage: 0 })],
+      "absent",
+      0,
+    ],
+    [
+      "a future-dated row is ignored",
+      [nd("2026-09-07"), nd("2026-09-06", { status: "active", coverage: 0 })],
+      "absent",
+      0,
+    ],
+  ];
+  for (const [name, days, wantState, wantCov] of cases) {
+    it(name, () => {
+      const e = nutritionEngagement(days, TODAY);
+      expect(e.state).toBe(wantState);
+      expect(e.coverage).toBeCloseTo(wantCov, 6);
+      expect(e.basis).toBeTruthy();
+    });
+  }
+
+  it("basis names the counts", () => {
+    const e = nutritionEngagement([nd("2026-09-05"), nd("2026-09-06", { status: "active", coverage: 0.5 })], TODAY);
+    expect(e.basis).toContain("1 fully logged");
+    expect(e.basis).toContain("1 partly logged");
+  });
+});
+
+describe("trainingEngagement", () => {
+  const knox = { status: "active", planName: "Knoxville HM 2026", raceDate: "2026-04-12" };
+  const pd = (day_date: string, o: Partial<PlanDayInput> = {}): PlanDayInput => ({ day_date, run_type: "easy", completed: false, ...o });
+
+  it("floor is 25%, calibrated from Knoxville's best month at 32% (#698)", () => {
+    expect(PLAN_COMPLETION_FLOOR).toBe(0.25);
+    expect(PLAN_LIVE_WINDOW_DAYS).toBe(7);
+  });
+
+  it("no plan is absent", () => {
+    const e = trainingEngagement(null, [], TODAY);
+    expect(e.state).toBe("absent");
+    expect(e.planLive).toBe(false);
+  });
+
+  it("an archived plan is absent even with recent days", () => {
+    const e = trainingEngagement({ ...knox, status: "archived" }, [pd("2026-09-05", { completed: true })], TODAY);
+    expect(e.state).toBe("absent");
+    expect(e.planLive).toBe(false);
+  });
+
+  it("THE BUG: Knoxville, status active, race five months ago, no days near today → dormant", () => {
+    const days = ["2026-03-01", "2026-03-15", "2026-04-01", "2026-04-10"].map((d) => pd(d, { completed: true }));
+    const e = trainingEngagement(knox, days, TODAY);
+    expect(e.state).toBe("dormant");
+    expect(e.planLive).toBe(false);
+    expect(e.basis).toContain("Knoxville");
+    expect(e.basis).toContain("2026-04-12");
+  });
+
+  it("a day exactly at the window edge counts as nearby", () => {
+    const e = trainingEngagement(knox, [pd("2026-09-13", { completed: false })], TODAY);
+    expect(e.state).not.toBe("dormant");
+  });
+
+  it("a day one past the window edge does not", () => {
+    const e = trainingEngagement(knox, [pd("2026-09-14")], TODAY);
+    expect(e.state).toBe("dormant");
+  });
+
+  it("nearby days but none prescribed in the trailing window (brand-new plan) is live and unpenalised", () => {
+    const e = trainingEngagement(knox, [pd("2026-09-08"), pd("2026-09-10")], TODAY);
+    expect(e.state).toBe("complete");
+    expect(e.planLive).toBe(true);
+    expect(e.trailingCompletion).toBeNull();
+  });
+
+  it("rest days are excluded from the completion denominator", () => {
+    const days = [pd("2026-09-01", { run_type: "rest", completed: false }), pd("2026-09-02", { completed: true }), pd("2026-09-08")];
+    const e = trainingEngagement(knox, days, TODAY);
+    expect(e.trailingCompletion).toBe(1);
+    expect(e.state).toBe("complete");
+  });
+
+  // Days are generated backwards from today; only those inside the 14-day
+  // trailing window count, so `total` is capped there and the expectation is
+  // computed from what actually lands in the window.
+  const followCases: [string, number, number, string, boolean][] = [
+    ["a Knoxville-like rate above the floor (4 of 14 ≈ 29%) is live", 4, 14, "complete", true],
+    ["exactly at the floor is live", 1, 4, "complete", true],
+    ["just under the floor: plan exists, not followed → partial, not live", 1, 5, "partial", false],
+    ["Knoxville April rate 0% → partial, not live", 0, 9, "partial", false],
+    ["everything done is live", 7, 7, "complete", true],
+    ["days beyond the trailing window are ignored in the rate", 6, 19, "complete", true],
+  ];
+  for (const [name, done, total, wantState, wantLive] of followCases) {
+    it(name, () => {
+      const days: PlanDayInput[] = [];
+      for (let i = 0; i < total; i++) {
+        const d = new Date(Date.UTC(2026, 8, 6 - i)).toISOString().slice(0, 10);
+        days.push(pd(d, { completed: i < done }));
+      }
+      const inWindow = Math.min(total, 14);
+      const doneInWindow = Math.min(done, inWindow);
+      const e = trainingEngagement(knox, days, TODAY);
+      expect(e.state).toBe(wantState);
+      expect(e.planLive).toBe(wantLive);
+      expect(e.trailingCompletion).toBeCloseTo(doneInWindow / inWindow, 6);
+    });
+  }
+});

--- a/web/lib/engagement.ts
+++ b/web/lib/engagement.ts
@@ -1,0 +1,190 @@
+/**
+ * Engagement — does a module actually have the user's data, or is it assuming?
+ *
+ * Every derived number in soma has an implicit coverage: the fraction of its
+ * inputs that were observed rather than assumed. Pages used to render as if
+ * that were always 100%. Readiness was the first fix (stale sleep no longer
+ * fabricates a green; it says "unknown"). This module generalises it: each
+ * module answers one small question, and every page gates on the answer.
+ *
+ * Four states, kept distinct on purpose:
+ *   absent   — nothing observed. Unknown, not zero.
+ *   partial  — something observed, known incomplete.
+ *   complete — enough observed to trust the module's inferences.
+ *   dormant  — a script exists (a plan) but the user is not living by it.
+ *
+ * Pure functions over already-fetched rows so they are trivially table-tested;
+ * the thin SQL loaders live next to them. Thresholds are calibrated from the
+ * user's own history (#698), not guessed, and are exported so the UI can quote
+ * the basis rather than the number.
+ */
+import { meetsCoverageFloor, daysBetween } from "@/lib/coverage";
+
+export type EngagementState = "absent" | "partial" | "complete" | "dormant";
+
+export interface Engagement {
+  state: EngagementState;
+  /** 0..1, how much of the window was observed at a trustworthy level. */
+  coverage: number;
+  /** Plain-language basis, for the UI to show instead of a bare number. */
+  basis: string;
+}
+
+// ── Nutrition ────────────────────────────────────────────────────────────────
+
+/**
+ * Complete days a week needs before its inferences (adherence, deficit streak,
+ * adaptive TDEE) are worth showing. Calibrated: the user logged 3+ of 4 slots
+ * on 33 of 48 closed days when actively using nutrition (Mar–Apr 2026).
+ */
+export const WEEK_ENGAGEMENT_FLOOR_DAYS = 3;
+export const WEEK_WINDOW_DAYS = 7;
+
+export interface NutritionDayInput {
+  date: string;
+  status: string | null;
+  /** Logging coverage 0..1 from lib/coverage, or null when unknown. */
+  coverage: number | null;
+}
+
+/** A single day: complete when closed at the floor; partial when anything was logged. */
+export function nutritionDayState(d: NutritionDayInput): Exclude<EngagementState, "dormant"> {
+  if (d.status === "closed" && meetsCoverageFloor(d.coverage)) return "complete";
+  if (typeof d.coverage === "number" && d.coverage > 0) return "partial";
+  return "absent";
+}
+
+/**
+ * Week-level engagement ending at `today`, inclusive. Rows outside the window
+ * are ignored so callers can pass whatever they already fetched.
+ */
+export function nutritionEngagement(days: NutritionDayInput[], today: string): Engagement {
+  const inWindow = days.filter((d) => {
+    const back = daysBetween(d.date, today);
+    return back >= 0 && back < WEEK_WINDOW_DAYS;
+  });
+  let complete = 0;
+  let partial = 0;
+  for (const d of inWindow) {
+    const s = nutritionDayState(d);
+    if (s === "complete") complete++;
+    else if (s === "partial") partial++;
+  }
+  const coverage = complete / WEEK_WINDOW_DAYS;
+  if (complete >= WEEK_ENGAGEMENT_FLOOR_DAYS) {
+    return { state: "complete", coverage, basis: `${complete} of ${WEEK_WINDOW_DAYS} days fully logged` };
+  }
+  if (complete > 0 || partial > 0) {
+    const bits = [];
+    if (complete > 0) bits.push(`${complete} fully logged`);
+    if (partial > 0) bits.push(`${partial} partly logged`);
+    return {
+      state: "partial",
+      coverage,
+      basis: `${bits.join(", ")} of the last ${WEEK_WINDOW_DAYS} days; ${WEEK_ENGAGEMENT_FLOOR_DAYS} full days needed`,
+    };
+  }
+  return { state: "absent", coverage: 0, basis: `nothing logged in the last ${WEEK_WINDOW_DAYS} days` };
+}
+
+// ── Training ─────────────────────────────────────────────────────────────────
+
+/**
+ * A plan is LIVE only when the user is living by it, not merely when a status
+ * flag says 'active'. Calibrated: the Knoxville HM plan was followed at 32% in
+ * its best month, so 25% is the floor for "following". ±7 days is the window
+ * in which a plan has to have prescribed something to count as current.
+ */
+export const PLAN_LIVE_WINDOW_DAYS = 7;
+export const PLAN_TRAILING_DAYS = 14;
+export const PLAN_COMPLETION_FLOOR = 0.25;
+
+export interface PlanInput {
+  status: string | null;
+  planName: string | null;
+  raceDate: string | null;
+}
+
+export interface PlanDayInput {
+  day_date: string;
+  run_type: string | null;
+  completed: boolean | null;
+}
+
+export interface TrainingEngagement extends Engagement {
+  planLive: boolean;
+  planName: string | null;
+  /** Prescribed non-rest days in the trailing window that were completed, 0..1, or null when none prescribed. */
+  trailingCompletion: number | null;
+}
+
+export function trainingEngagement(
+  plan: PlanInput | null,
+  days: PlanDayInput[],
+  today: string,
+): TrainingEngagement {
+  if (!plan || plan.status !== "active") {
+    return {
+      state: "absent",
+      coverage: 0,
+      basis: "no active training plan",
+      planLive: false,
+      planName: plan?.planName ?? null,
+      trailingCompletion: null,
+    };
+  }
+
+  const nearby = days.some((d) => Math.abs(daysBetween(d.day_date, today)) <= PLAN_LIVE_WINDOW_DAYS);
+  const trailing = days.filter((d) => {
+    const back = daysBetween(d.day_date, today);
+    return back >= 0 && back < PLAN_TRAILING_DAYS && d.run_type !== "rest";
+  });
+  const trailingCompletion = trailing.length
+    ? trailing.filter((d) => d.completed === true).length / trailing.length
+    : null;
+
+  if (!nearby) {
+    const ended = plan.raceDate ? ` (race ${plan.raceDate})` : "";
+    return {
+      state: "dormant",
+      coverage: 0,
+      basis: `${plan.planName ?? "plan"} has no sessions within ${PLAN_LIVE_WINDOW_DAYS} days${ended}`,
+      planLive: false,
+      planName: plan.planName,
+      trailingCompletion,
+    };
+  }
+
+  // Nearby days but nothing prescribed yet in the trailing window (brand-new
+  // plan): live, and not penalised for having no history.
+  if (trailingCompletion === null) {
+    return {
+      state: "complete",
+      coverage: 1,
+      basis: `${plan.planName ?? "plan"} is current; no sessions due yet`,
+      planLive: true,
+      planName: plan.planName,
+      trailingCompletion,
+    };
+  }
+
+  const pct = Math.round(trailingCompletion * 100);
+  if (trailingCompletion >= PLAN_COMPLETION_FLOOR) {
+    return {
+      state: "complete",
+      coverage: trailingCompletion,
+      basis: `${pct}% of planned sessions done in the last ${PLAN_TRAILING_DAYS} days`,
+      planLive: true,
+      planName: plan.planName,
+      trailingCompletion,
+    };
+  }
+  return {
+    state: "partial",
+    coverage: trailingCompletion,
+    basis: `plan exists but ${pct}% of planned sessions done in the last ${PLAN_TRAILING_DAYS} days`,
+    planLive: false,
+    planName: plan.planName,
+    trailingCompletion,
+  };
+}


### PR DESCRIPTION
Closes #700. Part of #698.

`lib/engagement.ts`: each module answers one question, does it have the user's data or is it assuming. Four states, kept distinct on purpose:

- **absent** is unknown, never zero
- **partial** is observed but known incomplete
- **complete** is enough to trust the module's inferences
- **dormant** is a script that exists but is not being lived by

Pure functions over already-fetched rows, 31 table-driven cases. Every page gates on the result in P5.

## nutritionEngagement

Week ending today. Complete when 3 or more of 7 days are closed at the coverage floor. Calibrated: 3+ of 4 slots on 33 of 48 closed days during the Mar–Apr 2026 active period. A closed day with zero coverage is absent, so the May–Jun poison rows cannot register as engagement. Days outside the window are ignored, so an April streak is not this week.

## trainingEngagement

A plan is live only when the user lives by it, not when a flag says active. Live requires `status='active'` **and** a prescribed day within 7 days of today **and** trailing-14-day completion of at least 25%, calibrated from Knoxville's best month at 32%.

Today's Knoxville plan, race five months gone and no days near today, comes out **dormant**, with a basis string naming the plan and the race date. A brand-new plan with nothing due yet is live and not penalised. Rest days are excluded from the completion denominator.

## One test was wrong, and the code was right

A case generated 19 days but the trailing window is 14, so the function measured 6 of 14 in-window and my expectation naively used 6 of 19. Fixed the test to compute from what lands in the window, and added a case asserting that days beyond the window are ignored.

tsc clean, vitest 250/250 across 35 files. No UI change; no route reads this yet.
