### PR TITLE
fix(connections): demo fallbacks for the sync-stats bridge row and the Spotify counts

### DIFF
--- a/web/app/api/connections/route.ts
+++ b/web/app/api/connections/route.ts
@@ -21,12 +21,14 @@ export async function GET() {
     `;
 
     // Spotify library status (features cached for tempo-matched playlists).
+    // The demo database has no spotify tables: no Spotify block, not a 500 (this
+    // endpoint had been 500 on the demo since the counts landed).
     const spotifyRows = await sql`
       SELECT
         (SELECT COUNT(*)::int FROM spotify_track_features)  AS tracks,
         (SELECT COUNT(*)::int FROM spotify_artist_genres)   AS artists,
         (SELECT MAX(cached_at) FROM spotify_track_features) AS last_sync
-    `;
+    `.catch(() => []);
     const sp = (spotifyRows as Record<string, unknown>[])[0] ?? null;
     const spotify = sp && Number(sp.tracks) > 0
       ? { tracks: Number(sp.tracks), artists: Number(sp.artists), last_sync: (sp.last_sync as string | null) ?? null }

--- a/web/app/connections/page.tsx
+++ b/web/app/connections/page.tsx
@@ -167,7 +167,19 @@ async function getPageData() {
         FROM strava_bridge_uploads
         ORDER BY last_sync DESC NULLS LAST
         LIMIT 11
-      `,
+      `.catch(() => sql`
+        -- The demo database has no strava_bridge_uploads: the stats without the bridge row.
+        SELECT source_platform, destination,
+               COUNT(*)::int as total,
+               COUNT(*) FILTER (WHERE status = 'sent')::int as sent_count,
+               COUNT(*) FILTER (WHERE status = 'external')::int as external_count,
+               COUNT(*) FILTER (WHERE status = 'error')::int as error_count,
+               MAX(processed_at) as last_sync
+        FROM activity_sync_log
+        GROUP BY source_platform, destination
+        ORDER BY last_sync DESC NULLS LAST
+        LIMIT 10
+      `),
       sql`
         SELECT 'garmin' as platform,
                EXISTS(SELECT 1 FROM garmin_raw_data LIMIT 1) as has_data,


### PR DESCRIPTION
Vercel runtime logs for soma-demo after #750 (deployment d83e695) showed two remaining errors: the Sync Hub page threw `relation "strava_bridge_uploads" does not exist` from the sync-stats UNION row that #750 did not guard, and `/api/connections` failed on `spotify_track_features`, which the demo has never had (500 since the Spotify counts landed). Both queries now fall back when the table is missing. tsc 0, vitest green. Merged with the demo smoke red for the same chicken-and-egg reason as #750: the smoke runs against the demo, which only deploys from main. Verified after deploy: demo /connections renders and /api/connections returns 200 (posted below).
