### PR TITLE
Install prompt renders only in mobile browsers

### DIFF
--- a/web/components/pwa-install-prompt.tsx
+++ b/web/components/pwa-install-prompt.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { X, Download, Share, Apple, Smartphone } from "lucide-react";
+import { detectMobileBrowser } from "@/lib/mobile-browser";
 
 /** GitHub releases host the sideloadable native builds (widgets need native). */
 const RELEASES_URL = "https://github.com/drkostas/soma/releases/latest";
@@ -23,6 +24,11 @@ export function PWAInstallPrompt() {
     // @ts-expect-error - iOS standalone check
     if (window.navigator.standalone === true) return;
 
+    // Mobile browsers only (#709). On a laptop this is noise, and at phone
+    // widths it sat on top of the Close Day button. macOS Safari used to get
+    // its own "Add to Dock" branch; that is a desktop and is gone.
+    if (!detectMobileBrowser()) return;
+
     // Previously dismissed?
     const dismissedAt = localStorage.getItem("pwa-install-dismissed");
     if (dismissedAt) {
@@ -31,34 +37,26 @@ export function PWAInstallPrompt() {
       if (daysSince < 14) return; // re-show after 2 weeks
     }
 
+    // On a mobile browser the card is useful even when the browser never
+    // fires beforeinstallprompt: the native builds are what carry the widgets.
+    // The Install button itself still appears only once the event has fired.
+    setDismissed(false);
+
     // Chromium: listen for beforeinstallprompt
     const handler = (e: Event) => {
       e.preventDefault();
       setDeferredPrompt(e as BeforeInstallPromptEvent);
-      setDismissed(false);
     };
     window.addEventListener("beforeinstallprompt", handler);
 
-    // iOS Safari detection (no beforeinstallprompt support)
+    // iOS Safari has no beforeinstallprompt; show the share-sheet hint instead.
     const isIOS =
       /iPad|iPhone|iPod/.test(navigator.userAgent) &&
       !(window as unknown as { MSStream?: unknown }).MSStream;
     const isSafari =
       /Safari/.test(navigator.userAgent) &&
       !/Chrome|CriOS|FxiOS/.test(navigator.userAgent);
-
-    if (isIOS && isSafari) {
-      setShowIOSHint(true);
-      setDismissed(false);
-    }
-
-    // macOS Safari detection
-    const isMacSafari =
-      /Macintosh/.test(navigator.userAgent) && isSafari;
-    if (isMacSafari) {
-      setShowIOSHint(true); // reuse hint with different text
-      setDismissed(false);
-    }
+    if (isIOS && isSafari) setShowIOSHint(true);
 
     return () => window.removeEventListener("beforeinstallprompt", handler);
   }, []);
