### PR TITLE
feat(dj): HR age is amber past five minutes; daemon state leaves /tmp (#668)

### DIFF
--- a/universal/src/app/(main)/live-dj.tsx
+++ b/universal/src/app/(main)/live-dj.tsx
@@ -25,10 +25,20 @@ function formatElapsed(ms: number): string {
   const m = Math.floor(s / 60);
   return m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
 }
+// Twin of web/lib/hr-freshness.ts (#668): five minutes is the line past which the
+// sample is no longer what your heart is doing, whatever the daemon still queues on.
+const HR_STALE_SECONDS = 300;
+function hrAgeTone(sec: number | null | undefined): "fresh" | "stale" | "old" {
+  if (sec == null) return "fresh";
+  if (sec >= 3600) return "old";
+  if (sec > HR_STALE_SECONDS) return "stale";
+  return "fresh";
+}
 function hrAgeLabel(sec: number): string {
   if (sec < 120) return "just now";
-  if (sec < 3600) return `${Math.round(sec / 60)}m ago`;
-  return `${Math.round(sec / 3600)}h ago — stale`;
+  if (sec <= HR_STALE_SECONDS) return `${Math.round(sec / 60)}m ago`;
+  if (sec < 3600) return `${Math.round(sec / 60)}m ago · stale`;
+  return `${Math.round(sec / 3600)}h ago · stale`;
 }
 const formatReason = (r: string) => r.replace(/_/g, " ");
 
@@ -230,7 +240,7 @@ export default function LiveDjScreen() {
 
             <View className="flex-row items-center gap-3">
               {status.hr ? (
-                <Text variant="caption" className="text-text-secondary">HR <Text variant="caption" className="text-text">{status.hr} bpm</Text>{status.hr_age_s != null ? ` (${hrAgeLabel(status.hr_age_s)})` : ""}</Text>
+                <Text variant="caption" className="text-text-secondary" testID="dj-hr">HR <Text variant="caption" className="text-text">{status.hr} bpm</Text>{status.hr_age_s != null ? <Text variant="caption" style={{ color: hrAgeTone(status.hr_age_s) === "fresh" ? undefined : "#e0a458" }}>{` (${hrAgeLabel(status.hr_age_s)})`}</Text> : null}</Text>
               ) : <Text variant="caption" className="italic text-text-muted">Waiting for Garmin HR…</Text>}
               {status.target_bpm ? <Text variant="caption" className="text-text-secondary">→ target <Text variant="caption" className="text-teal">{status.target_bpm} BPM</Text></Text> : null}
             </View>

--- a/web/app/api/playlist/dj/start/route.ts
+++ b/web/app/api/playlist/dj/start/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { spawn } from "child_process";
 import { writeFileSync, readFileSync, openSync } from "fs";
 import path from "path";
+import { ensureDjPaths } from "@/lib/dj-paths";
 
 export const runtime = "nodejs";
 
-const STATUS_FILE = "/tmp/soma-dj-status.json";
-const PID_FILE = "/tmp/soma-dj-pid";
-const LOG_FILE = "/tmp/soma-dj.log";
+// State lives outside /tmp (#668); the daemon gets the same paths on its argv.
+const { statusFile: STATUS_FILE, pidFile: PID_FILE, logFile: LOG_FILE } = ensureDjPaths();
 // TS daemon (port of the Python dj_daemon.py). Run with tsx (dev/local host).
 const DAEMON_SCRIPT = path.join(process.cwd(), "scripts/dj-daemon.mts");
 

--- a/web/app/api/playlist/dj/status/route.ts
+++ b/web/app/api/playlist/dj/status/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { readFileSync, existsSync } from "fs";
+import { ensureDjPaths } from "@/lib/dj-paths";
 
 export const runtime = "nodejs";
 
-const STATUS_FILE = "/tmp/soma-dj-status.json";
-const PID_FILE = "/tmp/soma-dj-pid";
+// State lives outside /tmp (#668): macOS purges /tmp, which read as "stopped" for a live daemon.
+const { statusFile: STATUS_FILE, pidFile: PID_FILE } = ensureDjPaths();
 
 export async function GET() {
   // Check if daemon is running

--- a/web/app/api/playlist/dj/stop/route.ts
+++ b/web/app/api/playlist/dj/stop/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
 import { readFileSync, unlinkSync } from "fs";
+import { ensureDjPaths } from "@/lib/dj-paths";
 
 export const runtime = "nodejs";
 
-const STATUS_FILE = "/tmp/soma-dj-status.json";
-const PID_FILE = "/tmp/soma-dj-pid";
+const { statusFile: STATUS_FILE, pidFile: PID_FILE } = ensureDjPaths();
 
 export async function POST() {
   try {

--- a/web/components/live-dj-tab.tsx
+++ b/web/components/live-dj-tab.tsx
@@ -1,6 +1,7 @@
 // web/components/live-dj-tab.tsx
 "use client";
 import { useState, useEffect, useRef, useCallback } from "react";
+import { hrAgeLabel, hrAgeTone } from "@/lib/hr-freshness";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -572,19 +573,18 @@ export default function LiveDjTab() {
             {/* HR + Target BPM */}
             <div className="flex items-center gap-3 text-xs">
               {status.hr ? (
-                <span className={cn(
-                  "text-muted-foreground",
-                  (status.hr_age_s ?? 0) > 3600 && "text-amber-600 dark:text-amber-400"
-                )}>
+                <span
+                  className={cn(
+                    "text-muted-foreground",
+                    hrAgeTone(status.hr_age_s) !== "fresh" && "text-amber-600 dark:text-amber-400",
+                  )}
+                  data-testid="dj-hr"
+                  data-hr-age-s={status.hr_age_s ?? ""}
+                  data-hr-tone={hrAgeTone(status.hr_age_s)}
+                >
                   HR <span className="font-medium">{status.hr} bpm</span>
                   {status.hr_age_s != null && (
-                    <span className="opacity-70 ml-1">
-                      ({status.hr_age_s < 120
-                        ? "just now"
-                        : status.hr_age_s < 3600
-                          ? `${Math.round(status.hr_age_s / 60)}m ago`
-                          : `${Math.round(status.hr_age_s / 3600)}h ago — stale`})
-                    </span>
+                    <span className="opacity-70 ml-1">({hrAgeLabel(status.hr_age_s)})</span>
                   )}
                 </span>
               ) : (

--- a/web/lib/dj-daemon.ts
+++ b/web/lib/dj-daemon.ts
@@ -6,6 +6,7 @@
  * and Neon. Stage: sync cutover (#187).
  */
 import { writeFileSync, renameSync, readFileSync, unlinkSync } from "fs";
+import { ensureDjPaths } from "./dj-paths";
 import { GarminAuth, DBTokenStore } from "garmin-auth";
 import { healGarminTokenRow } from "./garmin-token-heal";
 import { getDb } from "./db";
@@ -19,7 +20,7 @@ const HR_SHIFT_THRESHOLD = 8;
 const HR_WINDOW_SECONDS = 86_400; // Garmin syncs infrequently
 const SOURCE_REFRESH_INTERVAL = 20;
 const HR_HISTORY_MAX_SECONDS = 7_200;
-const PLAYED_HISTORY_FILE = "/tmp/soma-dj-played.json";
+const PLAYED_HISTORY_FILE = ensureDjPaths().playedFile; // outside /tmp (#668)
 const PROFILE_URL = "/userprofile-service/socialProfile";
 
 const nowS = () => Date.now() / 1000;

--- a/web/lib/dj-paths.test.ts
+++ b/web/lib/dj-paths.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { djStateDir, djPaths } from "./dj-paths";
+
+describe("dj-paths (#668)", () => {
+  it("SOMA_STATE_DIR wins everywhere", () => {
+    expect(djStateDir({ SOMA_STATE_DIR: "/srv/soma-state" }, "linux", "/home/k")).toBe("/srv/soma-state/dj");
+    expect(djStateDir({ SOMA_STATE_DIR: "/srv/soma-state" }, "darwin", "/Users/k")).toBe("/srv/soma-state/dj");
+  });
+  it("macOS uses Application Support, others ~/.soma; never /tmp", () => {
+    expect(djStateDir({}, "darwin", "/Users/k")).toBe("/Users/k/Library/Application Support/soma/dj");
+    expect(djStateDir({}, "linux", "/home/k")).toBe("/home/k/.soma/dj");
+    expect(djStateDir({}, "darwin", "/Users/k")).not.toMatch(/^\/tmp/);
+  });
+  it("the four files hang off the directory", () => {
+    const p = djPaths("/x/dj");
+    expect(p).toEqual({ dir: "/x/dj", statusFile: "/x/dj/status.json", pidFile: "/x/dj/pid", logFile: "/x/dj/daemon.log", playedFile: "/x/dj/played.json" });
+  });
+});

--- a/web/lib/dj-paths.ts
+++ b/web/lib/dj-paths.ts
@@ -1,0 +1,43 @@
+import { mkdirSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Where the Live DJ daemon keeps its state (#668).
+ *
+ * It used to be /tmp (soma-dj-status.json, soma-dj-pid, soma-dj.log,
+ * soma-dj-played.json). macOS purges /tmp, so a status read after a purge
+ * reported "stopped" for a daemon that was still running and the played
+ * history vanished between sessions. The state now lives in the user's
+ * Application Support on macOS, ~/.soma on other hosts, or wherever
+ * SOMA_STATE_DIR points. The directory is created on first use.
+ */
+export interface DjPaths {
+  dir: string;
+  statusFile: string;
+  pidFile: string;
+  logFile: string;
+  playedFile: string;
+}
+
+export function djStateDir(env: Record<string, string | undefined> = process.env, os: string = platform(), home: string = homedir()): string {
+  if (env.SOMA_STATE_DIR) return join(env.SOMA_STATE_DIR, "dj");
+  if (os === "darwin") return join(home, "Library", "Application Support", "soma", "dj");
+  return join(home, ".soma", "dj");
+}
+
+export function djPaths(dir: string = djStateDir()): DjPaths {
+  return {
+    dir,
+    statusFile: join(dir, "status.json"),
+    pidFile: join(dir, "pid"),
+    logFile: join(dir, "daemon.log"),
+    playedFile: join(dir, "played.json"),
+  };
+}
+
+/** djPaths() with the directory created (idempotent). */
+export function ensureDjPaths(dir: string = djStateDir()): DjPaths {
+  mkdirSync(dir, { recursive: true });
+  return djPaths(dir);
+}

--- a/web/lib/hr-freshness.test.ts
+++ b/web/lib/hr-freshness.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { hrAgeLabel, hrAgeTone, HR_STALE_SECONDS } from "./hr-freshness";
+
+describe("hr-freshness (#668)", () => {
+  it("five minutes is the line", () => { expect(HR_STALE_SECONDS).toBe(300); });
+  const cases: [number | null, string, string][] = [
+    [null, "fresh", ""],
+    [30, "fresh", "just now"],
+    [119, "fresh", "just now"],
+    [180, "fresh", "3m ago"],
+    [300, "fresh", "5m ago"],
+    [301, "stale", "5m ago · stale"],
+    [900, "stale", "15m ago · stale"],
+    [3599, "stale", "60m ago · stale"],
+    [3600, "old", "1h ago · stale"],
+    [3601, "old", "1h ago · stale"],
+    [86400, "old", "24h ago · stale"],
+  ];
+  for (const [age, tone, label] of cases) {
+    it(`${age}s → ${tone} "${label}"`, () => {
+      expect(hrAgeTone(age)).toBe(tone);
+      expect(hrAgeLabel(age)).toBe(label);
+    });
+  }
+});

--- a/web/lib/hr-freshness.ts
+++ b/web/lib/hr-freshness.ts
@@ -1,0 +1,25 @@
+/**
+ * How old may the heart-rate sample behind the Live DJ be before the screen
+ * says so? (#668) The daemon accepts a Garmin sample up to a day old
+ * (HR_WINDOW_SECONDS) so it can keep queueing through a slow sync, which is
+ * fine for the queue and dishonest for the display: five minutes is the line
+ * past which "HR 142" is no longer what your heart is doing.
+ */
+export const HR_STALE_SECONDS = 300;
+
+export type HrAgeTone = "fresh" | "stale" | "old";
+
+export function hrAgeTone(ageS: number | null | undefined): HrAgeTone {
+  if (ageS == null) return "fresh";
+  if (ageS >= 3600) return "old";
+  if (ageS > HR_STALE_SECONDS) return "stale";
+  return "fresh";
+}
+
+export function hrAgeLabel(ageS: number | null | undefined): string {
+  if (ageS == null) return "";
+  if (ageS < 120) return "just now";
+  if (ageS <= HR_STALE_SECONDS) return `${Math.round(ageS / 60)}m ago`;
+  if (ageS < 3600) return `${Math.round(ageS / 60)}m ago · stale`;
+  return `${Math.round(ageS / 3600)}h ago · stale`;
+}

--- a/web/scripts/dj-daemon.mts
+++ b/web/scripts/dj-daemon.mts
@@ -4,6 +4,7 @@
  * Python daemon took, loads the local env, and runs the loop until SIGTERM.
  */
 import { runDaemon } from "../lib/dj-daemon";
+import { ensureDjPaths } from "../lib/dj-paths";
 
 function arg(name: string, def: string): string {
   const i = process.argv.indexOf(`--${name}`);
@@ -17,6 +18,6 @@ await runDaemon({
   offset: parseInt(arg("offset", "0"), 10),
   genres: list(arg("genres", "")),
   sources: list(arg("sources", "liked")),
-  statusFile: arg("status-file", "/tmp/soma-dj-status.json"),
-  pidFile: arg("pid-file", "/tmp/soma-dj-pid"),
+  statusFile: arg("status-file", ensureDjPaths().statusFile),
+  pidFile: arg("pid-file", ensureDjPaths().pidFile),
 });


### PR DESCRIPTION
## What

T2.3 Live DJ honesty (#668).

- The daemon queues on a Garmin heart-rate sample up to a day old (`HR_WINDOW_SECONDS = 86400`) so a slow sync does not stop the music, but both screens showed "HR 142 (3h ago)" in the normal colour. `web/lib/hr-freshness.ts` (twin in the app): past 300 s the sample is stale, the age reads amber with "· stale", past an hour it reads in hours. The web Live DJ tab carries `data-hr-age-s` / `data-hr-tone` on the HR line.
- The status, pid, log and played-history files lived in `/tmp`, which macOS purges: a purged pid file read as "stopped" for a live daemon and the played history vanished between sessions. `web/lib/dj-paths.ts` puts them in `~/Library/Application Support/soma/dj` (`SOMA_STATE_DIR` to override, `~/.soma/dj` elsewhere), created on first use; the three `dj/*` routes, the daemon entry and the played history use it. Nothing writes to `/tmp` any more.

## Evidence

- tsc 0 (web + universal); vitest web 46 files / 360 tests (hr-freshness 12 boundary cases, dj-paths 3), universal 31.
- Live, on the Mac daemon host's working-tree server (this branch): `GET /api/playlist/dj/status` → `{"state":"stopped"}` 200, and `~/Library/Application Support/soma/dj` appeared on that first call; `/tmp/soma-dj*` no longer exists.
- No DJ run was started (a real run drives Spotify; user-triggered only). The app's Live DJ screen read from the daemon host after `deploy-main.sh` is added below.

Closes #668
