### PR TITLE
fix(connections): Strava state from the bridge too; card titles were invisible (#735)

### DIFF
--- a/web/app/api/connections/route.ts
+++ b/web/app/api/connections/route.ts
@@ -32,16 +32,19 @@ export async function GET() {
       ? { tracks: Number(sp.tracks), artists: Number(sp.artists), last_sync: (sp.last_sync as string | null) ?? null }
       : null;
 
-    // Strava coverage: of recent Garmin activities, how many were forwarded to
-    // Strava (activity_sync_log, source_id cast to text; ids are bigint there).
+    // Strava coverage: of recent Garmin activities, how many are on Strava,
+    // via soma's own sync (activity_sync_log) OR the Garmin→Strava bridge
+    // (strava_bridge_uploads), which is what actually runs today (#736).
     const stravaRows = (await sql`
       SELECT g.raw_json->>'activityName' AS name,
         (g.raw_json->>'startTimeLocal')::date::text AS date,
         g.raw_json->'activityType'->>'typeKey' AS type_key,
-        sl.destination_id AS strava_id
+        COALESCE(sl.destination_id, sbu.strava_activity_id::text) AS strava_id
       FROM garmin_activity_raw g
       LEFT JOIN activity_sync_log sl
         ON sl.source_id = g.activity_id::text AND sl.destination = 'strava' AND sl.status IN ('sent', 'external')
+      LEFT JOIN strava_bridge_uploads sbu
+        ON sbu.garmin_activity_id = g.activity_id
       WHERE g.endpoint_name = 'summary'
         AND (g.raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - 90
       ORDER BY (g.raw_json->>'startTimeLocal')::text DESC

--- a/web/app/connections/page.tsx
+++ b/web/app/connections/page.tsx
@@ -157,8 +157,16 @@ async function getPageData() {
                MAX(processed_at) as last_sync
         FROM activity_sync_log
         GROUP BY source_platform, destination
+        UNION ALL
+        SELECT 'garmin' AS source_platform, 'strava (bridge)' AS destination,
+               COUNT(*)::int AS total,
+               COUNT(*)::int AS sent_count,
+               0::int AS external_count,
+               0::int AS error_count,
+               MAX(uploaded_at) AS last_sync
+        FROM strava_bridge_uploads
         ORDER BY last_sync DESC NULLS LAST
-        LIMIT 10
+        LIMIT 11
       `,
       sql`
         SELECT 'garmin' as platform,
@@ -229,15 +237,19 @@ async function getPageData() {
              (ga.raw_json->>'duration')::numeric AS duration,
              (ga.raw_json->>'distance')::numeric AS distance,
              ga.raw_json->>'manufacturer' AS manufacturer,
-             asl.status AS sync_status,
-             asl.destination_id,
-             asl.processed_at AS synced_at
+             -- Synced when soma's own sync sent it OR the Garmin→Strava bridge uploaded it
+             -- (strava_bridge_uploads); the bridge is what actually runs today (#736).
+             COALESCE(asl.status, CASE WHEN sbu.strava_activity_id IS NOT NULL THEN 'external' END) AS sync_status,
+             COALESCE(asl.destination_id, sbu.strava_activity_id::text) AS destination_id,
+             COALESCE(asl.processed_at, sbu.uploaded_at) AS synced_at
       FROM garmin_activity_raw ga
       LEFT JOIN activity_sync_log asl
         ON asl.source_platform = 'garmin'
         AND asl.source_id = ga.activity_id::text
         AND asl.destination = 'strava'
         AND asl.status IN ('sent', 'external')
+      LEFT JOIN strava_bridge_uploads sbu
+        ON sbu.garmin_activity_id = ga.activity_id
       WHERE ga.endpoint_name = 'summary'
         AND ga.raw_json->>'startTimeGMT' >= to_char(NOW() - INTERVAL '30 days', 'YYYY-MM-DD')
       ORDER BY ga.raw_json->>'startTimeGMT' DESC

--- a/web/app/connections/page.tsx
+++ b/web/app/connections/page.tsx
@@ -561,7 +561,7 @@ export default async function ConnectionsPage() {
                       <Icon className="h-5 w-5 text-accent-foreground" />
                     </div>
                     <div>
-                      <CardTitle className="text-base">{config.label}</CardTitle>
+                      <CardTitle className="text-[1rem]">{config.label}</CardTitle>
                       <p className="text-xs text-muted-foreground mt-0.5">
                         {config.description}
                       </p>
@@ -619,7 +619,7 @@ export default async function ConnectionsPage() {
                   </svg>
                 </div>
                 <div>
-                  <CardTitle className="text-base">Spotify</CardTitle>
+                  <CardTitle className="text-[1rem]">Spotify</CardTitle>
                   {spotifyConnected && spotifyProfile && (
                     <p className="text-xs text-muted-foreground mt-0.5">{spotifyProfile.display_name}</p>
                   )}
@@ -678,7 +678,7 @@ export default async function ConnectionsPage() {
                   <Bell className="h-5 w-5 text-accent-foreground" />
                 </div>
                 <div>
-                  <CardTitle className="text-base">Push Notifications</CardTitle>
+                  <CardTitle className="text-[1rem]">Push Notifications</CardTitle>
                   <p className="text-xs text-muted-foreground mt-0.5">
                     Get notified when workouts sync, milestones hit, and more
                   </p>
@@ -720,7 +720,7 @@ export default async function ConnectionsPage() {
         <div>
           <Card className="h-full">
             <CardHeader>
-              <CardTitle className="text-base">Recent Sync Activity</CardTitle>
+              <CardTitle className="text-[1rem]">Recent Sync Activity</CardTitle>
             </CardHeader>
             <CardContent>
               {syncLog.length === 0 ? (
@@ -766,7 +766,7 @@ export default async function ConnectionsPage() {
       {/* Section 6: Pipeline Operations */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Pipeline Operations</CardTitle>
+          <CardTitle className="text-[1rem]">Pipeline Operations</CardTitle>
         </CardHeader>
         <CardContent>
           <PipelineOperations

--- a/web/app/training/page.tsx
+++ b/web/app/training/page.tsx
@@ -439,7 +439,7 @@ export default async function TrainingPage() {
             <CardContent className="py-6 flex items-start gap-4">
               <Target className="h-8 w-8 mt-0.5 text-muted-foreground opacity-50 shrink-0" />
               <div className="space-y-1">
-                <h2 className="text-base font-semibold text-foreground" data-testid="training-no-live-plan-title">
+                <h2 className="text-[1rem] font-semibold text-foreground" data-testid="training-no-live-plan-title">
                   {engagement.state === "dormant" ? "Plan is dormant" : engagement.state === "partial" ? "Plan exists, not being followed" : "No training plan"}
                 </h2>
                 <p className="text-sm text-muted-foreground">{engagement.basis}.</p>

--- a/web/components/activity-detail-modal.tsx
+++ b/web/components/activity-detail-modal.tsx
@@ -396,7 +396,7 @@ export function ActivityDetailModal({ activityId, onClose }: ActivityDetailModal
                                 <div key={i} className="flex items-center gap-3 py-2.5 border-b border-border/30 hover:bg-accent/10 -mx-2 px-2 rounded transition-colors">
                                   {/* Split number */}
                                   <div className="w-7 text-center shrink-0">
-                                    <span className="text-base font-bold">{i + 1}</span>
+                                    <span className="text-[1rem] font-bold">{i + 1}</span>
                                   </div>
 
                                   {/* Main metrics */}

--- a/web/components/activity-sync-manager.tsx
+++ b/web/components/activity-sync-manager.tsx
@@ -328,7 +328,7 @@ export function ActivitySyncManager({
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardTitle className="text-base">Activity Sync Manager</CardTitle>
+          <CardTitle className="text-[1rem]">Activity Sync Manager</CardTitle>
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <span>{syncedCount}/{activities.length} synced to Strava</span>
             {!stravaConnected && (

--- a/web/components/duplicate-resolver.tsx
+++ b/web/components/duplicate-resolver.tsx
@@ -110,7 +110,7 @@ function ActivityDetailSheet({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="w-[420px] sm:max-w-[420px] overflow-y-auto">
         <SheetHeader>
-          <SheetTitle className="text-base">
+          <SheetTitle className="text-[1rem]">
             {summary?.activityName || `Activity ${activityId}`}
           </SheetTitle>
           <SheetDescription>
@@ -486,7 +486,7 @@ export function DuplicateResolver() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <AlertTriangle className="h-4 w-4 text-yellow-400" />
-            <CardTitle className="text-base">Duplicate Activities</CardTitle>
+            <CardTitle className="text-[1rem]">Duplicate Activities</CardTitle>
           </div>
           <Badge variant="outline" className="text-xs">
             {currentIndex + 1} of {pairs.length}

--- a/web/components/pipeline-operations.tsx
+++ b/web/components/pipeline-operations.tsx
@@ -95,7 +95,7 @@ function BackfillTab({ progress }: { progress: BackfillProgress[] }) {
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <StatusIcon status={p.status} />
-                  <CardTitle className="text-base font-semibold">
+                  <CardTitle className="text-[1rem] font-semibold">
                     {p.source.replace(/_/g, " ")}
                   </CardTitle>
                 </div>
@@ -146,7 +146,7 @@ function DataCoverageTab({ dataCounts }: { dataCounts: DataCount[] }) {
       <CardHeader>
         <div className="flex items-center gap-2">
           <Database className="h-5 w-5 text-primary" />
-          <CardTitle className="text-base">
+          <CardTitle className="text-[1rem]">
             {totalRecords.toLocaleString()} total records
           </CardTitle>
         </div>

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -117,7 +117,7 @@ export function Sidebar() {
             aria-label="Go to home"
           >
             <SomaLogo size={24} />
-            <span className="text-base font-semibold">Soma</span>
+            <span className="text-[1rem] font-semibold">Soma</span>
           </Link>
         </div>
 

--- a/web/components/sync-rules-manager.tsx
+++ b/web/components/sync-rules-manager.tsx
@@ -134,7 +134,7 @@ export function SyncRulesManager({ initialRules }: SyncRulesManagerProps) {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Route className="h-5 w-5 text-primary" />
-            <CardTitle className="text-base">Sync Rules</CardTitle>
+            <CardTitle className="text-[1rem]">Sync Rules</CardTitle>
           </div>
           <Button
             variant="outline"

--- a/web/components/ui/input.tsx
+++ b/web/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-[1rem] shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/web/components/workout-hr-timeline.tsx
+++ b/web/components/workout-hr-timeline.tsx
@@ -194,7 +194,7 @@ function UnifiedTooltip({ active, payload, zones, extendedBlocks }: any) {
   return (
     <div className="bg-card text-card-foreground border border-border rounded-lg p-2.5 text-xs shadow-lg min-w-[140px]">
       <div className="flex items-center gap-2">
-        <span className="text-base font-bold" style={{ color: zoneInfo.color }}>
+        <span className="text-[1rem] font-bold" style={{ color: zoneInfo.color }}>
           {hr}
         </span>
         <span className="text-muted-foreground">bpm</span>

--- a/web/lib/no-text-base.test.ts
+++ b/web/lib/no-text-base.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * soma-style defines a colour token named `base` (the dark page background), so
+ * Tailwind resolves the utility `text-base` as `color: var(--color-base)` rather
+ * than the 1rem font size. Every card title on the Sync Hub rendered dark text on
+ * a dark card because of it (#737). Use `text-[1rem]` for the size instead.
+ */
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (name === "node_modules" || name.startsWith(".")) continue;
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.(tsx|ts|jsx|js)$/.test(name) && !name.endsWith(".test.ts")) out.push(p);
+  }
+  return out;
+}
+
+describe("no text-base utility (#737)", () => {
+  it("app/ and components/ never use the ambiguous text-base class", () => {
+    const root = join(__dirname, "..");
+    const offenders: string[] = [];
+    for (const f of [...walk(join(root, "app")), ...walk(join(root, "components"))]) {
+      const src = readFileSync(f, "utf8");
+      if (/\btext-base\b/.test(src)) offenders.push(f.replace(root + "/", ""));
+    }
+    expect(offenders, "replace text-base with text-[1rem]; a `base` colour token makes it a colour").toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Two findings from the 2026-09-06 sweep of the Sync Hub (#735).

Strava state (#736)
- The page counted an activity as on Strava only when soma's own sync had a `sent`/`external` row in `activity_sync_log`. The forwarding that actually runs is the Garmin→Strava bridge (`strava-bridge-ts.yml`, 4×/day), which writes `strava_bridge_uploads`, so the page said "0/22 synced to Strava" while every recent activity was on Strava (37 bridge uploads since July, 12/12 of the last 30 days).
- The page query and the app-facing `/api/connections` coverage now `LEFT JOIN strava_bridge_uploads` on `garmin_activity_id`, take the Strava id from either source (so the "On Strava" badge links to the real activity), and the sync-stats list carries a "Garmin → Strava (Bridge)" row with its last upload.

Invisible titles (#737)
- Every `CardTitle` on the page computed to `rgb(10,23,32)` on a `rgb(14,26,38)` card. Cause found in the rendered DOM: soma-style defines a colour token named `base`, so Tailwind resolves the utility `text-base` as `color: var(--color-base)` rather than the 1rem font size. All 16 usages across `app/` and `components/` become `text-[1rem]` (this also brought back the sidebar brand "Soma" and the Training page's card titles). `lib/no-text-base.test.ts` fails the suite if the class ever comes back.

## Evidence

- tsc 0; vitest 44 files / 345 tests (the guard fails against the pre-fix tree with 16 offenders, passes after).
- Real DB: the union stats query and the per-activity join run as written; 90-day coverage the app will show: 53/53.
- Rig (this branch, real DB), Playwright desktop 1440×900, read back: every card title rendered in `rgb(253,248,242)` (was `rgb(10,23,32)`), "22/22 synced to Strava", green "On Strava" on every recent activity, "Garmin → Strava (Bridge) 37" in Recent Sync Activity. Mobile 390×844 below.
- App: post-deploy device proof of the Connections screen's Strava coverage (53/53) below.

Closes #735
Closes #736
Closes #737
