### PR TITLE
Dormant-plan detection: every training route goes through one live rule

### DIFF
--- a/web/app/api/training/activity-match/route.ts
+++ b/web/app/api/training/activity-match/route.ts
@@ -1,19 +1,15 @@
 import { getDb } from "@/lib/db";
 import { NextResponse } from "next/server";
+import { getLivePlan } from "@/lib/live-plan";
 
 export async function GET() {
   try {
     const sql = getDb();
 
-    // Get active plan days
-    const planDays = await sql`
-      SELECT d.id, d.day_date::text as day_date, d.run_type, d.target_distance_km,
-             d.workout_steps, d.completed
-      FROM training_plan_day d
-      JOIN training_plan p ON d.plan_id = p.id
-      WHERE p.status = 'active'
-      ORDER BY d.day_date
-    `.catch(() => []);
+    // Only a LIVE plan has sessions worth matching activities against. A
+    // dormant plan (race months ago, nothing near today) would otherwise
+    // produce a wall of "missed" days for a script nobody is following (#701).
+    const { days: planDays } = await getLivePlan(sql);
 
     if (planDays.length === 0) return NextResponse.json([]);
 

--- a/web/app/api/training/forward-sim/route.ts
+++ b/web/app/api/training/forward-sim/route.ts
@@ -129,7 +129,12 @@ export async function GET() {
   const avgRawPlanLoad = rawPlanLoads.length > 0
     ? rawPlanLoads.reduce((s: number, v: number) => s + v, 0) / rawPlanLoads.length
     : 1;
-  const epocScaleFactor = avgActualLoad > 0 ? avgActualLoad / avgRawPlanLoad : 1;
+  // Only meaningful when there are plan loads to scale. With no live plan the
+  // denominator defaults to 1 and this would read as avgActualLoad (~67), a
+  // number that means nothing; report 1 so the client scales nothing by nothing.
+  const epocScaleFactor = livePlan.engagement.planLive && avgActualLoad > 0
+    ? avgActualLoad / avgRawPlanLoad
+    : 1;
 
   return NextResponse.json({
     today,

--- a/web/app/api/training/forward-sim/route.ts
+++ b/web/app/api/training/forward-sim/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { getLivePlan, getTrailingLoad } from "@/lib/live-plan";
 
 export const dynamic = "force-dynamic";
 
@@ -25,11 +26,12 @@ export async function GET() {
     readinessRows,
     calibRows,
     fitnessRows,
-    planDays,
+    livePlan,
     garminLoadRows,
     garminReadinessRows,
     garminVo2Rows,
     garminRaceRows,
+    trailingLoad,
   ] = await Promise.all([
     // Current PMC
     sql`SELECT ctl, atl, tsb FROM pmc_daily ORDER BY date DESC LIMIT 1`
@@ -53,17 +55,11 @@ export async function GET() {
         FROM fitness_trajectory WHERE vo2max IS NOT NULL
         ORDER BY date DESC LIMIT 1`
       .catch(() => []),
-    // All plan days (past + future for complete trajectory)
-    sql`SELECT d.id, d.day_date::text as day_date, d.week_number, d.run_type,
-               d.run_title, d.target_distance_km, d.workout_steps,
-               d.load_level, d.gym_workout, d.gym_notes, d.completed,
-               d.garmin_workout_id, d.garmin_push_status,
-               d.actual_distance_km
-        FROM training_plan_day d
-        JOIN training_plan p ON d.plan_id = p.id
-        WHERE p.status = 'active'
-        ORDER BY d.day_date`
-      .catch(() => []),
+    // The LIVE plan and all its days (past + future), or no plan at all. This
+    // no longer trusts status='active': a plan whose race was months ago and
+    // that has no sessions near today is dormant, and the sim must not project
+    // from it (#701). `livePlan.engagement` says which case we are in.
+    getLivePlan(sql, today),
     // Garmin 7-day/28-day load for comparison (last 90 days)
     sql`SELECT date::text as date, daily_load, ctl, atl
         FROM pmc_daily
@@ -94,7 +90,15 @@ export async function GET() {
           AND vo2max IS NOT NULL
         ORDER BY date`
       .catch(() => []),
+    // What the athlete has actually been doing over the trailing 28 days. When
+    // no plan is live this is the projection baseline: "if you keep doing what
+    // you're doing", which the UI must label as an observation, not a plan.
+    getTrailingLoad(sql, today, 28),
   ]);
+
+  // Empty unless the plan is live; every downstream use of planDays inherits
+  // the live rule from this one line.
+  const planDays = livePlan.days;
 
   const pmc = pmcRows[0] ?? { ctl: 0, atl: 0, tsb: 0 };
   const fitness = fitnessRows[0] ?? { vo2max: 47, vdot_adjusted: 47, weight_kg: 80.5 };
@@ -130,6 +134,16 @@ export async function GET() {
   return NextResponse.json({
     today,
     epocScaleFactor,
+    // Whether there is a plan worth simulating from, and why. Clients gate
+    // the plan-driven projection on `engagement.planLive` and otherwise draw
+    // the `fallback` baseline, labelled as what the athlete has been doing.
+    engagement: livePlan.engagement,
+    fallback: {
+      windowDays: trailingLoad.windowDays,
+      meanDailyLoad: Math.round(trailingLoad.meanDailyLoad * 10) / 10,
+      activeDays: trailingLoad.activeDays,
+      label: `if you keep doing what you're doing (last ${trailingLoad.windowDays} days, ${trailingLoad.activeDays} sessions)`,
+    },
     pmc: {
       ctl: Number(pmc.ctl),
       atl: Number(pmc.atl),

--- a/web/app/api/training/graph/route.ts
+++ b/web/app/api/training/graph/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { getLivePlan } from "@/lib/live-plan";
 import {
   type GraphNode,
   type GraphEdge,
@@ -145,20 +146,13 @@ export async function GET(request: Request) {
   const calibDataDays = calib ? Number(calib.data_days) || 0 : 0;
   const calibForceEqual = calib?.force_equal ?? false;
 
-  // Fetch today's run type from the active training plan
+  // Today's prescribed run type, but only from a LIVE plan. A dormant plan's
+  // day (if one even coincides) is not today's prescription (#701). With no
+  // live plan the pace node defaults to "easy", which is the honest neutral.
   const todayStr = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
-  let todayPlan: Record<string, unknown>[] = [];
-  try {
-    todayPlan = await sql`
-      SELECT d.run_type FROM training_plan_day d
-      JOIN training_plan p ON d.plan_id = p.id
-      WHERE p.status = 'active' AND d.day_date = ${todayStr}
-      LIMIT 1
-    `;
-  } catch {
-    // training_plan tables may not exist yet — gracefully skip
-  }
-  const runType = (todayPlan[0]?.run_type as string) || "easy";
+  const livePlan = await getLivePlan(sql, todayStr);
+  const todayPlanDay = livePlan.days.find((d) => d.day_date === todayStr);
+  const runType = todayPlanDay?.run_type || "easy";
   const currentVdot = vdotAdj ?? 0;
   const basePace = getBasePace(currentVdot, runType);
 

--- a/web/app/api/training/trajectory/route.ts
+++ b/web/app/api/training/trajectory/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { getLivePlan } from "@/lib/live-plan";
 import { projectVdotSeries, DEFAULT_BANISTER, type DailyLoad } from "@/lib/banister-projection";
 import { vdotFromHmSeconds } from "@/lib/vdot-utils";
 
@@ -18,12 +19,15 @@ async function safeQuery<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
 export async function GET() {
   const sql = getDb();
 
-  const raceRows = await safeQuery(
-    () => sql`SELECT race_date::text AS race_date, goal_time_seconds FROM training_plan WHERE status = 'active' LIMIT 1`,
-    [] as Record<string, unknown>[],
-  );
-  const race = raceRows[0] ?? null;
-  if (!race?.race_date) return NextResponse.json({ trajectory: [], raceDate: null, goalVdot: null });
+  // Only a LIVE plan has a race worth projecting toward. The Knoxville plan's
+  // race was five months ago; projecting "to the race" from it drew a curve
+  // toward a date in the past (#701). Dormant/absent → the same empty shape
+  // the app already handles, plus the engagement so it can say why.
+  const livePlan = await getLivePlan(sql);
+  const race = livePlan.plan;
+  if (!race?.race_date) {
+    return NextResponse.json({ trajectory: [], raceDate: null, goalVdot: null, engagement: livePlan.engagement });
+  }
   const raceDate = String(race.race_date);
   const goalVdot = race.goal_time_seconds ? vdotFromHmSeconds(Number(race.goal_time_seconds)) : null;
 
@@ -32,13 +36,11 @@ export async function GET() {
     [] as Record<string, unknown>[],
   ))[0] ?? null;
 
-  const planDays = await safeQuery(
-    () => sql`SELECT day_date::text AS day_date, run_type, target_distance_km
-              FROM training_plan_day
-              WHERE plan_id = (SELECT id FROM training_plan WHERE status = 'active' LIMIT 1)
-              ORDER BY day_date`,
-    [] as Record<string, unknown>[],
-  );
+  const planDays: Record<string, unknown>[] = livePlan.days.map((d) => ({
+    day_date: d.day_date,
+    run_type: d.run_type,
+    target_distance_km: d.target_distance_km,
+  }));
 
   const [actuals, pmcRows] = await Promise.all([
     safeQuery(() => sql`SELECT date::text AS date, vo2max FROM fitness_trajectory WHERE vo2max IS NOT NULL ORDER BY date`, [] as Record<string, unknown>[]),

--- a/web/lib/live-plan.test.ts
+++ b/web/lib/live-plan.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { resolveLivePlan, summariseTrailingLoad, type PlanRow, type PlanDayRow } from "./live-plan";
+
+const TODAY = "2026-09-06";
+
+const knox: PlanRow = { id: 1, plan_name: "Knoxville HM 2026", race_date: "2026-04-12", goal_time_seconds: 5400, status: "active" };
+
+function pd(day_date: string, o: Partial<PlanDayRow> = {}): PlanDayRow {
+  return {
+    id: 1, day_date, week_number: 1, run_type: "easy", run_title: "Easy", target_distance_km: 8,
+    target_duration_min: null, workout_steps: null, load_level: "low", gym_workout: null, gym_notes: null,
+    completed: false, garmin_workout_id: null, garmin_push_status: null, actual_distance_km: null, ...o,
+  };
+}
+
+describe("resolveLivePlan — the guard every training route goes through (#701)", () => {
+  it("no plan → absent, nothing to anchor to", () => {
+    const r = resolveLivePlan(null, [], TODAY);
+    expect(r.engagement.state).toBe("absent");
+    expect(r.plan).toBeNull();
+    expect(r.days).toEqual([]);
+  });
+
+  it("THE BUG: Knoxville, status active, race five months ago → dormant, and the routes get NO plan and NO days", () => {
+    const days = ["2026-03-10", "2026-03-20", "2026-04-05", "2026-04-11"].map((d) => pd(d, { completed: true }));
+    const r = resolveLivePlan(knox, days, TODAY);
+    expect(r.engagement.state).toBe("dormant");
+    expect(r.engagement.planLive).toBe(false);
+    expect(r.plan).toBeNull();
+    expect(r.days).toEqual([]);
+    expect(r.engagement.basis).toContain("Knoxville");
+  });
+
+  it("a live plan passes its plan and ALL its days through, past and future", () => {
+    const days = [
+      pd("2026-08-30", { completed: true }), pd("2026-09-02", { completed: true }),
+      pd("2026-09-04", { completed: false }), pd("2026-09-08"), pd("2026-09-12"),
+    ];
+    const r = resolveLivePlan(knox, days, TODAY);
+    expect(r.engagement.planLive).toBe(true);
+    expect(r.plan?.id).toBe(1);
+    expect(r.days).toHaveLength(5);
+  });
+
+  it("plan exists but is not being followed → partial, and routes still get NO plan", () => {
+    const days = [pd("2026-08-28"), pd("2026-08-31"), pd("2026-09-03"), pd("2026-09-05"), pd("2026-09-09")];
+    const r = resolveLivePlan(knox, days, TODAY);
+    expect(r.engagement.state).toBe("partial");
+    expect(r.engagement.planLive).toBe(false);
+    expect(r.plan).toBeNull();
+    expect(r.days).toEqual([]);
+  });
+
+  it("an archived plan is absent regardless of its days", () => {
+    const r = resolveLivePlan({ ...knox, status: "archived" }, [pd("2026-09-05", { completed: true })], TODAY);
+    expect(r.engagement.state).toBe("absent");
+    expect(r.plan).toBeNull();
+  });
+});
+
+describe("summariseTrailingLoad — the 'if you keep doing what you're doing' baseline", () => {
+  const row = (date: string, daily_load: number | null) => ({ date, daily_load });
+
+  it("empty is zero, not NaN", () => {
+    const t = summariseTrailingLoad([], TODAY);
+    expect(t).toEqual({ windowDays: 28, meanDailyLoad: 0, activeDays: 0 });
+  });
+
+  it("averages over the whole window, including rest days, so a 3-session week reads honestly", () => {
+    const rows = [row("2026-09-01", 280), row("2026-09-03", 140), row("2026-09-05", 280)];
+    const t = summariseTrailingLoad(rows, TODAY, 7);
+    expect(t.meanDailyLoad).toBe(100); // 700 / 7 days
+    expect(t.activeDays).toBe(3);
+  });
+
+  it("ignores rows outside the window, including future-dated ones", () => {
+    const rows = [row("2026-08-01", 999), row("2026-09-07", 999), row("2026-09-06", 70)];
+    const t = summariseTrailingLoad(rows, TODAY, 7);
+    expect(t.meanDailyLoad).toBe(10);
+    expect(t.activeDays).toBe(1);
+  });
+
+  it("null loads count as zero and not as active days", () => {
+    const rows = [row("2026-09-05", null), row("2026-09-06", 140)];
+    const t = summariseTrailingLoad(rows, TODAY, 7);
+    expect(t.meanDailyLoad).toBe(20);
+    expect(t.activeDays).toBe(1);
+  });
+
+  it("the window edge is inclusive on both ends", () => {
+    const rows = [row("2026-08-10", 28), row("2026-08-09", 999)];
+    const t = summariseTrailingLoad(rows, TODAY, 28); // window = Aug 10 .. Sep 6
+    expect(t.meanDailyLoad).toBe(1);
+    expect(t.activeDays).toBe(1);
+  });
+});

--- a/web/lib/live-plan.ts
+++ b/web/lib/live-plan.ts
@@ -1,0 +1,147 @@
+/**
+ * The one place that decides whether a training plan is LIVE.
+ *
+ * Four routes used to join `training_plan WHERE status = 'active'` directly and
+ * anchor everything to whatever row that returned. Today that row is the
+ * Knoxville HM plan, race 2026-04-12, five months gone, still flagged active
+ * (#701). "Active" is a flag nobody flipped, not a fact about the athlete.
+ *
+ * Every route now goes through `getLivePlan`, which applies the calibrated
+ * rule from lib/engagement: live = active AND a session within ±7 days AND
+ * trailing-14-day completion ≥ 25%. When no plan is live the routes get
+ * `plan: null, days: []` plus the engagement object explaining why, and fall
+ * back to what Garmin actually observed instead of a phantom script.
+ */
+import type { QueryFn } from "@/lib/db";
+import { trainingEngagement, type PlanInput, type TrainingEngagement } from "@/lib/engagement";
+
+export interface PlanRow {
+  id: number;
+  plan_name: string | null;
+  race_date: string | null;
+  goal_time_seconds: number | null;
+  status: string | null;
+}
+
+/** Superset of the columns the four consuming routes read. */
+export interface PlanDayRow {
+  id: number;
+  day_date: string;
+  week_number: number | null;
+  run_type: string | null;
+  run_title: string | null;
+  target_distance_km: number | null;
+  target_duration_min: number | null;
+  workout_steps: unknown;
+  load_level: string | null;
+  gym_workout: unknown;
+  gym_notes: string | null;
+  completed: boolean | null;
+  garmin_workout_id: string | null;
+  garmin_push_status: string | null;
+  actual_distance_km: number | null;
+}
+
+export interface LivePlan {
+  engagement: TrainingEngagement;
+  /** Non-null only when the plan is live. */
+  plan: PlanRow | null;
+  /** Empty unless the plan is live. */
+  days: PlanDayRow[];
+}
+
+/** Today in the athlete's timezone as YYYY-MM-DD; matches graph/route.ts. */
+export function todayLocal(): string {
+  return new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+}
+
+/**
+ * Pure: apply the live rule to an already-fetched plan and its days.
+ * Exposed for table tests; `getLivePlan` is the SQL wrapper.
+ */
+export function resolveLivePlan(plan: PlanRow | null, days: PlanDayRow[], today: string): LivePlan {
+  const input: PlanInput | null = plan
+    ? { status: plan.status, planName: plan.plan_name, raceDate: plan.race_date }
+    : null;
+  const engagement = trainingEngagement(
+    input,
+    days.map((d) => ({ day_date: d.day_date, run_type: d.run_type, completed: d.completed })),
+    today,
+  );
+  if (!engagement.planLive || !plan) return { engagement, plan: null, days: [] };
+  return { engagement, plan, days };
+}
+
+export async function getLivePlan(sql: QueryFn, today: string = todayLocal()): Promise<LivePlan> {
+  let plan: PlanRow | null = null;
+  let days: PlanDayRow[] = [];
+  try {
+    const rows = (await sql`
+      SELECT id, plan_name, race_date::text AS race_date, goal_time_seconds, status
+      FROM training_plan WHERE status = 'active'
+      ORDER BY created_at DESC LIMIT 1
+    `) as unknown as PlanRow[];
+    plan = rows[0] ?? null;
+    if (plan) {
+      days = (await sql`
+        SELECT id, day_date::text AS day_date, week_number, run_type, run_title,
+               target_distance_km, target_duration_min, workout_steps, load_level,
+               gym_workout, gym_notes, completed, garmin_workout_id,
+               garmin_push_status, actual_distance_km
+        FROM training_plan_day
+        WHERE plan_id = ${plan.id}
+        ORDER BY day_date
+      `) as unknown as PlanDayRow[];
+    }
+  } catch {
+    // training tables may not exist (demo DB): behave as "no plan", not as an error
+  }
+  return resolveLivePlan(plan, days, today);
+}
+
+/**
+ * What the athlete has actually been doing, for the no-plan fallback: mean
+ * daily Garmin load over the trailing window, and how many days carried load.
+ * "If you keep doing what you're doing" is projected from this, and the UI
+ * must label it as such rather than as a prescription.
+ */
+export interface TrailingLoad {
+  windowDays: number;
+  meanDailyLoad: number;
+  activeDays: number;
+}
+
+export function summariseTrailingLoad(
+  rows: { date: string; daily_load: number | null }[],
+  today: string,
+  windowDays = 28,
+): TrailingLoad {
+  const cutoff = shiftDate(today, -(windowDays - 1));
+  const inWindow = rows.filter((r) => r.date >= cutoff && r.date <= today);
+  const loads = inWindow.map((r) => Number(r.daily_load) || 0);
+  const total = loads.reduce((s, v) => s + v, 0);
+  return {
+    windowDays,
+    meanDailyLoad: windowDays > 0 ? total / windowDays : 0,
+    activeDays: loads.filter((v) => v > 0).length,
+  };
+}
+
+export async function getTrailingLoad(sql: QueryFn, today: string = todayLocal(), windowDays = 28): Promise<TrailingLoad> {
+  try {
+    const rows = (await sql`
+      SELECT date::text AS date, daily_load FROM pmc_daily
+      WHERE date >= ${today}::date - ${`${windowDays} days`}::interval AND date <= ${today}::date
+      ORDER BY date
+    `) as unknown as { date: string; daily_load: number | null }[];
+    return summariseTrailingLoad(rows, today, windowDays);
+  } catch {
+    return { windowDays, meanDailyLoad: 0, activeDays: 0 };
+  }
+}
+
+function shiftDate(iso: string, days: number): string {
+  const d = new Date(Date.UTC(+iso.slice(0, 4), +iso.slice(5, 7) - 1, +iso.slice(8, 10)));
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
Closes #701. Part of #698.

`lib/live-plan.ts` is now the one place that decides whether a training plan is **live**. Four routes used to join `training_plan WHERE status = 'active'` and anchor everything to whatever row came back. Today that row is the Knoxville HM plan, race 2026-04-12, five months gone, still flagged active. A flag nobody flipped is not a fact about the athlete.

`getLivePlan` applies the calibrated rule from `lib/engagement`: active **and** a session within 7 days **and** trailing-14-day completion ≥ 25%. When no plan is live, routes receive `plan: null, days: []` plus the engagement object explaining why, and fall back to what Garmin observed rather than to a phantom script.

## Per route

- **forward-sim**: `planDays` empty unless live. Response carries `engagement` and a `fallback` block: mean daily Garmin load over the trailing 28 days with the session count, labelled *"if you keep doing what you're doing"* so the UI cannot present an observation as a prescription.
- **activity-match**: returns `[]` for a dormant plan instead of a wall of missed days.
- **graph**: today's run type comes only from a live plan, else `easy`.
- **trajectory**: the race to project toward comes only from a live plan. Dormant returns the empty shape the app already handles, plus engagement. No more curve toward last April.

## Verified against the real database, not only tests

Ran the branch in an isolated worktree on a spare port (the 3456 host holds the dev lock and was left untouched):

```
forward-sim     state=dormant planLive=false planDays=0
                basis: Knoxville HM 2026 has no sessions within 7 days (race 2026-04-12)
                fallback: mean=38.7/day, 16 sessions in 28 days
trajectory      points=0 raceDate=null state=dormant
activity-match  []
```

**The live run found something reading did not.** With no plan days, `epocScaleFactor` computed as `avgActualLoad / 1 ≈ 67`, a meaningless number. Harmless, since nothing was scaled, but dishonest. It is now 1 unless a plan is live, as a separate commit.

Pure `resolveLivePlan` and `summariseTrailingLoad` with 10 table-driven cases. tsc clean, vitest 260/260 across 36 files. No UI change yet; P5 consumes `engagement` and `fallback`.
