### PR TITLE
feat(nutrition): trend rows read the running log for open days; honest rows on web and app (#717)

### DIFF
--- a/universal/.maestro/verify-nutrition-trend.yaml
+++ b/universal/.maestro/verify-nutrition-trend.yaml
@@ -1,0 +1,30 @@
+# Soma verify flow for the nutrition Trend tab (#717/#721): open the nutrition screen by
+# deep link, switch to the Trend tab, and assert a marker fetched live from the real API
+# is visible. Run via universal/scripts/verify-device.sh:
+#   universal/scripts/verify-device.sh nutrition --flow .maestro/verify-nutrition-trend.yaml --marker "(465)"
+appId: dev.gkos.soma
+name: Soma verify nutrition trend tab
+tags:
+  - verify
+---
+- stopApp
+- openLink: ${ROUTE}
+- waitForAnimationToEnd:
+    timeout: 10000
+- tapOn:
+    text: "Trend"
+- waitForAnimationToEnd:
+    timeout: 5000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+    optional: true
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+    visibilityPercentage: 60
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -57,11 +57,13 @@ function niceDate(iso: string): string {
 
 /** Color a day's deficit against the daily goal: green = met the goal deficit,
  *  amber = a deficit but short of goal, red = a surplus (ate above burn). */
+// The plan route's deficit is ate − burn: NEGATIVE when in deficit (good), positive
+// is a surplus. Same sign convention as the web's trend table (#721).
 function deficitTone(deficit: number, goalPerDay: number): string {
-  if (deficit <= 0) return "#e06060"; // surplus
-  if (goalPerDay > 0 && deficit >= goalPerDay) return "#6ad4a0"; // met goal
-  if (goalPerDay > 0) return "#e0a458"; // short of goal
-  return "#6ad4a0";
+  if (deficit > 0) return "#e06060"; // surplus
+  if (goalPerDay > 0 && deficit <= -goalPerDay) return "#6ad4a0"; // met goal
+  if (goalPerDay > 0 && deficit < 0) return "#e0a458"; // short of goal
+  return "#8a97a3";
 }
 
 function shiftDate(iso: string, days: number): string {
@@ -706,7 +708,7 @@ export default function NutritionScreen() {
               const totalActual = data?.trend7d?.totalDeficit != null
                 ? Number(data.trend7d.totalDeficit)
                 : days.reduce((s, d) => s + (d.deficit || 0), 0);
-              const goalTotal = goalPerDay * days.length;
+              const goalTotal = goalPerDay * (data?.trend7d?.closedDays ?? days.length);
               return (
                 <Card className="gap-0.5">
                   <View className="flex-row justify-between pb-1">
@@ -715,24 +717,41 @@ export default function NutritionScreen() {
                       ate / burn · deficit{goalPerDay > 0 ? ` · goal −${Math.round(goalPerDay)}/day` : ""}
                     </Text>
                   </View>
-                  {days.map((d) => (
-                    <View key={d.date} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">
-                      <Text variant="caption" className={d.isToday ? "font-semibold text-teal" : "text-text-secondary"}>
-                        {niceDate(d.date).replace(/,.*/, "").slice(0, 3)} {d.date.slice(8)}
-                      </Text>
-                      <Text variant="caption" className="tabular-nums text-text-muted">{Math.round(d.ate)} / {Math.round(d.burn)}</Text>
-                      <Text variant="caption" className="w-16 text-right tabular-nums" style={{ color: deficitTone(d.deficit, goalPerDay) }}>
-                        {d.deficit > 0 ? "+" : ""}{Math.round(d.deficit)}
+                  {days.map((d) => {
+                    // Same three readings as the web table (#703/#717/#721): a day with
+                    // nothing logged shows "–"; an open day (today or never closed) shows
+                    // its running log in parentheses; only a counted day earns a colour.
+                    const unobserved = (d.coverage ?? 0) === 0 && !(d.ate > 0);
+                    const open = !d.closed;
+                    const counted = d.counted === true;
+                    const ateText = unobserved ? "–" : open ? `(${Math.round(d.ate)})` : String(Math.round(d.ate));
+                    const defText = unobserved ? "–" : `${open ? "(" : ""}${d.deficit > 0 ? "+" : ""}${Math.round(d.deficit)}${open ? ")" : ""}`;
+                    return (
+                      <View key={d.date} className="flex-row items-center justify-between border-b border-border-subtle py-1.5" testID={`trend-row-${d.date}`}>
+                        <Text variant="caption" className={d.isToday ? "font-semibold text-teal" : "text-text-secondary"}>
+                          {niceDate(d.date).replace(/,.*/, "").slice(0, 3)} {d.date.slice(8)}
+                        </Text>
+                        <Text variant="caption" className="tabular-nums text-text-muted">{ateText} / {Math.round(d.burn)}</Text>
+                        <Text variant="caption" className="w-16 text-right tabular-nums" style={{ color: counted ? deficitTone(d.deficit, goalPerDay) : "#8a97a3" }}>
+                          {defText}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                  {/* A total over a partly logged week is not a week's deficit (#699/#703). */}
+                  {data?.engagement?.state === "complete" && (data?.trend7d?.closedDays ?? 0) > 0 ? (
+                    <View className="flex-row items-center justify-between pt-1.5">
+                      <Text variant="caption" className="font-semibold text-text">Total ({data?.trend7d?.closedDays}d)</Text>
+                      <Text variant="caption" className="tabular-nums text-text-muted">{Math.round(sumAte)} / {Math.round(sumBurn)}</Text>
+                      <Text variant="caption" className="w-16 text-right font-semibold tabular-nums" style={{ color: deficitTone(totalActual, goalTotal) }}>
+                        {totalActual > 0 ? "+" : ""}{Math.round(totalActual)}
                       </Text>
                     </View>
-                  ))}
-                  <View className="flex-row items-center justify-between pt-1.5">
-                    <Text variant="caption" className="font-semibold text-text">Total ({days.length}d)</Text>
-                    <Text variant="caption" className="tabular-nums text-text-muted">{Math.round(sumAte)} / {Math.round(sumBurn)}</Text>
-                    <Text variant="caption" className="w-16 text-right font-semibold tabular-nums" style={{ color: deficitTone(totalActual, goalTotal) }}>
-                      {totalActual > 0 ? "+" : ""}{Math.round(totalActual)}
+                  ) : (
+                    <Text variant="micro" className="pt-1.5 text-text-muted">
+                      Weekly total shows after {data?.engagement?.weekFloorDays ?? 3} full days.
                     </Text>
-                  </View>
+                  )}
                 </Card>
               );
             })() : (

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -80,7 +80,8 @@ export interface SomaBreakdown {
   targetIntake?: number;
   adjustedTargets?: { calories?: number; protein?: number; carbs?: number; fat?: number; fiber?: number };
 }
-export interface TrendDay { date: string; ate: number; burn: number; deficit: number; closed: boolean; isToday: boolean }
+/** One 7-day trend row. `counted` = closed AND over the coverage floor (#699); only those feed totals or earn a colour. */
+export interface TrendDay { date: string; ate: number; burn: number; deficit: number; closed: boolean; isToday: boolean; coverage?: number | null; counted?: boolean }
 export interface LoggedDrink {
   id: number; name: string; drink_type: string; quantity: number;
   calories: number; carbs?: number; alcohol_grams?: number; fat_oxidation_pause_hours?: number;
@@ -100,7 +101,7 @@ export interface SomaPlan {
   trend7d?: {
     adherence?: { ratio: number; status: string; weeklyActual: number; weeklyGoal: number } | null;
     days?: TrendDay[];
-    totalDeficit?: number; goalDeficit?: number;
+    totalDeficit?: number; goalDeficit?: number; closedDays?: number;
   };
   /** Is nutrition in use this week (#698/#714). Gate the log-derived numbers on state === "complete". */
   engagement?: { state: "absent" | "partial" | "complete"; coverage: number; basis: string; weekFloorDays?: number };

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -8,6 +8,7 @@ import { computeWeeklyAdherence } from "@/lib/adherence";
 import { meetsCoverageFloor } from "@/lib/coverage";
 import { nutritionEngagement, WEEK_ENGAGEMENT_FLOOR_DAYS } from "@/lib/engagement";
 import { getWeightTrend } from "@/lib/weight-trend";
+import { trendAte } from "@/lib/trend-ate";
 import { computeAlcoholDisplacement } from "macro-engine-core";
 
 export const runtime = "edge";
@@ -496,7 +497,13 @@ export async function GET(req: NextRequest) {
           SELECT unnest(COALESCE(n.skipped_slots, ARRAY[]::text[]))
         ) u
         WHERE u.s IN ('breakfast', 'lunch', 'dinner', 'pre_sleep')
-      ) AS coverage
+      ) AS coverage,
+      (
+        -- What was actually logged that day. Open days read this; closed
+        -- days keep actual_calories, which close-day reconciled (#717).
+        SELECT COALESCE((SELECT SUM(m.calories) FROM meal_log m WHERE m.date = n.date), 0)
+             + COALESCE((SELECT SUM(d.calories) FROM drink_log d WHERE d.date = n.date), 0)
+      ) AS logged_calories
     FROM nutrition_day n
     WHERE n.date >= ${date}::date - interval '6 days'
       AND n.date <= ${date}::date
@@ -531,7 +538,13 @@ export async function GET(req: NextRequest) {
     goalDeficit,
     days: trendRows.map((r: Record<string, unknown>) => {
       const isCurrentDay = String(r.date) === date;
-      const ate = isCurrentDay ? consumed.calories : (Number(r.actual_calories) || 0);
+      const ate = trendAte({
+        isToday: isCurrentDay,
+        closed: r.status === "closed",
+        actualCalories: r.actual_calories as number | null,
+        loggedCalories: r.logged_calories as number | null,
+        todayConsumed: consumed.calories,
+      });
       const burn = Math.round(computeBurn(r, isCurrentDay));
       const deficit = ate - burn; // negative = deficit (good), positive = surplus (bad)
       return {

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -852,11 +852,11 @@ export function NutritionDashboard({
                           </div>
                         </div>
                         {weightTrend && (
-                          <div className="flex justify-between items-baseline text-xs" data-testid="nutrition-weight-trend">
-                            <span className="text-muted-foreground">
+                          <div className="flex justify-between items-baseline gap-3 text-xs" data-testid="nutrition-weight-trend">
+                            <span className="text-muted-foreground shrink-0">
                               {weightTrend.kgPerWindow != null ? "Weight trend" : "Weight"}
                             </span>
-                            <span className={`tabular-nums ${weightTrend.kgPerWindow == null ? "text-muted-foreground" : weightTrend.kgPerWindow < 0 ? "text-green-500" : weightTrend.kgPerWindow > 0 ? "text-amber-400" : ""}`}>
+                            <span className={`tabular-nums text-right ${weightTrend.kgPerWindow == null ? "text-muted-foreground" : weightTrend.kgPerWindow < 0 ? "text-green-500" : weightTrend.kgPerWindow > 0 ? "text-amber-400" : ""}`}>
                               {weightTrend.basis}
                             </span>
                           </div>
@@ -881,7 +881,7 @@ export function NutritionDashboard({
                           <div className="text-[10px] lg:text-xs font-medium text-muted-foreground uppercase tracking-wider">7-Day Trend</div>
                           <div className="text-[9px] text-muted-foreground/60">goal: &minus;{trend7d.goalDeficit}/day</div>
                         </div>
-                        <div className="grid grid-cols-[1fr_auto_auto] sm:grid-cols-[1fr_auto_auto] gap-x-3 gap-y-0.5 text-xs">
+                        <div className="grid grid-cols-[1fr_auto] sm:grid-cols-[1fr_auto_auto] gap-x-3 gap-y-0.5 text-xs" data-testid="trend-table">
                           <span className="text-muted-foreground text-[10px]">Date</span>
                           <span className="text-muted-foreground text-[10px] text-right hidden sm:block">Ate / Burn</span>
                           <span className="text-muted-foreground text-[10px] text-right">Deficit / Goal</span>

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -890,11 +890,16 @@ export function NutritionDashboard({
                             const deficitColor = d.deficit <= -trend7d.goalDeficit ? "text-green-500"
                               : d.deficit < 0 ? "text-amber-500"
                               : d.deficit > 0 ? "text-rose-500" : "text-muted-foreground";
-                            const isInProgress = d.isToday && !d.closed;
+                            // Any open day is in progress, today or a past day never
+                            // closed: its ate is the running log (#717), so it reads
+                            // parenthesised and muted, never as a settled deficit.
+                            const isInProgress = !d.closed;
                             // A day with nothing logged has no deficit to show, in
                             // progress or not: "(−2363)" for an unlogged today is the
                             // same fabrication the hero no longer makes (#703).
                             const unobserved = (d.coverage ?? 0) === 0 && !(d.ate > 0);
+                            // Colour is a verdict; only a counted day earns one (#699).
+                            const tone = d.counted ? deficitColor : "text-muted-foreground";
                             return (
                               <React.Fragment key={d.date}>
                                 <span>
@@ -903,10 +908,10 @@ export function NutritionDashboard({
                                     ate {unobserved ? "–" : isInProgress ? `(${d.ate})` : d.ate} · burn {d.burn}
                                   </span>
                                 </span>
-                                <span className={`tabular-nums text-right hidden sm:block ${isInProgress ? "text-muted-foreground" : ""}`}>
+                                <span className={`tabular-nums text-right hidden sm:block ${isInProgress ? "text-muted-foreground" : ""}`} data-testid={`trend-ate-${d.date}`}>
                                   {unobserved ? "\u2013" : isInProgress ? `(${d.ate})` : d.ate || "\u2013"} / {d.burn || "\u2013"}
                                 </span>
-                                <span className={`tabular-nums text-right font-medium ${isInProgress || !(d.ate > 0) ? "text-muted-foreground" : deficitColor}`}>
+                                <span className={`tabular-nums text-right font-medium ${tone}`} data-testid={`trend-deficit-${d.date}`} data-counted={d.counted ? "1" : "0"}>
                                   {unobserved
                                     ? "\u2013"
                                     : isInProgress

--- a/web/lib/trend-ate.test.ts
+++ b/web/lib/trend-ate.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { trendAte, type TrendAteInput } from "./trend-ate";
+
+const row = (o: Partial<TrendAteInput>): TrendAteInput => ({
+  isToday: false,
+  closed: false,
+  actualCalories: 0,
+  loggedCalories: 0,
+  todayConsumed: 0,
+  ...o,
+});
+
+describe("trendAte (#717)", () => {
+  const cases: [string, TrendAteInput, number][] = [
+    ["today uses the live consumed total, not the (unset) actual", row({ isToday: true, todayConsumed: 812, actualCalories: 0, loggedCalories: 812 }), 812],
+    ["today with nothing eaten is 0", row({ isToday: true, todayConsumed: 0, loggedCalories: 0 }), 0],
+    ["closed day keeps actual_calories (close-day reconciled)", row({ closed: true, actualCalories: 1540, loggedCalories: 1480 }), 1540],
+    ["closed day with actual 0 stays 0 even if meal_log has rows (close wins)", row({ closed: true, actualCalories: 0, loggedCalories: 465 }), 0],
+    ["THE case: open past day, one meal logged, actual still 0 → the logged sum", row({ closed: false, actualCalories: 0, loggedCalories: 465 }), 465],
+    ["open past day with nothing logged is 0, not a fabricated number", row({ closed: false, actualCalories: 0, loggedCalories: 0 }), 0],
+    ["open past day: null logged sum reads as 0", row({ closed: false, loggedCalories: null }), 0],
+    ["closed day: null actual reads as 0", row({ closed: true, actualCalories: null, loggedCalories: 900 }), 0],
+    ["numeric strings from pg are coerced", row({ closed: false, loggedCalories: "465" as unknown as number }), 465],
+    ["a closed today is still today (the hero total is the freshest)", row({ isToday: true, closed: true, todayConsumed: 1200, actualCalories: 1150 }), 1200],
+  ];
+  for (const [name, input, want] of cases) {
+    it(name, () => {
+      expect(trendAte(input)).toBe(want);
+    });
+  }
+});

--- a/web/lib/trend-ate.ts
+++ b/web/lib/trend-ate.ts
@@ -1,0 +1,32 @@
+/**
+ * What did the user eat on a trend-row day? (#717)
+ *
+ * `nutrition_day.actual_calories` is written only when the day is closed.
+ * Before that it is 0, so an open past day with real meals logged rendered
+ * "ate –" while its coverage said something was there (2026-09-01: one meal,
+ * 465 kcal, actual_calories 0).
+ *
+ * Rule, one branch per source of truth:
+ * - today          → the live `consumed` total the hero already shows
+ * - closed day     → `actual_calories`, which close-day reconciled
+ * - open past day  → the sum of what was logged (meal_log + drink_log)
+ *
+ * The `counted` flag and the coverage floor (#699) are untouched: an open day
+ * still never feeds the weekly total; it just stops lying about its own row.
+ */
+export interface TrendAteInput {
+  isToday: boolean;
+  closed: boolean;
+  /** nutrition_day.actual_calories */
+  actualCalories: number | null | undefined;
+  /** SUM(meal_log.calories) + SUM(drink_log.calories) for that date */
+  loggedCalories: number | null | undefined;
+  /** the live consumed total for today */
+  todayConsumed: number;
+}
+
+export function trendAte(i: TrendAteInput): number {
+  if (i.isToday) return i.todayConsumed;
+  if (i.closed) return Number(i.actualCalories) || 0;
+  return Number(i.loggedCalories) || 0;
+}


### PR DESCRIPTION
## What

`nutrition_day.actual_calories` is written only when a day is closed. An open past day with real meals logged rendered "ate –" in the 7-day trend while its coverage said something was there (2026-09-01: 465 kcal in `meal_log`, `actual_calories` 0).

Route (#718)
- `web/lib/trend-ate.ts` picks the source per row: today → the live consumed total, closed → `actual_calories` (close-day reconciled), open past → `SUM(meal_log.calories) + SUM(drink_log.calories)`. Ten table cases.
- The trend SQL adds `logged_calories` per day. `counted` and the coverage floor from #699 are untouched, so an open day still never feeds the weekly total.

Web table (#719)
- Every open day (today or never closed) renders parenthesised and muted; colour only for `counted` rows. Test ids `trend-ate-<date>`, `trend-deficit-<date>` (`data-counted`), `trend-table`.
- Found in the mobile pass: at 390px the Ate/Burn cell is `display:none` but the grid still had three columns, so rows wrapped into the wrong cells. Two columns on mobile, three from `sm`.
- The Scale row rendered "Weight1 weigh-in…" at phone width (label and basis with no gap). Gap plus a right-aligned value.

App (#721)
- Same three readings as the web: "–" for unobserved, "(running)" for open days, settled for closed; colour only for counted rows.
- `deficitTone` had the sign inverted against the API (`deficit = ate − burn`, negative is good), so real deficit days were painted red. Fixed.
- The weekly total renders only when the week is complete, with "Weekly total shows after N full days" otherwise.
- `.maestro/verify-nutrition-trend.yaml` opens the Trend tab for the device proof.

## Evidence

- `npx tsc --noEmit` exit 0 (web and universal); vitest 39 files, 298 tests green.
- Rig (`DEMO_MODE=true`, this branch, real DB): `/api/nutrition/plan?date=2026-09-06` → 2026-09-01 `ate=465, closed=false, counted=false, coverage=0.25, deficit=-2248`.
- Playwright desktop 1440×900: row "Tue, 9/1 (465) / 2713 (-2248) / −800" muted, `data-counted=0`; 9/2, 9/3, 9/6 show "–". Scale block and hero unchanged.
- Playwright mobile 390×844: before the grid fix the rows were scrambled across cells; after, "Tue, 9/1 · ate (465) · burn 2713 · (-2248) / −800", the other rows "–", and "Weight  1 weigh-in in the last 14 days; 3 needed for a trend" with the gap.
- Android emulator, real account, release APK from this branch, Trend tab: rows render as "–" / "(0) / 2713 (-2713)" muted / "Weekly total shows after 3 full days." The 9/1 ate still reads 0 on device because the app calls production, which gets the route change only when this merges and deploys. Post-merge step: re-run `verify-device.sh nutrition --flow .maestro/verify-nutrition-trend.yaml --marker "(465)"` against the deployed route.

Closes #717
Closes #718
Closes #719
Closes #721
