### PR TITLE
feat(universal): engagement states on the training and nutrition screens (#714)

### DIFF
--- a/universal/scripts/verify-device.sh
+++ b/universal/scripts/verify-device.sh
@@ -53,6 +53,15 @@ export PATH="$JAVA_HOME/bin:$PATH"
 [ "$DRY" = 1 ] || "$JAVA_HOME/bin/java" -version 2>&1 | grep -qE 'version "(1[7-9]|[2-9][0-9])' \
   || { echo "FAIL: Java 17+ not found at $JAVA_HOME (maestro cannot run)"; exit 2; }
 
+# 0. A stale `offline` adb entry (a phone that dropped its Tailscale/tcpip link) makes Maestro's
+# device enumeration abort with "Device X was requested, but it is not connected" even though
+# X is fine. Drop only the offline entries; connected devices are never touched.
+if [ "$DRY" != 1 ]; then
+  $ADB devices 2>/dev/null | awk 'NR>1 && $2=="offline"{print $1}' | while read -r stale; do
+    echo "note: dropping stale offline adb entry $stale"; $ADB disconnect "$stale" >/dev/null 2>&1 || true
+  done
+fi
+
 # 1. Device up, app installed.
 if [ "$DRY" = 1 ]; then STATE=device; else
 STATE="$($ADB -s "$DEV" get-state 2>/dev/null || true)"

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -431,11 +431,39 @@ export default function NutritionScreen() {
                   <Text variant="micro" className="text-text-muted">{goalIntake.toLocaleString()} goal{deficitGoal > 0 ? ` (−${deficitGoal})` : ""}</Text>
                   <Text variant="micro" className="text-text-muted">{totalBurn.toLocaleString()} burn</Text>
                 </View>
-                <Text variant="micro" style={{ color: currentDeficit <= 0 ? "#6ad4a0" : "#f2868c" }}>
-                  {currentDeficit <= 0
-                    ? `${Math.abs(Math.round(currentDeficit)).toLocaleString()} kcal current deficit`
-                    : `+${Math.round(currentDeficit).toLocaleString()} kcal surplus`}
-                </Text>
+                {/* A deficit is a claim about today; make it only when today is
+                    observed. With nothing logged, eaten − burn is a fabricated
+                    green number, the exact "assumes I'm in deficit" complaint
+                    (#698/#714). Same rule as the web hero. */}
+                {(() => {
+                  const logged = new Set(meals.filter((m) => Number(m.calories) > 0).map((m) => String(m.meal_slot)));
+                  const loggedSlotCount = ["breakfast", "lunch", "dinner", "pre_sleep"].filter(
+                    (s) => logged.has(s) || skippedSlots.includes(s),
+                  ).length;
+                  const todayObserved = dayClosed || loggedSlotCount >= 3;
+                  if (todayObserved) {
+                    return (
+                      <Text variant="micro" style={{ color: currentDeficit <= 0 ? "#6ad4a0" : "#f2868c" }} testID="hero-deficit">
+                        {currentDeficit <= 0
+                          ? `${Math.abs(Math.round(currentDeficit)).toLocaleString()} kcal current deficit`
+                          : `+${Math.round(currentDeficit).toLocaleString()} kcal surplus`}
+                      </Text>
+                    );
+                  }
+                  return (
+                    <Text variant="micro" className="text-text-muted" testID="hero-not-observed">
+                      {loggedSlotCount === 0
+                        ? "nothing logged yet · deficit unknown"
+                        : `${Math.round(consumedCal).toLocaleString()} eaten so far · ${loggedSlotCount} of 4 meals logged · deficit unknown`}
+                    </Text>
+                  );
+                })()}
+                {/* The scale, whenever logging is not carrying the week. */}
+                {data?.weightTrendPrimary && data?.weightTrend ? (
+                  <Text variant="micro" className="text-text-muted" testID="hero-weight-trend">
+                    Scale: {data.weightTrend.basis}
+                  </Text>
+                ) : null}
               </View>
             );
           })() : null}
@@ -505,7 +533,42 @@ export default function NutritionScreen() {
               </Card>
             ) : null}
 
