### PR TITLE
Honesty pass: training and nutrition say what is observed, not what is assumed

### DIFF
--- a/web/app/nutrition/page.tsx
+++ b/web/app/nutrition/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getDb } from "@/lib/db";
+import { getLivePlan } from "@/lib/live-plan";
 import { NutritionDashboard } from "@/components/nutrition-dashboard";
 import { NutritionOnboarding } from "@/components/nutrition-onboarding";
 import { BodyCompChart } from "@/components/body-comp-chart";
@@ -180,18 +181,25 @@ async function getIngredients() {
   return sql`SELECT * FROM ingredients WHERE status = 'confirmed' ORDER BY category, name`;
 }
 
+/**
+ * Today's prescribed session, but only from a LIVE plan (#701). A dormant
+ * plan's day, if one even coincides with this date, is not a prescription and
+ * must not add planned-run calories to today's budget.
+ */
 async function getTrainingDay(date: string) {
   const sql = getDb();
-  const rows = await sql`
-    SELECT d.run_type, d.run_title, d.target_distance_km,
-           d.target_duration_min, d.load_level, d.gym_workout,
-           p.plan_name
-    FROM training_plan_day d
-    JOIN training_plan p ON d.plan_id = p.id
-    WHERE p.status = 'active' AND d.day_date = ${date}
-    LIMIT 1
-  `;
-  return rows[0] ?? null;
+  const live = await getLivePlan(sql, date);
+  const d = live.days.find((x) => x.day_date === date);
+  if (!d || !live.plan) return null;
+  return {
+    run_type: d.run_type,
+    run_title: d.run_title,
+    target_distance_km: d.target_distance_km,
+    target_duration_min: d.target_duration_min,
+    load_level: d.load_level,
+    gym_workout: d.gym_workout,
+    plan_name: live.plan.plan_name,
+  };
 }
 
 async function getHealthSummary(date: string) {

--- a/web/app/training/page.tsx
+++ b/web/app/training/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Card, CardContent } from "@/components/ui/card";
 import { TrainingDashboard } from "@/components/training-dashboard";
 import { getDb } from "@/lib/db";
+import { getLivePlan, getTrailingLoad, type LivePlan } from "@/lib/live-plan";
 import { Target } from "lucide-react";
 import { TrainingControls } from "@/components/training-controls";
 import { projectVdotSeries, DEFAULT_BANISTER, type DailyLoad } from "@/lib/banister-projection";
@@ -19,33 +20,31 @@ async function safeQuery<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
   }
 }
 
