### PR TITLE
feat(app): labelled reference lines and expand on every chart web has them on

### DIFF
--- a/universal/.maestro/verify-chart-fidelity.yaml
+++ b/universal/.maestro/verify-chart-fidelity.yaml
@@ -1,0 +1,54 @@
+# Soma verify flow: chart fidelity (soma#756, S2 of #578).
+# Proves on a device that (1) a chart's ⤢ expand opens the taller copy in a modal,
+# (2) reference-line labels render (the 10K steps goal in the Steps detail modal).
+# Run via universal/scripts/verify-device.sh running --flow .maestro/verify-chart-fidelity.yaml --marker "last 6M"
+appId: dev.gkos.soma
+name: Soma verify chart fidelity
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "expand-cadence-stride"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "expand-cadence-stride"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Cadence & stride · expanded.*"
+    timeout: 10000
+- takeScreenshot: verify-chart-expand-cadence
+- back
+- openLink: universal://overview
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "STEPS"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+    centerElement: true
+- tapOn:
+    text: "STEPS"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*10K goal.*"
+    timeout: 20000
+- takeScreenshot: verify-chart-steps-goal
+- back
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 5000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -185,7 +185,8 @@ export default function OverviewScreen() {
     { values: wVals, color: "#b17850", width: 2.2, label: "Weight" },
     ...(hasBf ? [{ values: bfVals, color: "#77c8d1", width: 1.6, dashed: true, axis: "right" as const, label: "Body fat" }] : []),
   ];
-  const bodyCompChart = { series: bodyCompSeries, labels: wLabels, yFormat: (v: number) => v.toFixed(1), yFormatRight: (v: number) => `${v.toFixed(0)}%` };
+  const wAvg = wSeries.length ? wSeries.reduce((a, b) => a + b, 0) / wSeries.length : null;
+  const bodyCompChart = { series: bodyCompSeries, labels: wLabels, yFormat: (v: number) => v.toFixed(1), yFormatRight: (v: number) => `${v.toFixed(0)}%`, refLine: wAvg != null ? { y: wAvg, color: "#b17850", label: `avg ${wAvg.toFixed(1)} kg` } : undefined };
 
   // Sleep glance: latest night's score + 7-day series
   const sleepSeries = (sleep?.current ?? []).map((p) => Number(p.value)).filter((v) => isFinite(v));
@@ -367,7 +368,7 @@ export default function OverviewScreen() {
                   kg{bfLatest != null ? ` · ${bfLatest.toFixed(1)}% bf` : ""}{wDelta != null ? ` · ${wDelta >= 0 ? "+" : ""}${wDelta.toFixed(1)} kg/${rangeLabel(range)}` : ""}
                 </Text>
               </View>
-              <LineChart height={130} interactive xTicks={4} labels={wLabels} yFormat={bodyCompChart.yFormat} yFormatRight={bodyCompChart.yFormatRight} series={bodyCompSeries} />
+              <LineChart height={130} interactive xTicks={4} labels={wLabels} yFormat={bodyCompChart.yFormat} yFormatRight={bodyCompChart.yFormatRight} refLine={bodyCompChart.refLine} series={bodyCompSeries} />
             </ExpandableChart>
             {hasBf ? <ChartLegend items={[{ color: "#b17850", label: "Weight (kg)" }, { color: "#77c8d1", label: "Body fat (%)", dashed: true }]} /> : null}
           </Card>

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -5,7 +5,7 @@ import { TimeRangeSelector } from "../../components/time-range-selector";
 import { useRangePref } from "../../lib/time-range";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { TrendArrow } from "../../components/trend-arrow";
-import { LineChart, ChartLegend } from "../../components/line-chart";
+import { LineChart, ChartLegend, ExpandableChart } from "../../components/line-chart";
 import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule, useWeekdayWeekend } from "../../lib/api";
 import { freshness, staleShort, todayKey } from "../../lib/freshness";
 import { SleepDashboard } from "../../components/sleep-dashboard";
