### PR TITLE
feat(running): a running-only status headlines; Garmin's is labelled all-sport (#738)

### DIFF
--- a/universal/src/app/(main)/running.tsx
+++ b/universal/src/app/(main)/running.tsx
@@ -28,6 +28,12 @@ interface RunningStats {
   longest_run: number | null;
 }
 
+/** Running-only status from soma's own run load (web lib/run-status, #738). */
+interface RunStatus {
+  kind: "none" | "lapsed" | "light" | "easing" | "steady" | "building" | "spiking";
+  label: string; detail: string; runs28: number; lastRun: string | null; daysSinceRun: number | null;
+  acute: number; chronic: number; acwr: number | null;
+}
 interface TrainingStatus {
   status_code: string | null;
   sport: string | null;
@@ -96,6 +102,7 @@ export interface MileageMonth { month: string; km: number; runs: number }
 interface RunningPayload {
   stats: RunningStats | null;
   trainingStatus: TrainingStatus | null;
+  runStatus?: RunStatus | null;
   hrDistribution: HrZone[];
   records: Records | null;
   shoeMileage: ShoeMileage[];
@@ -185,6 +192,7 @@ export default function RunningScreen() {
 
   const stats = data?.stats;
   const ts = data?.trainingStatus;
+  const rs = data?.runStatus ?? null;
   const zones = data?.hrDistribution ?? [];
   const records = data?.records;
   const shoes = data?.shoeMileage ?? [];
@@ -300,34 +308,41 @@ export default function RunningScreen() {
 
         {/* Training Status — only when Garmin actually populated it (else it was
             a card full of dashes next to the live VO2max + load-trend below). */}
-        {ts && (ts.status_code != null || ts.vo2max != null || ts.acute_load != null) ? (
+        {(rs || (ts && (ts.status_code != null || ts.vo2max != null || ts.acute_load != null))) ? (
           <Card className="gap-3">
             <View className="flex-row items-center justify-between">
               <Text variant="eyebrow">Training Status</Text>
-              {statusInfo ? (
+              {rs ? (
+                // soma's running-only verdict (#738); Garmin's all-sport status sits below as the comparison.
                 <Badge
-                  label={statusInfo.label}
-                  tone={
-                    ts.acwr_status === "OPTIMAL"
-                      ? "success"
-                      : ts.acwr_status === "HIGH"
-                        ? "warm"
-                        : "teal"
-                  }
+                  label={rs.label}
+                  tone={rs.kind === "steady" ? "success" : rs.kind === "spiking" ? "danger" : rs.kind === "building" ? "teal" : rs.kind === "easing" ? "warm" : "teal"}
                 />
               ) : null}
             </View>
+            {rs ? (
+              <View className="gap-0.5" testID="running-run-status">
+                <Text variant="micro" className="text-text-muted">Running · last 4 weeks</Text>
+                <Text variant="title" className={rs.kind === "steady" ? "text-success" : rs.kind === "spiking" ? "text-danger" : rs.kind === "building" ? "text-teal" : rs.kind === "easing" ? "text-warm" : "text-text-secondary"}>
+                  {rs.label}
+                </Text>
+                <Text variant="micro" className="text-text-secondary">{rs.detail}</Text>
+              </View>
+            ) : null}
+            {ts && (ts.status_code != null || ts.vo2max != null || ts.acute_load != null) ? (
+            <>
+            <Text variant="micro" className="text-text-muted" testID="running-garmin-status-label">
+              Garmin training status · all sports{ts.sport ? ` (Garmin tags it ${ts.sport.toLowerCase()})` : ""} · 7-day load vs 4-week
+            </Text>
             <View className="flex-row flex-wrap gap-3">
               <View className="min-w-[46%] flex-1 gap-0.5">
                 <Text variant="micro" className="text-text-muted">
-                  Status
+                  Garmin status
                 </Text>
                 <Text variant="title" className={statusInfo?.cls ?? "text-text"}>
                   {statusInfo?.label ?? "—"}
                 </Text>
-                <Text variant="micro" className="capitalize">
-                  {ts.sport?.toLowerCase() ?? ""}
-                </Text>
+                <Text variant="micro">all sports</Text>
               </View>
               <View className="min-w-[46%] flex-1 gap-0.5">
                 <Text variant="micro" className="text-text-muted">
@@ -340,18 +355,18 @@ export default function RunningScreen() {
               </View>
               <View className="min-w-[46%] flex-1 gap-0.5">
                 <Text variant="micro" className="text-text-muted">
-                  Training Load
+                  Garmin 7-day load
                 </Text>
                 <Text variant="title" className="text-warm">
                   {ts.acute_load != null ? Math.round(num(ts.acute_load)) : "—"}
                 </Text>
                 <Text variant="micro">
-                  {ts.chronic_load != null ? `Chronic ${Math.round(num(ts.chronic_load))}` : ""}
+                  {ts.chronic_load != null ? `4-week ${Math.round(num(ts.chronic_load))} · all sports` : "all sports"}
                 </Text>
               </View>
               <View className="min-w-[46%] flex-1 gap-0.5">
                 <Text variant="micro" className="text-text-muted">
-                  ACWR
+                  Garmin ACWR
                 </Text>
                 <Text variant="title" className="text-lime">
                   {ts.acwr != null ? num(ts.acwr).toFixed(2) : "—"}
@@ -361,6 +376,8 @@ export default function RunningScreen() {
                 </Text>
               </View>
             </View>
+            </>
+            ) : null}
           </Card>
         ) : null}
 

--- a/web/app/api/running/stats/route.ts
+++ b/web/app/api/running/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { loadRunStatus } from "@/lib/run-status-query";
 import { rangeToDays } from "@/lib/time-ranges";
 
 export const runtime = "edge";
@@ -233,9 +234,13 @@ export async function GET(request: Request) {
 
     const [fastest5k, fastest10k, longest, maxHR, maxCal, fastestPace] = records;
 
+    // Running-only status from soma's own run load; Garmin's trainingStatus below is
+    // all-sport and only tagged running (#738).
+    const runStatus = await loadRunStatus(sql);
     return NextResponse.json({
       stats: statsRows[0] || null,
       trainingStatus: trainingRows[0] || null,
+      runStatus,
       hrDistribution: hrRows,
       records: {
         fastest5k: fastest5k[0] || null,

--- a/web/app/running/page.tsx
+++ b/web/app/running/page.tsx
@@ -17,6 +17,7 @@ import { TrainingLoadChart } from "@/components/training-load-chart";
 import { TimeRangeSelector } from "@/components/time-range-selector";
 import { rangeToDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
+import { loadRunStatus } from "@/lib/run-status-query";
 import {
   Timer,
   MapPin,
@@ -550,7 +551,7 @@ export default async function RunningPage({
   const cutoffDays = Math.min(rangeDays, 730);
   const cutoff = new Date(Date.now() - cutoffDays * 86400000).toISOString().split("T")[0];
 
-  const [stats, paceHistory, mileage, vo2max, hrPaceData, cadenceStride, records, recentRuns, fitnessScores, trainingStatus, hrDistribution, shoeMileage, splitAnalysis, bestSplits, trainingLoadTrend] =
+  const [stats, paceHistory, mileage, vo2max, hrPaceData, cadenceStride, records, recentRuns, fitnessScores, trainingStatus, hrDistribution, shoeMileage, splitAnalysis, bestSplits, trainingLoadTrend, runStatus] =
     await Promise.all([
       getRunningStats(cutoff),
       getPaceHistory(cutoff),
@@ -567,6 +568,7 @@ export default async function RunningPage({
       getSplitAnalysis(cutoff),
       getBestSplits(cutoff),
       getTrainingLoadTrend(cutoff),
+      loadRunStatus(getDb()),
     ]);
 
   return (
@@ -623,7 +625,7 @@ export default async function RunningPage({
       </div>
 
       {/* Training Status + Training Load (most actionable — "should I run today?") */}
-      {trainingStatus && (
+      {(trainingStatus || runStatus) && (
         <Card className="mb-6">
           <CardHeader>
             <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
@@ -632,9 +634,27 @@ export default async function RunningPage({
             </CardTitle>
           </CardHeader>
           <CardContent>
+            {/* Running only, from soma's own run load (#738). Garmin's status below covers
+                every sport and is only tagged "running"; it is the comparison, not the verdict. */}
+            <div className="mb-4" data-testid="running-run-status">
+              <div className="text-xs text-muted-foreground mb-1">Running · last 4 weeks</div>
+              <div className={`text-lg font-bold ${
+                runStatus.kind === "steady" ? "text-green-400" :
+                runStatus.kind === "building" ? "text-blue-400" :
+                runStatus.kind === "spiking" ? "text-red-400" :
+                runStatus.kind === "easing" ? "text-yellow-400" : "text-muted-foreground"
+              }`}>{runStatus.label}</div>
+              <div className="text-xs text-muted-foreground">{runStatus.detail}</div>
+            </div>
+            {trainingStatus && (
+            <div className="text-xs text-muted-foreground mb-2" data-testid="running-garmin-status-label">
+              Garmin training status · all sports (Garmin tags it {trainingStatus.sport?.toLowerCase() || "by sport"}) · 7-day load vs 4-week
+            </div>
+            )}
+            {trainingStatus && (
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Status</div>
+                <div className="text-xs text-muted-foreground mb-1">Garmin status</div>
                 <div className="text-lg font-bold">
                   {(() => {
                     const statusMap: Record<string, { label: string; color: string }> = {
@@ -650,9 +670,7 @@ export default async function RunningPage({
                     return <span className={s.color}>{s.label}</span>;
                   })()}
                 </div>
-                <div className="text-xs text-muted-foreground capitalize">
-                  {trainingStatus.sport?.toLowerCase()}
-                </div>
+                <div className="text-xs text-muted-foreground">all sports</div>
               </div>
               <div>
                 <div className="text-xs text-muted-foreground mb-1">VO2 Max</div>
@@ -662,16 +680,16 @@ export default async function RunningPage({
                 <div className="text-xs text-muted-foreground">ml/kg/min</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground mb-1">Training Load</div>
+                <div className="text-xs text-muted-foreground mb-1">Garmin 7-day load</div>
                 <div className="text-lg font-bold">
                   {trainingStatus.acute_load ? Math.round(Number(trainingStatus.acute_load)) : "—"}
                 </div>
                 <div className="text-xs text-muted-foreground">
-                  {trainingStatus.chronic_load ? `Chronic: ${Math.round(Number(trainingStatus.chronic_load))}` : ""}
+                  {trainingStatus.chronic_load ? `4-week: ${Math.round(Number(trainingStatus.chronic_load))} · all sports` : "all sports"}
                 </div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground mb-1">ACWR</div>
+                <div className="text-xs text-muted-foreground mb-1">Garmin ACWR</div>
                 <div className="text-lg font-bold">
                   {trainingStatus.acwr ? Number(trainingStatus.acwr).toFixed(2) : "—"}
                 </div>
@@ -683,6 +701,7 @@ export default async function RunningPage({
                 </div>
               </div>
             </div>
+            )}
           </CardContent>
         </Card>
       )}

--- a/web/lib/run-status-query.ts
+++ b/web/lib/run-status-query.ts
@@ -1,0 +1,22 @@
+import type { QueryFn } from "@/lib/db";
+import { runStatus, type RunStatus } from "@/lib/run-status";
+import { todayKey } from "@/lib/freshness";
+
+/** soma's own running load (training_load, source garmin_running), last 35 days → RunStatus. */
+export async function loadRunStatus(sql: QueryFn, today: string = todayKey()): Promise<RunStatus> {
+  // The demo database is a subset without training_load: no runs, not a 500.
+  let rows: { date: string; load: number }[] = [];
+  try {
+  rows = (await sql`
+    SELECT activity_date::text AS date, SUM(load_value)::float AS load
+    FROM training_load
+    WHERE source = 'garmin_running'
+      AND activity_date >= CURRENT_DATE - 35
+    GROUP BY activity_date
+    ORDER BY activity_date
+  `) as { date: string; load: number }[];
+  } catch {
+    rows = [];
+  }
+  return runStatus(rows.map((r) => ({ date: r.date.slice(0, 10), load: Number(r.load) || 0 })), today);
+}

--- a/web/lib/run-status.test.ts
+++ b/web/lib/run-status.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { runStatus, RUN_TREND_MIN_RUNS, RUN_LAPSED_DAYS } from "./run-status";
+
+const T = "2026-09-06";
+const d = (date: string, load = 60) => ({ date, load });
+const daysAgo = (n: number) => { const x = new Date(Date.UTC(2026, 8, 6)); x.setUTCDate(x.getUTCDate() - n); return x.toISOString().slice(0, 10); };
+
+describe("runStatus (#738)", () => {
+  it("thresholds: 8 runs in 28 days to call a trend, 14 days without a run is lapsed", () => {
+    expect(RUN_TREND_MIN_RUNS).toBe(8);
+    expect(RUN_LAPSED_DAYS).toBe(14);
+  });
+
+  it("no runs at all → none", () => {
+    const s = runStatus([], T);
+    expect(s.kind).toBe("none");
+    expect(s.label).toBe("No runs in 4 weeks");
+    expect(s.acwr).toBeNull();
+  });
+
+  it("runs only older than 4 weeks → none, naming the last run", () => {
+    const s = runStatus([d("2026-07-01")], T);
+    expect(s.kind).toBe("none");
+    expect(s.detail).toBe("last run 2026-07-01");
+  });
+
+  it("THE case: five short runs in 4 weeks, last one four days ago → Light, not a verdict", () => {
+    const s = runStatus([d(daysAgo(4), 81), d(daysAgo(6), 37), d(daysAgo(7), 76), d(daysAgo(11), 54), d(daysAgo(19), 68)], T);
+    expect(s.kind).toBe("light");
+    expect(s.label).toBe("Light");
+    expect(s.runs28).toBe(5);
+    expect(s.detail).toBe("5 runs in 4 weeks, too few to call a trend");
+    expect(s.lastRun).toBe(daysAgo(4));
+    expect(s.daysSinceRun).toBe(4);
+  });
+
+  it("last run 15 days ago → lapsed even if the 4-week count is high", () => {
+    const runs = Array.from({ length: 10 }, (_, i) => d(daysAgo(15 + i)));
+    const s = runStatus(runs, T);
+    expect(s.kind).toBe("lapsed");
+    expect(s.detail).toContain("15 days ago");
+  });
+
+  it("a steady week-in week-out runner reads Steady with ACWR near 1", () => {
+    const runs = Array.from({ length: 12 }, (_, i) => d(daysAgo(i * 2 + 1), 60)); // every other day
+    const s = runStatus(runs, T);
+    expect(s.kind).toBe("steady");
+    expect(s.acwr).not.toBeNull();
+    expect(s.acwr as number).toBeGreaterThanOrEqual(0.8);
+    expect(s.acwr as number).toBeLessThanOrEqual(1.3);
+  });
+
+  it("a big last week on a light month reads Spiking", () => {
+    const light = Array.from({ length: 6 }, (_, i) => d(daysAgo(10 + i * 3), 30));
+    const heavy = Array.from({ length: 5 }, (_, i) => d(daysAgo(i + 1), 120));
+    const s = runStatus([...light, ...heavy], T);
+    expect(s.runs28).toBe(11);
+    expect(s.kind).toBe("spiking");
+    expect(s.acwr as number).toBeGreaterThan(1.5);
+  });
+
+  it("a quiet last week on a normal month reads Easing off", () => {
+    const month = Array.from({ length: 10 }, (_, i) => d(daysAgo(8 + i * 2), 80));
+    const s = runStatus([...month, d(daysAgo(2), 20)], T);
+    expect(s.kind).toBe("easing");
+    expect(s.acwr as number).toBeLessThan(0.8);
+  });
+
+  it("future-dated rows are ignored", () => {
+    const s = runStatus([d("2026-09-20", 500)], T);
+    expect(s.kind).toBe("none");
+  });
+});

--- a/web/lib/run-status.ts
+++ b/web/lib/run-status.ts
@@ -1,0 +1,65 @@
+import { daysBetween } from "@/lib/coverage";
+
+/**
+ * A running-only status for the Running page (#738).
+ *
+ * Garmin's "Training Status: Productive" is computed over every activity and
+ * only TAGGED with a sport; in a month of nine kite sessions and five short
+ * runs it still says Productive next to a mileage chart falling to nothing.
+ * This is the run-only reading, from soma's own running load (training_load,
+ * source garmin_running): acute = last 7 days, chronic = last 28, both per
+ * day, and a verdict only when there is enough running to call a trend.
+ */
+export interface RunLoadDay {
+  date: string;
+  load: number;
+}
+
+export type RunStatusKind = "none" | "lapsed" | "light" | "easing" | "steady" | "building" | "spiking";
+
+export interface RunStatus {
+  kind: RunStatusKind;
+  label: string;
+  detail: string;
+  runs28: number;
+  lastRun: string | null;
+  daysSinceRun: number | null;
+  /** load per day over the last 7 / 28 days */
+  acute: number;
+  chronic: number;
+  /** acute / chronic, null when chronic is 0 */
+  acwr: number | null;
+}
+
+/** Fewer runs than this in 28 days is too little to call a trend (2 a week). */
+export const RUN_TREND_MIN_RUNS = 8;
+/** No run for more than this many days reads as "not running lately". */
+export const RUN_LAPSED_DAYS = 14;
+
+export function runStatus(days: readonly RunLoadDay[], today: string): RunStatus {
+  const recent = days.filter((d) => daysBetween(d.date, today) >= 0 && daysBetween(d.date, today) < 28);
+  const last7 = recent.filter((d) => daysBetween(d.date, today) < 7);
+  const acute = Math.round((last7.reduce((s, d) => s + d.load, 0) / 7) * 10) / 10;
+  const chronic = Math.round((recent.reduce((s, d) => s + d.load, 0) / 28) * 10) / 10;
+  const acwr = chronic > 0 ? Math.round((acute / chronic) * 100) / 100 : null;
+  const all = [...days].sort((a, b) => a.date.localeCompare(b.date));
+  const lastRun = all.length ? all[all.length - 1].date : null;
+  const daysSinceRun = lastRun ? daysBetween(lastRun, today) : null;
+  const runs28 = recent.length;
+  const base = { runs28, lastRun, daysSinceRun, acute, chronic, acwr };
+
+  if (!lastRun || daysSinceRun == null || runs28 === 0) {
+    return { ...base, kind: "none", label: "No runs in 4 weeks", detail: lastRun ? `last run ${lastRun}` : "no run recorded" };
+  }
+  if (daysSinceRun > RUN_LAPSED_DAYS) {
+    return { ...base, kind: "lapsed", label: "Not running lately", detail: `last run ${lastRun}, ${daysSinceRun} days ago` };
+  }
+  if (runs28 < RUN_TREND_MIN_RUNS) {
+    return { ...base, kind: "light", label: "Light", detail: `${runs28} run${runs28 === 1 ? "" : "s"} in 4 weeks, too few to call a trend` };
+  }
+  const detail = `${runs28} runs in 4 weeks · load ${acute}/day vs ${chronic}/day (ACWR ${acwr})`;
+  if (acwr == null || acwr < 0.8) return { ...base, kind: "easing", label: "Easing off", detail };
+  if (acwr <= 1.3) return { ...base, kind: "steady", label: "Steady", detail };
+  if (acwr <= 1.5) return { ...base, kind: "building", label: "Building", detail };
+  return { ...base, kind: "spiking", label: "Spiking", detail };
+}


### PR DESCRIPTION
## What

"Training Status: Productive · Running" on the Running page and the app Running screen was Garmin's all-sport status, only tagged running, next to a mileage chart falling from 160 km in March to a few km in September (#738).

- `web/lib/run-status.ts` (#739): a running-only status from soma's own run load (`training_load`, source `garmin_running`): No runs in 4 weeks · Not running lately (last run > 14 days) · Light (fewer than 8 runs in 4 weeks, no trend verdict, says how many) · Easing off / Steady / Building / Spiking by ACWR (7-day vs 28-day load per day). Nine table tests. `lib/run-status-query.ts` reads the load; the demo database without `training_load` reads as no runs instead of a 500.
- Web Running page: the card headlines the run-only verdict with its detail; Garmin's block is captioned "Garmin training status · all sports (Garmin tags it running) · 7-day load vs 4-week" and its columns are "Garmin status", "Garmin 7-day load" (with "4-week: N · all sports"), "Garmin ACWR" (#740).
- App Running screen: same headline + captions; `/api/running/stats` carries `runStatus`.

## Evidence

- tsc 0 (web + universal); vitest web 44 files / 353 tests, universal 31.
- Real data today: 5 runs in 4 weeks, last run 2026-09-02, run load 118 (7 d) / 315 (28 d) → "Light · 5 runs in 4 weeks, too few to call a trend"; Garmin still says Productive / 358 / 297 / 1.20 underneath, now labelled all-sport.
- Playwright desktop + mobile and the emulator proof are added below.

Closes #738
Closes #739
Closes #740
