### PR TITLE
feat(app): one shared, persisted time range that every screen and route honours

### DIFF
--- a/universal/.maestro/verify-range.yaml
+++ b/universal/.maestro/verify-range.yaml
@@ -1,0 +1,57 @@
+# Soma verify flow: the shared time range (soma#754, S1 of #578).
+# Proves on a device that (1) tapping a range chip re-scopes the screen, (2) the choice
+# survives a cold restart (AsyncStorage), (3) another screen opens on the same choice.
+# Run via universal/scripts/verify-device.sh running --flow .maestro/verify-range.yaml --marker "last 6M"
+appId: dev.gkos.soma
+name: Soma verify shared time range
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "range-6m"
+    timeout: 20000
+# Normalise, then pick 1W: the headline must re-scope to the week.
+- tapOn:
+    id: "range-6m"
+- tapOn:
+    id: "range-1w"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*last 1W.*"
+    timeout: 20000
+# Cold restart: the persisted choice must come back without touching a chip.
+- stopApp
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*last 1W.*"
+    timeout: 20000
+- takeScreenshot: verify-range-running-1w
+# Another screen opens on the same choice.
+- openLink: universal://activities
+- waitForAnimationToEnd:
+    timeout: 5000
+- extendedWaitUntil:
+    visible:
+      id: "range-1w"
+      selected: true
+    timeout: 20000
+- takeScreenshot: verify-range-activities-1w
+# Leave the device on 6M and let the script's live marker close the loop.
+- tapOn:
+    id: "range-6m"
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 5000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -13,6 +13,7 @@
         "@expo/ui": "~57.0.6",
         "@expo/vector-icons": "^15.0.2",
         "@maplibre/maplibre-react-native": "^11.3.8",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "~57.0.6",
         "expo-constants": "~57.0.5",
         "expo-device": "~57.0.1",
