### PR TITLE
feat(chat): the browser reaches the Mac over the tailnet; Vercel stops proxying (#670)

### DIFF
--- a/web/app/api/chat/history/route.ts
+++ b/web/app/api/chat/history/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { join } from "node:path";
 import { readChatConfig } from "@/lib/chat-config";
 import { hydrateFromJsonl } from "@/lib/chat-history";
-import { chatMode, proxyToLocal, requireToken } from "@/lib/chat-transport";
+import { chatMode, chatGone, chatPreflight, proxyToLocal, requireToken, withCors } from "@/lib/chat-transport";
 
 export const runtime = "nodejs";
 
@@ -10,7 +10,8 @@ function repoRoot(): string {
   return join(process.cwd(), "..");
 }
 
-export async function GET(req: NextRequest) {
+async function getImpl(req: NextRequest) {
+  if (chatMode() === "gone") return chatGone();
   if (chatMode() === "proxy") return proxyToLocal(req, "/api/chat/history");
   const denied = requireToken(req);
   if (denied) return denied;
@@ -27,4 +28,13 @@ export async function GET(req: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+/** CORS preflight for the browser calling the Mac directly over the tailnet (#670). */
+export function OPTIONS(req: NextRequest) {
+  return chatPreflight(req);
+}
+
+export async function GET(req: NextRequest) {
+  return withCors(req, await getImpl(req));
 }

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readChatConfig, writeChatConfig } from "@/lib/chat-config";
-import { chatMode, proxyToLocal, requireToken } from "@/lib/chat-transport";
+import { chatMode, chatGone, chatPreflight, proxyToLocal, requireToken, withCors } from "@/lib/chat-transport";
 
 export const runtime = "nodejs";
 // Hobby-plan ceiling for serverless function lifetime. Cold-cache claude
@@ -78,8 +78,9 @@ function isMissingSessionError(evt: ResultEvent): boolean {
   return evt.errors.some((e) => /No conversation found/i.test(e));
 }
 
-export async function POST(req: NextRequest) {
+async function postImpl(req: NextRequest) {
   // Vercel deployment: just forward to the Mac via the cloudflared tunnel.
+  if (chatMode() === "gone") return chatGone();
   if (chatMode() === "proxy") return proxyToLocal(req, "/api/chat");
   // Local (Mac or dev): enforce the shared secret on non-same-origin calls.
   const denied = requireToken(req);
@@ -352,4 +353,13 @@ export async function POST(req: NextRequest) {
       "X-Accel-Buffering": "no",
     },
   });
+}
+
+/** CORS preflight for the browser calling the Mac directly over the tailnet (#670). */
+export function OPTIONS(req: NextRequest) {
+  return chatPreflight(req);
+}
+
+export async function POST(req: NextRequest) {
+  return withCors(req, await postImpl(req));
 }

--- a/web/app/api/chat/session/route.ts
+++ b/web/app/api/chat/session/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readChatConfig, writeChatConfig } from "@/lib/chat-config";
-import { chatMode, proxyToLocal, requireToken } from "@/lib/chat-transport";
+import { chatMode, chatGone, chatPreflight, proxyToLocal, requireToken, withCors } from "@/lib/chat-transport";
 
 export const runtime = "nodejs";
 
-export async function GET(req: NextRequest) {
+async function getImpl(req: NextRequest) {
+  if (chatMode() === "gone") return chatGone();
   if (chatMode() === "proxy") return proxyToLocal(req, "/api/chat/session");
   const denied = requireToken(req);
   if (denied) return denied;
@@ -13,7 +14,8 @@ export async function GET(req: NextRequest) {
   return NextResponse.json({ ...cfg, mode: "local" });
 }
 
-export async function PUT(req: NextRequest) {
+async function putImpl(req: NextRequest) {
+  if (chatMode() === "gone") return chatGone();
   if (chatMode() === "proxy") return proxyToLocal(req, "/api/chat/session");
   const denied = requireToken(req);
   if (denied) return denied;
@@ -28,4 +30,17 @@ export async function PUT(req: NextRequest) {
   // the next /api/chat call".
   await writeChatConfig({ sessionId: body.sessionId });
   return NextResponse.json({ sessionId: body.sessionId });
+}
+
+/** CORS preflight for the browser calling the Mac directly over the tailnet (#670). */
+export function OPTIONS(req: NextRequest) {
+  return chatPreflight(req);
+}
+
+export async function GET(req: NextRequest) {
+  return withCors(req, await getImpl(req));
+}
+
+export async function PUT(req: NextRequest) {
+  return withCors(req, await putImpl(req));
 }

--- a/web/app/api/chat/upload/route.ts
+++ b/web/app/api/chat/upload/route.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { chatMode, proxyToLocal, requireToken } from "@/lib/chat-transport";
+import { chatMode, chatGone, chatPreflight, proxyToLocal, requireToken, withCors } from "@/lib/chat-transport";
 
 export const runtime = "nodejs";
 
@@ -29,7 +29,8 @@ function extFor(mime: string): string {
   return "bin";
 }
 
-export async function POST(req: NextRequest) {
+async function postImpl(req: NextRequest) {
+  if (chatMode() === "gone") return chatGone();
   if (chatMode() === "proxy") return proxyToLocal(req, "/api/chat/upload");
   const denied = requireToken(req);
   if (denied) return denied;
@@ -71,4 +72,13 @@ export async function POST(req: NextRequest) {
   await writeFile(path, buf);
 
   return NextResponse.json({ path, name, mime, size: file.size });
+}
+
+/** CORS preflight for the browser calling the Mac directly over the tailnet (#670). */
+export function OPTIONS(req: NextRequest) {
+  return chatPreflight(req);
+}
+
+export async function POST(req: NextRequest) {
+  return withCors(req, await postImpl(req));
 }

--- a/web/components/chat-widget.tsx
+++ b/web/components/chat-widget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { chatUrl, chatTransport } from "@/lib/chat-origin";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -138,7 +139,7 @@ export function ChatWidget() {
   //   "proxy"   = Vercel forwarding to the cloudflared tunnel
   //   "offline" = tunnel unreachable / Mac asleep
   const [transportStatus, setTransportStatus] =
-    useState<"unknown" | "local" | "proxy" | "offline">("unknown");
+    useState<"unknown" | "local" | "proxy" | "tailnet" | "offline">("unknown");
   const scrollerRef = useRef<HTMLDivElement>(null);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -188,7 +189,7 @@ export function ChatWidget() {
   }, [open]);
 
   useEffect(() => {
-    fetch("/api/chat/session")
+    fetch(chatUrl("/api/chat/session"))
       .then(async (r) => {
         if (!r.ok) throw new Error(`session http ${r.status}`);
         return r.json();
@@ -201,7 +202,8 @@ export function ChatWidget() {
         // distinguish by host: localhost = direct local, anything else = proxy.
         const host = typeof window !== "undefined" ? window.location.hostname : "";
         const direct = host === "localhost" || host === "127.0.0.1";
-        setTransportStatus(direct ? "local" : "proxy");
+        // tailnet: the browser reached the Mac directly over tailscale serve (#670).
+        setTransportStatus(chatTransport() === "tailnet" ? "tailnet" : direct ? "local" : "proxy");
       })
       .catch(() => {
         setSessionId(null);
@@ -210,7 +212,7 @@ export function ChatWidget() {
     // Best-effort hydrate from the on-disk JSONL — source of truth across
     // devices/browsers. Falls back to localStorage if the route fails or
     // returns no messages.
-    fetch("/api/chat/history")
+    fetch(chatUrl("/api/chat/history"))
       .then((r) => r.json())
       .then((d) => {
         if (Array.isArray(d.messages) && d.messages.length > 0) {
@@ -384,7 +386,7 @@ export function ChatWidget() {
     };
 
     try {
-      const resp = await fetch("/api/chat", {
+      const resp = await fetch(chatUrl("/api/chat"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message }),
@@ -435,7 +437,7 @@ export function ChatWidget() {
           }
           if (eventName === "done") {
             mutateAssistant((m) => ({ ...m, done: true }));
-            fetch("/api/chat/session")
+            fetch(chatUrl("/api/chat/session"))
               .then((r) => r.json())
               .then((d) => setSessionId(d.sessionId ?? null))
               .catch(() => {});
@@ -631,7 +633,7 @@ export function ChatWidget() {
                 } catch {
                   // ignore
                 }
-                await fetch("/api/chat/session", {
+                await fetch(chatUrl("/api/chat/session"), {
                   method: "PUT",
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify({ sessionId: "" }),
@@ -692,7 +694,7 @@ export function ChatWidget() {
                   e.preventDefault();
                   const form = new FormData();
                   form.append("file", blob, blob.name || "pasted.png");
-                  void fetch("/api/chat/upload", { method: "POST", body: form })
+                  void fetch(chatUrl("/api/chat/upload"), { method: "POST", body: form })
                     .then((r) => r.json())
                     .then((d) => {
                       if (d?.path) {
@@ -1069,24 +1071,28 @@ function Dot({ delay = "0ms" }: { delay?: string }) {
 function TransportDot({
   status,
 }: {
-  status: "unknown" | "local" | "proxy" | "offline";
+  status: "unknown" | "local" | "proxy" | "tailnet" | "offline";
 }) {
   const cls =
     status === "local"
       ? "bg-emerald-400"
-      : status === "proxy"
-        ? "bg-sky-400"
-        : status === "offline"
-          ? "bg-rose-400"
-          : "bg-zinc-500";
+      : status === "tailnet"
+        ? "bg-teal-400"
+        : status === "proxy"
+          ? "bg-sky-400"
+          : status === "offline"
+            ? "bg-rose-400"
+            : "bg-zinc-500";
   const title =
     status === "local"
       ? "Local — claude -p running on this machine"
-      : status === "proxy"
-        ? "Proxied via Vercel → your Mac's cloudflared tunnel"
-        : status === "offline"
-          ? "Unreachable — is your Mac awake and the tunnel running?"
-          : "Status unknown";
+      : status === "tailnet"
+        ? "Direct to your Mac over the tailnet (tailscale serve)"
+        : status === "proxy"
+          ? "Proxied via Vercel → your Mac's cloudflared tunnel"
+          : status === "offline"
+            ? "Unreachable — is your Mac awake, and is this device on the tailnet?"
+            : "Status unknown";
   return <span title={title} className={`h-2 w-2 rounded-full ${cls}`} />;
 }
 

--- a/web/lib/chat-origin.test.ts
+++ b/web/lib/chat-origin.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { chatUrl, chatTransport } from "./chat-origin";
+
+describe("chat-origin (#670)", () => {
+  it("no base → same-origin path untouched", () => {
+    expect(chatUrl("/api/chat/session", "")).toBe("/api/chat/session");
+    expect(chatTransport("")).toBe("same-origin");
+  });
+  it("a base prefixes the path, trailing slash or not", () => {
+    expect(chatUrl("/api/chat", "https://gkos-mac.taile2630d.ts.net:8448")).toBe("https://gkos-mac.taile2630d.ts.net:8448/api/chat");
+    expect(chatUrl("api/chat", "https://h:8448")).toBe("https://h:8448/api/chat");
+    expect(chatTransport("https://h:8448")).toBe("tailnet");
+  });
+});

--- a/web/lib/chat-origin.ts
+++ b/web/lib/chat-origin.ts
@@ -1,0 +1,21 @@
+/**
+ * Where the browser sends chat traffic (#670).
+ *
+ * The chat runs on the Mac (it spawns `claude`), never on Vercel. It used to
+ * be reached through a Vercel proxy and a cloudflared tunnel; now the browser
+ * talks to the Mac directly over the tailnet, at the tailscale-serve mount.
+ * NEXT_PUBLIC_SOMA_CHAT_BASE is inlined at build time; unset (local dev, the
+ * demo) keeps the same-origin routes.
+ */
+export const CHAT_BASE = (process.env.NEXT_PUBLIC_SOMA_CHAT_BASE ?? "").replace(/\/+$/, "");
+
+/** `/api/chat/session` → `https://gkos-mac…:8448/api/chat/session` when a base is configured. */
+export function chatUrl(path: string, base: string = CHAT_BASE): string {
+  if (!base) return path;
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+/** Same-origin when no base is set; "tailnet" when the Mac is reached directly. */
+export function chatTransport(base: string = CHAT_BASE): "same-origin" | "tailnet" {
+  return base ? "tailnet" : "same-origin";
+}

--- a/web/lib/chat-transport.test.ts
+++ b/web/lib/chat-transport.test.ts
@@ -88,3 +88,73 @@ describe("requireToken", () => {
     ).toBeNull();
   });
 });
+
+// ---- #670: the browser reaches the Mac over the tailnet; Vercel no longer proxies ----
+import { chatGone, tailnetIdentityOk, allowedChatOrigin, withCors, chatPreflight } from "./chat-transport";
+import { NextResponse } from "next/server";
+
+describe("chatMode gone (#670)", () => {
+  const saved = { url: process.env.SOMA_CHAT_TUNNEL_URL, vercel: process.env.VERCEL };
+  afterEach(() => {
+    if (saved.url === undefined) delete process.env.SOMA_CHAT_TUNNEL_URL; else process.env.SOMA_CHAT_TUNNEL_URL = saved.url;
+    if (saved.vercel === undefined) delete process.env.VERCEL; else process.env.VERCEL = saved.vercel;
+  });
+  it("Vercel without a tunnel URL is gone, and gone answers 410", async () => {
+    delete process.env.SOMA_CHAT_TUNNEL_URL; process.env.VERCEL = "1";
+    expect(chatMode()).toBe("gone");
+    const res = chatGone();
+    expect(res.status).toBe(410);
+    expect((await res.json()).error).toMatch(/tailnet/);
+  });
+  it("Vercel with a tunnel URL still proxies; a dev box without VERCEL is local", () => {
+    process.env.VERCEL = "1"; process.env.SOMA_CHAT_TUNNEL_URL = "https://chat.example";
+    expect(chatMode()).toBe("proxy");
+    delete process.env.VERCEL; delete process.env.SOMA_CHAT_TUNNEL_URL;
+    expect(chatMode()).toBe("local");
+  });
+});
+
+describe("tailnet identity + CORS (#670)", () => {
+  const saved = { login: process.env.SOMA_CHAT_TAILNET_LOGIN, origin: process.env.SOMA_CHAT_ALLOWED_ORIGIN, token: process.env.SOMA_CHAT_TOKEN };
+  beforeEach(() => {
+    process.env.SOMA_CHAT_TAILNET_LOGIN = "someone@github";
+    process.env.SOMA_CHAT_ALLOWED_ORIGIN = "https://soma.gkos.dev";
+    process.env.SOMA_CHAT_TOKEN = "secret";
+  });
+  afterEach(() => {
+    for (const [k, v] of [["SOMA_CHAT_TAILNET_LOGIN", saved.login], ["SOMA_CHAT_ALLOWED_ORIGIN", saved.origin], ["SOMA_CHAT_TOKEN", saved.token]] as const) {
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+  });
+  it("the injected Tailscale-User-Login matches the configured login, case-insensitively", () => {
+    expect(tailnetIdentityOk(mockReq({ "tailscale-user-login": "Someone@github", host: "gkos-mac.taile2630d.ts.net:8448" }))).toBe(true);
+    expect(tailnetIdentityOk(mockReq({ "tailscale-user-login": "other@github", host: "gkos-mac.taile2630d.ts.net:8448" }))).toBe(false);
+    expect(tailnetIdentityOk(mockReq({ host: "gkos-mac.taile2630d.ts.net:8448" }))).toBe(false);
+  });
+  it("no configured login → identity never suffices", () => {
+    delete process.env.SOMA_CHAT_TAILNET_LOGIN;
+    expect(tailnetIdentityOk(mockReq({ "tailscale-user-login": "someone@github" }))).toBe(false);
+  });
+  it("requireToken accepts the identity, still accepts the token, still refuses strangers", () => {
+    const tailnetHost = { host: "gkos-mac.taile2630d.ts.net:8448" };
+    expect(requireToken(mockReq({ ...tailnetHost, "tailscale-user-login": "someone@github" }))).toBeNull();
+    expect(requireToken(mockReq({ ...tailnetHost, "x-soma-chat-token": "secret" }))).toBeNull();
+    const denied = requireToken(mockReq({ ...tailnetHost, "tailscale-user-login": "stranger@github" }));
+    expect(denied?.status).toBe(401);
+  });
+  it("only the configured origin gets CORS headers", () => {
+    expect(allowedChatOrigin(mockReq({ origin: "https://soma.gkos.dev" }))).toBe("https://soma.gkos.dev");
+    expect(allowedChatOrigin(mockReq({ origin: "https://evil.example" }))).toBeNull();
+    expect(allowedChatOrigin(mockReq({}))).toBeNull();
+    const res = withCors(mockReq({ origin: "https://soma.gkos.dev" }), NextResponse.json({ ok: true }));
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://soma.gkos.dev");
+    expect(res.headers.get("access-control-allow-headers")).toContain("x-soma-chat-token");
+    const plain = withCors(mockReq({ origin: "https://evil.example" }), NextResponse.json({ ok: true }));
+    expect(plain.headers.get("access-control-allow-origin")).toBeNull();
+  });
+  it("preflight: 204 for the allowed origin, 403 otherwise", () => {
+    expect(chatPreflight(mockReq({ origin: "https://soma.gkos.dev" })).status).toBe(204);
+    expect(chatPreflight(mockReq({ origin: "https://soma.gkos.dev" })).headers.get("access-control-max-age")).toBe("600");
+    expect(chatPreflight(mockReq({ origin: "https://evil.example" })).status).toBe(403);
+  });
+});

--- a/web/lib/chat-transport.ts
+++ b/web/lib/chat-transport.ts
@@ -21,10 +21,85 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 
-export type ChatMode = "local" | "proxy";
+export type ChatMode = "local" | "proxy" | "gone";
 
+/**
+ * local  — this process can spawn `claude` (the Mac, or a dev server).
+ * proxy  — the old Vercel path: forward to SOMA_CHAT_TUNNEL_URL.
+ * gone   — Vercel with no tunnel URL: the chat moved to the Mac over the
+ *          tailnet (#670); answer 410 instead of trying to spawn claude here.
+ */
 export function chatMode(): ChatMode {
-  return process.env.SOMA_CHAT_TUNNEL_URL ? "proxy" : "local";
+  if (process.env.SOMA_CHAT_TUNNEL_URL) return "proxy";
+  if (process.env.VERCEL) return "gone";
+  return "local";
+}
+
+/** 410 for the Vercel routes once the tunnel is gone: the browser must call the Mac directly. */
+export function chatGone(): NextResponse {
+  return NextResponse.json(
+    { error: "The chat runs on the Mac over the tailnet now; open soma from a tailnet device (NEXT_PUBLIC_SOMA_CHAT_BASE)." },
+    { status: 410 },
+  );
+}
+
+/**
+ * Tailnet identity (#670). tailscale serve injects Tailscale-User-Login on
+ * every proxied request and strips any client-supplied copy (probed
+ * 2026-09-07: a spoofed header never reached the origin). The Mac listens on
+ * loopback only, so a request carrying the configured login came through
+ * serve from that tailnet user. No shared secret leaves the Mac.
+ */
+export function tailnetIdentityOk(req: NextRequest): boolean {
+  const expected = process.env.SOMA_CHAT_TAILNET_LOGIN;
+  if (!expected) return false;
+  const got = req.headers.get("tailscale-user-login");
+  return !!got && got.toLowerCase() === expected.toLowerCase();
+}
+
+/** The browser origin allowed to call the Mac's chat routes cross-origin (https://soma.gkos.dev). */
+export function allowedChatOrigin(req: NextRequest): string | null {
+  const allowed = (process.env.SOMA_CHAT_ALLOWED_ORIGIN ?? "").split(",").map((s) => s.trim().replace(/\/+$/, "")).filter(Boolean);
+  const origin = req.headers.get("origin");
+  if (!origin || !allowed.includes(origin)) return null;
+  return origin;
+}
+
+const CORS_METHODS = "GET, POST, PUT, OPTIONS";
+const CORS_HEADERS = "content-type, x-soma-chat-token";
+
+/** Add CORS headers for the allowed origin; a no-op for same-origin calls. */
+export function withCors<T extends Response>(req: NextRequest, res: T): T {
+  const origin = allowedChatOrigin(req);
+  if (!origin) return res;
+  try {
+    res.headers.set("Access-Control-Allow-Origin", origin);
+    res.headers.set("Vary", "Origin");
+    res.headers.set("Access-Control-Allow-Methods", CORS_METHODS);
+    res.headers.set("Access-Control-Allow-Headers", CORS_HEADERS);
+    return res;
+  } catch {
+    // immutable headers (a fetch() Response): rebuild with the same body
+    const copy = new Response(res.body, { status: res.status, statusText: res.statusText, headers: new Headers(res.headers) });
+    copy.headers.set("Access-Control-Allow-Origin", origin);
+    copy.headers.set("Vary", "Origin");
+    copy.headers.set("Access-Control-Allow-Methods", CORS_METHODS);
+    copy.headers.set("Access-Control-Allow-Headers", CORS_HEADERS);
+    return copy as unknown as T;
+  }
+}
+
+/** OPTIONS preflight for the chat routes: 204 for the allowed origin, 403 otherwise. */
+export function chatPreflight(req: NextRequest): NextResponse {
+  const origin = allowedChatOrigin(req);
+  if (!origin) return new NextResponse(null, { status: 403 });
+  const res = new NextResponse(null, { status: 204 });
+  res.headers.set("Access-Control-Allow-Origin", origin);
+  res.headers.set("Vary", "Origin");
+  res.headers.set("Access-Control-Allow-Methods", CORS_METHODS);
+  res.headers.set("Access-Control-Allow-Headers", CORS_HEADERS);
+  res.headers.set("Access-Control-Max-Age", "600");
+  return res;
 }
 
 /**
@@ -49,6 +124,7 @@ export function requireToken(req: NextRequest): NextResponse | null {
   ) {
     return null;
   }
+  if (tailnetIdentityOk(req)) return null;
   const got = req.headers.get("x-soma-chat-token");
   if (got !== expected) {
     return NextResponse.json(

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/auth";
 import { NextResponse } from "next/server";
+import { tailnetIdentityOk } from "@/lib/chat-transport";
 
 const isDev = process.env.NODE_ENV !== "production";
 
@@ -45,6 +46,10 @@ export default auth((req) => {
   const { pathname } = req.nextUrl;
   const isApi = pathname.startsWith("/api/");
 
+  // The chat routes answer their own preflight with an origin allowlist (#670): the
+  // browser calls the Mac over the tailnet from https://soma.gkos.dev.
+  if (isApi && pathname.startsWith("/api/chat") && req.method === "OPTIONS") return NextResponse.next();
+
   if (isDev && isApi && req.method === "OPTIONS") {
     return withDevCors(new NextResponse(null, { status: 204 }), true);
   }
@@ -52,8 +57,9 @@ export default auth((req) => {
   // Personal API token: native apps + widgets reach /api/* without a session.
   if (isApi && hasApiToken(req)) return withTokenCors(NextResponse.next());
 
-  // Chat tunnel: the shared chat token reaches /api/chat* without a session or demo mode.
-  if (isApi && pathname.startsWith("/api/chat") && hasChatToken(req)) return NextResponse.next();
+  // Chat: the shared chat token (the old Vercel proxy) or the tailnet identity that
+  // tailscale serve injects (#670) reaches /api/chat* without a session or demo mode.
+  if (isApi && pathname.startsWith("/api/chat") && (hasChatToken(req) || tailnetIdentityOk(req))) return NextResponse.next();
 
   // Demo mode: READ-ONLY. Reads and page views need no auth, but every /api/*
   // handler runs auth-less here, so an anonymous visitor could otherwise POST/


### PR DESCRIPTION
## What

T2.5 (#670): the chat no longer goes browser → Vercel proxy → cloudflared tunnel → Mac. The browser calls the Mac's tailscale-serve mount directly, authenticated by tailnet identity.

- `web/lib/chat-origin.ts`: `NEXT_PUBLIC_SOMA_CHAT_BASE` (build-time, set to `https://gkos-mac.taile2630d.ts.net:8448` on the personal project) prefixes the six chat fetches in the widget; unset keeps the same-origin routes (dev, demo).
- `web/lib/chat-transport.ts`: `requireToken` accepts a request whose `Tailscale-User-Login` equals `SOMA_CHAT_TAILNET_LOGIN`. Probed 2026-09-07 with a throwaway serve mount and an echo server: serve injects the real login and **strips a client-supplied copy**, and the Mac listens on loopback only, so the header can only come from serve. No shared secret leaves the Mac. `chatMode()` is `gone` on Vercel without a tunnel URL and the routes answer 410. CORS for `SOMA_CHAT_ALLOWED_ORIGIN` with an OPTIONS preflight on all four chat routes; every response carries the headers.
- `web/middleware.ts`: `/api/chat*` passes with the tailnet identity (the old chat token still works) and the chat preflight reaches the route.
- Transport dot shows "tailnet"; the offline hint names the tailnet.

## Evidence

- tsc 0; vitest 48 files / 378 tests (chat-origin 2, chat-transport +7: gone/410, identity, requireToken paths, CORS allowlist, preflight).
- Working-tree server on the Mac with the two env vars set: `OPTIONS /api/chat/session` from `https://soma.gkos.dev` → 204 with `access-control-allow-origin: https://soma.gkos.dev`, from a stranger origin → 403; `GET /api/chat/session` with a tailnet Host and the injected login → 200 + CORS header + `{"sessionId":…,"mode":"local"}`; stranger identity → 307; no identity/no token → 307; the token → 200.
- After merge (posted below): `deploy-main.sh` on the pinned host, the real mount over the tailnet (`curl --resolve` to :8448), Vercel `SOMA_CHAT_TUNNEL_URL` removed → `/api/chat/session` 410, cloudflared retired (`pgrep` empty), `chat.gkos.dev` gone (DNS record saved to `~/.config/soma/retired/`).

Known limit: this Mac has Tailscale DNS disabled (`tailscale dns status`), so a browser on the Mac itself cannot resolve the ts.net name until `tailscale set --accept-dns=true`; the phone resolves it. Left for Kostas.

Closes #670