-async function getTrainingPlan() {
+/**
+ * The plan this page renders, gated by the live rule (#701). A plan whose race
+ * was months ago and that has no sessions near today is DORMANT: it comes back
+ * with no days and no race, plus the engagement object saying why, and the
+ * page shows what Garmin actually observed instead of a phantom schedule.
+ */
+async function getPlanForPage(): Promise<{
+  planDays: any[];
+  raceInfo: { race_date: string; goal_time_seconds: number | null; plan_name: string | null } | null;
+  live: LivePlan;
+}> {
   const sql = getDb();
-  return safeQuery(
-    () => sql`
-      SELECT d.*, d.day_date::text as day_date,
-             p.plan_name, p.race_date::text as race_date, p.goal_time_seconds
-      FROM training_plan_day d
-      JOIN training_plan p ON d.plan_id = p.id
-      WHERE p.status = 'active'
-      ORDER BY d.day_date
-    `,
-    [],
-  );
-}
-
-async function getRaceInfo() {
-  const sql = getDb();
-  const rows = await safeQuery(
-    () => sql`
-      SELECT race_date::text as race_date, goal_time_seconds, plan_name
-      FROM training_plan
-      WHERE status = 'active'
-      LIMIT 1
-    `,
-    [],
-  );
-  return rows[0] || null;
+  const live = await getLivePlan(sql);
+  if (!live.plan) return { planDays: [], raceInfo: null, live };
+  const { plan } = live;
+  const planDays = live.days.map((d) => ({
+    ...d,
+    plan_name: plan.plan_name,
+    race_date: plan.race_date,
+    goal_time_seconds: plan.goal_time_seconds,
+  }));
+  const raceInfo = plan.race_date
+    ? { race_date: plan.race_date, goal_time_seconds: plan.goal_time_seconds, plan_name: plan.plan_name }
+    : null;
+  return { planDays, raceInfo, live };
 }
 
 async function getReadiness() {
@@ -174,16 +173,10 @@ async function getTrajectoryData(
 
   if (actuals.length === 0) return { trajectory: [], norms: { ctlMin: 0, ctlRange: 1, readinessMin: 0, readinessRange: 1, weightMin: 70, weightRange: 10 } };
 
-  // Query rest days from the active plan to filter them from the X-axis
-  const restDays = await safeQuery(
-    () => sql`
-      SELECT day_date::text as day_date FROM training_plan_day
-      WHERE plan_id = (SELECT id FROM training_plan WHERE status = 'active' LIMIT 1)
-        AND run_type = 'rest'
-    `,
-    [],
-  );
-  const restDatesSet = new Set(restDays.map((r: any) => r.day_date));
+  // Rest days come from the LIVE plan's days passed in (already gated by the
+  // live rule), not from a raw status='active' join that would resurrect a
+  // dormant plan's calendar (#701).
+  const restDatesSet = new Set(planDays.filter((d: any) => d.run_type === "rest").map((d: any) => d.day_date));
 
   // Race-calibrated VDOT from Banister model — no Garmin fallback
   const banisterCurrentVdot = banister?.current_vdot ? Number(banister.current_vdot) : 0;
@@ -358,17 +351,24 @@ async function getTrajectoryData(
 }
 
 export default async function TrainingPage() {
-  const [planDays, raceInfo, readiness, pmcLatest, fitnessLatest, referenceData, banisterParams] = await Promise.all([
-    getTrainingPlan(),
-    getRaceInfo(),
+  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const [planForPage, readiness, pmcLatest, fitnessLatest, referenceData, banisterParams, trailingLoad] = await Promise.all([
+    getPlanForPage(),
     getReadiness(),
     getPMCLatest(),
     getFitnessLatest(),
     getReferenceData(),
     getBanisterParams(),
+    getTrailingLoad(getDb(), today, 28),
   ]);
-
-  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const { planDays, raceInfo, live } = planForPage;
+  const engagement = live.engagement;
+  const fallback = {
+    windowDays: trailingLoad.windowDays,
+    meanDailyLoad: Math.round(trailingLoad.meanDailyLoad * 10) / 10,
+    activeDays: trailingLoad.activeDays,
+    label: `if you keep doing what you're doing (last ${trailingLoad.windowDays} days, ${trailingLoad.activeDays} sessions)`,
+  };
 
   // Trajectory data (depends on raceInfo, banister params, and plan days)
   let trajectoryData: { date: string; optimal: number; actual: number | null; projectedVdot: number | null; ctl: number | null; readiness: number | null; weightEffect: number | null }[] = [];
@@ -396,7 +396,12 @@ export default async function TrainingPage() {
     ? vdotFromHmSeconds(Number(raceInfo.goal_time_seconds))
     : 49;
 
-  const hasNoPlan = planDays.length === 0;
+  // "No live plan" is a first-class state, not an empty one (#698, #701). The
+  // athlete may be training without a script — Garmin still records every
+  // session — so load, fitness, readiness and the model-vs-Garmin comparison
+  // all render regardless. Only the plan-specific surfaces (schedule, race
+  // countdown, week counter) go away, replaced by what was actually observed.
+  const planLive = engagement.planLive;
 
   // Days until race for the thin header bar. Keep the raw (signed) value: a
   // negative number means the race is in the past — clamping it to 0 made a
@@ -407,11 +412,12 @@ export default async function TrainingPage() {
   const daysUntilRace = rawDaysUntilRace != null ? Math.max(0, rawDaysUntilRace) : 0;
   const racePast = rawDaysUntilRace != null && rawDaysUntilRace < 0;
 
-  // Header subtitle. Don't present a past race or an out-of-window plan as live:
-  // a finished race shows "race completed Nd ago", and the week indicator only
-  // shows when today actually falls inside the plan (not the "Week 1" fallback).
-  const planSubtitle = hasNoPlan
-    ? "No active training plan."
+  // Header subtitle. Never present a dormant or unfollowed plan as live: the
+  // engagement basis says exactly what the situation is, in plain words.
+  const planSubtitle = !planLive
+    ? engagement.state === "absent"
+      ? `No training plan · ${fallback.activeDays} sessions in the last ${fallback.windowDays} days`
+      : `${engagement.basis} · ${fallback.activeDays} sessions in the last ${fallback.windowDays} days`
     : racePast
       ? `${raceInfo?.plan_name || "Training Plan"} · race completed ${Math.abs(rawDaysUntilRace as number)}d ago`
       : `${raceInfo?.plan_name || "Training Plan"} · ${daysUntilRace}d to race${todayEntry ? ` · Week ${currentWeek}/${totalWeeks}` : ""}`;
@@ -422,39 +428,42 @@ export default async function TrainingPage() {
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold">Training</h1>
-          <p className="text-sm text-muted-foreground">{planSubtitle}</p>
+          <p className="text-sm text-muted-foreground" data-testid="training-subtitle">{planSubtitle}</p>
         </div>
-        {!hasNoPlan && <TrainingControls />}
+        {planLive && <TrainingControls />}
       </div>
 
-      {hasNoPlan ? (
-        <Card>
-          <CardContent className="py-16 text-center">
-            <Target
-              className="h-12 w-12 mx-auto mb-4 text-muted-foreground opacity-50"
-            />
-            <h2 className="text-lg font-semibold mb-2">No Active Training Plan</h2>
-            <p className="text-sm text-muted-foreground max-w-md mx-auto">
-              Create a training plan via the sync pipeline to see your schedule,
-              race countdown, and weekly breakdown here.
-            </p>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-6">
-          {/* Training Dashboard — client component managing graph, trajectory, and plan */}
-          <TrainingDashboard
-            planDays={planDays as any}
-            today={today}
-            raceInfo={raceInfo as any}
-            trajectoryData={trajectoryData}
-            trajectoryNorms={trajectoryNorms}
-            currentVdot={currentVdot}
-            goalVdot={goalVdot}
-            referenceData={referenceData as any}
-          />
-        </div>
-      )}
+      <div className="space-y-6">
+        {!planLive && (
+          <Card data-testid="training-no-live-plan">
+            <CardContent className="py-6 flex items-start gap-4">
+              <Target className="h-8 w-8 mt-0.5 text-muted-foreground opacity-50 shrink-0" />
+              <div className="space-y-1">
+                <h2 className="text-base font-semibold">
+                  {engagement.state === "dormant" ? "Plan is dormant" : engagement.state === "partial" ? "Plan exists, not being followed" : "No training plan"}
+                </h2>
+                <p className="text-sm text-muted-foreground">{engagement.basis}.</p>
+                <p className="text-sm text-muted-foreground">
+                  Everything below is from what you actually did. Projections assume {fallback.label}.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+        {/* Training Dashboard — client component managing graph, trajectory, and plan */}
+        <TrainingDashboard
+          planDays={planDays as any}
+          today={today}
+          raceInfo={raceInfo as any}
+          trajectoryData={trajectoryData}
+          trajectoryNorms={trajectoryNorms}
+          currentVdot={currentVdot}
+          goalVdot={goalVdot}
+          referenceData={referenceData as any}
+          engagement={engagement}
+          fallback={fallback}
+        />
+      </div>
     </div>
   );
 }

--- a/web/app/training/page.tsx
+++ b/web/app/training/page.tsx
@@ -439,7 +439,7 @@ export default async function TrainingPage() {
             <CardContent className="py-6 flex items-start gap-4">
               <Target className="h-8 w-8 mt-0.5 text-muted-foreground opacity-50 shrink-0" />
               <div className="space-y-1">
-                <h2 className="text-base font-semibold">
+                <h2 className="text-base font-semibold text-foreground" data-testid="training-no-live-plan-title">
                   {engagement.state === "dormant" ? "Plan is dormant" : engagement.state === "partial" ? "Plan exists, not being followed" : "No training plan"}
                 </h2>
                 <p className="text-sm text-muted-foreground">{engagement.basis}.</p>

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { MACRO_COLORS } from "soma-style/colors";
 import { AlertTriangle, Lock, Moon, Footprints, Dumbbell, ChevronLeft, ChevronRight, X } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
@@ -336,6 +336,13 @@ export function NutritionDashboard({
   const [breakdown, setBreakdown] = useState<any>(null);
   const [trend7d, setTrend7d] = useState<any>(null);
   const [adaptive, setAdaptive] = useState<any>(null);
+  // Engagement-aware rendering (#698): is nutrition actually in use this
+  // week, and what does the scale say regardless of logging.
+  const [engagement, setEngagement] = useState<any>(null);
+  const [weightTrend, setWeightTrend] = useState<any>(null);
+  const [weightTrendPrimary, setWeightTrendPrimary] = useState<boolean>(false);
+  // Close-day prompt: which slots are neither logged nor explicitly skipped.
+  const [closePrompt, setClosePrompt] = useState<string[] | null>(null);
   const [dataReady, setDataReady] = useState(false);
   const [rebalanceToast, setRebalanceToast] = useState<string | null>(null);
 
@@ -360,6 +367,9 @@ export function NutritionDashboard({
         if (data.breakdown) setBreakdown(data.breakdown);
         if (data.trend7d) setTrend7d(data.trend7d);
         setAdaptive(data.adaptive ?? null);
+        setEngagement(data.engagement ?? null);
+        setWeightTrend(data.weightTrend ?? null);
+        setWeightTrendPrimary(Boolean(data.weightTrendPrimary));
       }
       if (presetsRes.ok) {
         const presetsData = await presetsRes.json();
@@ -495,8 +505,19 @@ export function NutritionDashboard({
     }
   };
 
-  // Close day handler
-  const handleCloseDay = async () => {
+  // Slots that are neither logged with calories nor explicitly skipped. These
+  // are ABSENT, not zero: closing over them silently would turn a
+  // breakfast-only day into a 600-kcal "intake" (#699, #703).
+  const unloggedSlots = useMemo(() => {
+    const logged = new Set(
+      meals.filter((m: any) => Number(m.calories) > 0).map((m: any) => String(m.meal_slot)),
+    );
+    return ["breakfast", "lunch", "dinner", "pre_sleep"].filter(
+      (s) => !logged.has(s) && !skippedSlots.includes(s),
+    );
+  }, [meals, skippedSlots]);
+
+  const postClose = async () => {
     setClosing(true);
     try {
       const res = await fetch("/api/nutrition/close-day", {
@@ -509,7 +530,35 @@ export function NutritionDashboard({
       }
     } finally {
       setClosing(false);
+      setClosePrompt(null);
     }
+  };
+
+  // Close day handler. Asks ONCE about unlogged slots so the day can become
+  // complete (skipped) or stay open, instead of closing over absent data.
+  const handleCloseDay = async () => {
+    if (unloggedSlots.length > 0) {
+      setClosePrompt(unloggedSlots);
+      return;
+    }
+    await postClose();
+  };
+
+  // "I did not eat those": mark each unlogged slot skipped, then close.
+  const skipUnloggedAndClose = async () => {
+    setClosing(true);
+    try {
+      for (const slot of closePrompt ?? []) {
+        await fetch("/api/nutrition/skip-slot", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ date, slot }),
+        });
+      }
+    } finally {
+      setClosing(false);
+    }
+    await postClose();
   };
 
   // Format sleep hours
@@ -761,6 +810,44 @@ export function NutritionDashboard({
                       </div>
                     )}
 
+                    {/* Engagement + the scale (#698, #702, #703).
+                        The scale is the ground truth that survives not logging.
+                        When the week is not fully engaged it leads; the
+                        log-derived totals below are hidden rather than shown
+                        as a deficit computed from nothing. */}
+                    {engagement && (
+                      <div className="space-y-1" data-testid="nutrition-engagement">
+                        <div className="flex items-center justify-between">
+                          <div className="text-[10px] lg:text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                            {weightTrendPrimary ? "Scale" : "This Week"}
+                          </div>
+                          <div className="text-[9px] text-muted-foreground/60" data-testid="nutrition-engagement-basis">
+                            {engagement.basis}
+                          </div>
+                        </div>
+                        {weightTrend && (
+                          <div className="flex justify-between items-baseline text-xs" data-testid="nutrition-weight-trend">
+                            <span className="text-muted-foreground">
+                              {weightTrend.kgPerWindow != null ? "Weight trend" : "Weight"}
+                            </span>
+                            <span className={`tabular-nums ${weightTrend.kgPerWindow == null ? "text-muted-foreground" : weightTrend.kgPerWindow < 0 ? "text-green-500" : weightTrend.kgPerWindow > 0 ? "text-amber-400" : ""}`}>
+                              {weightTrend.basis}
+                            </span>
+                          </div>
+                        )}
+                        {engagement.state === "absent" && (
+                          <div className="text-xs text-muted-foreground" data-testid="nutrition-not-tracking">
+                            Not tracking meals this week. Weigh in to keep the trend honest.
+                          </div>
+                        )}
+                        {engagement.state === "partial" && (
+                          <div className="text-xs text-muted-foreground" data-testid="nutrition-partial">
+                            Partly logged. Weekly totals show after {engagement.weekFloorDays} full days; skip a meal you did not eat so the day counts.
+                          </div>
+                        )}
+                      </div>
+                    )}
+
                     {/* 7-day trend table */}
                     {trend7d && trend7d.days.length > 0 && (
                       <div className="space-y-1">
@@ -798,8 +885,9 @@ export function NutritionDashboard({
                               </React.Fragment>
                             );
                           })}
-                          {/* Total */}
-                          {trend7d.closedDays > 0 && (() => {
+                          {/* Total — only over a fully engaged week. A total over
+                              two closed days is not a week's deficit (#699, #703). */}
+                          {trend7d.closedDays > 0 && engagement?.state === "complete" && (() => {
                             const total = trend7d.totalDeficit; // negative = deficit
                             const goal = -(trend7d.closedDays * trend7d.goalDeficit); // negative target
                             return (
@@ -813,7 +901,7 @@ export function NutritionDashboard({
                             );
                           })()}
                         </div>
-                        {trend7d.adherence && (() => {
+                        {trend7d.adherence && engagement?.state === "complete" && (() => {
                           const a = trend7d.adherence;
                           const label = a.status === "on_track" ? "on track" : a.status === "under" ? "under goal" : "over goal";
                           const color = a.status === "on_track" ? "text-green-500" : "text-amber-400";
@@ -1109,13 +1197,36 @@ export function NutritionDashboard({
           onDrinkLogged={() => handleMealChanged()}
         />
 
-        {/* Close Day button */}
-        {!isClosed && targetCal > 0 && (
+        {/* Close Day button, with a one-time prompt about unlogged slots (#703) */}
+        {!isClosed && targetCal > 0 && closePrompt && (
+          <div className="rounded-lg border border-border bg-card p-3 space-y-2 text-sm" data-testid="close-day-prompt">
+            <div>
+              <span className="font-medium">{closePrompt.length} meal{closePrompt.length === 1 ? "" : "s"} not logged:</span>{" "}
+              <span className="text-muted-foreground">{closePrompt.map((s) => s.replace("_", "-")).join(", ")}</span>
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Did you skip them, or did you just not log them? Skipped meals make the day count as complete; unlogged ones are unknown and the day will not feed your weekly numbers.
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" onClick={skipUnloggedAndClose} disabled={closing} data-testid="close-day-skip">
+                {closing ? "Closing..." : "I skipped them"}
+              </Button>
+              <Button size="sm" variant="outline" onClick={postClose} disabled={closing} data-testid="close-day-anyway">
+                Close anyway
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setClosePrompt(null)} disabled={closing} data-testid="close-day-cancel">
+                Leave open
+              </Button>
+            </div>
+          </div>
+        )}
+        {!isClosed && targetCal > 0 && !closePrompt && (
           <Button
             variant="outline"
             className="w-full"
             onClick={handleCloseDay}
             disabled={closing}
+            data-testid="close-day"
           >
             {closing ? "Closing..." : "Close Day"}
           </Button>

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -891,21 +891,27 @@ export function NutritionDashboard({
                               : d.deficit < 0 ? "text-amber-500"
                               : d.deficit > 0 ? "text-rose-500" : "text-muted-foreground";
                             const isInProgress = d.isToday && !d.closed;
+                            // A day with nothing logged has no deficit to show, in
+                            // progress or not: "(−2363)" for an unlogged today is the
+                            // same fabrication the hero no longer makes (#703).
+                            const unobserved = (d.coverage ?? 0) === 0 && !(d.ate > 0);
                             return (
                               <React.Fragment key={d.date}>
                                 <span>
                                   {dayLabel}
                                   <span className="block sm:hidden text-[9px] text-muted-foreground/60">
-                                    ate {isInProgress ? `(${d.ate})` : d.ate} · burn {d.burn}
+                                    ate {unobserved ? "–" : isInProgress ? `(${d.ate})` : d.ate} · burn {d.burn}
                                   </span>
                                 </span>
                                 <span className={`tabular-nums text-right hidden sm:block ${isInProgress ? "text-muted-foreground" : ""}`}>
-                                  {isInProgress ? `(${d.ate})` : d.ate || "\u2013"} / {d.burn || "\u2013"}
+                                  {unobserved ? "\u2013" : isInProgress ? `(${d.ate})` : d.ate || "\u2013"} / {d.burn || "\u2013"}
                                 </span>
-                                <span className={`tabular-nums text-right font-medium ${isInProgress ? "text-muted-foreground" : deficitColor}`}>
-                                  {isInProgress
-                                    ? `(${d.deficit > 0 ? "+" : ""}${d.deficit})`
-                                    : d.ate > 0 ? `${d.deficit > 0 ? "+" : ""}${d.deficit}` : "\u2013"
+                                <span className={`tabular-nums text-right font-medium ${isInProgress || !(d.ate > 0) ? "text-muted-foreground" : deficitColor}`}>
+                                  {unobserved
+                                    ? "\u2013"
+                                    : isInProgress
+                                      ? `(${d.deficit > 0 ? "+" : ""}${d.deficit})`
+                                      : d.ate > 0 ? `${d.deficit > 0 ? "+" : ""}${d.deficit}` : "\u2013"
                                   } / &minus;{trend7d.goalDeficit}
                                 </span>
                               </React.Fragment>

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -695,10 +695,36 @@ export function NutritionDashboard({
                       <span>{goalIntake} goal{deficit > 0 && <span className="text-muted-foreground/50"> (&minus;{deficit})</span>}</span>
                       <span>{totalBurn} burn</span>
                     </div>
-                    {/* Current deficit */}
-                    <div className="text-xs text-center">
-                      <span className={currentDeficit < 0 ? "text-green-500" : "text-rose-500"}>{currentDeficit > 0 ? "+" : ""}{Math.round(currentDeficit)} current deficit</span>
-                    </div>
+                    {/* Current deficit — only a claim when today is actually
+                        observed. With nothing logged, "eaten − burn" is a
+                        fabricated −2363 in green, which is exactly the
+                        "assumes I'm always in deficit" complaint (#698, #703).
+                        Below the coverage floor, say what is true instead. */}
+                    {(() => {
+                      const loggedSlotCount = 4 - unloggedSlots.length;
+                      const todayObserved = isClosed || loggedSlotCount >= 3;
+                      if (todayObserved) {
+                        return (
+                          <div className="text-xs text-center" data-testid="hero-deficit">
+                            <span className={currentDeficit < 0 ? "text-green-500" : "text-rose-500"}>{currentDeficit > 0 ? "+" : ""}{Math.round(currentDeficit)} current deficit</span>
+                          </div>
+                        );
+                      }
+                      return (
+                        <div className="text-xs text-center text-muted-foreground" data-testid="hero-not-observed">
+                          {loggedSlotCount === 0
+                            ? "nothing logged yet · deficit unknown"
+                            : `${Math.round(consumedCal)} eaten so far · ${loggedSlotCount} of 4 meals logged · deficit unknown`}
+                        </div>
+                      );
+                    })()}
+                    {/* The scale, at hero level, whenever logging is not
+                        carrying the week — visible without expanding. */}
+                    {weightTrendPrimary && weightTrend && (
+                      <div className="text-[11px] text-center text-muted-foreground" data-testid="hero-weight-trend">
+                        Scale: {weightTrend.basis}
+                      </div>
+                    )}
                   </div>
                 );
               })()}

--- a/web/components/training-dashboard.tsx
+++ b/web/components/training-dashboard.tsx
@@ -62,6 +62,10 @@ interface TrainingDashboardProps {
   currentVdot: number;
   goalVdot: number;
   referenceData: ReferenceData;
+  /** Whether a plan is live and why (#701). Absent means "assume live" for older callers. */
+  engagement?: { state: string; planLive: boolean; basis: string; planName: string | null };
+  /** What the athlete has actually been doing; the projection baseline when no plan is live. */
+  fallback?: { windowDays: number; meanDailyLoad: number; activeDays: number; label: string };
 }
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -253,7 +257,14 @@ export function TrainingDashboard({
   currentVdot,
   goalVdot,
   referenceData,
+  engagement,
+  fallback,
 }: TrainingDashboardProps) {
+  // A plan is live unless the server said otherwise. Everything that is
+  // ABOUT the plan (schedule, next session, edits) hides when it is not;
+  // everything from Garmin (load, fitness, readiness, comparison) stays.
+  const planLive = engagement ? engagement.planLive : true;
+
   // Client-side state
   const [sliderValue, setSliderValue] = useState(1.0);
   const [graphData, setGraphData] = useState<GraphApiResponse | null>(null);
@@ -747,20 +758,35 @@ export function TrainingDashboard({
         </>
       )}
 
-      {/* Training Plan — full 5-week plan */}
-      <h3 className="text-sm font-medium text-muted-foreground">Training Plan</h3>
-      <TrainingPlanView
-        days={planDays}
-        today={today}
-        activityMatches={activityMatches}
-        deltaWorkouts={deltaWorkouts}
-        onStepsEdited={setEditedSteps}
-        projectedDays={forwardSim}
-        sliderActive={Math.abs(sliderValue - 1.0) > 0.001}
-      />
+      {/* Training Plan — only when a plan is LIVE. A dormant or unfollowed
+          plan is not shown as a schedule with missed days; the page-level card
+          has already said what the situation is, and the fallback label below
+          says what the projections assume instead (#701, #703). */}
+      {planLive ? (
+        <>
+          <h3 className="text-sm font-medium text-muted-foreground">Training Plan</h3>
+          <div data-testid="training-plan-section">
+            <TrainingPlanView
+              days={planDays}
+              today={today}
+              activityMatches={activityMatches}
+              deltaWorkouts={deltaWorkouts}
+              onStepsEdited={setEditedSteps}
+              projectedDays={forwardSim}
+              sliderActive={Math.abs(sliderValue - 1.0) > 0.001}
+            />
+          </div>
+        </>
+      ) : (
+        fallback && (
+          <p className="text-xs text-muted-foreground" data-testid="training-fallback-note">
+            Projections assume {fallback.label}: about {Math.round(fallback.meanDailyLoad)} load/day.
+          </p>
+        )
+      )}
 
-      {/* Delta save button */}
-      {isDirty && (
+      {/* Delta save button — only meaningful against a live plan */}
+      {planLive && isDirty && (
         <div className="sticky bottom-4 flex justify-center z-40">
           <button
             onClick={handleSave}
@@ -780,14 +806,17 @@ export function TrainingDashboard({
         </div>
       )}
 
-      {/* Floating training intensity slider */}
-      <FloatingSlider
-        value={sliderValue}
-        onChange={setSliderValue}
-        savedValue={1.0}
-        onSave={handleSave}
-        onReset={() => setSliderValue(1.0)}
-      />
+      {/* Floating training intensity slider — it scales PLAN workouts, so
+          there is nothing for it to scale without a live plan */}
+      {planLive && (
+        <FloatingSlider
+          value={sliderValue}
+          onChange={setSliderValue}
+          savedValue={1.0}
+          onSave={handleSave}
+          onReset={() => setSliderValue(1.0)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #703. Also closes the gap #706 left on #701. Part of #698.

The pages now change what they **say** based on whether the module is in use, not only what they compute.

## Training: "no plan" is a first-class state

The server pages had four `status = 'active'` joins the API routes had already dropped (three in `app/training/page.tsx`, one in `app/nutrition/page.tsx`, where a dormant plan's coinciding day would have added planned-run calories to today's budget). All four now go through `getLivePlan`.

The training page used to unmount the entire dashboard when it had no plan, throwing away load, fitness, readiness and the model-vs-Garmin comparison. The dashboard now always renders; only plan-specific surfaces hide (schedule, week counter, race countdown, workout-scaling slider, delta save). A card states the engagement basis in plain words, and projections are labelled *"if you keep doing what you're doing (last 28 days, 16 sessions)"*.

## Nutrition: the scale leads when the week is not engaged

A Scale block shows the 14-day weight trend with its weigh-in count, or how many weigh-ins are still needed, plus a calm line for the week's state. The 7-day table keeps its rows but hides its Total and weekly adherence unless the week is complete. `adaptive` is hidden the same way.

**Close Day asks once.** Unlogged slots are absent, not zero. The prompt names them and offers *I skipped them* (marks each skipped, day counts as complete), *Close anyway* (partial coverage, feeds nothing), *Leave open*. Inline card, not a browser confirm.

## What the screenshots caught, four times

Every one of these passed tsc and vitest and would have shipped without the screenshots.

1. **Card heading invisible** on the dark training card. Inherited a near-background colour; the basis line under it read fine. Explicit `text-foreground`.
2. **The hero said "0 eaten … −2363 current deficit" in green.** Eaten minus burn with eaten assumed zero: the exact fabrication #698 is about, front and centre on mobile while the honest block sat behind "show details". The deficit line now makes a claim only when today is observed (closed, or 3+ meals logged or skipped); otherwise *"nothing logged yet · deficit unknown"*. The scale line surfaces at hero level so the phone shows it without expanding.
3. **Today's trend row printed (−2363)** directly under a hero that said unknown. Zero-coverage rows now show a dash like the other unlogged days.
4. **The dash on unlogged past days was green**, keyed off a deficit that only exists by assuming zero intake. A row showing a dash has no deficit to colour.

Finding 4 exposed a data-shape quirk: 2026-09-01 has a logged meal in `meal_log` but `actual_calories` 0, because actuals are only written at close. The colour rule handles it honestly. Making the trend sum `meal_log` for open past days is a semantic change, left as a **follow-up**.

## Verified

Playwright against a worktree build of this branch on a spare port with `DEMO_MODE=true` (lifts the page session gate, changes no data), desktop 1440×900 and mobile 390×844, your real database:

- `/training` desktop + mobile: subtitle *"Knoxville HM 2026 has no sessions within 7 days (race 2026-04-12) · 16 sessions in the last 28 days"*, dormant card legible, model graph and comparison charts still render, no plan section, no slider, fallback note *"about 39 load/day"*. Server HTML asserts `training-no-live-plan` present and `training-plan-section` absent.
- `/nutrition` desktop + mobile: hero *"nothing logged yet · deficit unknown"*, *"Scale: 1 weigh-in in the last 14 days; 3 needed for a trend"*, Scale block basis *"1 partly logged of the last 7 days; 3 full days needed"*, all four unlogged trend rows neutral, no Total, no adherence. Close Day opens the prompt listing breakfast, lunch, dinner, pre-sleep with three actions; *Leave open* dismisses it.
- Console clean on every load. The only errors were HMR reconnects after I killed the server.
- tsc exit 0, vitest 274/274 across 37 files.

Not exercised: the *I skipped them* and *Close anyway* POSTs, refused by demo mode by design. `skip-slot` takes `{ date, slot }`, which is what is sent.