@@ -3223,6 +3224,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {
@@ -7072,6 +7085,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -7860,6 +7882,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/universal/package.json
+++ b/universal/package.json
@@ -7,6 +7,7 @@
     "@expo/ui": "~57.0.6",
     "@expo/vector-icons": "^15.0.2",
     "@maplibre/maplibre-react-native": "^11.3.8",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~57.0.6",
     "expo-constants": "~57.0.5",
     "expo-device": "~57.0.1",

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { TimeRangeSelector } from "../../components/time-range-selector";
+import { useRangePref, rangeToDays, rangeLabel } from "../../lib/time-range";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
 import { LineChart, ChartLegend, ExpandableChart, chartDateLabel } from "../../components/line-chart";
@@ -47,17 +49,17 @@ function useOverviewTrends() {
 
 interface WeightRow { date: string; weight_kg: number | null; bmi: number | null; body_fat_pct: number | null }
 /** Last 30 days of weigh-ins (ascending) for the weight glance + sparkline. */
-function useWeightTrend() {
+function useWeightTrend(days: number) {
   const [rows, setRows] = useState<WeightRow[]>([]);
   useEffect(() => {
     let alive = true;
-    fetchJson<WeightRow[]>("/api/health/weight?days=90")
+    fetchJson<WeightRow[]>(`/api/health/weight?days=${days}`)
       .then((d) => alive && setRows(Array.isArray(d) ? d : []))
       .catch(() => {});
     return () => {
       alive = false;
     };
-  }, []);
+  }, [days]);
   return rows;
 }
 
@@ -97,15 +99,15 @@ function useOverviewFitness() {
 
 interface Vo2maxResp { stats: { vo2max: number | null } | null; trends: { vo2max: number[] } }
 /** Current VO2max + its trend, from /api/running/stats. */
-function useVo2max() {
+function useVo2max(range: string) {
   const [v, setV] = useState<{ current: number | null; trend: number[] }>({ current: null, trend: [] });
   useEffect(() => {
     let alive = true;
-    fetchJson<Vo2maxResp>("/api/running/stats?range=90d")
+    fetchJson<Vo2maxResp>(`/api/running/stats?range=${range}`)
       .then((d) => alive && setV({ current: d.stats?.vo2max ?? (d.trends?.vo2max?.at(-1) ?? null), trend: d.trends?.vo2max ?? [] }))
       .catch(() => {});
     return () => { alive = false; };
-  }, []);
+  }, [range]);
   return v;
 }
 
@@ -147,13 +149,14 @@ export default function OverviewScreen() {
   const { data, error, refetch } = useToday();
   const { data: training, refetch: refetchTraining } = useTraining(todayLocal());
   const { data: plan, refetch: refetchPlan } = useSomaPlan(todayLocal());
-  const weight = useWeightTrend();
+  const [range, setRange] = useRangePref();
+  const weight = useWeightTrend(rangeToDays(range));
   const sleep = useSleepGlance();
   const trends = useOverviewTrends();
   const weekly = useWeeklyTraining();
-  const vo2 = useVo2max();
+  const vo2 = useVo2max(range);
   const recovery = useRecoverySummary("30d");
-  const { data: activitiesDeep } = useActivitiesDeep("180d");
+  const { data: activitiesDeep } = useActivitiesDeep(range);
   const fitness = useOverviewFitness();
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
@@ -217,6 +220,7 @@ export default function OverviewScreen() {
           <Text variant="headline">Overview</Text>
           <Text variant="caption" className="text-text-secondary">Today at a glance</Text>
         </View>
+        <TimeRangeSelector value={range} onChange={setRange} />
 
         {error ? <Card><Text variant="body" className="text-danger">API: {error}</Text></Card> : null}
 
@@ -345,7 +349,7 @@ export default function OverviewScreen() {
             <Text variant="eyebrow">Weight</Text>
             <Text variant="headline" className="text-warm">{wLatest != null ? wLatest.toFixed(1) : "—"}</Text>
             <Text variant="micro">
-              {wDelta != null ? `${wDelta >= 0 ? "+" : ""}${wDelta.toFixed(1)} kg/90d` : bfLatest != null ? `${bfLatest.toFixed(1)}% bf` : "kg"}
+              {wDelta != null ? `${wDelta >= 0 ? "+" : ""}${wDelta.toFixed(1)} kg/${rangeLabel(range)}` : bfLatest != null ? `${bfLatest.toFixed(1)}% bf` : "kg"}
             </Text>
             {wSeries.length >= 2 ? (
               <View className="mt-1"><Sparkline data={wSeries} color="#b17850" height={22} baseline /></View>
@@ -360,7 +364,7 @@ export default function OverviewScreen() {
               <View className="flex-row items-end gap-2">
                 <Text variant="display" className="text-warm">{wLatest != null ? wLatest.toFixed(1) : "—"}</Text>
                 <Text variant="caption" className="text-text-muted mb-1">
-                  kg{bfLatest != null ? ` · ${bfLatest.toFixed(1)}% bf` : ""}{wDelta != null ? ` · ${wDelta >= 0 ? "+" : ""}${wDelta.toFixed(1)} kg/90d` : ""}
+                  kg{bfLatest != null ? ` · ${bfLatest.toFixed(1)}% bf` : ""}{wDelta != null ? ` · ${wDelta >= 0 ? "+" : ""}${wDelta.toFixed(1)} kg/${rangeLabel(range)}` : ""}
                 </Text>
               </View>
               <LineChart height={130} interactive xTicks={4} labels={wLabels} yFormat={bodyCompChart.yFormat} yFormatRight={bodyCompChart.yFormatRight} series={bodyCompSeries} />

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
 import { TimeRangeSelector } from "../../components/time-range-selector";
-import { useRangePref, statsRange } from "../../lib/time-range";
+import { useRangePref } from "../../lib/time-range";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { TrendArrow } from "../../components/trend-arrow";
 import { LineChart, ChartLegend } from "../../components/line-chart";
@@ -62,8 +62,7 @@ function useSleepRecovery(range: string) {
   useEffect(() => {
     let alive = true;
     setLoading(true);
-    // /api/stats/* only accepts 7d/30d/90d/1y — clamp the shared range to it.
-    const get = (m: string) => fetchJson<StatSeries>(`/api/stats/${m}?range=${statsRange(range)}`);
+    const get = (m: string) => fetchJson<StatSeries>(`/api/stats/${m}?range=${range}`);
 
     Promise.all([
       get("sleep"),

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -166,6 +166,7 @@ export default function WorkoutsScreen() {
         <Text variant="caption" className="text-text-secondary">
           Training history and Garmin sync
         </Text>
+        <TimeRangeSelector value={range} onChange={setRange} />
 
         {error ? (
           <Card>
@@ -216,10 +217,7 @@ export default function WorkoutsScreen() {
         </View>
 
         {/* Workout data — volume, stats, top exercises, recent (new /api/workouts/summary) */}
-        <View className="flex-row items-center gap-3">
-          <View className="flex-1">
-            <TimeRangeSelector value={range} onChange={setRange} />
-          </View>
+        <View className="flex-row items-center justify-end gap-3">
           <View className="w-24">
             <SegmentedControl options={["kg", "lb"] as const} value={unit} onChange={(v) => setUnit(v as "kg" | "lb")} />
           </View>

--- a/universal/src/app/_layout.tsx
+++ b/universal/src/app/_layout.tsx
@@ -3,8 +3,14 @@ import { Stack } from "expo-router";
 import { View } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { useEffect, useState } from "react";
+import { hydrateRangePref } from "../lib/time-range";
 
 export default function RootLayout() {
+  // Read the persisted time range once before any screen fetches with it (soma#754).
+  const [ready, setReady] = useState(false);
+  useEffect(() => { hydrateRangePref().finally(() => setReady(true)); }, []);
+  if (!ready) return <View className="flex-1 bg-base" />;
   return (
     <SafeAreaProvider>
       <View className="flex-1 bg-base">

--- a/universal/src/components/time-range-selector.tsx
+++ b/universal/src/components/time-range-selector.tsx
@@ -14,7 +14,7 @@ export function TimeRangeSelector({ value, onChange }: { value: string; onChange
       {RANGES.map((r) => {
         const active = value === r.value;
         return (
-          <Pressable key={r.value} onPress={() => onChange(r.value)} hitSlop={4} accessibilityRole="button" accessibilityLabel={r.label}>
+          <Pressable key={r.value} onPress={() => onChange(r.value)} hitSlop={4} accessibilityRole="button" accessibilityLabel={r.label} accessibilityState={{ selected: active }} testID={`range-${r.value}`}>
             <View
               className="rounded-full px-3 py-1.5"
               style={{ backgroundColor: active ? "#77c8d1" : "#152232", borderWidth: 1, borderColor: active ? "#77c8d1" : "#1a3040" }}

--- a/universal/src/lib/time-range.test.ts
+++ b/universal/src/lib/time-range.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const store = new Map<string, string>();
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(async (k: string) => store.get(k) ?? null),
+    setItem: vi.fn(async (k: string, v: string) => { store.set(k, v); }),
+  },
+}));
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  RANGES, rangeToDays, rangeLabel, isRangeKey, getRangePref, setRangePref, hydrateRangePref,
+  isRangeHydrated, __resetRangePrefForTests, DEFAULT_RANGE,
+} from "./time-range";
+
+beforeEach(() => { store.clear(); __resetRangePrefForTests(); vi.clearAllMocks(); });
+
+describe("range tokens (mirror web/lib/time-ranges.ts)", () => {
+  it("has the ten web keys with the same day counts", () => {
+    expect(RANGES.map((r) => [r.value, r.days])).toEqual([
+      ["1w", 7], ["2w", 14], ["1m", 30], ["3m", 90], ["6m", 180], ["9m", 270], ["1y", 365], ["2y", 730], ["3y", 1095], ["all", 3650],
+    ]);
+    expect(rangeToDays("2y")).toBe(730);
+    expect(rangeToDays(undefined)).toBe(180);
+    expect(rangeLabel("1w")).toBe("1W");
+    expect(isRangeKey("90d")).toBe(false);
+  });
+});
+
+describe("shared persisted range (#754)", () => {
+  it("starts at 6M and writes every change to storage", () => {
+    expect(getRangePref()).toBe(DEFAULT_RANGE);
+    setRangePref("1w");
+    expect(getRangePref()).toBe("1w");
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith("soma_time_range", "1w");
+  });
+  it("ignores unknown keys and no-op writes", () => {
+    setRangePref("90d");
+    setRangePref("nope");
+    expect(getRangePref()).toBe(DEFAULT_RANGE);
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+  it("hydrates the stored choice once at startup", async () => {
+    store.set("soma_time_range", "2y");
+    expect(isRangeHydrated()).toBe(false);
+    await hydrateRangePref();
+    await hydrateRangePref();
+    expect(getRangePref()).toBe("2y");
+    expect(isRangeHydrated()).toBe(true);
+    expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1);
+  });
+  it("keeps the default when storage holds garbage or nothing", async () => {
+    store.set("soma_time_range", "forever");
+    await hydrateRangePref();
+    expect(getRangePref()).toBe(DEFAULT_RANGE);
+    expect(isRangeHydrated()).toBe(true);
+  });
+  it("a choice made before hydration finishes wins over the stored one", async () => {
+    store.set("soma_time_range", "1y");
+    const p = hydrateRangePref();
+    setRangePref("1m");
+    await p;
+    expect(getRangePref()).toBe("1m");
+  });
+});

--- a/universal/src/lib/time-range.ts
+++ b/universal/src/lib/time-range.ts
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useSyncExternalStore } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 /** The 10 time ranges, matching web/lib/time-ranges.ts (same tokens hit the same
- *  :3456 backend). */
+ *  backend routes, which parse them through parseRangeDays). */
 export interface TimeRange { label: string; value: string; days: number; }
 export const RANGES: TimeRange[] = [
   { label: "1W", value: "1w", days: 7 },
@@ -16,6 +17,8 @@ export const RANGES: TimeRange[] = [
   { label: "All", value: "all", days: 3650 },
 ];
 
+export const DEFAULT_RANGE = "6m";
+
 export function rangeToDays(range: string | undefined): number {
   if (!range) return 180;
   const f = RANGES.find((r) => r.value === range);
@@ -26,32 +29,57 @@ export function rangeLabel(range: string): string {
   return RANGES.find((r) => r.value === range)?.label ?? range;
 }
 
-/** Clamp a range to the nearest token the /api/stats/* endpoint accepts
- *  (only 7d/30d/90d/1y). Used where a shared range must call that endpoint. */
-export function statsRange(range: string): string {
-  const d = rangeToDays(range);
-  if (d <= 10) return "7d";
-  if (d <= 45) return "30d";
-  if (d <= 200) return "90d";
-  return "1y";
+export function isRangeKey(v: unknown): v is string {
+  return typeof v === "string" && RANGES.some((r) => r.value === v);
 }
 
+/* ---- one shared, persisted range (soma#754) ----
+   Web keeps the choice in localStorage["soma_time_range"] and carries it across pages.
+   The app does the same: one module-level value every screen subscribes to, written to
+   AsyncStorage (localStorage on Expo web) and read back once at startup, so 1W chosen on
+   Running is what Activities opens with, today and after a cold start. */
 const STORAGE_KEY = "soma_time_range";
+let current = DEFAULT_RANGE;
+let hydrated = false;
+let touched = false; // a choice made before the stored value arrives must win
+let hydration: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+const emit = () => { for (const l of listeners) l(); };
+const subscribe = (l: () => void) => { listeners.add(l); return () => { listeners.delete(l); }; };
 
-/** Shared, persisted selected time range — mirrors the web's single
- *  `localStorage["soma_time_range"]` so the choice carries across screens and
- *  sessions. Falls back to in-memory on native (until AsyncStorage is added). */
-export function useRangePref(defaultRange = "6m"): [string, (r: string) => void] {
-  const [range, setRangeState] = useState<string>(() => {
-    try {
-      const raw = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
-      if (raw && RANGES.some((r) => r.value === raw)) return raw;
-    } catch { /* native / unavailable */ }
-    return defaultRange;
-  });
-  const setRange = (r: string) => {
-    setRangeState(r);
-    try { if (typeof localStorage !== "undefined") localStorage.setItem(STORAGE_KEY, r); } catch { /* native */ }
-  };
-  return [range, setRange];
+export function getRangePref(): string { return current; }
+export function isRangeHydrated(): boolean { return hydrated; }
+
+export function setRangePref(next: string): void {
+  if (!isRangeKey(next) || next === current) return;
+  current = next;
+  touched = true;
+  emit();
+  AsyncStorage.setItem(STORAGE_KEY, next).catch(() => { /* storage unavailable: in-memory only */ });
+}
+
+/** Read the stored choice once. Safe to call many times; resolves after the first read. */
+export function hydrateRangePref(): Promise<void> {
+  if (!hydration) {
+    hydration = AsyncStorage.getItem(STORAGE_KEY)
+      .then((v) => { if (!touched && isRangeKey(v) && v !== current) current = v; })
+      .catch(() => { /* keep the default */ })
+      .then(() => { hydrated = true; emit(); });
+  }
+  return hydration;
+}
+
+/** [range, setRange] — shared across screens and sessions. */
+export function useRangePref(): [string, (r: string) => void] {
+  const range = useSyncExternalStore(subscribe, getRangePref, getRangePref);
+  return [range, setRangePref];
+}
+
+export function useRangeHydrated(): boolean {
+  return useSyncExternalStore(subscribe, isRangeHydrated, isRangeHydrated);
+}
+
+/** Test hook: forget everything (module state survives between vitest cases). */
+export function __resetRangePrefForTests(): void {
+  current = DEFAULT_RANGE; hydrated = false; touched = false; hydration = null; listeners.clear();
 }

--- a/web/app/api/activities/deep/route.ts
+++ b/web/app/api/activities/deep/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
 export const runtime = "edge";
@@ -23,11 +24,7 @@ const sportOf = (t: string): string => SPORT_OF[t] ?? "Other";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const range = searchParams.get("range") || "1y";
-  const days =
-    range === "1m" || range === "30d" ? 30 :
-    range === "3m" || range === "90d" ? 91 :
-    range === "6m" ? 182 :
-    range === "all" ? 20000 : 365;
+  const days = parseRangeDays(range, 365); // all 10 web keys + legacy Nd (soma#754)
 
   const sql = getDb();
 

--- a/web/app/api/activities/summary/route.ts
+++ b/web/app/api/activities/summary/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
 export const runtime = "edge";
@@ -27,8 +28,6 @@ const ACTIVITY_LABELS: Record<string, string> = {
   other: "Other",
 };
 
-// Screen sends 30d/90d/1y/all; keep a robust local map (web rangeToDays uses 1m/3m/…).
-const RANGE_DAYS: Record<string, number> = { "30d": 30, "90d": 90, "1y": 365, all: 3650 };
 
 function extractJump(name: string | null): number {
   if (!name) return 0;
@@ -40,7 +39,7 @@ const n = (v: unknown): number => (v == null ? 0 : Number(v));
 
 export async function GET(req: NextRequest) {
   const range = req.nextUrl.searchParams.get("range") ?? "1y";
-  const days = RANGE_DAYS[range] ?? 365;
+  const days = parseRangeDays(range, 365); // all 10 web keys + legacy Nd (soma#754)
   const cutoff = new Date(Date.now() - days * 86400000).toISOString().split("T")[0];
   const sql = getDb();
 

--- a/web/app/api/stats/[metric]/route.ts
+++ b/web/app/api/stats/[metric]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
 export const runtime = "edge";
@@ -55,10 +56,10 @@ export async function GET(
   }
 
   const range = request.nextUrl.searchParams.get("range") || "30d";
-  const days = RANGE_DAYS[range];
+  const days = RANGE_DAYS[range] ?? parseRangeDays(range, 0); // web keys too (soma#754)
   if (!days) {
     return NextResponse.json(
-      { error: `Invalid range: ${range}. Use 7d, 30d, 90d, or 1y` },
+      { error: `Invalid range: ${range}. Use 7d, 30d, 90d, 1y or a web range key (1w … all)` },
       { status: 400 }
     );
   }

--- a/web/app/api/workouts/bodymap/route.ts
+++ b/web/app/api/workouts/bodymap/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 import { getExerciseMuscles, ALL_MUSCLE_GROUPS, type MuscleGroup } from "@/lib/muscle-groups";
 
@@ -24,7 +25,7 @@ const initMetric = (): MetricMap => {
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const range = searchParams.get("range") || "1y";
-  const days = range === "30d" ? 30 : range === "90d" ? 90 : range === "6m" ? 182 : range === "all" ? 36500 : 365;
+  const days = parseRangeDays(range, 365); // all 10 web keys + legacy Nd (soma#754)
   const cutoff = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
 
   const sql = getDb();

--- a/web/app/api/workouts/insights/route.ts
+++ b/web/app/api/workouts/insights/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
 export const runtime = "nodejs";
@@ -14,7 +15,7 @@ export const dynamic = "force-dynamic";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const range = searchParams.get("range") || "90d";
-  const days = range === "30d" ? 30 : range === "1y" ? 365 : range === "6m" ? 182 : 90;
+  const days = parseRangeDays(range, 90); // all 10 web keys + legacy Nd (soma#754)
   const cutoff = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
 
   const sql = getDb();

--- a/web/app/api/workouts/summary/route.ts
+++ b/web/app/api/workouts/summary/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
 export const runtime = "edge";
@@ -11,7 +12,7 @@ export const runtime = "edge";
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const range = searchParams.get("range") || "90d";
-  const days = range === "30d" ? 30 : range === "1y" ? 365 : range === "6m" ? 182 : 90;
+  const days = parseRangeDays(range, 90); // all 10 web keys + legacy Nd (soma#754)
 
   const sql = getDb();
 


### PR DESCRIPTION
S1 of #578 shipped the ten-range selector, but a side-by-side of web and app (rig from main vs emulator, real account) found it only half wired. Ledger and evidence on #754.

**App**
- One shared, persisted range (`lib/time-range.ts`): a module store every screen subscribes to through `useSyncExternalStore`, written to AsyncStorage (localStorage on Expo web) and read back once at startup (`_layout.tsx` waits for the read before the first screen fetches). 1W chosen on Running is what Activities opens with, today and after a cold start. A choice made before the stored value arrives wins.
- Overview gets the selector under the subtitle, like web; the range now drives weight and body composition, VO2max, the activity calendar, recent activity, breakdown, gym frequency and last gym session (weight was pinned to 90 days, activities to 180).
- Workouts: the selector moves to the top under the subtitle, like web and the other four screens.
- Sleep: the `/api/stats/*` clamp is gone now that the route takes the web keys.
- Selector chips carry `testID=range-<key>` and `accessibilityState.selected` so Maestro can assert them.

**Web API (used by the app; web pages compute server-side and are unchanged)**
- `workouts/summary`, `workouts/insights`, `workouts/bodymap`, `activities/deep`, `activities/summary`, `stats/[metric]` parse every range through `parseRangeDays`. Before: 1W, 3M and 3Y all returned the same 19 workouts (90-day fallback) and 1W = 3Y = 39 activities (365-day fallback). After, on the branch server: 2 / 19 / 239 workouts and 3 / 84 activities; `stats/sleep?range=2y` 200, `range=bogus` still 400.

**Verification**
- `universal/.maestro/verify-range.yaml` through `verify-device.sh`: tap 1W on Running → headline `last 1W`; cold restart → still `last 1W`; Activities opens with the 1W chip selected; back to 6M with the live marker. Release APK built from this branch against the working-tree server so the API changes were exercised on the device before merge.
- tsc + vitest green in `universal` (37) and `web` (378); new `time-range.test.ts` covers the store (persist, hydrate once, garbage ignored, pre-hydration choice wins).

Closes #754
