### PR TITLE
feat(sync): heal a flat Garmin DI token row before every DBTokenStore (#723)

### DIFF
--- a/universal/.maestro/verify-nutrition-trend.yaml
+++ b/universal/.maestro/verify-nutrition-trend.yaml
@@ -27,4 +27,5 @@ tags:
     timeout: 40000
     speed: 40
     visibilityPercentage: 60
+    centerElement: true
 - takeScreenshot: verify-${SCREEN}

--- a/web/lib/dj-daemon.ts
+++ b/web/lib/dj-daemon.ts
@@ -7,6 +7,7 @@
  */
 import { writeFileSync, renameSync, readFileSync, unlinkSync } from "fs";
 import { GarminAuth, DBTokenStore } from "garmin-auth";
+import { healGarminTokenRow } from "./garmin-token-heal";
 import { getDb } from "./db";
 import { spotifyFetch } from "./spotify-client";
 import { hrrToBpm, latestHrFromGarminData } from "./bpm-formula";
@@ -147,6 +148,7 @@ export async function runDaemon(opts: DaemonOpts): Promise<void> {
   process.on("SIGTERM", onStop);
   process.on("SIGINT", onStop);
 
+  await healGarminTokenRow(getDb()); // flat DI row → nested, before DBTokenStore reads it (#723)
   const auth = new GarminAuth({ store: new DBTokenStore(process.env.DATABASE_URL!) });
   const garmin = await auth.client();
   const profile = (await garmin.connectapi(PROFILE_URL)) as { displayName?: string };

--- a/web/lib/garmin-ingest.ts
+++ b/web/lib/garmin-ingest.ts
@@ -9,6 +9,7 @@
  * params inline (the TS client's connectapi(path) takes no separate params arg).
  */
 import { GarminAuth, DBTokenStore, type GarminClient } from "garmin-auth";
+import { healGarminTokenRow } from "./garmin-token-heal";
 import type { QueryFn } from "./db";
 import {
   DAILY_ENDPOINTS, RANGE_ENDPOINTS, DISCOVERY_ENDPOINTS, ACTIVITY_DETAIL_ENDPOINTS,
@@ -194,6 +195,8 @@ export interface IngestResult {
 
 /** Top-level ingestion: auth, resolve stale dates, sync each. */
 export async function runGarminIngest(databaseUrl: string, sql: QueryFn): Promise<IngestResult> {
+  // A flat DI row (Python fresh-login) would read as "needs MFA" (#723).
+  await healGarminTokenRow(sql);
   const auth = new GarminAuth({ store: new DBTokenStore(databaseUrl) });
   const client = await auth.client();
   const profile = (await client.connectapi(PROFILE_URL)) as { displayName?: string };

--- a/web/lib/garmin-token-heal.test.ts
+++ b/web/lib/garmin-token-heal.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { healGarminTokenRow, resetGarminTokenHealForTests, GARMIN_TOKEN_PLATFORM } from "./garmin-token-heal";
+import type { QueryFn } from "./db";
+
+function recorder(result: unknown[] | Error) {
+  const queries: { text: string; values: unknown[] }[] = [];
+  const sql = ((strings: TemplateStringsArray, ...values: unknown[]) => {
+    queries.push({ text: strings.join("?").replace(/\s+/g, " ").trim(), values });
+    if (result instanceof Error) return Promise.reject(result);
+    return Promise.resolve(result);
+  }) as unknown as QueryFn;
+  return { sql, queries };
+}
+
+describe("healGarminTokenRow (#723, port of hevy2garmin#459)", () => {
+  beforeEach(() => resetGarminTokenHealForTests());
+
+  it("issues the flat→nested UPDATE, guarded so an already-nested row is untouched", async () => {
+    const { sql, queries } = recorder([]);
+    const n = await healGarminTokenRow(sql);
+    expect(n).toBe(0);
+    expect(queries).toHaveLength(1);
+    const q = queries[0].text;
+    expect(q).toContain("UPDATE platform_credentials SET credentials = jsonb_build_object('garmin_tokens', credentials)");
+    expect(q).toContain("WHERE platform = ?");
+    expect(q).toContain("credentials ? 'di_token'");
+    expect(q).toContain("NOT (credentials ? 'garmin_tokens')");
+    expect(q).toContain("RETURNING platform");
+    expect(queries[0].values).toEqual([GARMIN_TOKEN_PLATFORM]);
+    expect(GARMIN_TOKEN_PLATFORM).toBe("garmin_tokens");
+  });
+
+  it("reports how many rows it nested", async () => {
+    const { sql } = recorder([{ platform: "garmin_tokens" }]);
+    expect(await healGarminTokenRow(sql)).toBe(1);
+  });
+
+  it("runs once per process per platform: the second call does not touch the DB", async () => {
+    const { sql, queries } = recorder([]);
+    await healGarminTokenRow(sql);
+    await healGarminTokenRow(sql);
+    expect(queries).toHaveLength(1);
+    await healGarminTokenRow(sql, "garmin_scratch");
+    expect(queries).toHaveLength(2);
+    expect(queries[1].values).toEqual(["garmin_scratch"]);
+  });
+
+  it("never throws: a failing query returns null and leaves the next attempt free to retry", async () => {
+    const { sql, queries } = recorder(new Error("relation platform_credentials does not exist"));
+    await expect(healGarminTokenRow(sql)).resolves.toBeNull();
+    await healGarminTokenRow(sql);
+    expect(queries).toHaveLength(2);
+  });
+});

--- a/web/lib/garmin-token-heal.ts
+++ b/web/lib/garmin-token-heal.ts
@@ -1,0 +1,49 @@
+import type { QueryFn } from "./db";
+
+/** The DI tokens live in platform_credentials at this platform key (DBTokenStore's default). */
+export const GARMIN_TOKEN_PLATFORM = "garmin_tokens";
+
+const healed = new Set<string>();
+
+/**
+ * Self-heal the Garmin token row before DBTokenStore reads it (#723, port of
+ * hevy2garmin#459).
+ *
+ * garmin-auth's Python fresh-login writes the DI payload FLAT ({di_token, …}
+ * at the top level of `credentials`); the TS DBTokenStore reads only the
+ * NESTED shape `credentials->'garmin_tokens'`. After every manual re-login the
+ * ingest, the sync pipeline and the DJ daemon all failed with "needs MFA"
+ * until someone ran this UPDATE by hand.
+ *
+ * Idempotent (the WHERE excludes an already-nested row), once per process per
+ * platform key, and it never throws: a failed heal must not block auth, since
+ * DBTokenStore reports the real problem with a better message.
+ *
+ * Returns the number of rows nested (0 when the row was already fine), or
+ * null when the query itself failed.
+ */
+export async function healGarminTokenRow(sql: QueryFn, platform: string = GARMIN_TOKEN_PLATFORM): Promise<number | null> {
+  if (healed.has(platform)) return 0;
+  try {
+    const rows = await sql`
+      UPDATE platform_credentials
+         SET credentials = jsonb_build_object('garmin_tokens', credentials),
+             auth_type = 'oauth',
+             status = 'active'
+       WHERE platform = ${platform}
+         AND credentials ? 'di_token'
+         AND NOT (credentials ? 'garmin_tokens')
+       RETURNING platform`;
+    healed.add(platform);
+    const n = Array.isArray(rows) ? rows.length : 0;
+    if (n > 0) console.log(`[garmin-token-heal] nested a flat DI token row for ${platform}`);
+    return n;
+  } catch {
+    return null;
+  }
+}
+
+/** Tests only: forget which platforms this process already healed. */
+export function resetGarminTokenHealForTests(): void {
+  healed.clear();
+}

--- a/web/scripts/sync-pipeline.mts
+++ b/web/scripts/sync-pipeline.mts
@@ -7,6 +7,7 @@
  */
 import { neon } from "@neondatabase/serverless";
 import { GarminAuth, DBTokenStore } from "garmin-auth";
+import { healGarminTokenRow } from "../lib/garmin-token-heal";
 import { HevyClient } from "hevy2garmin";
 import type { QueryFn } from "../lib/db";
 import { runGarminIngest } from "../lib/garmin-ingest";
@@ -86,6 +87,7 @@ await step("hevy", async () => {
 // 3+4. Garmin client for the external-write steps (plan push + run enrichment).
 let garminClient: Awaited<ReturnType<GarminAuth["client"]>> | null = null;
 try {
+  await healGarminTokenRow(sql); // flat DI row → nested, before DBTokenStore reads it (#723)
   garminClient = await new GarminAuth({ store: new DBTokenStore(databaseUrl) }).client();
 } catch (e) {
   console.error("[sync] Garmin auth for push/enrich failed:", (e as Error).message);


### PR DESCRIPTION
## What

Port of hevy2garmin's `normalizeGarminTokenRow` (h2g#459) into soma.

The Python garmin-auth fresh-login writes the DI payload FLAT at the top level of `platform_credentials.credentials`. The TS `DBTokenStore` reads only the NESTED `credentials->'garmin_tokens'`. After every manual re-login the Garmin ingest, the sync pipeline (plan push + run enrichment) and the DJ daemon all failed with "needs MFA" until someone ran the nesting UPDATE by hand.

- `web/lib/garmin-token-heal.ts` (#724): `healGarminTokenRow(sql, platform = "garmin_tokens")` runs `UPDATE platform_credentials SET credentials = jsonb_build_object('garmin_tokens', credentials), auth_type = 'oauth', status = 'active' WHERE platform = $1 AND credentials ? 'di_token' AND NOT (credentials ? 'garmin_tokens') RETURNING platform`. Idempotent (the WHERE excludes a nested row), once per process per platform key, never throws (a failed heal must not block auth; DBTokenStore reports the real problem), returns the rows nested. Four table tests.
- Wired (#725) with the existing DB handle right before `new DBTokenStore(...)` in `runGarminIngest` (lib/garmin-ingest.ts), `scripts/sync-pipeline.mts`, and `runDaemon` (lib/dj-daemon.ts).

## Evidence (#726)

- `npx tsc --noEmit` exit 0; vitest 39 files, 292 tests green.
- Real DB, inside a transaction that was rolled back: a flat fixture row under `garmin_scratch_723` (`nested=f, flat=t`) → the heal returned the row → `nested=t, flat=f`, `credentials->'garmin_tokens'->>'di_token' = x`; running it again returned 0 rows; running it against the live `garmin_tokens` row returned 0 rows (already nested). After ROLLBACK the scratch row is gone and the live row reads `nested=t`.
- Real auth path with the heal in front: `healGarminTokenRow(neon(url))` then `new GarminAuth({ store: new DBTokenStore(url) }).client()` and a read of the social profile → authenticated, displayName present. No writes to Garmin.

Closes #723
Closes #724
Closes #725
Closes #726