@@ -326,9 +326,9 @@ export default function SleepScreen() {
               yMax={100}
               yFormat={(v) => String(Math.round(v))}
               refLines={[
-                { y: 25, color: "#6ad4a0" },
-                { y: 50, color: "#e0c458" },
-                { y: 75, color: "#e06060" },
+                { y: 25, color: "#6ad4a0", label: "low" },
+                { y: 50, color: "#e0c458", label: "med" },
+                { y: 75, color: "#e06060", label: "high" },
               ]}
               series={[
                 { values: stress!.current.map((p) => finiteOrNull(p.value2)), color: "#e06060", dashed: true, width: 1.5, label: "Peak" },
@@ -341,22 +341,23 @@ export default function SleepScreen() {
 
         {(battery?.current?.length ?? 0) >= 2 ? (
           <Card className="gap-2">
-            <View className="flex-row items-center justify-between">
-              <Text variant="eyebrow">Body Battery</Text>
-              <Text variant="micro" className="text-text-muted">charged + drained</Text>
-            </View>
-            <LineChart
-              height={130}
-              interactive
-              labels={battery!.current.map((p) => chartLabel(p.date))}
-              xTicks={4}
-              yFormat={(v) => String(Math.round(v))}
-              yMin={0}
-              series={[
-                { values: battery!.current.map((p) => finiteOrNull(p.value2)), color: "#e06060", width: 1.5, dashed: true, label: "Drained" },
-                { values: battery!.current.map((p) => finiteOrNull(p.value)), color: "#cbe896", width: 2.2, label: "Charged" },
-              ]}
-            />
+            {(() => {
+              const bbChart = {
+                labels: battery!.current.map((p) => chartLabel(p.date)),
+                xTicks: 4,
+                yFormat: (v: number) => String(Math.round(v)),
+                yMin: 0,
+                series: [
+                  { values: battery!.current.map((p) => finiteOrNull(p.value2)), color: "#e06060", width: 1.5, dashed: true, label: "Drained" },
+                  { values: battery!.current.map((p) => finiteOrNull(p.value)), color: "#cbe896", width: 2.2, label: "Charged" },
+                ],
+              };
+              return (
+                <ExpandableChart title="Body Battery" chart={bbChart}>
+                  <LineChart height={130} interactive {...bbChart} />
+                </ExpandableChart>
+              );
+            })()}
             <ChartLegend items={[{ color: "#cbe896", label: "Charged" }, { color: "#e06060", label: "Drained", dashed: true }]} />
           </Card>
         ) : null}
@@ -445,16 +446,17 @@ export default function SleepScreen() {
             {durVals.length >= 2 ? (
               <LineChart
                 height={140}
+                interactive
                 labels={durLabels}
                 yFormat={(v) => `${v.toFixed(1)}h`}
-                refLine={{ y: 7, color: "#6ad4a0" }}
+                refLines={[{ y: 7, color: "#6ad4a0", label: "7h min" }, { y: 9, color: "#77c8d1", label: "9h target" }]}
                 series={[{ values: durSeries, color: "#8b9df0", width: 2.2 }]}
               />
             ) : (
               <Text variant="micro">No sleep data in this range.</Text>
             )}
             <Text variant="micro">
-              Dashed line = 7h target. Showing last {durVals.length} nights.
+              Dashed lines = 7h minimum · 9h target. Showing last {durVals.length} nights.
             </Text>
           </Card>
         </Pressable>

--- a/universal/src/components/activities-deep.tsx
+++ b/universal/src/components/activities-deep.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { View, Pressable, TextInput } from "react-native";
 import Svg, { Circle, Polyline } from "react-native-svg";
+import { ExpandableChart } from "./line-chart";
 import { Text, Card } from "soma-style";
 import type { ActivitiesDeep, ActivityRow, KiteSession } from "../lib/api";
 import { ActivityDetailModal } from "./activity-detail-modal";
@@ -46,24 +47,28 @@ export function ActivitiesMonthly({ monthly }: { monthly: ActivitiesDeep["monthl
   const max = Math.max(...totals) || 1;
   const sports = [...new Set(data.flatMap((m) => Object.keys(m.sports)))];
 
+  const bars = (height: number) => (
+    <View className="flex-row items-end gap-1" style={{ height }}>
+      {data.map((m, i) => {
+        const total = totals[i];
+        return (
+          <View key={m.month} className="flex-1 items-center justify-end self-stretch gap-0.5">
+            <View className="w-full overflow-hidden rounded-t-sm" style={{ height: `${Math.max(3, (total / max) * 100)}%` }}>
+              {Object.entries(m.sports).map(([s, c]) => (
+                <View key={s} style={{ height: `${(c / total) * 100}%`, backgroundColor: sportColor(s) }} />
+              ))}
+            </View>
+            <Text variant="micro" className="text-text-muted" style={{ fontSize: 8 }}>{i % labelStep === 0 || i === data.length - 1 ? shortMonth(m.month) : ""}</Text>
+          </View>
+        );
+      })}
+    </View>
+  );
   return (
     <Card className="gap-2">
-      <Text variant="eyebrow">Monthly activity</Text>
-      <View className="h-28 flex-row items-end gap-1">
-        {data.map((m, i) => {
-          const total = totals[i];
-          return (
-            <View key={m.month} className="flex-1 items-center justify-end self-stretch gap-0.5">
-              <View className="w-full overflow-hidden rounded-t-sm" style={{ height: `${Math.max(3, (total / max) * 100)}%` }}>
-                {Object.entries(m.sports).map(([s, c]) => (
-                  <View key={s} style={{ height: `${(c / total) * 100}%`, backgroundColor: sportColor(s) }} />
-                ))}
-              </View>
-              <Text variant="micro" className="text-text-muted" style={{ fontSize: 8 }}>{i % labelStep === 0 || i === data.length - 1 ? shortMonth(m.month) : ""}</Text>
-            </View>
-          );
-        })}
-      </View>
+      <ExpandableChart title="Monthly activity" renderExpanded={() => bars(240)}>
+        {bars(112)}
+      </ExpandableChart>
       <View className="flex-row flex-wrap gap-x-3 gap-y-1">
         {sports.map((s) => (
           <View key={s} className="flex-row items-center gap-1">
@@ -101,7 +106,17 @@ export function KiteDeepDive({ sessions }: { sessions: KiteSession[] }) {
   const minS = Math.min(...speeds), maxS = Math.max(...speeds), rS = maxS - minS || 1;
   const H = 90;
   const x = (i: number) => (i / Math.max(1, speeds.length - 1)) * 96 + 2;
-  const y = (v: number) => H - ((v - minS) / rS) * (H - 10) - 5;
+  const speedSvg = (h: number) => {
+    const y = (v: number) => h - ((v - minS) / rS) * (h - 10) - 5;
+    return (
+      <Svg width="100%" height={h} viewBox={`0 0 100 ${h}`} preserveAspectRatio="none">
+        <Polyline points={ma.map((v, i) => `${x(i)},${y(v)}`).join(" ")} fill="none" stroke="#22d3ee" strokeWidth={1.4} opacity={0.9} />
+        {speeds.map((v, i) => (
+          <Circle key={i} cx={x(i)} cy={y(v)} r={2} fill="#22d3ee" fillOpacity={0.5} />
+        ))}
+      </Svg>
+    );
+  };
 
   return (
     <Card className="gap-3">
@@ -112,12 +127,9 @@ export function KiteDeepDive({ sessions }: { sessions: KiteSession[] }) {
 
       {speeds.length >= 3 ? (
         <View className="gap-1">
-          <Svg width="100%" height={H} viewBox={`0 0 100 ${H}`} preserveAspectRatio="none">
-            <Polyline points={ma.map((v, i) => `${x(i)},${y(v)}`).join(" ")} fill="none" stroke="#22d3ee" strokeWidth={1.4} opacity={0.9} />
-            {speeds.map((v, i) => (
-              <Circle key={i} cx={x(i)} cy={y(v)} r={2} fill="#22d3ee" fillOpacity={0.5} />
-            ))}
-          </Svg>
+          <ExpandableChart title="Max speed progression" renderExpanded={() => speedSvg(240)}>
+            {speedSvg(H)}
+          </ExpandableChart>
           <Text variant="micro" className="text-text-muted">max speed per session · line = moving avg</Text>
         </View>
       ) : null}

--- a/universal/src/components/activity-content.tsx
+++ b/universal/src/components/activity-content.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { View, Pressable, ScrollView } from "react-native";
 import { Text, Card } from "soma-style";
 import type { ActivityRow, MonthSports } from "../lib/api";
-import { LineChart } from "./line-chart";
+import { LineChart, ExpandableChart, ChartLegend } from "./line-chart";
 
 const SPORT_META: Record<string, { color: string; emoji: string; label: string }> = {
   running: { color: "#77c8d1", emoji: "🏃", label: "Run" },
@@ -199,11 +199,24 @@ export function GymFrequency({ activities }: { activities: ActivityRow[] }) {
     return { weeks: w, labels: l };
   }, [activities]);
   if (weeks.every((v) => v === 0)) return null;
+  // Web's expanded gym-frequency dialog draws a moving average over the bars; a
+  // 4-week window is the weekly-series equivalent of its 3-month line (soma#756).
+  const ma = weeks.map((_, i) => { const from = Math.max(0, i - 3); const slice = weeks.slice(from, i + 1); return slice.reduce((a, b) => a + b, 0) / slice.length; });
+  const chart = {
+    labels,
+    xTicks: 4,
+    yFormat: (v: number) => String(Math.round(v)),
+    series: [
+      { values: weeks, color: "#e0a458", width: 2.2, label: "Sessions" },
+      { values: ma, color: "#5a7a8a", width: 1.4, dashed: true, label: "4-wk avg" },
+    ],
+  };
   return (
     <Card className="gap-2">
-      <Text variant="eyebrow">Gym frequency</Text>
-      <LineChart height={110} series={[{ values: weeks, color: "#e0a458", width: 2.2 }]} labels={labels} yFormat={(v) => String(Math.round(v))} />
-      <Text variant="micro" className="text-text-muted">sessions / week · last 12 weeks</Text>
+      <ExpandableChart title="Gym frequency" chart={chart}>
+        <LineChart height={110} interactive {...chart} />
+      </ExpandableChart>
+      <ChartLegend items={[{ color: "#e0a458", label: "sessions / week · last 12 weeks" }, { color: "#5a7a8a", label: "4-wk avg", dashed: true }]} />
     </Card>
   );
 }

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -1,6 +1,6 @@
-import { useState, type ReactNode } from "react";
-import { View, type LayoutChangeEvent, type GestureResponderEvent } from "react-native";
-import Svg, { Polyline, Line, Circle, Rect } from "react-native-svg";
+import { Fragment, useState, type ReactNode } from "react";
+import { View, Pressable, type LayoutChangeEvent, type GestureResponderEvent } from "react-native";
+import Svg, { Polyline, Line, Circle, Rect, Text as SvgText } from "react-native-svg";
 import { Text, Modal } from "soma-style";
 
 /**
@@ -29,8 +29,9 @@ export interface LineChartProps {
   yFormat?: (v: number) => string;
   /** Format a right-axis y value (dual-axis). */
   yFormatRight?: (v: number) => string;
-  refLine?: { y: number; color?: string };
-  refLines?: { y: number; color?: string; dashed?: boolean }[];
+  /** A dashed horizontal reference (goal / average / threshold). `label` is drawn at the right edge, like web's ReferenceLine labels (soma#756). */
+  refLine?: { y: number; color?: string; label?: string };
+  refLines?: { y: number; color?: string; dashed?: boolean; label?: string }[];
   /** Translucent horizontal zones (e.g. Ready ≥70 / Moderate 40–70 bands). */
   refAreas?: { y1: number; y2: number; color: string; opacity?: number }[];
   yMin?: number;
@@ -108,6 +109,9 @@ export function LineChart(props: LineChartProps) {
     setActive(i);
   };
   const onLayout = (e: LayoutChangeEvent) => setPlotW(e.nativeEvent.layout.width);
+  // SVG text is invisible to the accessibility tree; expose the reference labels so a
+  // screen reader (and the Maestro device flow) can read "10K goal", "avg 52", … (soma#756).
+  const refLabels = [...(refLine ? [refLine] : []), ...(refLines ?? [])].map((r) => r.label).filter((l): l is string => !!l);
 
   // Active-point callout data
   const callout = active != null
@@ -133,6 +137,8 @@ export function LineChart(props: LineChartProps) {
         <View
           className="flex-1"
           onLayout={onLayout}
+          accessible={refLabels.length > 0}
+          accessibilityLabel={refLabels.length ? `reference lines: ${refLabels.join(", ")}` : undefined}
           onStartShouldSetResponder={() => !!interactive}
           onMoveShouldSetResponder={() => !!interactive}
           onResponderGrant={onTouch}
@@ -158,6 +164,22 @@ export function LineChart(props: LineChartProps) {
                 <Line key={`rl-${ri}`} x1={0} y1={yAtL(r.y)} x2={VBW} y2={yAtL(r.y)} stroke={r.color ?? "#3a5563"} strokeWidth={1} strokeDasharray={r.dashed === false ? undefined : "4 4"} />
               ) : null,
             )}
+            {/* reference-line labels (web parity: "10K goal", "avg 52", "180 spm" …) */}
+            {[...(refLine ? [refLine] : []), ...(refLines ?? [])].map((r, ri) => {
+              if (!r.label || r.y < loL || r.y > hiL) return null;
+              // Sit above the line, or just below it when the line hugs the top edge; keep
+              // clear of the right-axis labels on dual-axis charts by using the left edge.
+              const ly = yAtL(r.y);
+              const ty = ly < 14 ? ly + 10 : ly - 3;
+              const tw = r.label.length * 4.4 + 4;
+              const atRight = rightS.length === 0;
+              return (
+                <Fragment key={`rt-${ri}`}>
+                  <Rect x={atRight ? VBW - 2 - tw : 2} y={ty - 8} width={tw} height={10} rx={2} fill="#0c1519" fillOpacity={0.8} />
+                  <SvgText x={atRight ? VBW - 4 : 4} y={ty} fontSize={8} fill={r.color ?? "#3a5563"} textAnchor={atRight ? "end" : "start"} opacity={0.95}>{r.label}</SvgText>
+                </Fragment>
+              );
+            })}
             {series.map((s, si) => {
               if (s.mode === "dots") {
                 return s.values.map((v, i) =>
@@ -253,27 +275,38 @@ export function ChartLegend({ items }: { items: { color: string; label: string; 
 }
 
 /** Wraps a chart card with a maximize affordance that opens the same chart,
- *  taller + interactive, in a Modal. Pass the inline chart as children and the
- *  LineChart props to render big in the modal. */
+ *  taller + interactive, in a Modal (web's ExpandableChartCard). Pass the inline
+ *  chart as children and either the LineChart props to render big, or
+ *  `renderExpanded` for bespoke bar/SVG charts (soma#756). */
 export function ExpandableChart({
   title,
   children,
   chart,
+  renderExpanded,
+  testID,
 }: {
   title: string;
   children: ReactNode;
-  chart: LineChartProps;
+  chart?: LineChartProps;
+  renderExpanded?: () => ReactNode;
+  testID?: string;
 }) {
   const [open, setOpen] = useState(false);
+  const id = testID ?? `expand-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
   return (
     <View>
       <View className="flex-row items-center justify-between">
         <Text variant="eyebrow">{title}</Text>
-        <Text variant="micro" className="text-teal" onPress={() => setOpen(true)}>⤢ expand</Text>
+        <Pressable onPress={() => setOpen(true)} hitSlop={8} accessibilityRole="button" accessibilityLabel={`Expand ${title}`} testID={id}>
+          <Text variant="micro" className="text-teal">⤢ expand</Text>
+        </Pressable>
       </View>
       {children}
       <Modal visible={open} onClose={() => setOpen(false)} title={title}>
-        <LineChart {...chart} height={300} interactive xTicks={chart.xTicks ?? 4} />
+        <View className="gap-2" testID="expanded-chart">
+          {renderExpanded ? renderExpanded() : chart ? <LineChart {...chart} height={300} interactive xTicks={chart.xTicks ?? 4} /> : null}
+          <Text variant="micro" className="text-text-muted text-center">{title} · expanded</Text>
+        </View>
       </Modal>
     </View>
   );

--- a/universal/src/components/running-deep-trends.tsx
+++ b/universal/src/components/running-deep-trends.tsx
@@ -2,7 +2,7 @@ import { View } from "react-native";
 import Svg, { Polyline } from "react-native-svg";
 import { Text, Card, Badge } from "soma-style";
 import type { RunningTrends } from "../lib/api";
-import { LineChart, ChartLegend } from "./line-chart";
+import { LineChart, ChartLegend, ExpandableChart } from "./line-chart";
 
 /** Two lines on a shared y-scale (acute vs chronic load). */
 function DualLine({ a, b, colorA, colorB, height = 44 }: { a: number[]; b: number[]; colorA: string; colorB: string; height?: number }) {
@@ -45,6 +45,15 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
   const cadSeries = cad.map((p) => (p.cadence != null && isFinite(Number(p.cadence)) ? Number(p.cadence) : null));
   const strideSeries = cad.map((p) => (p.stride != null && isFinite(Number(p.stride)) ? Number(p.stride) : null));
   const hasStride = strideSeries.filter((v) => v != null).length >= 2;
+  const cadChart = {
+    yFormat: (v: number) => String(Math.round(v)),
+    yFormatRight: (v: number) => `${Math.round(v)}cm`,
+    refLine: { y: 180, color: "#77c8d1", label: "180 spm" },
+    series: [
+      { values: cadSeries, color: "#cbe896", width: 2.2, label: "Cadence" },
+      ...(hasStride ? [{ values: strideSeries, color: "#8b9df0", width: 1.8, axis: "right" as const, label: "Stride" }] : []),
+    ],
+  };
 
   return (
     <View className="gap-4">
@@ -79,12 +88,13 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
               <Text variant="micro" className="text-text-muted">ACWR ratio · sweet spot 0.8–1.3</Text>
               <LineChart
                 height={110}
+                interactive
                 yFormat={(v) => v.toFixed(2)}
                 series={[{ values: acwrSeries, color: "#77c8d1", width: 2 }]}
                 refLines={[
-                  { y: 0.8, color: "#6ad4a0" },
-                  { y: 1.3, color: "#e0c458" },
-                  { y: 1.5, color: "#e06060" },
+                  { y: 0.8, color: "#6ad4a0", label: "0.8" },
+                  { y: 1.3, color: "#e0c458", label: "1.3" },
+                  { y: 1.5, color: "#e06060", label: "1.5 high" },
                 ]}
               />
               <ChartLegend items={[{ color: "#6ad4a0", label: "0.8", dashed: true }, { color: "#e0c458", label: "1.3", dashed: true }, { color: "#e06060", label: "1.5 high", dashed: true }]} />
@@ -95,25 +105,13 @@ export function RunningDeepTrends({ trends }: { trends: RunningTrends | null | u
 
       {cadLast && cadSeries.length >= 2 ? (
         <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Cadence &amp; stride</Text>
-            <Text variant="micro" className="tabular-nums text-text-muted">{cadLast.stride != null ? `stride ${cadLast.stride} cm` : ""}</Text>
-          </View>
-          <View className="flex-row items-end gap-2">
-            <Text variant="display" className="text-lime">{cadLast.cadence}</Text>
-            <Text variant="caption" className="text-text-muted mb-1">spm</Text>
-          </View>
-          <LineChart
-            height={120}
-            interactive
-            yFormat={(v) => String(Math.round(v))}
-            yFormatRight={(v) => `${Math.round(v)}cm`}
-            refLine={{ y: 180, color: "#77c8d1" }}
-            series={[
-              { values: cadSeries, color: "#cbe896", width: 2.2, label: "Cadence" },
-              ...(hasStride ? [{ values: strideSeries, color: "#8b9df0", width: 1.8, axis: "right" as const, label: "Stride" }] : []),
-            ]}
-          />
+          <ExpandableChart title="Cadence & stride" chart={cadChart}>
+            <View className="flex-row items-end gap-2">
+              <Text variant="display" className="text-lime">{cadLast.cadence}</Text>
+              <Text variant="caption" className="text-text-muted mb-1">spm{cadLast.stride != null ? ` · stride ${cadLast.stride} cm` : ""}</Text>
+            </View>
+            <LineChart height={120} interactive {...cadChart} />
+          </ExpandableChart>
           {hasStride ? (
             <ChartLegend items={[{ color: "#cbe896", label: "Cadence spm (L)" }, { color: "#8b9df0", label: "Stride cm (R)" }, { color: "#77c8d1", label: "180 target", dashed: true }]} />
           ) : (

--- a/universal/src/components/running-mileage.tsx
+++ b/universal/src/components/running-mileage.tsx
@@ -1,5 +1,6 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
+import { ExpandableChart } from "./line-chart";
 
 interface MileageMonth { month: string; km: number; runs: number }
 
@@ -11,7 +12,24 @@ function monthLabel(ym: string): string {
 
 /** Monthly mileage bar chart (last N months), peak month highlighted. When the
     dated detail is available each bar is labelled with its month + run count
-    (web parity); otherwise it falls back to the value-only series. */
+    (web parity); otherwise it falls back to the value-only series. Expands
+    into a taller copy like web's ExpandableChartCard (soma#756). */
+function MileageBars({ values, maxIdx, height }: { values: number[]; maxIdx: number; height: number }) {
+  const max = Math.max(...values) || 1;
+  return (
+    <View className="flex-row items-end gap-1" style={{ height }}>
+      {values.map((m, i) => (
+        <View key={i} className="flex-1 items-center justify-end self-stretch">
+          <View
+            className="w-full rounded-t-sm"
+            style={{ height: `${Math.max(3, (m / max) * 100)}%`, backgroundColor: i === maxIdx ? "#77c8d1" : "#2f4a58" }}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+
 export function RunningMileage({ mileage, months }: { mileage?: number[] | null; months?: MileageMonth[] | null }) {
   const detail = (months ?? []).filter((m) => isFinite(m.km));
   const useDetail = detail.length >= 2;
@@ -20,36 +38,26 @@ export function RunningMileage({ mileage, months }: { mileage?: number[] | null;
   const max = Math.max(...values) || 1;
   const maxIdx = values.indexOf(max);
   const total = values.reduce((a, b) => a + b, 0);
+  const labelsRow = useDetail ? (
+    <View className="flex-row gap-1">
+      {detail.map((m, i) => (
+        <View key={i} className="flex-1 items-center">
+          <Text variant="micro" className="text-text-muted">{monthLabel(m.month)}</Text>
+          <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(m.km)}·{m.runs}</Text>
+        </View>
+      ))}
+    </View>
+  ) : null;
 
   return (
     <Card className="gap-2">
-      <View className="flex-row items-center justify-between">
-        <Text variant="eyebrow">Monthly mileage</Text>
-        <Text variant="micro" className="text-text-muted">last {values.length} mo</Text>
-      </View>
-      <View className="h-24 flex-row items-end gap-1">
-        {values.map((m, i) => (
-          <View key={i} className="flex-1 items-center justify-end self-stretch">
-            <View
-              className="w-full rounded-t-sm"
-              style={{ height: `${Math.max(3, (m / max) * 100)}%`, backgroundColor: i === maxIdx ? "#77c8d1" : "#2f4a58" }}
-            />
-          </View>
-        ))}
-      </View>
-      {useDetail ? (
-        <View className="flex-row gap-1">
-          {detail.map((m, i) => (
-            <View key={i} className="flex-1 items-center">
-              <Text variant="micro" className="text-text-muted">{monthLabel(m.month)}</Text>
-              <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(m.km)}·{m.runs}</Text>
-            </View>
-          ))}
-        </View>
-      ) : null}
+      <ExpandableChart title="Monthly mileage" renderExpanded={() => <View className="gap-2"><MileageBars values={values} maxIdx={maxIdx} height={220} />{labelsRow}</View>}>
+        <MileageBars values={values} maxIdx={maxIdx} height={96} />
+      </ExpandableChart>
+      {labelsRow}
       <View className="flex-row justify-between">
         <Text variant="micro" className="text-text-muted">
-          peak {Math.round(max)} km{useDetail ? ` · ${MONTHS.length && detail[maxIdx] ? monthLabel(detail[maxIdx].month) : ""}` : ""}
+          peak {Math.round(max)} km{useDetail ? ` · ${MONTHS.length && detail[maxIdx] ? monthLabel(detail[maxIdx].month) : ""}` : ""} · last {values.length} mo
         </Text>
         <Text variant="micro" className="tabular-nums text-text-muted">
           {Math.round(total)} km{useDetail ? ` · ${detail.reduce((a, b) => a + b.runs, 0)} runs` : " total"}

--- a/universal/src/components/sleep-dashboard.tsx
+++ b/universal/src/components/sleep-dashboard.tsx
@@ -44,12 +44,24 @@ function StageBar({ n, height = 14 }: { n: SleepNight; height?: number }) {
 }
 
 /** Per-night stacked stage columns (last N nights), heights scaled to max total. */
-function StagesTrend({ nights }: { nights: SleepNight[] }) {
+/** Stacked stage bars per night with web's 7h-min / 9h-target guide lines (soma#756). */
+const SLEEP_GUIDES = [{ h: 7, label: "7h min", color: "#77c8d1" }, { h: 9, label: "9h target", color: "#6ad4a0" }];
+function StagesTrend({ nights, height = 112 }: { nights: SleepNight[]; height?: number }) {
   const data = nights.filter((n) => (n.total ?? 0) > 0).slice(-30);
   if (data.length < 2) return null;
-  const maxTotal = Math.max(...data.map((n) => n.total ?? 0)) || 1;
+  // Keep the 9h target inside the plot even on short-sleep months.
+  const maxTotal = Math.max(...data.map((n) => n.total ?? 0), 9 * 3600) || 1;
   return (
-    <View className="h-28 flex-row items-end gap-0.5">
+    <View style={{ height }}>
+      {SLEEP_GUIDES.map((g) => {
+        const pct = ((g.h * 3600) / maxTotal) * 100;
+        return pct > 0 && pct < 100 ? (
+          <View key={g.label} pointerEvents="none" className="absolute left-0 right-0 items-end" style={{ bottom: `${pct}%`, borderTopWidth: 1, borderColor: g.color, borderStyle: "dashed", opacity: 0.85, zIndex: 1 }}>
+            <Text variant="micro" style={{ color: g.color, fontSize: 8, lineHeight: 10, marginTop: -11 }}>{g.label}</Text>
+          </View>
+        ) : null;
+      })}
+    <View className="absolute inset-0 flex-row items-end gap-0.5">
       {data.map((n, i) => {
         const total = n.total ?? 0;
         const colH = (total / maxTotal) * 100;
@@ -67,6 +79,7 @@ function StagesTrend({ nights }: { nights: SleepNight[] }) {
           </View>
         );
       })}
+    </View>
     </View>
   );
 }
@@ -121,12 +134,13 @@ export function SleepDashboard({ summary }: { summary: SleepSummary | null | und
       ) : null}
 
       <Card className="gap-2">
+        <ExpandableChart title="Sleep stages" renderExpanded={() => <View className="gap-2"><StagesTrend nights={summary.trend} height={240} /><Legend /></View>}>
+          <StagesTrend nights={summary.trend} />
+        </ExpandableChart>
         <View className="flex-row items-center justify-between">
-          <Text variant="eyebrow">Sleep stages</Text>
+          <Legend />
           <Text variant="micro" className="text-text-muted">last {Math.min(30, summary.trend.length)} nights</Text>
         </View>
-        <StagesTrend nights={summary.trend} />
-        <Legend />
       </Card>
 
       {scoreCount >= 2 ? (

--- a/universal/src/components/sleep-schedule-chart.tsx
+++ b/universal/src/components/sleep-schedule-chart.tsx
@@ -54,6 +54,7 @@ export function SleepScheduleChart({ schedule }: { schedule: SchedulePoint[] | u
       </View>
       <LineChart
         height={150}
+        interactive
         labels={labels}
         yFormat={(v) => fmtHour(v)}
         series={[

--- a/universal/src/components/stat-detail-modal.tsx
+++ b/universal/src/components/stat-detail-modal.tsx
@@ -35,6 +35,20 @@ interface StatSeries {
   summary: { current_avg: number | null; current_min: number | null; current_max: number | null; previous_avg: number | null };
 }
 type Range = "7d" | "30d" | "90d" | "1y";
+type RefLine = { y: number; color?: string; dashed?: boolean; label?: string };
+/** Web's stat dialogs draw goal / threshold / average reference lines; mirror them
+ *  per metric (soma#756): 10K steps goal, stress low/med/high, BMR on calories,
+ *  7h/9h on sleep, otherwise the period average. */
+function refLinesFor(metric: string | undefined, avg: number | null | undefined, secondaryAvg: number | null): RefLine[] {
+  switch (metric) {
+    case "steps": return [{ y: 10000, color: "#77c8d1", label: "10K goal" }];
+    case "stress": return [{ y: 25, color: "#6ad4a0", label: "low" }, { y: 50, color: "#e0c458", label: "med" }, { y: 75, color: "#e06060", label: "high" }];
+    case "calories": return secondaryAvg != null && isFinite(secondaryAvg) ? [{ y: secondaryAvg, color: "#e0a458", label: `BMR ~${Math.round(secondaryAvg)}` }] : [];
+    case "sleep": return [{ y: 7, color: "#77c8d1", label: "7h min" }, { y: 9, color: "#6ad4a0", label: "9h target" }];
+    default: return avg != null && isFinite(avg) ? [{ y: avg, color: "#5a7a8a", label: `avg ${Math.round(avg).toLocaleString()}` }] : [];
+  }
+}
+const mean = (xs: (number | null)[]): number | null => { const v = xs.filter((x): x is number => x != null && isFinite(x)); return v.length ? v.reduce((a, b) => a + b, 0) / v.length : null; };
 const RANGES: readonly Range[] = ["7d", "30d", "90d", "1y"] as const;
 
 /** Detail dialog for a stat card. With `metric`, fetches the real trend for a
@@ -85,6 +99,7 @@ export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; on
                 labels={labels}
                 xTicks={4}
                 yFormat={(v) => `${Math.round(v).toLocaleString()}`}
+                refLine={avg != null ? { y: avg, color: "#5a7a8a", label: "avg" } : undefined}
                 series={dots
                   ? [{ values: vals, color: stat.color, mode: "dots" as const, width: 3 }]
                   : [{ values: vals, color: stat.color, width: 2.2 }]}
@@ -131,6 +146,7 @@ export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; on
                 labels={labels}
                 xTicks={4}
                 yFormat={(v) => `${Math.round(v).toLocaleString()}`}
+                refLines={refLinesFor(stat.metric, sm?.current_avg, hasTwo ? mean(cur2) : null)}
                 series={hasTwo ? [
                   { values: cur, color: stat.color, width: 2.2, label: two!.primary },
                   { values: cur2, color: two!.color, width: 1.6, dashed: true, label: two!.secondary },
@@ -178,7 +194,7 @@ export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; on
         {s.length >= 2 ? (
           <View className="gap-1">
             <Text variant="eyebrow" className="text-text-muted">Trend · last {s.length} days</Text>
-            <LineChart height={160} interactive series={[{ values: s, color: stat.color, width: 2.2 }]} yFormat={(v) => `${Math.round(v).toLocaleString()}`} />
+            <LineChart height={160} interactive refLine={avg != null ? { y: avg, color: "#5a7a8a", label: `avg ${Math.round(avg).toLocaleString()}` } : undefined} series={[{ values: s, color: stat.color, width: 2.2 }]} yFormat={(v) => `${Math.round(v).toLocaleString()}`} />
             <View className="mt-1 flex-row justify-between">
               <Text variant="micro" className="text-text-muted tabular-nums">min {fmt(min)}</Text>
               <Text variant="micro" className="text-text-muted tabular-nums">avg {fmt(avg)}</Text>

--- a/universal/src/components/workout-activity.tsx
+++ b/universal/src/components/workout-activity.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { View, Pressable } from "react-native";
 import { Text, Card } from "soma-style";
-import { LineChart, ChartLegend } from "./line-chart";
+import { LineChart, ChartLegend, ExpandableChart } from "./line-chart";
 import type { WorkoutInsights } from "../lib/api";
 
 const num = (v: unknown): number => { const n = Number(v); return isFinite(n) ? n : 0; };
@@ -213,21 +213,25 @@ export function WorkoutActivity({ insights }: { insights: WorkoutInsights | null
 
       {hrAvg.filter((v) => v != null).length >= 2 ? (
         <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Avg HR per workout</Text>
-            <Text variant="micro" className="text-text-muted">bpm</Text>
-          </View>
-          <LineChart
-            height={130}
-            interactive
-            xTicks={4}
-            labels={hrLabels}
-            yFormat={(v) => String(Math.round(v))}
-            series={[
-              { values: hrMax, color: "#e06060", dashed: true, width: 1.5, label: "Max" },
-              { values: hrAvg, color: "#e0a458", width: 2.2, label: "Avg" },
-            ]}
-          />
+          {(() => {
+            const nn = hrAvg.filter((v): v is number => v != null);
+            const hrMean = nn.reduce((a, b) => a + b, 0) / nn.length;
+            const hrChart = {
+              xTicks: 4,
+              labels: hrLabels,
+              yFormat: (v: number) => String(Math.round(v)),
+              refLine: { y: hrMean, color: "#5a7a8a", label: `avg ${Math.round(hrMean)}` },
+              series: [
+                { values: hrMax, color: "#e06060", dashed: true, width: 1.5, label: "Max" },
+                { values: hrAvg, color: "#e0a458", width: 2.2, label: "Avg" },
+              ],
+            };
+            return (
+              <ExpandableChart title="Avg HR per workout" chart={hrChart}>
+                <LineChart height={130} interactive {...hrChart} />
+              </ExpandableChart>
+            );
+          })()}
           <ChartLegend items={[{ color: "#e0a458", label: "avg" }, { color: "#e06060", label: "max", dashed: true }]} />
         </Card>
       ) : null}

--- a/universal/src/components/workout-strength.tsx
+++ b/universal/src/components/workout-strength.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { View, Pressable, ScrollView } from "react-native";
 import { Text, Card } from "soma-style";
-import { LineChart } from "./line-chart";
+import { LineChart, ExpandableChart } from "./line-chart";
 import { fetchJson } from "../lib/api";
 import type { WorkoutInsights } from "../lib/api";
 
@@ -27,10 +27,13 @@ function StrengthProgression({ names, unit }: { names: string[]; unit: "kg" | "l
   }, [sel]);
   if (!names.length) return null;
   const vals = prog.map((p) => (unit === "lb" ? p.maxWeight * KG_TO_LB : p.maxWeight));
+  const chart = { series: [{ values: vals, color: "#cbe896", width: 2.2 }], labels: prog.map((p) => p.date), yFormat: (v: number) => `${Math.round(v)} ${unit}` };
 
   return (
     <Card className="gap-2">
-      <Text variant="eyebrow">Strength progression</Text>
+      <ExpandableChart title="Strength progression" chart={chart}>
+      <View />
+      </ExpandableChart>
       <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-2 pr-2">
         {names.map((n) => (
           <Pressable key={n} onPress={() => setSel(n)} className={`rounded-full px-3 py-1 ${sel === n ? "bg-teal" : "bg-surface-subtle"}`}>
@@ -41,7 +44,7 @@ function StrengthProgression({ names, unit }: { names: string[]; unit: "kg" | "l
       {loading && !vals.length ? (
         <Text variant="micro" className="text-text-muted">Loading…</Text>
       ) : vals.length >= 2 ? (
-        <LineChart height={140} series={[{ values: vals, color: "#cbe896", width: 2.2 }]} yFormat={(v) => `${Math.round(v)} ${unit}`} />
+        <LineChart height={140} interactive xTicks={4} {...chart} />
       ) : (
         <Text variant="micro" className="text-text-muted">Not enough sessions for {sel}.</Text>
       )}

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { View, Pressable } from "react-native";
 import { Text, Card, Sparkline } from "soma-style";
 import type { WorkoutSummary, TopExerciseRich } from "../lib/api";
-import { LineChart } from "./line-chart";
+import { LineChart, ExpandableChart, type LineChartProps } from "./line-chart";
 import { ExerciseDetailModal } from "./exercise-detail-modal";
 import { WorkoutDetailModal } from "./workout-detail-modal";
 
@@ -21,22 +21,20 @@ function kvol(v: number): string {
 }
 
 /** Weekly training-volume as a full trend chart (axes + dated x-labels). */
-function VolumeChart({ weeks }: { weeks: WorkoutSummary["weeklyVolume"] }) {
+/** Weekly volume line with web's average reference line; null when < 2 weeks have volume. */
+function volumeChart(weeks: WorkoutSummary["weeklyVolume"]): LineChartProps | null {
   const recent = weeks.slice(-16);
   const vals = recent.map((w) => num(w.total_volume));
   const nonZero = vals.filter((v) => v > 0);
   if (nonZero.length < 2) return null;
   const labels = recent.map((w) => shortDate(String(w.week)));
   const avg = nonZero.reduce((a, b) => a + b, 0) / nonZero.length;
-  return (
-    <LineChart
-      height={130}
-      labels={labels}
-      yFormat={(v) => kvol(v)}
-      refLine={{ y: avg, color: "#5a7a8a" }}
-      series={[{ values: vals.map((v) => (v > 0 ? v : null)), color: "#77c8d1", width: 2.4 }]}
-    />
-  );
+  return {
+    labels,
+    yFormat: (v: number) => kvol(v),
+    refLine: { y: avg, color: "#5a7a8a", label: `avg ${kvol(avg)}` },
+    series: [{ values: vals.map((v) => (v > 0 ? v : null)), color: "#77c8d1", width: 2.4 }],
+  };
 }
 
 /** Workouts dashboard: summary stats + weekly volume + top exercises (+ optional
@@ -56,6 +54,7 @@ export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", top
       ]
     : [];
   const peakVol = Math.max(0, ...summary.weeklyVolume.map((w) => num(w.total_volume)));
+  const volChart = volumeChart(summary.weeklyVolume);
 
   return (
     <View className="gap-4">
@@ -73,14 +72,12 @@ export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", top
 
       <Text variant="micro" className="text-text-muted">Tap an exercise or workout for detail</Text>
 
-      {summary.weeklyVolume.length >= 2 ? (
+      {volChart ? (
         <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Weekly volume</Text>
-            <Text variant="micro" className="tabular-nums text-text-muted">peak {kvol(peakVol)} kg</Text>
-          </View>
-          <VolumeChart weeks={summary.weeklyVolume} />
-          <Text variant="micro" className="text-text-muted">weight × reps, normal sets</Text>
+          <ExpandableChart title="Weekly volume" chart={volChart}>
+            <LineChart height={130} interactive {...volChart} />
+          </ExpandableChart>
+          <Text variant="micro" className="text-text-muted">weight × reps, normal sets · peak {kvol(peakVol)} kg</Text>
         </Card>
       ) : null}
 


### PR DESCRIPTION
S2 of #578 shipped bands and the shared chart, but a chart-by-chart pass against web (rig from main vs emulator, real account; ledger on #756) found web renders no reference bands on the five screens at all: what the app dropped were web's labelled reference **lines** and the **expand** affordance.

**Shared chart (`line-chart.tsx`)**
- `refLine` / `refLines` take a `label`, drawn at the right edge like Recharts' `ReferenceLine` labels ("10K goal", "avg 52", "180 spm", "7h min", "9h target", "BMR ~2053", low/med/high).
- Reference labels get a dark backing, sit below the line when it hugs the top edge, and move to the left edge on dual-axis charts so they never collide with the right-axis labels. The chart exposes them as an accessibility label (SVG text is invisible to screen readers and to Maestro).
- `ExpandableChart` accepts `renderExpanded` for bespoke bar/SVG charts, exposes `testID=expand-<title>` on the affordance, and stamps the modal with "<title> · expanded" so a device flow can assert it opened.

**Wired**
- Overview: Steps modal carries the 10K goal, Calories the BMR average, Stress low/med/high, every other metric its period average; Body composition gets the average-weight line; Gym frequency gets a 4-week moving average (web's expanded dialog draws a 3-month one over monthly bars), tap-to-read and expand.
- Running: ACWR chart is tap-to-read with labelled 0.8 / 1.3 / 1.5 lines; Cadence & stride expands with the 180 spm label; Monthly mileage expands.
- Sleep: Sleep stages carry web's 7h-min and 9h-target guides and expand; Sleep duration adds the 9h target and tap-to-read; Body Battery expands; Stress lines are labelled; Sleep schedule is tap-to-read.
- Activities: Monthly activity and Max speed progression expand.
- Workouts: Weekly volume expands, is tap-to-read and labels its average; Strength progression expands and is tap-to-read; Avg HR per workout gets the average line and expands.

Documented reductions (unchanged): bespoke bar/SVG charts stay bespoke; the sleep-schedule filled band stays two lines; Shoe Mileage is a whole missing card, not part of S2.

**Verification**
- `universal/.maestro/verify-chart-fidelity.yaml` through `verify-device.sh`: Running → Cadence & stride → expand → modal stamped "Cadence & stride · expanded"; Overview → Steps → "10K goal" label; back on Running the live `last 6M` marker. Plus sleep (`9h target`) and workouts (avg-labelled volume caption) live-marker runs. Release APK built from this branch on the emulator.
- tsc + vitest green in `universal` (37); web untouched.

Closes #756