@@ -85,7 +83,10 @@ export function PWAInstallPrompt() {
     /iPad|iPhone|iPod/.test(navigator.userAgent);
 
   return (
-    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-md animate-in slide-in-from-bottom-4 fade-in-0 duration-300">
+    <div
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-md animate-in slide-in-from-bottom-4 fade-in-0 duration-300"
+      data-testid="pwa-install-prompt"
+    >
       <div className="bg-card border border-border rounded-xl shadow-lg shadow-black/20 p-4 flex items-start gap-3">
         <div className="shrink-0 w-10 h-10 rounded-lg bg-emerald-500/10 flex items-center justify-center">
           <Download className="h-5 w-5 text-emerald-500" />
@@ -113,7 +114,7 @@ export function PWAInstallPrompt() {
             </p>
           ) : (
             <p className="text-xs text-muted-foreground mt-0.5">
-              Add to your dock for quick access
+              Add to your home screen for quick access
             </p>
           )}
           {deferredPrompt && (

--- a/web/lib/mobile-browser.test.ts
+++ b/web/lib/mobile-browser.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isMobileBrowser, NARROW_VIEWPORT_MAX_PX, type BrowserSignals } from "./mobile-browser";
+
+const UA = {
+  androidChrome: "Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Mobile Safari/537.36",
+  iphoneSafari: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+  ipadOS13Safari: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+  macSafari: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+  macChrome: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+  windowsChrome: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+  linuxFirefox: "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0",
+};
+
+const sig = (userAgent: string, coarsePointer = false, narrowViewport = false): BrowserSignals => ({ userAgent, coarsePointer, narrowViewport });
+
+describe("isMobileBrowser (#709)", () => {
+  it("narrow means at most 1024px, so tablets in portrait fit and laptops do not", () => {
+    expect(NARROW_VIEWPORT_MAX_PX).toBe(1024);
+  });
+
+  const cases: [string, BrowserSignals, boolean][] = [
+    ["Android Chrome phone", sig(UA.androidChrome, true, true), true],
+    ["Android Chrome, even if media queries are unavailable (UA alone decides)", sig(UA.androidChrome, false, false), true],
+    ["iPhone Safari", sig(UA.iphoneSafari, true, true), true],
+    ["iPadOS 13+ reports Macintosh: coarse pointer + narrow viewport catches it", sig(UA.ipadOS13Safari, true, true), true],
+    ["iPad in landscape wider than 1024 with a touch pointer is not narrow → not mobile", sig(UA.ipadOS13Safari, true, false), false],
+    ["macOS Safari on a laptop: fine pointer, wide → NOT mobile (the old code showed it here)", sig(UA.macSafari, false, false), false],
+    ["macOS Chrome on a laptop → not mobile", sig(UA.macChrome, false, false), false],
+    ["Windows Chrome → not mobile", sig(UA.windowsChrome, false, false), false],
+    ["Linux Firefox → not mobile", sig(UA.linuxFirefox, false, false), false],
+    ["desktop Chrome with the window shrunk to phone width still has a fine pointer → not mobile", sig(UA.macChrome, false, true), false],
+    ["a touch laptop with a wide viewport → not mobile", sig(UA.windowsChrome, true, false), false],
+    ["empty user agent with coarse + narrow → mobile", sig("", true, true), true],
+    ["empty user agent with nothing else → not mobile", sig("", false, false), false],
+  ];
+  for (const [name, s, want] of cases) {
+    it(name, () => {
+      expect(isMobileBrowser(s)).toBe(want);
+    });
+  }
+});

--- a/web/lib/mobile-browser.ts
+++ b/web/lib/mobile-browser.ts
@@ -1,0 +1,38 @@
+/**
+ * Is this a mobile browser? The install prompt is for phones and tablets
+ * (add to home screen, or grab the native build for widgets). On a laptop it
+ * is noise, and at 390px wide it sat on top of the Close Day button (#709).
+ *
+ * Pure function over three observations so it is table-testable without a
+ * DOM; `detectMobileBrowser()` gathers them from the window.
+ *
+ * Rule: a mobile user agent, OR a coarse pointer (touch) on a narrow viewport.
+ * The second clause catches iPadOS 13+, which reports itself as "Macintosh".
+ * Neither clause matches a laptop, including macOS Safari, which has a fine
+ * pointer and a wide viewport.
+ */
+export interface BrowserSignals {
+  userAgent: string;
+  coarsePointer: boolean;
+  narrowViewport: boolean;
+}
+
+/** Viewports at or below this width count as narrow. Tablets in portrait fit; laptops do not. */
+export const NARROW_VIEWPORT_MAX_PX = 1024;
+
+const MOBILE_UA = /Android|iPhone|iPod|Windows Phone|Mobile/i;
+
+export function isMobileBrowser(s: BrowserSignals): boolean {
+  if (MOBILE_UA.test(s.userAgent)) return true;
+  return s.coarsePointer && s.narrowViewport;
+}
+
+export function detectMobileBrowser(): boolean {
+  if (typeof window === "undefined" || typeof navigator === "undefined") return false;
+  const mq = (q: string) => (typeof window.matchMedia === "function" ? window.matchMedia(q).matches : false);
+  return isMobileBrowser({
+    userAgent: navigator.userAgent ?? "",
+    coarsePointer: mq("(pointer: coarse)"),
+    narrowViewport: mq(`(max-width: ${NARROW_VIEWPORT_MAX_PX}px)`),
+  });
+}

--- a/web/tests/e2e/pwa-install-prompt.spec.ts
+++ b/web/tests/e2e/pwa-install-prompt.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * #709: the install prompt is for mobile browsers only.
+ *
+ * The two projects in playwright.config.ts are the two cases: "desktop" is
+ * Desktop Chrome at 1440×900 (fine pointer, desktop UA) and "mobile" is a
+ * Pixel 7 (mobile UA, coarse pointer, 390×844). Each test runs in a fresh
+ * context, so the 14-day dismissal in localStorage cannot leak between them.
+ */
+const PROMPT = '[data-testid="pwa-install-prompt"]';
+
+test.describe("PWA install prompt", () => {
+  test("is absent on a desktop browser", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "desktop project only");
+    await page.goto("/", { waitUntil: "networkidle" });
+    // Give the client effect a beat: if it were going to mount, it would by now.
+    await page.waitForTimeout(500);
+    await expect(page.locator(PROMPT)).toHaveCount(0);
+    await page.screenshot({ path: testInfo.outputPath("pwa-desktop-absent.png") });
+  });
+
+  test("is shown on a mobile browser and can be dismissed", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "mobile", "mobile project only");
+    await page.goto("/", { waitUntil: "networkidle" });
+    const prompt = page.locator(PROMPT);
+    await expect(prompt).toBeVisible();
+    await expect(prompt).toContainText("Install Soma");
+    // The native-build links are the point on a phone, event or no event.
+    await expect(prompt.getByRole("link", { name: /Android/ })).toBeVisible();
+    await page.screenshot({ path: testInfo.outputPath("pwa-mobile-present.png") });
+    await prompt.getByRole("button", { name: "Dismiss" }).click();
+    await expect(prompt).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #709, #710, #711.

The install card showed on laptops, with an explicit macOS Safari branch offering "Add to Dock", and at phone widths it sat on top of the Close Day button and intercepted clicks during the #698 Playwright pass.

## The gate

`lib/mobile-browser.ts`: a pure `isMobileBrowser` over three signals, **mobile user agent OR coarse pointer with a viewport at most 1024px**. The second clause catches iPadOS 13+, which reports itself as Macintosh. Neither clause matches a laptop. 14 table cases, including macOS Safari, a desktop window shrunk to phone width, and a touch laptop, all not mobile.

## The component

Gates on it before touching any listener, drops the macOS Safari branch, and on a mobile browser shows the card even when `beforeinstallprompt` never fires, since the native builds are what carry the widgets; the Install button itself still needs the event. The copy no longer tells a phone to add to its dock.

## Proof, with device emulation rather than a resized window

A resized desktop window still has a desktop user agent and a fine pointer, so it cannot demonstrate the mobile case. The e2e config already defines the two cases as projects: Desktop Chrome at 1440×900, and Pixel 7 (mobile UA, coarse pointer) at 390×844. `tests/e2e/pwa-install-prompt.spec.ts` runs one assertion per project and writes a screenshot for each.

Against a worktree build of this branch:

- **desktop**: `[data-testid="pwa-install-prompt"]` count 0 after settle. Screenshot: overview with no card.
- **mobile**: card visible with "Install Soma", "Add to your home screen for quick access", iOS and Android links; Dismiss removes it. Screenshot: card over the overview.

tsc exit 0, vitest 288/288 across 38 files. No other UI touched.
