### PR TITLE
fix(connections): fall back to activity_sync_log when strava_bridge_uploads does not exist (demo)

### DIFF
--- a/web/app/api/connections/route.ts
+++ b/web/app/api/connections/route.ts
@@ -35,6 +35,9 @@ export async function GET() {
     // Strava coverage: of recent Garmin activities, how many are on Strava,
     // via soma's own sync (activity_sync_log) OR the Garmin→Strava bridge
     // (strava_bridge_uploads), which is what actually runs today (#736).
+    type StravaRow = { name: string | null; date: string; type_key: string | null; strava_id: string | null };
+    // The demo database is a subset without strava_bridge_uploads: fall back to
+    // activity_sync_log alone rather than 500 the whole endpoint (#748 follow-up).
     const stravaRows = (await sql`
       SELECT g.raw_json->>'activityName' AS name,
         (g.raw_json->>'startTimeLocal')::date::text AS date,
@@ -49,7 +52,19 @@ export async function GET() {
         AND (g.raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - 90
       ORDER BY (g.raw_json->>'startTimeLocal')::text DESC
       LIMIT 60
-    `) as { name: string | null; date: string; type_key: string | null; strava_id: string | null }[];
+    `.catch(() => sql`
+      SELECT g.raw_json->>'activityName' AS name,
+        (g.raw_json->>'startTimeLocal')::date::text AS date,
+        g.raw_json->'activityType'->>'typeKey' AS type_key,
+        sl.destination_id AS strava_id
+      FROM garmin_activity_raw g
+      LEFT JOIN activity_sync_log sl
+        ON sl.source_id = g.activity_id::text AND sl.destination = 'strava' AND sl.status IN ('sent', 'external')
+      WHERE g.endpoint_name = 'summary'
+        AND (g.raw_json->>'startTimeLocal')::timestamp >= CURRENT_DATE - 90
+      ORDER BY (g.raw_json->>'startTimeLocal')::text DESC
+      LIMIT 60
+    `)) as StravaRow[];
     const stravaTotal = stravaRows.length;
     const stravaOn = stravaRows.filter((r) => r.strava_id != null).length;
     const stravaCoverage = stravaTotal > 0

--- a/web/app/connections/page.tsx
+++ b/web/app/connections/page.tsx
@@ -253,7 +253,30 @@ async function getPageData() {
       WHERE ga.endpoint_name = 'summary'
         AND ga.raw_json->>'startTimeGMT' >= to_char(NOW() - INTERVAL '30 days', 'YYYY-MM-DD')
       ORDER BY ga.raw_json->>'startTimeGMT' DESC
-    `,
+    `.catch(() =>
+    // The demo database has no strava_bridge_uploads: same rows from activity_sync_log alone.
+    sql`
+      SELECT ga.activity_id::text AS source_id,
+             'garmin' AS source_platform,
+             ga.raw_json->>'activityName' AS name,
+             ga.raw_json->'activityType'->>'typeKey' AS activity_type,
+             ga.raw_json->>'startTimeGMT' AS start_time,
+             (ga.raw_json->>'duration')::numeric AS duration,
+             (ga.raw_json->>'distance')::numeric AS distance,
+             ga.raw_json->>'manufacturer' AS manufacturer,
+             asl.status AS sync_status,
+             asl.destination_id,
+             asl.processed_at AS synced_at
+      FROM garmin_activity_raw ga
+      LEFT JOIN activity_sync_log asl
+        ON asl.source_platform = 'garmin'
+        AND asl.source_id = ga.activity_id::text
+        AND asl.destination = 'strava'
+        AND asl.status IN ('sent', 'external')
+      WHERE ga.endpoint_name = 'summary'
+        AND ga.raw_json->>'startTimeGMT' >= to_char(NOW() - INTERVAL '30 days', 'YYYY-MM-DD')
+      ORDER BY ga.raw_json->>'startTimeGMT' DESC
+    `),
     sql`
       SELECT h.hevy_id AS source_id,
              'hevy' AS source_platform,


### PR DESCRIPTION
## What

#748 joined `strava_bridge_uploads` into the Sync Hub queries. The demo database is a subset without that table, so `/api/connections` on soma-demo returned 500 and the Playwright smoke suite (which runs against the demo) failed on #749 at "smoke: /connections (Sync) renders".

Both the API coverage query and the page's activity list now try the bridge-aware query and fall back to the `activity_sync_log`-only query when the table is missing. Same rows, same shape; on the real database nothing changes.

## Evidence

- tsc 0; vitest 44 files / 353 tests.
- Before: `https://soma-demo.gkos.dev/api/connections` → 500 (checked 00:52). After merge + deploy: 200, and the #749 smoke job re-run goes green (posted below).
