### PR TITLE
feat(nutrition): trajectory sums the current deficit window only, and says so (#728)

### DIFF
--- a/universal/src/components/body-comp-chart.tsx
+++ b/universal/src/components/body-comp-chart.tsx
@@ -87,10 +87,11 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
             {slope > 0 ? "+" : ""}{slope.toFixed(2)} kg/wk
           </Text>
         </View>
-        {p.totalActualDeficit != null ? (
+        {p.totalActualDeficit != null && (!p.window || p.window.active) ? (
           <View>
             <Text variant="micro" className="text-text-muted">Total deficit</Text>
             <Text variant="caption" className="tabular-nums">{Math.round(p.totalActualDeficit).toLocaleString()} kcal</Text>
+            {p.window ? <Text variant="micro" className="text-text-muted">{p.window.label}</Text> : null}
           </View>
         ) : null}
         {p.daysRemaining != null ? (
@@ -105,17 +106,24 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
             <Text variant="caption" className="tabular-nums">{p.fatToLose.toFixed(1)} kg</Text>
           </View>
         ) : null}
-        {p.avgActualDeficit != null ? (
+        {p.avgActualDeficit != null && (!p.window || p.window.active) ? (
           <View>
             <Text variant="micro" className="text-text-muted">Avg deficit</Text>
             <Text variant="caption" className="tabular-nums">{Math.round(p.avgActualDeficit).toLocaleString()}/day</Text>
           </View>
         ) : null}
       </View>
+      {p.window && !p.window.active ? (
+        // No counted day inside the gap: there is no current deficit to total or average (#728).
+        <Text variant="micro" className="text-text-muted" testID="bodycomp-window-inactive">
+          {p.window.label}
+          {p.window.start ? ` · last window ${shortLabel(p.window.start)} → ${shortLabel(p.window.end ?? p.window.start)}, ${p.window.countedDays} counted days` : ""}
+        </Text>
+      ) : null}
       {p.requiredDeficit != null && p.requiredDeficit > 0 ? (
         <Text variant="micro" className="text-text-muted">
           Need {Math.round(p.requiredDeficit).toLocaleString()} kcal/day{p.targetDate ? ` to hit ${shortLabel(p.targetDate)}` : ""}
-          {p.avgActualDeficit != null ? ` · averaging ${Math.round(p.avgActualDeficit).toLocaleString()}` : ""}
+          {p.avgActualDeficit != null && (!p.window || p.window.active) ? ` · averaging ${Math.round(p.avgActualDeficit).toLocaleString()}` : ""}
         </Text>
       ) : null}
     </Card>
@@ -203,6 +211,11 @@ export function BodyCompChart({ visible }: { visible: boolean }) {
             <Text variant="eyebrow">Cumulative deficit</Text>
             <Text variant="micro" className="text-text-muted tabular-nums">goal {Math.round(goalDeficit)}/day</Text>
           </View>
+          {profile.window ? (
+            <Text variant="micro" className="text-text-muted" testID="bodycomp-cumulative-window">
+              {profile.window.active ? `Summed ${profile.window.label}` : `${profile.window.label} · line ends at the last window`}
+            </Text>
+          ) : null}
           <LineChart
             height={130}
             labels={dLabels}
@@ -222,6 +235,11 @@ export function BodyCompChart({ visible }: { visible: boolean }) {
       {hasBurn && dailyDeficits.length >= 2 ? (
         <Card className="gap-2">
           <Text variant="eyebrow">Burn vs eaten</Text>
+          {profile.window ? (
+            <Text variant="micro" className="text-text-muted">
+              {profile.window.active ? `Counted ${profile.window.label}` : profile.window.label} · days outside the window are context, not a sum
+            </Text>
+          ) : null}
           <LineChart
             height={140}
             labels={dLabels}

--- a/universal/src/components/body-comp-chart.tsx
+++ b/universal/src/components/body-comp-chart.tsx
@@ -117,7 +117,7 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
         // No counted day inside the gap: there is no current deficit to total or average (#728).
         <Text variant="micro" className="text-text-muted" testID="bodycomp-window-inactive">
           {p.window.label}
-          {p.window.start ? ` · last window ${shortLabel(p.window.start)} → ${shortLabel(p.window.end ?? p.window.start)}, ${p.window.countedDays} counted days` : ""}
+          {p.window.start ? ` · last window ${shortLabel(p.window.start)} → ${shortLabel(p.window.end ?? p.window.start)}, ${p.window.countedDays} counted day${p.window.countedDays === 1 ? "" : "s"}` : ""}
         </Text>
       ) : null}
       {p.requiredDeficit != null && p.requiredDeficit > 0 ? (

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -1146,6 +1146,8 @@ export interface BodyCompProfile {
   totalActualDeficit?: number; realisticDate?: string | null;
   fatToLose?: number; requiredDeficit?: number; avgActualDeficit?: number;
   targetDatePassed?: boolean;
+  /** The window every summed deficit number refers to (#728): counted days only, gaps > 7 d break it. */
+  window?: { start: string | null; end: string | null; countedDays: number; active: boolean; label: string };
 }
 export interface BodyComp {
   profile: BodyCompProfile;
@@ -1153,8 +1155,9 @@ export interface BodyComp {
   goalLine: { date: string; weight: number; bf: number }[];
   trendPrediction: { date: string; weight: number; bf: number }[];
   dailyDeficits: {
-    date: string; deficit: number; cumulative: number; goalPace: number; closed: boolean; isToday: boolean;
+    date: string; deficit: number; cumulative: number | null; goalPace: number | null; closed: boolean; isToday: boolean;
     bmr?: number; dailyActivity?: number; runCal?: number; gymCal?: number; totalBurn?: number; consumed?: number;
+    coverage?: number | null; counted?: boolean; inWindow?: boolean;
   }[];
   goalDeficit: number;
 }

--- a/web/app/api/nutrition/body-comp/route.ts
+++ b/web/app/api/nutrition/body-comp/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { deficitWindow, countsForDeficit, windowLabel } from "@/lib/deficit-window";
 
 export const runtime = "edge";
 
@@ -167,6 +168,15 @@ export async function GET() {
   const deficitRows = await sql`
     SELECT n.date::text AS date, n.target_calories, n.actual_calories, n.deficit_used, n.status,
            h.total_kilocalories AS garmin_burn, h.bmr_kilocalories AS bmr, h.total_steps,
+           (
+             SELECT COUNT(DISTINCT s)::float / 4
+             FROM (
+               SELECT m.meal_slot AS s FROM meal_log m WHERE m.date = n.date AND m.calories > 0
+               UNION
+               SELECT unnest(COALESCE(n.skipped_slots, ARRAY[]::text[]))
+             ) u
+             WHERE u.s IN ('breakfast', 'lunch', 'dinner', 'pre_sleep')
+           ) AS coverage,
            COALESCE((SELECT SUM((raw_json->>'calories')::float) FROM garmin_activity_raw
              WHERE endpoint_name = 'summary' AND raw_json->'activityType'->>'typeKey' = 'running'
              AND (raw_json->>'startTimeLocal')::date = n.date), 0) AS run_cal,
@@ -194,11 +204,16 @@ export async function GET() {
   `;
   const todayConsumed = Number(todayMealRows[0]?.total || 0) + Number(todayDrinkRows[0]?.total || 0);
 
-  let cumulativeDeficit = 0;
+  // Per-day rows first; the cumulative/goal-pace series is filled afterwards
+  // over the CURRENT window only (#728): a day counts when it is closed and its
+  // coverage clears the floor, and a window breaks at a gap of more than seven
+  // days. Days outside the window are still returned for the charts, with
+  // cumulative/goalPace null, so they render as context, never as a sum.
   const dailyDeficits: {
     date: string; bmr: number; dailyActivity: number; runCal: number; runDistKm: number;
     gymCal: number; gymTitle: string; totalBurn: number; consumed: number;
-    deficit: number; cumulative: number; goalPace: number; closed: boolean; isToday: boolean;
+    deficit: number; cumulative: number | null; goalPace: number | null; closed: boolean; isToday: boolean;
+    coverage: number | null; counted: boolean; inWindow: boolean;
   }[] = [];
 
   for (let i = 0; i < deficitRows.length; i++) {
@@ -235,7 +250,7 @@ export async function GET() {
     }
 
     const deficit = consumed - totalBurn; // negative = deficit (good)
-    cumulativeDeficit += deficit;
+    const coverage = typeof r.coverage === "number" ? r.coverage : r.coverage != null ? Number(r.coverage) : null;
 
     dailyDeficits.push({
       date: dateStr,
@@ -248,25 +263,36 @@ export async function GET() {
       totalBurn: Math.round(totalBurn),
       consumed: Math.round(consumed),
       deficit: Math.round(deficit),
-      cumulative: Math.round(cumulativeDeficit),
-      goalPace: -goalDeficit * dailyDeficits.length, // will fix after push
+      cumulative: null,
+      goalPace: null,
       closed: isClosed,
       isToday,
+      coverage,
+      counted: countsForDeficit({ date: dateStr, closed: isClosed, coverage, deficit }),
+      inWindow: false,
     });
-    // Fix goalPace for this entry (index-based)
-    dailyDeficits[dailyDeficits.length - 1].goalPace = -(goalDeficit * dailyDeficits.length);
+  }
+  // The current window: cumulative and goal pace run over its counted days only.
+  const win = deficitWindow(dailyDeficits.map(d => ({ date: d.date, closed: d.closed, coverage: d.coverage, deficit: d.deficit })), todayStr);
+  let cumulativeDeficit = 0;
+  let windowIndex = 0;
+  for (const d of dailyDeficits) {
+    if (!win.countedDates.has(d.date)) continue;
+    d.inWindow = true;
+    windowIndex += 1;
+    cumulativeDeficit += d.deficit;
+    d.cumulative = Math.round(cumulativeDeficit);
+    d.goalPace = -(goalDeficit * windowIndex);
   }
 
   // Deficit stats from dailyDeficits
-  const closedEntries = dailyDeficits.filter(d => d.closed);
-  const totalActualDeficit = closedEntries.length > 0
-    ? closedEntries.reduce((s, d) => s + d.deficit, 0)
-    : 0;
-  const closedDeficitDays = closedEntries.length;
-  const avgActualDeficit = closedDeficitDays > 0 ? Math.round(-totalActualDeficit / closedDeficitDays) : 0;
+  // Deficit stats over the window; 0 when no day counts (the UI reads window.active).
+  const totalActualDeficit = -win.totalDeficit; // negative = deficit, matching the per-day sign
+  const closedDeficitDays = win.countedDays;
+  const avgActualDeficit = win.avgDeficit ?? 0;
 
   // Compute calorie-predicted weight from cumulative deficit
-  const firstDeficitDate = dailyDeficits.length > 0 ? dailyDeficits[0].date : null;
+  const firstDeficitDate = win.start;
   let startWeightForPrediction = currentWeight;
   if (firstDeficitDate && weights.length > 0) {
     const match = weights.findLast(w => w.date <= firstDeficitDate);
@@ -274,11 +300,13 @@ export async function GET() {
     else if (weights[0]) startWeightForPrediction = weights[0].smoothed;
   }
 
-  const calPredicted: { date: string; weight: number; closed: boolean }[] = dailyDeficits.map(d => ({
-    date: d.date,
-    weight: Math.round((startWeightForPrediction + d.cumulative / 7700) * 10) / 10, // cumulative is negative for deficit
-    closed: d.closed,
-  }));
+  const calPredicted: { date: string; weight: number; closed: boolean }[] = dailyDeficits
+    .filter(d => d.inWindow && d.cumulative != null)
+    .map(d => ({
+      date: d.date,
+      weight: Math.round((startWeightForPrediction + (d.cumulative as number) / 7700) * 10) / 10, // cumulative is negative for deficit
+      closed: d.closed,
+    }));
 
   // On track assessment
   const onTrack = !targetDatePassed && requiredDeficit <= deficit * 1.1; // within 10% of current deficit
@@ -316,6 +344,14 @@ export async function GET() {
       avgActualDeficit,
       closedDeficitDays,
       totalActualDeficit: Math.round(-totalActualDeficit), // positive = total deficit achieved
+      // The window every summed number above refers to (#728).
+      window: {
+        start: win.start,
+        end: win.end,
+        countedDays: win.countedDays,
+        active: win.active,
+        label: windowLabel(win),
+      },
     },
     weights,
     goalLine,

--- a/web/components/body-comp-chart.tsx
+++ b/web/components/body-comp-chart.tsx
@@ -397,7 +397,7 @@ export function BodyCompChart() {
             {profile.window && (
               <div className="text-[10px] text-muted-foreground mb-2" data-testid="bodycomp-burn-window">
                 {profile.window.active ? `Summed ${profile.window.label}` : profile.window.label}
-                {outside > 0 ? ` · ${outside} faded day${outside === 1 ? "" : "s"} outside the window (open, or under the coverage floor)` : ""}
+                {outside > 0 ? ` · ${outside} faded day${outside === 1 ? "" : "s"} outside the current window` : ""}
               </div>
             )}
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted-foreground mb-2">

--- a/web/components/body-comp-chart.tsx
+++ b/web/components/body-comp-chart.tsx
@@ -529,7 +529,7 @@ export function BodyCompChart() {
               <div className="text-[10px] text-muted-foreground mb-2" data-testid="bodycomp-cumulative-window">
                 {profile.window.active
                   ? `Summed ${profile.window.label}`
-                  : `${profile.window.label}${profile.window.start ? ` · last window ${profile.window.start} → ${profile.window.end}, ${profile.window.countedDays} counted days` : ""}`}
+                  : `${profile.window.label}${profile.window.start ? ` · last window ${profile.window.start} → ${profile.window.end}, ${profile.window.countedDays} counted day${profile.window.countedDays === 1 ? "" : "s"}` : ""}`}
               </div>
             )}
             <div className="flex items-center gap-3 text-[10px] text-muted-foreground mb-2">

--- a/web/components/body-comp-chart.tsx
+++ b/web/components/body-comp-chart.tsx
@@ -34,6 +34,8 @@ interface BodyCompData {
     avgActualDeficit: number;
     closedDeficitDays: number;
     totalActualDeficit: number;
+    /** The window every summed number refers to (#728). Absent on older payloads. */
+    window?: { start: string | null; end: string | null; countedDays: number; active: boolean; label: string };
   };
   weights: { date: string; weight: number; smoothed: number; bf: number; smoothedBf: number }[];
   goalLine: { date: string; weight: number; bf: number }[];
@@ -42,7 +44,8 @@ interface BodyCompData {
   dailyDeficits: {
     date: string; bmr: number; dailyActivity: number; runCal: number; runDistKm: number;
     gymCal: number; gymTitle: string; totalBurn: number; consumed: number;
-    deficit: number; cumulative: number; goalPace: number; closed: boolean; isToday: boolean;
+    deficit: number; cumulative: number | null; goalPace: number | null; closed: boolean; isToday: boolean;
+    coverage?: number | null; counted?: boolean; inWindow?: boolean;
   }[];
   goalDeficit: number;
 }
@@ -208,13 +211,16 @@ export function BodyCompChart() {
             </div>
           </div>
           <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 mt-3 text-xs">
-            <span className="text-muted-foreground">
+            <span className="text-muted-foreground" data-testid="bodycomp-deficit-header">
               deficit: {profile.deficit}/day goal
-              {profile.closedDeficitDays > 0 && (
+              {profile.window && !profile.window.active ? (
+                // No counted day inside the gap: there is no current average to claim (#728).
+                <span className="text-muted-foreground">{" · "}{profile.window.label}</span>
+              ) : profile.closedDeficitDays > 0 ? (
                 <span className={profile.avgActualDeficit >= profile.deficit * 0.9 ? "text-green-500" : "text-amber-500"}>
-                  {" · "}{profile.avgActualDeficit}/day avg ({profile.closedDeficitDays}d)
+                  {" · "}{profile.avgActualDeficit}/day avg{profile.window ? ` (${profile.window.label})` : ` (${profile.closedDeficitDays}d)`}
                 </span>
-              )}
+              ) : null}
             </span>
             <span className="text-muted-foreground">&middot;</span>
             <span className="text-muted-foreground">{profile.fatToLose}kg to lose</span>
@@ -380,11 +386,20 @@ export function BodyCompChart() {
           ...d,
           goalLine: Math.max(0, d.totalBurn - goalDeficit),
           eatenDot: d.consumed, // separate key for scatter overlay
+          // A day outside the current window is context, not a sum: fade it (#728).
+          barOpacity: d.inWindow === false ? 0.3 : 1,
         }));
+        const outside = chartData.filter(d => d.inWindow === false).length;
         return (
         <Card>
           <CardContent className="py-4">
             <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-3">Burn vs Eaten</div>
+            {profile.window && (
+              <div className="text-[10px] text-muted-foreground mb-2" data-testid="bodycomp-burn-window">
+                {profile.window.active ? `Summed ${profile.window.label}` : profile.window.label}
+                {outside > 0 ? ` · ${outside} faded day${outside === 1 ? "" : "s"} outside the window (open, or under the coverage floor)` : ""}
+              </div>
+            )}
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-muted-foreground mb-2">
               <span className="flex items-center gap-1"><span className="w-3 h-3 rounded-sm bg-[#94a3b8]" />BMR</span>
               <span className="flex items-center gap-1"><span className="w-3 h-3 rounded-sm bg-[#14b8a6]" />activity</span>
@@ -475,10 +490,18 @@ export function BodyCompChart() {
                     }}
                   />
                   {/* Stacked burn bars */}
-                  <Bar dataKey="bmr" stackId="burn" fill="#94a3b8" radius={[0, 0, 0, 0]} />
-                  <Bar dataKey="dailyActivity" stackId="burn" fill="#14b8a6" radius={[0, 0, 0, 0]} />
-                  <Bar dataKey="runCal" stackId="burn" fill="#3b82f6" radius={[0, 0, 0, 0]} />
-                  <Bar dataKey="gymCal" stackId="burn" fill="#f97316" radius={[4, 4, 0, 0]} />
+                  <Bar dataKey="bmr" stackId="burn" fill="#94a3b8" radius={[0, 0, 0, 0]}>
+                    {chartData.map((d, i) => <Cell key={i} fillOpacity={d.barOpacity} />)}
+                  </Bar>
+                  <Bar dataKey="dailyActivity" stackId="burn" fill="#14b8a6" radius={[0, 0, 0, 0]}>
+                    {chartData.map((d, i) => <Cell key={i} fillOpacity={d.barOpacity} />)}
+                  </Bar>
+                  <Bar dataKey="runCal" stackId="burn" fill="#3b82f6" radius={[0, 0, 0, 0]}>
+                    {chartData.map((d, i) => <Cell key={i} fillOpacity={d.barOpacity} />)}
+                  </Bar>
+                  <Bar dataKey="gymCal" stackId="burn" fill="#f97316" radius={[4, 4, 0, 0]}>
+                    {chartData.map((d, i) => <Cell key={i} fillOpacity={d.barOpacity} />)}
+                  </Bar>
                   {/* Goal line (burn - 800) */}
                   <Line type="stepAfter" dataKey="goalLine" stroke="rgba(255,255,255,0.6)" strokeWidth={2} strokeDasharray="6 4" dot={false} connectNulls={true} />
                   {/* Eaten dots */}
@@ -502,6 +525,13 @@ export function BodyCompChart() {
         <Card>
           <CardContent className="py-4">
             <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-3">Cumulative Deficit</div>
+            {profile.window && (
+              <div className="text-[10px] text-muted-foreground mb-2" data-testid="bodycomp-cumulative-window">
+                {profile.window.active
+                  ? `Summed ${profile.window.label}`
+                  : `${profile.window.label}${profile.window.start ? ` · last window ${profile.window.start} → ${profile.window.end}, ${profile.window.countedDays} counted days` : ""}`}
+              </div>
+            )}
             <div className="flex items-center gap-3 text-[10px] text-muted-foreground mb-2">
               <span className="flex items-center gap-1"><span className="w-4 h-0.5 bg-[#3b82f6]" />actual</span>
               <span className="flex items-center gap-1"><span className="w-4 h-0.5 bg-[#f97316]" />goal pace (&minus;{goalDeficit}/day)</span>
@@ -518,10 +548,14 @@ export function BodyCompChart() {
                     deficitData.push({ date: d.date, cumulative: d.cumulative, goalPace: null });
                   }
                   // Add goal pace line: daily samples so it renders as a smooth straight line
-                  if (goalStart && dailyDeficits.length > 0) {
-                    const startMs = new Date(goalStart.date + "T12:00").getTime();
-                    const lastDataMs = new Date(dailyDeficits[dailyDeficits.length - 1].date + "T12:00").getTime();
-                    const endMs = lastDataMs + 14 * 86400000;
+                  // Goal pace runs over the current window only: from its first counted
+                  // day to its last (+14 days while it is still active) (#728).
+                  const winStart = profile.window?.start ?? goalStart?.date ?? null;
+                  const winEnd = profile.window?.end ?? (dailyDeficits.length ? dailyDeficits[dailyDeficits.length - 1].date : null);
+                  if (winStart && winEnd) {
+                    const startMs = new Date(winStart + "T12:00").getTime();
+                    const lastDataMs = new Date(winEnd + "T12:00").getTime();
+                    const endMs = lastDataMs + (profile.window && !profile.window.active ? 0 : 14) * 86400000;
                     for (let ms = startMs; ms <= endMs; ms += 86400000) { // daily, not weekly
                       const dateStr = new Date(ms).toISOString().slice(0, 10);
                       const days = (ms - startMs) / 86400000;
@@ -551,15 +585,17 @@ export function BodyCompChart() {
                       // Interpolate goal pace
                       let goalPaceVal: number | null = null;
                       if (goalStart) {
-                        const days = (new Date(String(label) + "T12:00").getTime() - new Date(goalStart.date + "T12:00").getTime()) / 86400000;
+                        const paceStart = profile.window?.start ?? goalStart.date;
+                        const days = (new Date(String(label) + "T12:00").getTime() - new Date(paceStart + "T12:00").getTime()) / 86400000;
                         if (days >= 0) goalPaceVal = Math.round(-goalDeficit * days);
                       }
                       return (
                         <div style={{ backgroundColor: "rgba(10,10,12,0.95)", border: "1px solid rgba(255,255,255,0.15)", borderRadius: "8px", padding: "8px 12px", fontSize: "12px" }}>
                           <div style={{ fontWeight: "bold", marginBottom: 4 }}>{formatDate(String(label))}</div>
-                          {day && <div style={{ color: "#3b82f6" }}>Actual: {day.cumulative.toLocaleString()} kcal</div>}
+                          {day && day.cumulative != null && <div style={{ color: "#3b82f6" }}>Actual: {day.cumulative.toLocaleString()} kcal</div>}
+                          {day && day.cumulative == null && <div style={{ color: "rgba(255,255,255,0.6)" }}>Not counted (outside the current window)</div>}
                           {goalPaceVal != null && <div style={{ color: "#f97316" }}>Goal pace: {goalPaceVal.toLocaleString()} kcal</div>}
-                          {day && goalPaceVal != null && (
+                          {day && day.cumulative != null && goalPaceVal != null && (
                             <div style={{ color: day.cumulative <= goalPaceVal ? "#22c55e" : "#f59e0b", fontSize: 11, marginTop: 2, borderTop: "1px solid rgba(255,255,255,0.1)", paddingTop: 3 }}>
                               {day.cumulative <= goalPaceVal
                                 ? `${(goalPaceVal - day.cumulative).toLocaleString()} kcal ahead`
@@ -572,7 +608,7 @@ export function BodyCompChart() {
                   />
                   <ReferenceLine y={0} stroke="rgba(255,255,255,0.2)" strokeDasharray="4 4" />
                   <Line type="linear" dataKey="goalPace" stroke="#f97316" strokeWidth={2} dot={false} connectNulls isAnimationActive={false} />
-                  <Line type="monotone" dataKey="cumulative" stroke="#3b82f6" strokeWidth={2} dot={{ r: 3, fill: "#3b82f6" }} connectNulls={true} />
+                  <Line type="monotone" dataKey="cumulative" stroke="#3b82f6" strokeWidth={2} dot={{ r: 3, fill: "#3b82f6" }} connectNulls={false} />
                 </ComposedChart>
               </ResponsiveContainer>
             </div>

--- a/web/lib/deficit-window.test.ts
+++ b/web/lib/deficit-window.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { deficitWindow, windowLabel, countsForDeficit, type WindowDay } from "./deficit-window";
+
+const d = (date: string, deficit: number, closed = true, coverage: number | null = 1): WindowDay => ({ date, closed, coverage, deficit });
+
+describe("deficitWindow (#728)", () => {
+  it("a day counts only when closed and over the coverage floor", () => {
+    expect(countsForDeficit(d("2026-03-01", -800))).toBe(true);
+    expect(countsForDeficit(d("2026-03-01", -800, false, 1))).toBe(false);
+    expect(countsForDeficit(d("2026-03-01", -800, true, 0.5))).toBe(false);
+    expect(countsForDeficit(d("2026-03-01", -800, true, null))).toBe(false);
+    expect(countsForDeficit(d("2026-03-01", -800, true, 0.75))).toBe(true);
+  });
+
+  it("no counted day ever → empty, inactive, labelled yet", () => {
+    const w = deficitWindow([d("2026-09-01", -2248, false, 0.25)], "2026-09-06");
+    expect(w).toMatchObject({ start: null, end: null, countedDays: 0, totalDeficit: 0, avgDeficit: null, active: false });
+    expect(windowLabel(w)).toBe("no counted day yet");
+  });
+
+  it("THE case: a March–May diet, then four empty months → the window is that spring, inactive", () => {
+    const spring = ["2026-03-14", "2026-03-15", "2026-03-16", "2026-03-20", "2026-03-27", "2026-04-02"].map((x) => d(x, -900));
+    const summerClosedEmpty = ["2026-05-20", "2026-06-10"].map((x) => d(x, -2300, true, 0)); // closed, nothing logged: absent
+    const w = deficitWindow([...spring, ...summerClosedEmpty, d("2026-09-01", -2248, false, 0.25)], "2026-09-06");
+    expect(w.start).toBe("2026-03-14");
+    expect(w.end).toBe("2026-04-02");
+    expect(w.countedDays).toBe(6);
+    expect(w.totalDeficit).toBe(5400);
+    expect(w.avgDeficit).toBe(900);
+    expect(w.active).toBe(false);
+    expect(windowLabel(w)).toBe("no counted day since 2026-04-02");
+    expect(w.countedDates.has("2026-05-20")).toBe(false);
+  });
+
+  it("a gap wider than 7 days splits windows; only the latest is summed", () => {
+    const first = ["2026-03-01", "2026-03-02", "2026-03-03"].map((x) => d(x, -1000));
+    const second = ["2026-03-15", "2026-03-16"].map((x) => d(x, -500));
+    const w = deficitWindow([...first, ...second], "2026-03-17");
+    expect(w.start).toBe("2026-03-15");
+    expect(w.countedDays).toBe(2);
+    expect(w.totalDeficit).toBe(1000);
+    expect(w.avgDeficit).toBe(500);
+    expect(w.active).toBe(true);
+    expect(w.allCountedDates.size).toBe(5);
+    expect(windowLabel(w)).toBe("since 2026-03-15, 2 counted days");
+  });
+
+  it("a gap of exactly 7 days does not split; 8 does", () => {
+    const a = deficitWindow([d("2026-03-01", -800), d("2026-03-08", -800)], "2026-03-09");
+    expect(a.countedDays).toBe(2);
+    const b = deficitWindow([d("2026-03-01", -800), d("2026-03-09", -800)], "2026-03-10");
+    expect(b.countedDays).toBe(1);
+    expect(b.start).toBe("2026-03-09");
+  });
+
+  it("active flips off when the last counted day is more than 7 days before today", () => {
+    const days = [d("2026-08-20", -800), d("2026-08-21", -800)];
+    expect(deficitWindow(days, "2026-08-28").active).toBe(true);
+    expect(deficitWindow(days, "2026-08-29").active).toBe(false);
+  });
+
+  it("a surplus day inside the window lowers the total, never breaks it", () => {
+    const w = deficitWindow([d("2026-03-01", -800), d("2026-03-02", 400), d("2026-03-03", -800)], "2026-03-04");
+    expect(w.countedDays).toBe(3);
+    expect(w.totalDeficit).toBe(1200);
+    expect(w.avgDeficit).toBe(400);
+  });
+
+  it("order of input does not matter", () => {
+    const w = deficitWindow([d("2026-03-03", -800), d("2026-03-01", -800), d("2026-03-02", -800)], "2026-03-04");
+    expect(w.start).toBe("2026-03-01");
+    expect(w.end).toBe("2026-03-03");
+  });
+});

--- a/web/lib/deficit-window.ts
+++ b/web/lib/deficit-window.ts
@@ -1,0 +1,76 @@
+import { meetsCoverageFloor, daysBetween, STREAK_MAX_GAP_DAYS } from "@/lib/coverage";
+
+/**
+ * The current deficit window (#728). The #699 rule, applied to the trajectory:
+ * a day COUNTS only when it is closed and its logging coverage clears the
+ * floor; a run of counted days is one window as long as no two of them are
+ * more than STREAK_MAX_GAP_DAYS apart. Everything summed for the user — the
+ * cumulative deficit, the average, the projected weight — is summed over the
+ * latest window only, and the page says which window that is.
+ *
+ * Without this the cumulative line walked from March across four empty months
+ * to −49k and the header claimed "916/day avg (45d)" over a diet nobody was on.
+ */
+export interface WindowDay {
+  date: string;
+  closed: boolean;
+  coverage: number | null;
+  /** consumed − burn for the day; negative is a deficit. */
+  deficit: number;
+}
+
+export interface DeficitWindow {
+  /** First and last counted date of the latest window; null when no day ever counted. */
+  start: string | null;
+  end: string | null;
+  countedDays: number;
+  /** Sum of deficits over counted days in the window, positive = achieved deficit. */
+  totalDeficit: number;
+  avgDeficit: number | null;
+  /** True when the window's last counted day is within the gap of today. */
+  active: boolean;
+  /** Dates that count (closed + coverage) and belong to the window. */
+  countedDates: ReadonlySet<string>;
+  /** All dates that count, any window (for chart segmentation). */
+  allCountedDates: ReadonlySet<string>;
+}
+
+export function countsForDeficit(d: WindowDay): boolean {
+  return d.closed && meetsCoverageFloor(d.coverage);
+}
+
+export function deficitWindow(days: readonly WindowDay[], today: string, maxGap: number = STREAK_MAX_GAP_DAYS): DeficitWindow {
+  const sorted = [...days].sort((a, b) => a.date.localeCompare(b.date));
+  const counted = sorted.filter(countsForDeficit);
+  const allCountedDates = new Set(counted.map((d) => d.date));
+  if (counted.length === 0) {
+    return { start: null, end: null, countedDays: 0, totalDeficit: 0, avgDeficit: null, active: false, countedDates: new Set(), allCountedDates };
+  }
+  // Walk back from the latest counted day; stop at the first gap wider than maxGap.
+  const window: WindowDay[] = [];
+  for (let i = counted.length - 1; i >= 0; i--) {
+    const d = counted[i];
+    if (window.length && daysBetween(d.date, window[window.length - 1].date) > maxGap) break;
+    window.push(d);
+  }
+  window.reverse();
+  const total = window.reduce((s, d) => s + d.deficit, 0);
+  const end = window[window.length - 1].date;
+  return {
+    start: window[0].date,
+    end,
+    countedDays: window.length,
+    totalDeficit: Math.round(-total),
+    avgDeficit: Math.round(-total / window.length),
+    active: daysBetween(end, today) <= maxGap,
+    countedDates: new Set(window.map((d) => d.date)),
+    allCountedDates,
+  };
+}
+
+/** "since 2026-03-14, 45 counted days" / "no counted day since 2026-05-12" / "no counted day yet". */
+export function windowLabel(w: DeficitWindow): string {
+  if (!w.end) return "no counted day yet";
+  if (!w.active) return `no counted day since ${w.end}`;
+  return `since ${w.start}, ${w.countedDays} counted day${w.countedDays === 1 ? "" : "s"}`;
+}


### PR DESCRIPTION
## What

The body-comp endpoint (which feeds the web Trajectory view and the app Trend tab) summed every closed day since March into one cumulative line (−49k) and headlined "916/day avg (45d)" over months in which nothing was logged. The plan route and adaptive TDEE stopped doing this in #699/#704; this endpoint never got the rule (#728).

- `web/lib/deficit-window.ts` (#729): a day counts when it is closed AND its coverage clears the floor (3 of 4 slots), a window breaks at a gap of more than 7 days, and the latest window is the only one summed. Exposes `window = { start, end, countedDays, active, label }` where `active` means the last counted day is within the gap of today. 8 table tests, including the real shape (a spring diet, then four empty months, then one partly logged day → the window is the spring, inactive, "no counted day since <end>").
- `/api/nutrition/body-comp`: per-day coverage joined in; `counted`/`inWindow` per day; `cumulative` and `goalPace` are null outside the window; total, average, calorie-predicted weight and the goal-pace origin all run over the window; the response carries `profile.window`.
- Web Trajectory view: header shows "N/day avg (since <start>, N counted days)" when the window is active, otherwise "no counted day since <end>" and no average; Burn-vs-eaten fades days outside the window and says how many; Cumulative deficit no longer bridges nulls, its goal pace starts at the window start and stops at the window end when inactive, and its tooltip says "Not counted (outside the current window)".
- App Trend tab (#730): Total deficit / Avg deficit / "averaging …" hide when the window is inactive and the card says "no counted day since <end> · last window <start> → <end>, N counted days"; both charts carry the window label; the cumulative line ends at the last window.

## Evidence

- tsc 0 (web + universal); vitest web 43 files / 344 tests, universal 31.
- Rig (this branch, real DB): `/api/nutrition/body-comp` → `window` (added below), Playwright desktop 1440×900 + mobile 390×844 of the Trajectory view (added below).
- App: release APK from this branch on the emulator, Trend tab, after merge + deploy (added below).

Closes #728
Closes #729
Closes #730
