### PR TITLE
fix(api): app-facing sleep and recovery routes understand the app's range keys (#743)

### DIFF
--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -157,8 +157,12 @@ export default function SleepScreen() {
   }[] = [
     {
       label: "Avg Sleep",
-      value: fmt1(sleep?.summary.current_avg, "h"),
-      sub: `${fmt1(sleep?.summary.current_min, "h")}–${fmt1(sleep?.summary.current_max, "h")}`,
+      // The average rests on sleep_data nights (the web's number over the same
+      // window), not on the subset of days daily_health_summary carries (#743).
+      value: sleepSum?.stats?.avg_hours != null ? fmt1(sleepSum.stats.avg_hours, "h") : fmt1(sleep?.summary.current_avg, "h"),
+      sub: sleepSum?.stats?.nights
+        ? `based on ${sleepSum.stats.nights} nights · ${fmt1(sleep?.summary.current_min, "h")}–${fmt1(sleep?.summary.current_max, "h")}`
+        : `${fmt1(sleep?.summary.current_min, "h")}–${fmt1(sleep?.summary.current_max, "h")}`,
       cls: "text-indigo",
       spark: { data: seriesVals(sleep?.current), color: "#6366b0" },
       unit: "h",

--- a/web/app/api/recovery/summary/route.ts
+++ b/web/app/api/recovery/summary/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { parseRangeDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
 
@@ -11,7 +12,7 @@ export const runtime = "edge";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const range = searchParams.get("range") || "30d";
-  const days = range === "7d" ? 7 : range === "14d" ? 14 : range === "90d" ? 90 : range === "1y" ? 365 : 30;
+  const days = parseRangeDays(range, 30); // app keys (6m…) and legacy Nd keys (#743)
 
   const sql = getDb();
 

--- a/web/app/api/sleep/respiratory/route.ts
+++ b/web/app/api/sleep/respiratory/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { parseRangeDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
 
@@ -11,7 +12,7 @@ export const runtime = "edge";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const range = searchParams.get("range") || "30d";
-  const days = range === "7d" ? 7 : range === "14d" ? 14 : range === "90d" ? 90 : range === "1y" ? 365 : 30;
+  const days = parseRangeDays(range, 30); // app keys (6m…) and legacy Nd keys (#743)
 
   const sql = getDb();
 

--- a/web/app/api/sleep/schedule/route.ts
+++ b/web/app/api/sleep/schedule/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { parseRangeDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
 
@@ -18,7 +19,7 @@ const stddev = (a: number[]) => {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const range = searchParams.get("range") || "30d";
-  const days = range === "7d" ? 7 : range === "14d" ? 14 : range === "90d" ? 90 : range === "1y" ? 365 : 30;
+  const days = parseRangeDays(range, 30); // app keys (6m…) and legacy Nd keys (#743)
 
   const sql = getDb();
   const rows = (await sql`

--- a/web/app/api/sleep/summary/route.ts
+++ b/web/app/api/sleep/summary/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { parseRangeDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
 
@@ -11,7 +12,7 @@ export const runtime = "edge";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const range = searchParams.get("range") || "30d";
-  const days = range === "7d" ? 7 : range === "14d" ? 14 : range === "90d" ? 90 : range === "1y" ? 365 : 30;
+  const days = parseRangeDays(range, 30); // app keys (6m…) and legacy Nd keys (#743)
 
   const sql = getDb();
   const rows = (await sql`

--- a/web/lib/time-ranges.test.ts
+++ b/web/lib/time-ranges.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { parseRangeDays, rangeToDays } from "./time-ranges";
+
+describe("parseRangeDays (#743)", () => {
+  const cases: [string | null | undefined, number][] = [
+    ["6m", 180], ["1w", 7], ["2w", 14], ["1m", 30], ["3m", 90], ["9m", 270], ["1y", 365], ["2y", 730], ["all", 3650],
+    ["7d", 7], ["14d", 14], ["30d", 30], ["90d", 90], ["180d", 180],
+    ["bogus", 180], [null, 180], [undefined, 180], ["", 180],
+  ];
+  for (const [input, want] of cases) {
+    it(`${String(input)} → ${want}`, () => { expect(parseRangeDays(input)).toBe(want); });
+  }
+  it("a custom fallback applies only when the key is unknown", () => {
+    expect(parseRangeDays("nope", 30)).toBe(30);
+    expect(parseRangeDays("6m", 30)).toBe(180);
+  });
+  it("agrees with rangeToDays for every web key", () => {
+    for (const k of ["1w", "2w", "1m", "3m", "6m", "9m", "1y", "2y", "3y", "all"]) expect(parseRangeDays(k)).toBe(rangeToDays(k));
+  });
+});

--- a/web/lib/time-ranges.ts
+++ b/web/lib/time-ranges.ts
@@ -16,3 +16,17 @@ export function rangeToDays(range: string | undefined): number {
   const found = RANGES.find((r) => r.value === range);
   return found ? found.days : 180;
 }
+
+/**
+ * Days for a range key coming from either client. The web sends the RANGES
+ * keys (1w … all); the app's JSON routes historically accepted "7d/14d/90d/1y"
+ * and silently fell back to 30 days for anything else, which turned the app's
+ * default 6M into a 30-day window (#743). Accept both shapes.
+ */
+export function parseRangeDays(range: string | null | undefined, fallbackDays = 180): number {
+  if (!range) return fallbackDays;
+  const m = /^(\d+)d$/.exec(range);
+  if (m) return Number(m[1]);
+  const found = RANGES.find((r) => r.value === range);
+  return found ? found.days : fallbackDays;
+}


### PR DESCRIPTION
## What

Found on the emulator right after #742: with 6M selected the app's sleep screen said "9 nights logged". The four app-facing JSON routes (`/api/sleep/summary`, `/api/sleep/schedule`, `/api/sleep/respiratory`, `/api/recovery/summary`) parsed only `7d/14d/90d/1y` and fell back to 30 days for anything else, so the app's `6m` (its default) was a 30-day window on every card derived from them: nights badge, avg score, avg deep, avg sleep HR, HRV trend, readiness trend, respiration, schedule. The header count and the stats sparklines were six months.

- `lib/time-ranges.ts` gains `parseRangeDays(range, fallback)`: the web keys (`1w … all`) and the legacy `Nd` keys; 20 table tests (#744). The four routes use it.
- App Avg Sleep card reads `sleep_data`'s average from the summary route and says "based on N nights", instead of the `daily_health_summary` subset (4.3h over 43 days vs the web's 5.8h over 132 nights) (#745).

## Evidence

- tsc 0 (web + universal); vitest web green, universal 31 tests.
- Post-deploy device proof on the emulator with the real account: 6M → "132 nights logged" (added below when production serves the change).

Closes #743
Closes #744
Closes #745
