### PR TITLE
Weight trend as the low-engagement primary signal; adaptive hidden when the week is not engaged

### DIFF
--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -6,6 +6,8 @@ import type { SlotBudgets } from "@/lib/nutrition-types";
 import { computeAdaptiveContext } from "@/lib/adaptive-tdee";
 import { computeWeeklyAdherence } from "@/lib/adherence";
 import { meetsCoverageFloor } from "@/lib/coverage";
+import { nutritionEngagement, WEEK_ENGAGEMENT_FLOOR_DAYS } from "@/lib/engagement";
+import { getWeightTrend } from "@/lib/weight-trend";
 import { computeAlcoholDisplacement } from "macro-engine-core";
 
 export const runtime = "edge";
@@ -568,6 +570,23 @@ export async function GET(req: NextRequest) {
   // Adaptive TDEE + deficit-duration (display-only — never changes targets).
   const adaptive = await computeAdaptiveContext(sql).catch(() => null);
 
+  // Is nutrition actually in use this week? trendRows is exactly the 7-day
+  // window ending today with per-day coverage, so no extra query (#700).
+  const engagement = nutritionEngagement(
+    trendRows.map((r: Record<string, unknown>) => ({
+      date: String(r.date),
+      status: (r.status as string | null) ?? null,
+      coverage: typeof r.coverage === "number" ? r.coverage : null,
+    })),
+    date,
+  );
+
+  // The scale is the ground truth that survives not logging. When the week
+  // is not fully engaged this is the PRIMARY signal and the log-derived
+  // numbers above are secondary or hidden; when it is, the roles swap (#702).
+  const weightTrend = await getWeightTrend(sql, date);
+  const weightTrendPrimary = engagement.state !== "complete";
+
   return NextResponse.json({
     plan,
     meals: mealRows,
@@ -581,6 +600,11 @@ export async function GET(req: NextRequest) {
     gymCalories,
     breakdown,
     trend7d,
-    adaptive,
+    // Only meaningful when the week is engaged; the UI hides it otherwise
+    // rather than showing a drift computed from nothing.
+    adaptive: engagement.state === "complete" ? adaptive : null,
+    engagement: { ...engagement, weekFloorDays: WEEK_ENGAGEMENT_FLOOR_DAYS },
+    weightTrend,
+    weightTrendPrimary,
   });
 }

--- a/web/lib/weight-trend.test.ts
+++ b/web/lib/weight-trend.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { computeWeightTrend, WEIGHT_TREND_MIN_POINTS, WEIGHT_TREND_WINDOW_DAYS, type WeighInPoint } from "./weight-trend";
+
+const TODAY = "2026-09-06";
+const w = (date: string, weightKg: number): WeighInPoint => ({ date, weightKg });
+
+describe("computeWeightTrend (#702)", () => {
+  it("window is 14 days and needs 3 weigh-ins", () => {
+    expect(WEIGHT_TREND_WINDOW_DAYS).toBe(14);
+    expect(WEIGHT_TREND_MIN_POINTS).toBe(3);
+  });
+
+  const noTrend: [string, WeighInPoint[], number, string][] = [
+    ["no points → null with a basis that says so", [], 0, "no weigh-ins"],
+    ["one point is not a trend", [w("2026-09-06", 80)], 1, "1 weigh-in in"],
+    ["two points is not a trend", [w("2026-09-01", 80), w("2026-09-06", 79.5)], 2, "2 weigh-ins in"],
+    ["points outside the window do not count", [w("2026-08-01", 82), w("2026-08-10", 81), w("2026-08-20", 80), w("2026-09-06", 79)], 1, "1 weigh-in"],
+    ["future-dated points are ignored", [w("2026-09-07", 70), w("2026-09-08", 70), w("2026-09-06", 80)], 1, "1 weigh-in"],
+    ["non-positive weights are ignored", [w("2026-09-04", 0), w("2026-09-05", -1), w("2026-09-06", 80)], 1, "1 weigh-in"],
+  ];
+  for (const [name, pts, wantN, wantBasis] of noTrend) {
+    it(name, () => {
+      const t = computeWeightTrend(pts, TODAY);
+      expect(t.kgPerWindow).toBeNull();
+      expect(t.weighIns).toBe(wantN);
+      expect(t.basis).toContain(wantBasis);
+    });
+  }
+
+  it("a clean linear loss reports the change over the window exactly", () => {
+    // −0.1 kg/day for 14 days = −1.4 kg over the window
+    const pts: WeighInPoint[] = [];
+    for (let i = 0; i < 14; i++) {
+      const d = new Date(Date.UTC(2026, 8, 6 - i)).toISOString().slice(0, 10);
+      pts.push(w(d, 80 - 0.1 * (13 - i)));
+    }
+    const t = computeWeightTrend(pts, TODAY);
+    expect(t.kgPerWindow).toBeCloseTo(-1.4, 6);
+    expect(t.weighIns).toBe(14);
+    expect(t.basis).toBe("-1.4 kg over 14 days (14 weigh-ins)");
+    expect(t.from).toBe("2026-08-24");
+    expect(t.to).toBe("2026-09-06");
+    // oldest day is 80.0; today, 13 days of −0.1, is 78.7
+    expect(t.latestKg).toBeCloseTo(78.7, 6);
+  });
+
+  it("a gain carries a plus sign", () => {
+    const t = computeWeightTrend([w("2026-08-24", 79), w("2026-08-31", 79.5), w("2026-09-06", 80)], TODAY);
+    expect(t.kgPerWindow).toBeGreaterThan(0);
+    expect(t.basis.startsWith("+")).toBe(true);
+  });
+
+  it("three sparse weigh-ins is enough, and OLS is not fooled by one noisy day", () => {
+    // Real loss of ~0.5 kg with one water-heavy reading in the middle
+    const t = computeWeightTrend([w("2026-08-24", 81.0), w("2026-08-30", 81.4), w("2026-09-06", 80.5)], TODAY);
+    expect(t.weighIns).toBe(3);
+    expect(t.kgPerWindow).not.toBeNull();
+    expect(t.kgPerWindow!).toBeLessThan(0);
+    expect(t.kgPerWindow!).toBeGreaterThan(-1.5);
+  });
+
+  it("a flat weight is ~0, not null", () => {
+    const t = computeWeightTrend([w("2026-08-24", 80), w("2026-08-31", 80), w("2026-09-06", 80)], TODAY);
+    expect(t.kgPerWindow).toBe(0);
+    expect(t.basis).toContain("0.0 kg");
+  });
+
+  it("duplicate dates keep the last value and count once", () => {
+    const t = computeWeightTrend([w("2026-09-06", 90), w("2026-09-06", 80), w("2026-08-30", 80.5), w("2026-08-24", 81)], TODAY);
+    expect(t.weighIns).toBe(3);
+    expect(t.latestKg).toBe(80);
+  });
+
+  it("the window edge is inclusive: a weigh-in 13 days ago counts, 14 does not", () => {
+    const inside = computeWeightTrend([w("2026-08-24", 81), w("2026-08-30", 80.5), w("2026-09-06", 80)], TODAY);
+    expect(inside.weighIns).toBe(3);
+    const outside = computeWeightTrend([w("2026-08-23", 81), w("2026-08-30", 80.5), w("2026-09-06", 80)], TODAY);
+    expect(outside.weighIns).toBe(2);
+  });
+
+  it("the user's actual recent state: an August blackout with no scale either → honest null", () => {
+    const t = computeWeightTrend([w("2026-08-05", 80.2)], TODAY);
+    expect(t.kgPerWindow).toBeNull();
+    expect(t.weighIns).toBe(0);
+    expect(t.basis).toBe("no weigh-ins in the last 14 days");
+  });
+});

--- a/web/lib/weight-trend.ts
+++ b/web/lib/weight-trend.ts
@@ -1,0 +1,124 @@
+/**
+ * Weight trend — the ground truth that survives not logging.
+ *
+ * Logged intake is a SAMPLED observation whose bias is exactly the logging
+ * gap. Body weight is an INTEGRATED one: it reflects true energy balance over
+ * the preceding days whether or not a single meal was logged. So when logging
+ * coverage is thin, the scale is the only signal worth trusting, and it
+ * answers the question the user actually asks, "am I in deficit", more
+ * honestly than any partial log ever could (#702).
+ *
+ * The trend is an ordinary-least-squares slope over the trailing window,
+ * reported as kg per window so the number is directly readable ("−0.4 kg over
+ * 14 days"). Daily weigh-ins are noisy with water; a 14-day slope over 3+
+ * points smooths that without hiding a real change.
+ */
+import type { QueryFn } from "@/lib/db";
+import { daysBetween } from "@/lib/coverage";
+
+export const WEIGHT_TREND_WINDOW_DAYS = 14;
+/** Fewer weigh-ins than this and a slope is noise, not a trend. */
+export const WEIGHT_TREND_MIN_POINTS = 3;
+
+export interface WeighInPoint {
+  date: string;
+  weightKg: number;
+}
+
+export interface WeightTrend {
+  /** Change over the window in kg, negative = losing. null when too few points. */
+  kgPerWindow: number | null;
+  windowDays: number;
+  weighIns: number;
+  /** First and last weigh-in dates used, or null. */
+  from: string | null;
+  to: string | null;
+  /** Latest weigh-in in the window, or null. */
+  latestKg: number | null;
+  /** Plain-language line for the UI. */
+  basis: string;
+}
+
+/**
+ * Pure: OLS slope of weight against day-offset over the trailing window
+ * ending at `today`. Points outside the window are ignored; duplicate dates
+ * keep the last value.
+ */
+export function computeWeightTrend(
+  points: WeighInPoint[],
+  today: string,
+  windowDays = WEIGHT_TREND_WINDOW_DAYS,
+): WeightTrend {
+  const byDate = new Map<string, number>();
+  for (const p of points) {
+    if (!Number.isFinite(p.weightKg) || p.weightKg <= 0) continue;
+    const back = daysBetween(p.date, today);
+    if (back < 0 || back >= windowDays) continue;
+    byDate.set(p.date, p.weightKg);
+  }
+  const xs: number[] = [];
+  const ys: number[] = [];
+  const dates = [...byDate.keys()].sort();
+  for (const d of dates) {
+    xs.push(-daysBetween(d, today)); // 0 = today, negative = past
+    ys.push(byDate.get(d)!);
+  }
+  const n = xs.length;
+  const latestKg = n ? ys[n - 1] : null;
+
+  if (n < WEIGHT_TREND_MIN_POINTS) {
+    return {
+      kgPerWindow: null,
+      windowDays,
+      weighIns: n,
+      from: n ? dates[0] : null,
+      to: n ? dates[n - 1] : null,
+      latestKg,
+      basis: n === 0
+        ? `no weigh-ins in the last ${windowDays} days`
+        : `${n} weigh-in${n === 1 ? "" : "s"} in the last ${windowDays} days; ${WEIGHT_TREND_MIN_POINTS} needed for a trend`,
+    };
+  }
+
+  const mx = xs.reduce((s, v) => s + v, 0) / n;
+  const my = ys.reduce((s, v) => s + v, 0) / n;
+  let sxy = 0;
+  let sxx = 0;
+  for (let i = 0; i < n; i++) {
+    sxy += (xs[i] - mx) * (ys[i] - my);
+    sxx += (xs[i] - mx) * (xs[i] - mx);
+  }
+  // All weigh-ins on one day: no slope is defined.
+  if (sxx === 0) {
+    return { kgPerWindow: null, windowDays, weighIns: n, from: dates[0], to: dates[n - 1], latestKg,
+      basis: `${n} weigh-ins on a single day; no trend` };
+  }
+  const slopePerDay = sxy / sxx;
+  const kgPerWindow = Math.round(slopePerDay * windowDays * 100) / 100;
+  const sign = kgPerWindow > 0 ? "+" : "";
+  return {
+    kgPerWindow,
+    windowDays,
+    weighIns: n,
+    from: dates[0],
+    to: dates[n - 1],
+    latestKg,
+    basis: `${sign}${kgPerWindow.toFixed(1)} kg over ${windowDays} days (${n} weigh-ins)`,
+  };
+}
+
+export async function getWeightTrend(sql: QueryFn, today: string, windowDays = WEIGHT_TREND_WINDOW_DAYS): Promise<WeightTrend> {
+  try {
+    const rows = (await sql`
+      SELECT date::text AS date, weight_grams / 1000.0 AS weight_kg
+      FROM weight_log
+      WHERE weight_grams IS NOT NULL
+        AND date >= ${today}::date - ${`${windowDays} days`}::interval
+        AND date <= ${today}::date
+      ORDER BY date
+    `) as unknown as { date: string; weight_kg: number }[];
+    return computeWeightTrend(rows.map((r) => ({ date: r.date, weightKg: Number(r.weight_kg) })), today, windowDays);
+  } catch {
+    return computeWeightTrend([], today, windowDays);
+  }
+}


### PR DESCRIPTION
Closes #702. Part of #698.

Logged intake is a **sampled** observation whose bias is exactly the logging gap. Body weight is an **integrated** one: it reflects true energy balance over the preceding days whether or not a single meal was logged. When logging coverage is thin, the scale is the only signal worth trusting, and it answers "am I in deficit" more honestly than any partial log ever could.

## lib/weight-trend.ts

OLS slope over the trailing 14 days of `weight_log`, reported as kg per window so it reads directly ("−0.4 kg over 14 days (5 weigh-ins)"). Needs 3 weigh-ins; fewer returns `null` with a basis that says how many more. Duplicate dates keep the last value, non-positive weights and out-of-window points are ignored, all weigh-ins on one day yields no slope. 14 table-driven cases.

## plan/route.ts

Computes `nutritionEngagement` from `trendRows`, which is already the 7-day window with per-day coverage, so no extra query. Returns `engagement`, `weightTrend`, and `weightTrendPrimary` (true whenever the week is not fully engaged). `adaptive` is now `null` unless the week is complete: a TDEE drift computed from nothing is not information.

## Verified live against the real database

Isolated worktree on a spare port, `GET /api/nutrition/plan?date=2026-09-06`:

```
engagement     partial — "1 partly logged of the last 7 days; 3 full days needed"
weightTrend    null    — "1 weigh-in in the last 14 days; 3 needed for a trend"
weightTrendPrimary  true
adaptive       null
trend7d        countedDays=0, adherence=null      ← the #699 guard on the live route
```

Every field is an honest statement about what was observed. The nudge it produces, weigh in three times, is the correct one.

## One test was wrong, the code was right

My linear-loss fixture put 80 kg on the oldest day and 78.7 on today, so `latestKg` was correctly 78.7 while I had asserted 80. The slope expectation passed throughout.

tsc clean, vitest 274/274 across 37 files. No UI change; P5 renders these fields.