-            {/* Adaptive (display-only) */}
+            {/* Engagement + the scale (#698/#714). When the week is not fully
+                logged the scale leads and the log-derived numbers are hidden
+                rather than shown as a deficit computed from nothing. */}
+            {data?.engagement ? (
+              <Card className="gap-1" testID="nutrition-engagement">
+                <View className="flex-row items-center justify-between">
+                  <Text variant="eyebrow">{data.weightTrendPrimary ? "Scale" : "This week"}</Text>
+                  <Text variant="micro" className="text-text-muted" testID="nutrition-engagement-basis">{data.engagement.basis}</Text>
+                </View>
+                {data.weightTrend ? (
+                  <View className="flex-row justify-between">
+                    <Text variant="caption" className="text-text-secondary">{data.weightTrend.kgPerWindow != null ? "Weight trend" : "Weight"}</Text>
+                    <Text
+                      variant="caption"
+                      className="tabular-nums"
+                      style={{ color: data.weightTrend.kgPerWindow == null ? "#8a97a3" : data.weightTrend.kgPerWindow < 0 ? "#6ad4a0" : data.weightTrend.kgPerWindow > 0 ? "#e0a458" : "#e6edf3" }}
+                      testID="nutrition-weight-trend"
+                    >
+                      {data.weightTrend.basis}
+                    </Text>
+                  </View>
+                ) : null}
+                {data.engagement.state === "absent" ? (
+                  <Text variant="caption" className="text-text-muted" testID="nutrition-not-tracking">
+                    Not tracking meals this week. Weigh in to keep the trend honest.
+                  </Text>
+                ) : null}
+                {data.engagement.state === "partial" ? (
+                  <Text variant="caption" className="text-text-muted" testID="nutrition-partial">
+                    Partly logged. Weekly totals show after {data.engagement.weekFloorDays ?? 3} full days; skip a meal you did not eat so the day counts.
+                  </Text>
+                ) : null}
+              </Card>
+            ) : null}
+
+            {/* Adaptive (display-only) — the server already nulls it unless the week is complete */}
             {adaptive && (adaptive.driftFlag || adaptive.dietBreakLevel !== "none") ? (
               <Card className="gap-1">
                 <Text variant="eyebrow">Adaptive</Text>
@@ -619,7 +682,7 @@ export default function NutritionScreen() {
           <>
             {/* Trend tab — body-composition trajectory, then adherence + 7-day table */}
             <BodyCompChart visible={tab === "Trend"} />
-            {adherence ? (
+            {adherence && data?.engagement?.state === "complete" ? (
               <Card className="gap-2">
                 <Text variant="eyebrow">Weekly adherence</Text>
                 <ProgressBar pct={Math.min(adherence.ratio, 1)} color="#6ad4a0" />

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -543,11 +543,11 @@ export default function NutritionScreen() {
                   <Text variant="micro" className="text-text-muted" testID="nutrition-engagement-basis">{data.engagement.basis}</Text>
                 </View>
                 {data.weightTrend ? (
-                  <View className="flex-row justify-between">
+                  <View className="flex-row justify-between gap-3">
                     <Text variant="caption" className="text-text-secondary">{data.weightTrend.kgPerWindow != null ? "Weight trend" : "Weight"}</Text>
                     <Text
                       variant="caption"
-                      className="tabular-nums"
+                      className="tabular-nums flex-1 text-right"
                       style={{ color: data.weightTrend.kgPerWindow == null ? "#8a97a3" : data.weightTrend.kgPerWindow < 0 ? "#6ad4a0" : data.weightTrend.kgPerWindow > 0 ? "#e0a458" : "#e6edf3" }}
                       testID="nutrition-weight-trend"
                     >

--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -168,6 +168,31 @@ export default function TrainingScreen() {
           <Card><Text variant="body" className="text-danger">API: {error} — is soma running on :3456?</Text></Card>
         ) : null}
 
+        {/* No live plan is a first-class state (#698/#714). The athlete may train
+            without a script and Garmin records every session either way, so
+            load, readiness and fitness stay; only the schedule goes. Say why in
+            plain words, and label what the projections assume instead. */}
+        {sim?.engagement && !sim.engagement.planLive ? (
+          <Card className="gap-1" testID="training-no-live-plan">
+            <Text variant="eyebrow">Plan</Text>
+            <Text variant="body" className="text-text" testID="training-no-live-plan-title">
+              {sim.engagement.state === "dormant"
+                ? "Plan is dormant"
+                : sim.engagement.state === "partial"
+                  ? "Plan exists, not being followed"
+                  : "No training plan"}
+            </Text>
+            <Text variant="caption" className="text-text-secondary" testID="training-no-live-plan-basis">
+              {sim.engagement.basis}.
+            </Text>
+            {sim.fallback ? (
+              <Text variant="micro" testID="training-fallback-note">
+                Everything below is from what you actually did. Projections assume {sim.fallback.label}: about {Math.round(sim.fallback.meanDailyLoad)} load/day.
+              </Text>
+            ) : null}
+          </Card>
+        ) : null}
+
         {/* Safety-rail overrides — hard readiness rules that force RED/YELLOW */}
         {graphOverrides.length ? (
           <View className="gap-2">

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -102,6 +102,11 @@ export interface SomaPlan {
     days?: TrendDay[];
     totalDeficit?: number; goalDeficit?: number;
   };
+  /** Is nutrition in use this week (#698/#714). Gate the log-derived numbers on state === "complete". */
+  engagement?: { state: "absent" | "partial" | "complete"; coverage: number; basis: string; weekFloorDays?: number };
+  /** The scale: OLS over 14 days, null slope until 3 weigh-ins. Leads when weightTrendPrimary. */
+  weightTrend?: { kgPerWindow: number | null; windowDays: number; weighIns: number; latestKg: number | null; basis: string } | null;
+  weightTrendPrimary?: boolean;
 }
 
 export interface Today {
@@ -273,6 +278,17 @@ export interface ForwardSim {
     fitness: ComparisonPoint[];
     racePrediction: ComparisonPoint[];
   } | null;
+  /** Whether a plan is LIVE and why (#698/#714). planDays is empty unless planLive. */
+  engagement?: {
+    state: "absent" | "partial" | "complete" | "dormant";
+    coverage: number;
+    basis: string;
+    planLive: boolean;
+    planName: string | null;
+    trailingCompletion: number | null;
+  };
+  /** What the athlete actually did over the trailing window; the projection baseline when no plan is live. */
+  fallback?: { windowDays: number; meanDailyLoad: number; activeDays: number; label: string };
 }
 
 /** The full forward-simulation payload: schedule + PMC + readiness + fitness + comparison. */


### PR DESCRIPTION
## What

The native app now shows the same engagement states the web got in #698 (PRs #704 to #708), read from the same endpoints.

Training screen (#715)
- `ForwardSim` gains `engagement` and `fallback`.
- When `engagement.planLive` is false a Plan card renders first: "Plan is dormant" / "Plan exists, not being followed" / "No training plan", the basis sentence, and the fallback note ("Everything below is from what you actually did. Projections assume <label>: about N load/day").
- The race header stays hidden when there are fewer than 2 plan days, so there is no duplicate plan block.

Nutrition screen (#716)
- `SomaPlan` gains `engagement`, `weightTrend`, `weightTrendPrimary`.
- Hero: the deficit line only claims a deficit once the day is observed (closed, or 3 of 4 slots logged or skipped). Otherwise it says "nothing logged yet · deficit unknown" or "N eaten so far · k of 4 meals logged · deficit unknown", plus a Scale line when the weight trend is the primary signal.
- New Scale / This week card before Adaptive: weight trend row, basis, and the absent/partial copy.
- Adherence in the Trend tab renders only when the week is complete.

Harness
- `scripts/verify-device.sh` drops stale `offline` adb entries before calling Maestro. A dropped Tailscale phone entry made Maestro abort with "Device emulator-5554 was requested, but it is not connected" even though the emulator was fine.

## Evidence (Android emulator, real account, release APK built from this branch)

- `verify-device.sh training --marker "Plan is dormant"` → VERIFIED. Screenshot shows the Plan card: "Plan is dormant", "Knoxville HM 2026 has no sessions within 7 days (race 2026-04-12)", "last 28 days, 16 sessions: about 39 load/day", then the PMC with real numbers.
- `verify-device.sh nutrition --marker "deficit unknown"` → VERIFIED. Hero shows "nothing logged yet · deficit unknown" and "Scale: 1 weigh-in in the last 14 days; 3 needed for a trend".
- Scale card seen after scrolling: state `partial`, "1 partly logged of the last 7 days; 3 full days needed". The first screenshot exposed the label and basis running together ("Weight1 weigh-in"); fixed with a gap and a right-aligned flexible value column, rebuilt, re-verified.
- `npx tsc --noEmit -p universal` exit 0.

Expo web was not used as evidence.

Closes #714
Closes #715
Closes #716
