### PR TITLE
feat(recovery): absent recovery data reads as unknown, never as the last value seen (#731)

### DIFF
--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -19,6 +19,7 @@ import {
   type ActivityRow,
 } from "../../lib/api";
 import { readinessScore } from "../../lib/readiness";
+import { freshness, staleShort, todayKey } from "../../lib/freshness";
 
 interface OverviewTrends {
   steps: number[];
@@ -190,6 +191,8 @@ export default function OverviewScreen() {
 
   const hrvLatest = recovery.data?.hrv?.latest ?? null;
   const hrvSpark = (recovery.data?.hrv?.trend ?? []).map((p) => Number(p.weekly_avg)).filter((v) => isFinite(v));
+  // An HRV reading older than two days is not today's metric (#731).
+  const hrvFresh = freshness(hrvLatest?.date ?? null, todayKey());
 
   const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string; metric?: string; inverted?: boolean }[] = [
     { label: "Steps", value: data?.total_steps != null ? data.total_steps.toLocaleString() : "—", sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1", metric: "steps" },
@@ -199,7 +202,7 @@ export default function OverviewScreen() {
     { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${Math.abs(data?.body_battery_drained ?? 0)} drained`, cls: "text-lime", spark: trends?.bodyBattery, color: "#cbe896", metric: "body_battery" },
     { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0", unit: "min" },
     { label: "VO₂max", value: vo2.current != null ? Number(vo2.current).toFixed(1) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1", metric: "vo2max" },
-    { label: "HRV", value: hrvLatest?.weekly_avg != null ? String(hrvLatest.weekly_avg) : "—", sub: hrvLatest?.status ? String(hrvLatest.status) : "7-night avg", cls: "text-lime", spark: hrvSpark, color: "#cbe896", unit: "ms" },
+    { label: "HRV", value: !hrvFresh.stale && hrvLatest?.weekly_avg != null ? String(hrvLatest.weekly_avg) : "—", sub: hrvFresh.stale ? `${staleShort("HRV", hrvFresh)}${hrvLatest?.weekly_avg != null ? ` · last ${hrvLatest.weekly_avg}` : ""}` : hrvLatest?.status ? String(hrvLatest.status) : "7-night avg", cls: "text-lime", spark: hrvSpark, color: "#cbe896", unit: "ms" },
     { label: "Total activities", value: fitness?.total_activities != null && fitness.total_activities > 0 ? fitness.total_activities.toLocaleString() : "—", sub: "all time", cls: "text-teal", color: "#77c8d1" },
   ];
 

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -7,6 +7,7 @@ import { StatDetailModal, type StatDetail } from "../../components/stat-detail-m
 import { TrendArrow } from "../../components/trend-arrow";
 import { LineChart, ChartLegend } from "../../components/line-chart";
 import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule, useWeekdayWeekend } from "../../lib/api";
+import { freshness, staleShort, todayKey } from "../../lib/freshness";
 import { SleepDashboard } from "../../components/sleep-dashboard";
 import { RecoveryVitals } from "../../components/recovery-vitals";
 import { SleepRespiratory } from "../../components/sleep-respiratory";
@@ -122,7 +123,10 @@ export default function SleepScreen() {
   const { refreshing, onRefresh } = usePullRefresh(refetch);
 
   const lastSleep = last(sleep);
-  const nights = sleep?.current.length ?? 0;
+  // A night is one sleep_data record with time > 0 (the web header's count),
+  // not the days daily_health_summary happens to carry (#734).
+  const nights = sleepSum?.stats?.nights ?? sleep?.current.length ?? 0;
+  const lastNightFresh = freshness(lastSleep?.date ?? null, todayKey());
 
   // Sleep score isn't served by the stats API; recovery.value2 carries HRV weekly avg.
   const lastRecovery = last(recovery);
@@ -130,6 +134,7 @@ export default function SleepScreen() {
   // below) — /api/stats/recovery.value2 is null here, which rendered the top card
   // as "—" while the card right beneath it showed 64ms. Wire both to one source.
   const hrvLatest = recoveryVitals?.hrv?.latest ?? null;
+  const hrvFresh = freshness(hrvLatest?.date ?? null, todayKey());
   const hrvTrend = (recoveryVitals?.hrv?.trend ?? [])
     .map((p) => p.weekly_avg)
     .filter((v): v is number => v != null);
@@ -160,10 +165,13 @@ export default function SleepScreen() {
       metric: "sleep",
     },
     {
+      // Dated, and demoted once the night is older than two days (#731).
       label: "Last Night",
-      value: fmt1(lastSleep?.value, "h"),
-      sub: lastSleep?.date ?? "no data",
-      cls: "text-teal",
+      value: lastNightFresh.stale ? "—" : fmt1(lastSleep?.value, "h"),
+      sub: lastNightFresh.stale
+        ? `${staleShort("night", lastNightFresh)}${lastSleep?.value != null ? ` · last ${fmt1(lastSleep.value, "h")}` : ""}`
+        : lastSleep?.date ?? "no data",
+      cls: lastNightFresh.stale ? "text-text-muted" : "text-teal",
     },
     {
       label: "Resting HR",
@@ -180,9 +188,11 @@ export default function SleepScreen() {
     },
     {
       label: "HRV (weekly)",
-      value: fmt0(hrvLatest?.weekly_avg, " ms"),
-      sub: hrvLatest?.last_night_avg != null ? `last night ${hrvLatest.last_night_avg} ms` : "weekly avg",
-      cls: "text-lime",
+      value: hrvFresh.stale ? "—" : fmt0(hrvLatest?.weekly_avg, " ms"),
+      sub: hrvFresh.stale
+        ? `${staleShort("HRV", hrvFresh)}${hrvLatest?.weekly_avg != null ? ` · last ${hrvLatest.weekly_avg} ms` : ""}`
+        : hrvLatest?.last_night_avg != null ? `last night ${hrvLatest.last_night_avg} ms · ${hrvLatest.date}` : "weekly avg",
+      cls: hrvFresh.stale ? "text-text-muted" : "text-lime",
       spark: { data: hrvTrend, color: "#cbe896" },
       unit: "ms",
     },

--- a/universal/src/lib/freshness.test.ts
+++ b/universal/src/lib/freshness.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { freshness, staleShort, todayKey, RECOVERY_MAX_AGE_DAYS } from "./freshness";
+
+const T = "2026-09-06";
+describe("freshness (app twin, #731)", () => {
+  it("cadence is two days", () => { expect(RECOVERY_MAX_AGE_DAYS).toBe(2); });
+  const cases: [string, string | null, boolean, number | null][] = [
+    ["today", "2026-09-06", false, 0],
+    ["two days ago still fresh", "2026-09-04", false, 2],
+    ["three days ago stale", "2026-09-03", true, 3],
+    ["2026-08-23 on 2026-09-06 is 14 days stale", "2026-08-23", true, 14],
+    ["timestamp uses its date part", "2026-09-05T02:00:00Z", false, 1],
+    ["null is missing and stale", null, true, null],
+    ["garbage is stale, not missing", "nope", true, null],
+  ];
+  for (const [name, obs, stale, age] of cases) {
+    it(name, () => { const f = freshness(obs, T); expect(f.stale).toBe(stale); expect(f.ageDays).toBe(age); expect(f.missing).toBe(obs == null); });
+  }
+  it("short copy names the month-day, or yet", () => {
+    expect(staleShort("HRV", freshness("2026-08-21", T))).toBe("no HRV since 08-21");
+    expect(staleShort("night", freshness(null, T))).toBe("no night yet");
+  });
+  it("todayKey is the New York day", () => { expect(todayKey(new Date("2026-09-07T03:30:00Z"))).toBe("2026-09-06"); });
+});

--- a/universal/src/lib/freshness.ts
+++ b/universal/src/lib/freshness.ts
@@ -1,0 +1,39 @@
+/**
+ * Is an observed recovery value still current? Twin of web/lib/freshness.ts
+ * (#731): a night, HRV, SpO2 or body-battery reading is current for two days
+ * after the date it describes; older is stale and reads as unknown, never as
+ * the last value we saw.
+ */
+export const RECOVERY_MAX_AGE_DAYS = 2;
+
+export interface Freshness {
+  observed: string | null;
+  ageDays: number | null;
+  missing: boolean;
+  stale: boolean;
+}
+
+function dayMs(d: string): number {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(d);
+  if (!m) return NaN;
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+}
+
+export function freshness(observed: string | null | undefined, today: string, maxAgeDays: number = RECOVERY_MAX_AGE_DAYS): Freshness {
+  if (!observed) return { observed: null, ageDays: null, missing: true, stale: true };
+  const a = dayMs(observed);
+  const b = dayMs(today);
+  if (Number.isNaN(a) || Number.isNaN(b)) return { observed: observed.slice(0, 10), ageDays: null, missing: false, stale: true };
+  const ageDays = Math.round((b - a) / 86_400_000);
+  return { observed: observed.slice(0, 10), ageDays, missing: false, stale: ageDays > maxAgeDays };
+}
+
+/** Short phone copy: "no night since 08-23", "no HRV since 08-21", "no night yet". */
+export function staleShort(noun: "night" | "HRV" | "SpO2" | "body battery", f: Freshness): string {
+  return f.observed ? `no ${noun} since ${f.observed.slice(5)}` : `no ${noun} yet`;
+}
+
+/** Today's date in soma's day boundary (New York), YYYY-MM-DD. */
+export function todayKey(now: Date = new Date()): string {
+  return now.toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -16,6 +16,7 @@ import { InteractiveThisWeek } from "@/components/interactive-this-week";
 import { TimeRangeSelector } from "@/components/time-range-selector";
 import { rangeToDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
+import { freshness, staleHeadline, todayKey, RECOVERY_MAX_AGE_DAYS } from "@/lib/freshness";
 import { readinessScore, trafficLightText } from "@/lib/readiness";
 import {
   Footprints,
@@ -446,6 +447,7 @@ async function getRecoverySummary() {
   const [bb, hrv, tr, model] = await Promise.all([
     sql`
       SELECT
+        date::text as date,
         (raw_json->>'bodyBatteryChargedValue')::int as charged,
         (raw_json->>'bodyBatteryDrainedValue')::int as drained
       FROM garmin_raw_data
@@ -456,6 +458,7 @@ async function getRecoverySummary() {
     `,
     sql`
       SELECT
+        date::text as date,
         (raw_json->'hrvSummary'->>'weeklyAvg')::int as weekly_avg,
         (raw_json->'hrvSummary'->>'lastNightAvg')::int as last_night,
         raw_json->'hrvSummary'->>'status' as status
@@ -466,6 +469,7 @@ async function getRecoverySummary() {
     `,
     sql`
       SELECT
+        date::text as date,
         (raw_json->0->>'score')::int as score,
         raw_json->0->>'level' as level
       FROM garmin_raw_data
@@ -474,7 +478,7 @@ async function getRecoverySummary() {
       ORDER BY date DESC LIMIT 1
     `,
     sql`
-      SELECT traffic_light, composite_score
+      SELECT date::text as date, traffic_light, composite_score
       FROM daily_readiness
       ORDER BY date DESC LIMIT 1
     `.catch(() => []),  // demo DB has no daily_readiness table — fall back to Garmin readiness
@@ -870,18 +874,19 @@ export default async function HomePage({
           {
             metric: "sleep",
             title: "Sleep",
+            // A night older than the watch's cadence is not the headline: absent is
+            // unknown, not the last night we saw (#713, #731).
             value: (() => {
-              const secs = health?.sleep_time_seconds || latestSleep?.total;
-              return secs ? `${(secs / 3600).toFixed(1)}h` : "—";
+              if (health?.sleep_time_seconds) return `${(health.sleep_time_seconds / 3600).toFixed(1)}h`;
+              const f = freshness(latestSleep?.date ?? null, todayKey());
+              return !f.stale && latestSleep?.total ? `${(latestSleep.total / 3600).toFixed(1)}h` : "—";
             })(),
-            // The value falls back to the latest recorded night; say WHEN that was
-            // once it is older than last night, instead of passing it off as today's (#647).
             subtitle: (() => {
-              const score = latestSleep?.score ? `Score: ${latestSleep.score}` : "";
-              const yesterday = new Date(Date.now() - 86_400_000).toLocaleDateString("en-CA", { timeZone: "America/New_York" });
-              const stale = !health?.sleep_time_seconds && latestSleep?.date && latestSleep.date < yesterday;
-              const when = stale ? `last recorded ${latestSleep.date}` : "";
-              return [score, when].filter(Boolean).join(" · ") || undefined;
+              if (health?.sleep_time_seconds) return latestSleep?.score ? `Score: ${latestSleep.score}` : undefined;
+              const f = freshness(latestSleep?.date ?? null, todayKey());
+              if (!f.stale) return [latestSleep?.score ? `Score: ${latestSleep.score}` : "", latestSleep?.date ?? ""].filter(Boolean).join(" · ") || undefined;
+              const last = latestSleep?.total ? ` · last ${(latestSleep.total / 3600).toFixed(1)}h` : "";
+              return `${staleHeadline("night", f)}${last}`;
             })(),
             icon: <Moon className="h-4 w-4 text-indigo-400" />,
             info: "Total sleep time from Garmin sleep tracking. Recommended: 7-9 hours",
@@ -941,7 +946,15 @@ export default async function HomePage({
                 {(recovery.model || recovery.readiness) && (
                   <div>
                     <div className="text-xs text-muted-foreground mb-1">Readiness</div>
-                    {recovery.model?.composite_score != null ? (
+                    {recovery.model?.traffic_light === "unknown" ? (
+                      // soma's own model says it cannot know (no night): say so, Garmin as the comparison (#731).
+                      <>
+                        <div className="text-2xl font-bold text-muted-foreground" data-testid="overview-readiness-unknown">unknown</div>
+                        <div className="text-xs text-muted-foreground">
+                          {recovery.readiness ? `Garmin ${recovery.readiness.score} · no night since ${recovery.model.date}` : "no night recorded"}
+                        </div>
+                      </>
+                    ) : recovery.model?.composite_score != null ? (
                       // soma's own model readiness (headlined); Garmin below as the comparison.
                       <>
                         <div className={`text-2xl font-bold ${trafficLightText(recovery.model.traffic_light)}`}>
@@ -966,29 +979,35 @@ export default async function HomePage({
                     ) : null}
                   </div>
                 )}
-                {recovery.bodyBattery && (
-                  <div>
-                    <div className="text-xs text-muted-foreground mb-1">Body Battery</div>
+                {recovery.bodyBattery && (() => {
+                  const f = freshness(recovery.bodyBattery.date, todayKey());
+                  return (
+                  <div data-testid="overview-body-battery" data-freshness={f.stale ? "stale" : "fresh"} data-observed={recovery.bodyBattery.date} data-max-age-days={RECOVERY_MAX_AGE_DAYS}>
+                    <div className="text-xs text-muted-foreground mb-1">Body Battery{f.stale ? "" : ` · ${recovery.bodyBattery.date}`}</div>
                     <div className="text-2xl font-bold">
-                      +{recovery.bodyBattery.charged}
+                      {f.stale ? "—" : `+${recovery.bodyBattery.charged}`}
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      −{recovery.bodyBattery.drained} drained
+                      {f.stale ? `${staleHeadline("body battery reading", f)}` : `−${recovery.bodyBattery.drained} drained`}
                     </div>
                   </div>
-                )}
-                {recovery.hrv && (
-                  <div>
-                    <div className="text-xs text-muted-foreground mb-1">HRV</div>
+                  );
+                })()}
+                {recovery.hrv && (() => {
+                  const f = freshness(recovery.hrv.date, todayKey());
+                  return (
+                  <div data-testid="overview-hrv" data-freshness={f.stale ? "stale" : "fresh"} data-observed={recovery.hrv.date} data-max-age-days={RECOVERY_MAX_AGE_DAYS}>
+                    <div className="text-xs text-muted-foreground mb-1">HRV{f.stale ? "" : ` · ${recovery.hrv.date}`}</div>
                     <div className="text-2xl font-bold">
-                      {recovery.hrv.last_night ?? recovery.hrv.weekly_avg} ms
+                      {f.stale ? "—" : `${recovery.hrv.last_night ?? recovery.hrv.weekly_avg} ms`}
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      Weekly avg: {recovery.hrv.weekly_avg} ms
+                      {f.stale ? `${staleHeadline("HRV reading", f)} · last ${recovery.hrv.last_night ?? recovery.hrv.weekly_avg} ms` : `Weekly avg: ${recovery.hrv.weekly_avg} ms`}
                     </div>
                   </div>
-                )}
-                {recovery.hrv?.status && (
+                  );
+                })()}
+                {recovery.hrv?.status && !freshness(recovery.hrv.date, todayKey()).stale && (
                   <div>
                     <div className="text-xs text-muted-foreground mb-1">HRV Status</div>
                     <div className={`text-2xl font-bold ${

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -951,7 +951,7 @@ export default async function HomePage({
                       <>
                         <div className="text-2xl font-bold text-muted-foreground" data-testid="overview-readiness-unknown">unknown</div>
                         <div className="text-xs text-muted-foreground">
-                          {recovery.readiness ? `Garmin ${recovery.readiness.score} · no night since ${recovery.model.date}` : "no night recorded"}
+                          {[recovery.readiness ? `Garmin ${recovery.readiness.score}` : "", latestSleep?.date ? `no night recorded since ${latestSleep.date}` : "no night recorded"].filter(Boolean).join(" · ")}
                         </div>
                       </>
                     ) : recovery.model?.composite_score != null ? (

--- a/web/app/sleep/page.tsx
+++ b/web/app/sleep/page.tsx
@@ -797,7 +797,7 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
                   {f.stale && <div className="text-xs text-muted-foreground">last {Number(last?.weekly_avg) || "—"} ms</div>}
                 </div>
                 <div>
-                  <div className="text-xs text-muted-foreground">{f.stale ? "Last night" : `Last night · ${last?.date}`}</div>
+                  <div className="text-xs text-muted-foreground">{f.stale ? "Night" : `Last night · ${last?.date}`}</div>
                   <div className="text-2xl font-bold">
                     {f.stale ? "—" : Number(last?.last_night_avg) || "—"}
                     {f.stale ? null : <span className="text-sm font-normal text-muted-foreground ml-1">ms</span>}
@@ -939,7 +939,7 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
                     )}
                     <div className="grid grid-cols-3 gap-4">
                       <div>
-                        <div className="text-xs text-muted-foreground">{fresh.stale ? "Last night" : `Last night · ${latest.date}`}</div>
+                        <div className="text-xs text-muted-foreground">{fresh.stale ? "Night" : `Last night · ${latest.date}`}</div>
                         <div className="text-2xl font-bold">{fresh.stale ? "—" : `${Number(latest.avg_spo2).toFixed(0)}%`}</div>
                         {fresh.stale && <div className="text-xs text-muted-foreground">last {Number(latest.avg_spo2).toFixed(0)}%</div>}
                       </div>

--- a/web/app/sleep/page.tsx
+++ b/web/app/sleep/page.tsx
@@ -17,6 +17,7 @@ import { RespirationChart } from "@/components/respiration-chart";
 import { TimeRangeSelector } from "@/components/time-range-selector";
 import { rangeToDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
+import { freshness, staleHeadline, todayKey, RECOVERY_MAX_AGE_DAYS } from "@/lib/freshness";
 import {
   Moon,
   Sunrise,
@@ -408,7 +409,7 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
           <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Sleep & Recovery</h1>
           <p className="text-sm text-muted-foreground mt-1">
             {stats?.total_nights
-              ? `${Number(stats.total_nights)} nights tracked`
+              ? `${Number(stats.total_nights)} nights recorded in this range${lastNight?.date ? ` · last night recorded ${lastNight.date}` : ""}`
               : "No sleep data yet."}
           </p>
         </div>
@@ -420,6 +421,7 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
         <StatCard
           title="Avg Sleep"
           value={stats?.avg_hours ? `${Number(stats.avg_hours).toFixed(1)}h` : "—"}
+          subtitle={stats?.total_nights ? `based on ${Number(stats.total_nights)} nights` : undefined}
           icon={<Moon className="h-4 w-4 text-indigo-400" />}
           info="Average total sleep time per night. Recommended: 7-9 hours"
         />
@@ -446,17 +448,30 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
         />
       </div>
 
-      {/* Last Night Detail */}
-      {lastNight && (
-        <Card className="mb-6">
+      {/* Last Night Detail — dated, and demoted once the night is older than the
+          watch's cadence allows: absent is unknown, not the last night we saw (#731). */}
+      {lastNight && (() => {
+        const f = freshness(lastNight.date, todayKey());
+        return (
+        <Card className={`mb-6 ${f.stale ? "opacity-80" : ""}`} data-testid="sleep-last-night">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+            <CardTitle
+              className="text-sm font-medium text-muted-foreground flex items-center gap-2"
+              data-freshness={f.stale ? "stale" : "fresh"}
+              data-observed={lastNight.date}
+              data-max-age-days={RECOVERY_MAX_AGE_DAYS}
+            >
               <Moon className="h-4 w-4" />
-              Last Night
-              {qualityBadge(lastNight.quality)}
+              {f.stale ? staleHeadline("night", f) : `Last night · ${lastNight.date}`}
+              {f.stale ? null : qualityBadge(lastNight.quality)}
             </CardTitle>
+            {f.stale && (
+              <p className="text-xs text-muted-foreground" data-testid="sleep-last-night-stale">
+                The values below are from {lastNight.date}, {f.ageDays} days ago, not last night.
+              </p>
+            )}
           </CardHeader>
-          <CardContent>
+          <CardContent className={f.stale ? "text-muted-foreground" : ""}>
             <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
               <div>
                 <div className="text-xs text-muted-foreground mb-1">Total</div>
@@ -500,7 +515,8 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
             </div>
           </CardContent>
         </Card>
-      )}
+        );
+      })()}
 
       {/* Charts Row 1: Sleep Stages + Score */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
@@ -565,7 +581,7 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
             <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               <Clock className="h-4 w-4 text-emerald-400" />
               Sleep Regularity
-              <span className="ml-auto text-xs font-normal">Last {sleepRegularity.nights} nights</span>
+              <span className="ml-auto text-xs font-normal">based on {sleepRegularity.nights} nights in this range</span>
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -757,27 +773,39 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-3 gap-4 mb-4">
+              {(() => {
+                const last = hrvTrend[hrvTrend.length - 1] as { date?: string; weekly_avg?: number; last_night_avg?: number; status?: string } | undefined;
+                const f = freshness(last?.date ?? null, todayKey());
+                return (
+              <div
+                className="grid grid-cols-3 gap-4 mb-4"
+                data-testid="sleep-hrv-latest"
+                data-freshness={f.stale ? "stale" : "fresh"}
+                data-observed={last?.date ?? ""}
+                data-max-age-days={RECOVERY_MAX_AGE_DAYS}
+              >
                 <div>
-                  <div className="text-xs text-muted-foreground">Weekly Avg</div>
+                  <div className="text-xs text-muted-foreground">Weekly Avg{f.stale ? "" : ` · ${last?.date}`}</div>
                   <div className="text-2xl font-bold">
-                    {Number(hrvTrend[hrvTrend.length - 1]?.weekly_avg) || "—"}
-                    <span className="text-sm font-normal text-muted-foreground ml-1">ms</span>
+                    {f.stale ? "—" : Number(last?.weekly_avg) || "—"}
+                    {f.stale ? null : <span className="text-sm font-normal text-muted-foreground ml-1">ms</span>}
                   </div>
+                  {f.stale && <div className="text-xs text-muted-foreground">last {Number(last?.weekly_avg) || "—"} ms on {last?.date}</div>}
                 </div>
                 <div>
-                  <div className="text-xs text-muted-foreground">Last Night</div>
+                  <div className="text-xs text-muted-foreground">{f.stale ? staleHeadline("HRV reading", f) : `Last night · ${last?.date}`}</div>
                   <div className="text-2xl font-bold">
-                    {Number(hrvTrend[hrvTrend.length - 1]?.last_night_avg) || "—"}
-                    <span className="text-sm font-normal text-muted-foreground ml-1">ms</span>
+                    {f.stale ? "—" : Number(last?.last_night_avg) || "—"}
+                    {f.stale ? null : <span className="text-sm font-normal text-muted-foreground ml-1">ms</span>}
                   </div>
+                  {f.stale && <div className="text-xs text-muted-foreground">last {Number(last?.last_night_avg) || "—"} ms on {last?.date}</div>}
                 </div>
                 <div>
                   <div className="text-xs text-muted-foreground">Status</div>
                   <div className="text-2xl font-bold capitalize">
                     {(() => {
-                      const s = hrvTrend[hrvTrend.length - 1]?.status as string;
-                      if (!s) return "—";
+                      const s = last?.status as string;
+                      if (!s || f.stale) return "—";
                       const colors: Record<string, string> = {
                         BALANCED: "text-green-400",
                         LOW: "text-red-400",
@@ -788,6 +816,8 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
                   </div>
                 </div>
               </div>
+                );
+              })()}
               <HRVChart
                 data={(hrvTrend as any[]).map((h: any) => ({
                   date: h.date,
@@ -885,19 +915,27 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
                 const data = (spo2Trend as any[]).filter((d: any) => d.avg_spo2 > 0);
                 if (data.length === 0) return <p className="text-sm text-muted-foreground">No SpO2 data</p>;
                 const latest = data[data.length - 1];
+                const fresh = freshness(latest?.date ?? null, todayKey());
                 const recent7 = data.slice(-7);
                 const avg7 = recent7.reduce((s: number, d: any) => s + Number(d.avg_spo2), 0) / recent7.length;
                 const lowVals = data.filter((d: any) => d.low_spo2 && Number(d.low_spo2) > 0).map((d: any) => Number(d.low_spo2));
                 const minSpo2 = lowVals.length > 0 ? Math.min(...lowVals) : null;
                 return (
                   <>
-                    <div className="grid grid-cols-3 gap-4 mb-4">
+                    <div
+                      className="grid grid-cols-3 gap-4 mb-4"
+                      data-testid="sleep-spo2-latest"
+                      data-freshness={fresh.stale ? "stale" : "fresh"}
+                      data-observed={latest?.date ?? ""}
+                      data-max-age-days={RECOVERY_MAX_AGE_DAYS}
+                    >
                       <div>
-                        <div className="text-xs text-muted-foreground">Last Night</div>
-                        <div className="text-2xl font-bold">{Number(latest.avg_spo2).toFixed(0)}%</div>
+                        <div className="text-xs text-muted-foreground">{fresh.stale ? staleHeadline("SpO2 reading", fresh) : `Last night · ${latest.date}`}</div>
+                        <div className="text-2xl font-bold">{fresh.stale ? "—" : `${Number(latest.avg_spo2).toFixed(0)}%`}</div>
+                        {fresh.stale && <div className="text-xs text-muted-foreground">last {Number(latest.avg_spo2).toFixed(0)}% on {latest.date}</div>}
                       </div>
                       <div>
-                        <div className="text-xs text-muted-foreground">7-Day Avg</div>
+                        <div className="text-xs text-muted-foreground">{fresh.stale ? "Avg of the last 7 recorded" : "7-Day Avg"}</div>
                         <div className="text-2xl font-bold">{avg7.toFixed(0)}%</div>
                       </div>
                       <div>

--- a/web/app/sleep/page.tsx
+++ b/web/app/sleep/page.tsx
@@ -778,27 +778,31 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
                 const f = freshness(last?.date ?? null, todayKey());
                 return (
               <div
-                className="grid grid-cols-3 gap-4 mb-4"
+                className="mb-4"
                 data-testid="sleep-hrv-latest"
                 data-freshness={f.stale ? "stale" : "fresh"}
                 data-observed={last?.date ?? ""}
                 data-max-age-days={RECOVERY_MAX_AGE_DAYS}
               >
+              {f.stale && (
+                <p className="text-xs text-muted-foreground mb-2">{staleHeadline("HRV reading", f)} · the last values are from {last?.date}</p>
+              )}
+              <div className="grid grid-cols-3 gap-4">
                 <div>
                   <div className="text-xs text-muted-foreground">Weekly Avg{f.stale ? "" : ` · ${last?.date}`}</div>
                   <div className="text-2xl font-bold">
                     {f.stale ? "—" : Number(last?.weekly_avg) || "—"}
                     {f.stale ? null : <span className="text-sm font-normal text-muted-foreground ml-1">ms</span>}
                   </div>
-                  {f.stale && <div className="text-xs text-muted-foreground">last {Number(last?.weekly_avg) || "—"} ms on {last?.date}</div>}
+                  {f.stale && <div className="text-xs text-muted-foreground">last {Number(last?.weekly_avg) || "—"} ms</div>}
                 </div>
                 <div>
-                  <div className="text-xs text-muted-foreground">{f.stale ? staleHeadline("HRV reading", f) : `Last night · ${last?.date}`}</div>
+                  <div className="text-xs text-muted-foreground">{f.stale ? "Last night" : `Last night · ${last?.date}`}</div>
                   <div className="text-2xl font-bold">
                     {f.stale ? "—" : Number(last?.last_night_avg) || "—"}
                     {f.stale ? null : <span className="text-sm font-normal text-muted-foreground ml-1">ms</span>}
                   </div>
-                  {f.stale && <div className="text-xs text-muted-foreground">last {Number(last?.last_night_avg) || "—"} ms on {last?.date}</div>}
+                  {f.stale && <div className="text-xs text-muted-foreground">last {Number(last?.last_night_avg) || "—"} ms</div>}
                 </div>
                 <div>
                   <div className="text-xs text-muted-foreground">Status</div>
@@ -815,6 +819,7 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
                     })()}
                   </div>
                 </div>
+              </div>
               </div>
                 );
               })()}
@@ -923,16 +928,20 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
                 return (
                   <>
                     <div
-                      className="grid grid-cols-3 gap-4 mb-4"
+                      className="mb-4"
                       data-testid="sleep-spo2-latest"
                       data-freshness={fresh.stale ? "stale" : "fresh"}
                       data-observed={latest?.date ?? ""}
                       data-max-age-days={RECOVERY_MAX_AGE_DAYS}
                     >
+                    {fresh.stale && (
+                      <p className="text-xs text-muted-foreground mb-2">{staleHeadline("SpO2 reading", fresh)} · the last value is from {latest.date}</p>
+                    )}
+                    <div className="grid grid-cols-3 gap-4">
                       <div>
-                        <div className="text-xs text-muted-foreground">{fresh.stale ? staleHeadline("SpO2 reading", fresh) : `Last night · ${latest.date}`}</div>
+                        <div className="text-xs text-muted-foreground">{fresh.stale ? "Last night" : `Last night · ${latest.date}`}</div>
                         <div className="text-2xl font-bold">{fresh.stale ? "—" : `${Number(latest.avg_spo2).toFixed(0)}%`}</div>
-                        {fresh.stale && <div className="text-xs text-muted-foreground">last {Number(latest.avg_spo2).toFixed(0)}% on {latest.date}</div>}
+                        {fresh.stale && <div className="text-xs text-muted-foreground">last {Number(latest.avg_spo2).toFixed(0)}%</div>}
                       </div>
                       <div>
                         <div className="text-xs text-muted-foreground">{fresh.stale ? "Avg of the last 7 recorded" : "7-Day Avg"}</div>
@@ -942,6 +951,7 @@ export default async function SleepPage({ searchParams }: { searchParams: Promis
                         <div className="text-xs text-muted-foreground">Lowest</div>
                         <div className="text-2xl font-bold">{minSpo2 && minSpo2 < 100 ? `${minSpo2}%` : "—"}</div>
                       </div>
+                    </div>
                     </div>
                     <SpO2Chart data={data} />
                   </>

--- a/web/lib/freshness.test.ts
+++ b/web/lib/freshness.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { freshness, staleHeadline, todayKey, RECOVERY_MAX_AGE_DAYS } from "./freshness";
+
+const T = "2026-09-06";
+
+describe("freshness (#731)", () => {
+  it("two days is the recovery cadence", () => {
+    expect(RECOVERY_MAX_AGE_DAYS).toBe(2);
+  });
+
+  const cases: [string, string | null | undefined, boolean, number | null][] = [
+    ["today is fresh", "2026-09-06", false, 0],
+    ["yesterday is fresh", "2026-09-05", false, 1],
+    ["two days ago is still fresh (a late sync is not shouted about)", "2026-09-04", false, 2],
+    ["three days ago is stale", "2026-09-03", true, 3],
+    ["THE case: 2026-08-23 on 2026-09-06 is stale by 14 days", "2026-08-23", true, 14],
+    ["a timestamp is read by its date part", "2026-09-06T03:12:00.000Z", false, 0],
+    ["a future date (clock skew) is fresh, not stale", "2026-09-07", false, -1],
+    ["null is missing and stale", null, true, null],
+    ["undefined is missing and stale", undefined, true, null],
+    ["garbage is stale but not missing", "not-a-date", true, null],
+  ];
+  for (const [name, observed, stale, age] of cases) {
+    it(name, () => {
+      const f = freshness(observed, T);
+      expect(f.stale).toBe(stale);
+      expect(f.ageDays).toBe(age);
+      expect(f.missing).toBe(observed == null);
+    });
+  }
+
+  it("a custom cadence moves the line", () => {
+    expect(freshness("2026-09-03", T, 3).stale).toBe(false);
+    expect(freshness("2026-09-02", T, 3).stale).toBe(true);
+  });
+
+  it("headlines name the date, or say yet when nothing was ever observed", () => {
+    expect(staleHeadline("night", freshness("2026-08-23", T))).toBe("No night recorded since 2026-08-23");
+    expect(staleHeadline("HRV reading", freshness("2026-08-21", T))).toBe("No HRV reading since 2026-08-21");
+    expect(staleHeadline("SpO2 reading", freshness(null, T))).toBe("No SpO2 reading yet");
+    expect(staleHeadline("night", freshness(null, T))).toBe("No night recorded yet");
+  });
+
+  it("todayKey uses the New York day boundary", () => {
+    expect(todayKey(new Date("2026-09-07T03:30:00Z"))).toBe("2026-09-06");
+    expect(todayKey(new Date("2026-09-07T12:00:00Z"))).toBe("2026-09-07");
+  });
+});

--- a/web/lib/freshness.ts
+++ b/web/lib/freshness.ts
@@ -1,0 +1,57 @@
+/**
+ * Is an observed value still "current"? (#731, the #698 principle applied to
+ * recovery data: absent is unknown, not the last thing we saw.)
+ *
+ * The watch stopped recording nights on 2026-08-23 and two weeks later the
+ * pages still said "Last Night · 3h43m", "HRV last night 76 ms", "SpO2 last
+ * night 92%". Every headline that claims recency now carries the date it was
+ * observed and demotes itself once that date is older than the source's
+ * cadence allows.
+ *
+ * One rule for all recovery signals: a night, HRV, SpO2 or body-battery
+ * reading is current for RECOVERY_MAX_AGE_DAYS after the date it describes.
+ * Two days, not one, so a sync that lands a night late is not shouted about.
+ */
+export const RECOVERY_MAX_AGE_DAYS = 2;
+
+export interface Freshness {
+  /** YYYY-MM-DD the value describes, or null when nothing was ever observed. */
+  observed: string | null;
+  /** Whole days between observed and today (0 = today). null when missing. */
+  ageDays: number | null;
+  /** True when there is no observation at all. */
+  missing: boolean;
+  /** True when observed is older than maxAgeDays (also true when missing). */
+  stale: boolean;
+}
+
+/** YYYY-MM-DD → UTC midnight ms; tolerates timestamps by taking the date part. */
+function dayMs(d: string): number {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(d);
+  if (!m) return NaN;
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+}
+
+export function freshness(
+  observed: string | null | undefined,
+  today: string,
+  maxAgeDays: number = RECOVERY_MAX_AGE_DAYS,
+): Freshness {
+  if (!observed) return { observed: null, ageDays: null, missing: true, stale: true };
+  const a = dayMs(observed);
+  const b = dayMs(today);
+  if (Number.isNaN(a) || Number.isNaN(b)) return { observed: observed.slice(0, 10), ageDays: null, missing: false, stale: true };
+  const ageDays = Math.round((b - a) / 86_400_000);
+  return { observed: observed.slice(0, 10), ageDays, missing: false, stale: ageDays > maxAgeDays };
+}
+
+/** "No night recorded since 2026-08-23", "No HRV reading since …", or "No night recorded yet". */
+export function staleHeadline(noun: "night" | "HRV reading" | "SpO2 reading" | "body battery reading", f: Freshness): string {
+  const what = noun === "night" ? "No night recorded" : `No ${noun}`;
+  return f.observed ? `${what} since ${f.observed}` : `${what} yet`;
+}
+
+/** Today's date in the user's day boundary (New York, like the rest of soma), YYYY-MM-DD. */
+export function todayKey(now: Date = new Date()): string {
+  return now.toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+}

--- a/web/tests/e2e/freshness.spec.ts
+++ b/web/tests/e2e/freshness.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Freshness guard (#741, part of #731): a page must never label a value older
+ * than its source cadence as "today" or "last night".
+ *
+ * Every headline that claims recency carries three attributes set by the page:
+ *   data-observed="YYYY-MM-DD"   the date the value describes
+ *   data-max-age-days="2"        the cadence the source allows
+ *   data-freshness="fresh|stale" what the page decided
+ * The spec recomputes staleness ITSELF from data-observed and today's date and
+ * checks the visible copy, so a page cannot pass by lying to itself:
+ *   stale ⇒ the copy says "since <date>" (or "yet") and never "Last night"/"today"
+ *   fresh ⇒ the copy carries the date and never says "since"
+ * With no rows at all (an empty demo DB) there are no such elements and the guard
+ * passes vacuously; on a real database it is the regression test for #713/#731.
+ */
+
+const PAGES = ["/", "/sleep"];
+
+function todayNY(): string {
+  return new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+}
+function dayMs(d: string): number {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(d);
+  return m ? Date.UTC(+m[1], +m[2] - 1, +m[3]) : NaN;
+}
+
+for (const path of PAGES) {
+  test(`freshness labels are honest on ${path}`, async ({ page }) => {
+    await page.goto(path);
+    await page.waitForLoadState("networkidle");
+    const els = page.locator("[data-observed][data-max-age-days]");
+    const n = await els.count();
+    test.info().annotations.push({ type: "freshness-elements", description: String(n) });
+    const today = todayNY();
+    for (let i = 0; i < n; i++) {
+      const el = els.nth(i);
+      const observed = (await el.getAttribute("data-observed")) ?? "";
+      const maxAge = Number(await el.getAttribute("data-max-age-days"));
+      const decided = await el.getAttribute("data-freshness");
+      const text = ((await el.textContent()) ?? "").replace(/\s+/g, " ").trim();
+      const age = observed ? Math.round((dayMs(today) - dayMs(observed)) / 86_400_000) : Infinity;
+      const stale = !observed || Number.isNaN(age) || age > maxAge;
+      const where = `${path} [${i}] observed=${observed || "none"} age=${age} max=${maxAge} text="${text.slice(0, 80)}"`;
+      expect(decided, `page decision must match the recomputed one: ${where}`).toBe(stale ? "stale" : "fresh");
+      if (stale) {
+        expect(text, `stale copy must say since/yet: ${where}`).toMatch(/\bsince\b|\byet\b/i);
+        expect(text, `stale copy must not claim recency: ${where}`).not.toMatch(/last night(?!\s*·)|\btoday\b/i);
+      } else {
+        expect(text, `fresh copy must carry its date: ${where}`).toContain(observed);
+        expect(text, `fresh copy must not say since: ${where}`).not.toMatch(/\bsince\b/i);
+      }
+    }
+  });
+}


### PR DESCRIPTION
## What

The watch stopped recording nights on 2026-08-23. Two weeks later the pages still said "Last Night · 3h43m", "HRV last night 76 ms · Balanced", "SpO2 last night 92%", and the overview tiles headlined the same numbers. Absent is unknown, not the last thing we saw (#698, #713, #731).

One pure rule, `web/lib/freshness.ts` (twin `universal/src/lib/freshness.ts`): a night, HRV, SpO2 or body-battery value is current for two days after the date it describes, stale after. 14 + 10 table tests.

Web `/sleep` (#732)
- Header: "N nights recorded in this range · last night recorded <date>"; Avg Sleep says "based on N nights"; Sleep Regularity says "based on N nights in this range".
- Last Night block: dated when fresh ("Last night · <date>" + quality badge); stale → "No night recorded since <date>" with "The values below are from <date>, N days ago, not last night" and the values muted.
- HRV and SpO2 blocks: dated when fresh; stale → a notice line "No HRV reading since <date>" / "No SpO2 reading since <date>", the headline values become "—" with "last 76 ms" / "last 92%" underneath, HRV Status hidden; the 7-day SpO2 average is labelled "Avg of the last 7 recorded".

Web overview (#733, #713)
- Sleep tile: a stale night is no longer the headline: "—" with "No night recorded since <date> · last 3.7h".
- Recovery Status: HRV, body battery and readiness queries carry their date; HRV/body battery are dated when fresh and demote to "—" + "No … reading since <date> · last …" when stale; HRV Status hides when stale; when soma's own readiness says `unknown` the tile says **unknown** with "Garmin 74 · no night recorded since <date>" instead of quietly showing Garmin's number (matches the Training page).

App (#733, #734)
- Overview HRV tile and Sleep screen HRV / Last Night cards follow the same rule ("—" + "no HRV since 08-21 · last 71", "no night since 08-23 · last 3.7h").
- The "nights logged" badge counts sleep_data nights like the web header (was `daily_health_summary` days: 43 vs 132).

Guard (#741)
- `web/tests/e2e/freshness.spec.ts`: every recency headline carries `data-observed`, `data-max-age-days`, `data-freshness`; the spec recomputes staleness itself from the date and asserts the visible copy (stale ⇒ "since/yet", never "last night/today"; fresh ⇒ carries the date, never "since"). Runs in the existing web-e2e workflow against the demo.

## Evidence

- tsc 0 (web + universal); vitest web 41 files / 316 tests, universal 3 files / 31 tests.
- e2e guard against the rig (this branch, real DB, DEMO_MODE): 4/4 passed on desktop and mobile; it found 3 stale elements on /sleep (night 08-23, HRV 08-21, SpO2 08-23) and 2 on / (HRV stale, body battery fresh 09-06).
- Playwright desktop 1440×900 and mobile 390×844, read back: /sleep header "132 nights recorded in this range · last night recorded 2026-08-23", Last Night block "No night recorded since 2026-08-23", HRV "No HRV reading since 2026-08-21 · Weekly Avg — last 71 ms · Night — last 76 ms · Status —", SpO2 "No SpO2 reading since 2026-08-23 · — last 92%"; overview Sleep tile "— · No night recorded since 2026-08-23 · last 3.7h", Recovery "unknown · Garmin 74 · no night recorded since 2026-08-23", "Body Battery · 2026-09-06 +16", "HRV — No HRV reading since 2026-08-21 · last 76 ms". First mobile pass showed the HRV columns misaligned by the wrapped stale label; the notice moved above the grid and the columns realigned.
- App: release APK from this branch on the emulator with the real account (added below once the build lands).

Closes #731
Closes #732
Closes #733
Closes #734
Closes #713
Closes #741
