### PR TITLE
feat(app): info hints on every stat card, a real overview Sleep card, honest 7-day trends

### DIFF
--- a/universal/.maestro/verify-chart-fidelity.yaml
+++ b/universal/.maestro/verify-chart-fidelity.yaml
@@ -44,9 +44,11 @@ tags:
     timeout: 20000
 - takeScreenshot: verify-chart-steps-goal
 - back
+# Cold open: a warm deep link keeps the previous scroll position and the headline sits off-screen.
+- stopApp
 - openLink: universal://running
 - waitForAnimationToEnd:
-    timeout: 5000
+    timeout: 10000
 - extendedWaitUntil:
     visible:
       text: "${MARKER}"

--- a/universal/.maestro/verify-stat-info.yaml
+++ b/universal/.maestro/verify-stat-info.yaml
@@ -1,0 +1,67 @@
+# Soma verify flow: stat-card info hints + the overview Sleep card (soma#758, S3 of #578).
+# Run via universal/scripts/verify-device.sh overview --flow .maestro/verify-stat-info.yaml --marker "<today's steps>"
+appId: dev.gkos.soma
+name: Soma verify stat info hints
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://overview
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "info-sleep"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "info-sleep"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Recommended: 7-9 hours.*"
+    timeout: 10000
+- takeScreenshot: verify-stat-info-sleep
+- back
+- scrollUntilVisible:
+    element:
+      id: "info-steps"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "info-steps"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Daily step count from your Garmin watch.*"
+    timeout: 10000
+- takeScreenshot: verify-stat-info-steps
+- back
+- openLink: universal://sleep
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "info-avg-score"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "info-avg-score"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*80\\+ = Excellent.*"
+    timeout: 10000
+- takeScreenshot: verify-stat-info-score
+- back
+- openLink: universal://overview
+- waitForAnimationToEnd:
+    timeout: 5000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { TimeRangeSelector } from "../../components/time-range-selector";
 import { useRangePref, rangeToDays, rangeLabel } from "../../lib/time-range";
+import { InfoHint, STAT_INFO, TREND_7D, TREND_7D_LOWER } from "../../components/info-hint";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
 import { LineChart, ChartLegend, ExpandableChart, chartDateLabel } from "../../components/line-chart";
@@ -15,6 +16,7 @@ import {
   useSomaPlan,
   useRecoverySummary,
   useActivitiesDeep,
+  useWorkoutsSummary,
   fetchJson,
   usePullRefresh,
   todayLocal,
@@ -97,14 +99,14 @@ function useOverviewFitness() {
   return f;
 }
 
-interface Vo2maxResp { stats: { vo2max: number | null } | null; trends: { vo2max: number[] } }
+interface Vo2maxResp { stats: { vo2max: number | null; total_runs?: number | string | null; total_km?: number | string | null } | null; trends: { vo2max: number[] } }
 /** Current VO2max + its trend, from /api/running/stats. */
 function useVo2max(range: string) {
-  const [v, setV] = useState<{ current: number | null; trend: number[] }>({ current: null, trend: [] });
+  const [v, setV] = useState<{ current: number | null; trend: number[]; runs: number; km: number }>({ current: null, trend: [], runs: 0, km: 0 });
   useEffect(() => {
     let alive = true;
     fetchJson<Vo2maxResp>(`/api/running/stats?range=${range}`)
-      .then((d) => alive && setV({ current: d.stats?.vo2max ?? (d.trends?.vo2max?.at(-1) ?? null), trend: d.trends?.vo2max ?? [] }))
+      .then((d) => alive && setV({ current: d.stats?.vo2max ?? (d.trends?.vo2max?.at(-1) ?? null), trend: d.trends?.vo2max ?? [], runs: Number(d.stats?.total_runs ?? 0) || 0, km: Number(d.stats?.total_km ?? 0) || 0 }))
       .catch(() => {});
     return () => { alive = false; };
   }, [range]);
@@ -157,6 +159,7 @@ export default function OverviewScreen() {
   const vo2 = useVo2max(range);
   const recovery = useRecoverySummary("30d");
   const { data: activitiesDeep } = useActivitiesDeep(range);
+  const { data: wkSum } = useWorkoutsSummary(range);
   const fitness = useOverviewFitness();
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
@@ -198,16 +201,23 @@ export default function OverviewScreen() {
   // An HRV reading older than two days is not today's metric (#731).
   const hrvFresh = freshness(hrvLatest?.date ?? null, todayKey());
 
-  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string; metric?: string; inverted?: boolean }[] = [
-    { label: "Steps", value: data?.total_steps != null ? data.total_steps.toLocaleString() : "—", sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1", metric: "steps" },
-    { label: "Active Calories", value: data?.active_kilocalories != null ? Math.round(data.active_kilocalories).toLocaleString() : "—", sub: `${data?.total_kilocalories != null ? Math.round(data.total_kilocalories).toLocaleString() : "—"} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850", unit: "kcal", metric: "calories" },
-    { label: "Resting HR", value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060", unit: "bpm", metric: "rhr", inverted: true },
-    { label: "Avg Stress", value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458", metric: "stress", inverted: true },
+  // Web's "Total Activities" card counts every Garmin activity plus Hevy workouts in the
+  // range, with a running-km subtitle (soma#758). The activity feed here excludes runs and
+  // gym, so add the runs from the running stats and the workouts from the summary.
+  const rangeOther = activitiesDeep?.all?.length ?? 0;
+  const rangeGym = Number(wkSum?.stats?.total_workouts ?? 0) || 0;
+  const rangeTotal = rangeOther + vo2.runs + rangeGym;
+  const rangeRunKm = vo2.km;
+  const stats: { label: string; value: string; sub: string; cls: string; spark?: number[]; color: string; unit?: string; metric?: string; inverted?: boolean; info?: string; trend?: string }[] = [
+    { label: "Steps", info: STAT_INFO.steps, trend: TREND_7D, value: data?.total_steps != null ? data.total_steps.toLocaleString() : "—", sub: `${km} km`, cls: "text-teal", spark: trends?.steps, color: "#77c8d1", metric: "steps" },
+    { label: "Active Calories", info: STAT_INFO.calories, trend: TREND_7D, value: data?.active_kilocalories != null ? Math.round(data.active_kilocalories).toLocaleString() : "—", sub: `${data?.total_kilocalories != null ? Math.round(data.total_kilocalories).toLocaleString() : "—"} total`, cls: "text-warm", spark: trends?.calories, color: "#b17850", unit: "kcal", metric: "calories" },
+    { label: "Resting HR", info: STAT_INFO.rhr, trend: TREND_7D_LOWER, value: `${data?.resting_heart_rate ?? "—"}`, sub: `${data?.min_heart_rate ?? "—"}–${data?.max_heart_rate ?? "—"} bpm`, cls: "text-danger", spark: trends?.rhr, color: "#e06060", unit: "bpm", metric: "rhr", inverted: true },
+    { label: "Avg Stress", info: STAT_INFO.stress, trend: TREND_7D_LOWER, value: `${data?.avg_stress_level ?? "—"}`, sub: `Peak ${data?.max_stress_level ?? "—"}`, cls: "text-warning", spark: trends?.stress, color: "#e0a458", metric: "stress", inverted: true },
     { label: "Body Battery", value: `${data?.body_battery_max ?? "—"}`, sub: `−${Math.abs(data?.body_battery_drained ?? 0)} drained`, cls: "text-lime", spark: trends?.bodyBattery, color: "#cbe896", metric: "body_battery" },
     { label: "Intensity min", value: `${(data?.moderate_intensity_minutes ?? 0) + (data?.vigorous_intensity_minutes ?? 0)}`, sub: `${data?.vigorous_intensity_minutes ?? 0} vigorous`, cls: "text-indigo", spark: trends?.intensity, color: "#6366b0", unit: "min" },
-    { label: "VO₂max", value: vo2.current != null ? Number(vo2.current).toFixed(1) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1", metric: "vo2max" },
+    { label: "VO₂max", info: STAT_INFO.vo2max, trend: TREND_7D, value: vo2.current != null ? Number(vo2.current).toFixed(1) : "—", sub: "ml/kg/min", cls: "text-teal", spark: vo2.trend.filter((x) => isFinite(x)), color: "#77c8d1", metric: "vo2max" },
     { label: "HRV", value: !hrvFresh.stale && hrvLatest?.weekly_avg != null ? String(hrvLatest.weekly_avg) : "—", sub: hrvFresh.stale ? `${staleShort("HRV", hrvFresh)}${hrvLatest?.weekly_avg != null ? ` · last ${hrvLatest.weekly_avg}` : ""}` : hrvLatest?.status ? String(hrvLatest.status) : "7-night avg", cls: "text-lime", spark: hrvSpark, color: "#cbe896", unit: "ms" },
-    { label: "Total activities", value: fitness?.total_activities != null && fitness.total_activities > 0 ? fitness.total_activities.toLocaleString() : "—", sub: "all time", cls: "text-teal", color: "#77c8d1" },
+    { label: "Total activities", info: STAT_INFO.activities, value: rangeTotal ? rangeTotal.toLocaleString() : "—", sub: rangeTotal ? `${Math.round(rangeRunKm)} km running · ${rangeLabel(range)}` : "in this range", cls: "text-teal", color: "#77c8d1", metric: "activities" },
   ];
 
   return (
@@ -341,11 +351,23 @@ export default function OverviewScreen() {
               {plan?.plan ? `of ${Math.round(plan.plan.target_calories)} target` : "no plan today"}
             </Text>
           </Card>
-          <Card className="min-w-[30%] flex-1 gap-1">
-            <Text variant="eyebrow">Sleep</Text>
-            <Text variant="headline" className="text-indigo">{sleepLatest != null ? `${sleepLatest.toFixed(1)}h` : "—"}</Text>
-            <Text variant="micro">{sleepAvg != null ? `7d avg ${sleepAvg.toFixed(1)}h` : "hours"}</Text>
-          </Card>
+          <Pressable
+            className="min-w-[30%] flex-1"
+            disabled={sleepSeries.length < 2}
+            onPress={() => setStatDetail({ label: "Sleep", value: sleepLatest != null ? `${sleepLatest.toFixed(1)}h` : "—", sub: sleepAvg != null ? `7d avg ${sleepAvg.toFixed(1)}h` : "hours", spark: sleepSeries, color: "#8b9df0", unit: "h", metric: "sleep", info: STAT_INFO.sleep })}
+          >
+            <Card className="gap-1">
+              <View className="flex-row items-center justify-between">
+                <View className="flex-row items-center gap-1.5">
+                  <Text variant="eyebrow">Sleep</Text>
+                  <InfoHint title="Sleep" text={STAT_INFO.sleep} trend={TREND_7D} />
+                </View>
+                <TrendArrow series={sleep?.current?.map((p) => (p.value != null ? Number(p.value) : null))} />
+              </View>
+              <Text variant="headline" className="text-indigo">{sleepLatest != null ? `${sleepLatest.toFixed(1)}h` : "—"}</Text>
+              <Text variant="micro">{sleepAvg != null ? `7d avg ${sleepAvg.toFixed(1)}h` : "hours"}</Text>
+            </Card>
+          </Pressable>
           <Card className="min-w-[30%] flex-1 gap-1">
             <Text variant="eyebrow">Weight</Text>
             <Text variant="headline" className="text-warm">{wLatest != null ? wLatest.toFixed(1) : "—"}</Text>
@@ -381,7 +403,10 @@ export default function OverviewScreen() {
             <Pressable key={s.label} className="min-w-[46%] flex-1" onPress={() => setStatDetail(s)}>
               <Card className="gap-1">
                 <View className="flex-row items-center justify-between">
-                  <Text variant="eyebrow">{s.label}</Text>
+                  <View className="flex-row items-center gap-1.5">
+                    <Text variant="eyebrow">{s.label}</Text>
+                    {s.info ? <InfoHint title={s.label} text={s.info} trend={s.trend} /> : null}
+                  </View>
                   <View className="flex-row items-center gap-1.5">
                     <TrendArrow series={s.spark} inverted={s.inverted} />
                     <Text variant="micro" className="text-text-muted">›</Text>

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -6,6 +6,7 @@ import { useRangePref } from "../../lib/time-range";
 import { StatDetailModal, type StatDetail } from "../../components/stat-detail-modal";
 import { TrendArrow } from "../../components/trend-arrow";
 import { LineChart, ChartLegend, ExpandableChart } from "../../components/line-chart";
+import { InfoHint, STAT_INFO, TREND_7D, TREND_7D_LOWER } from "../../components/info-hint";
 import { fetchJson, usePullRefresh, useSleepSummary, useRecoverySummary, useRespiratory, useSleepSchedule, useWeekdayWeekend } from "../../lib/api";
 import { freshness, staleShort, todayKey } from "../../lib/freshness";
 import { SleepDashboard } from "../../components/sleep-dashboard";
@@ -153,9 +154,13 @@ export default function SleepScreen() {
     unit?: string;
     metric?: string;
     inverted?: boolean;
+    info?: string;
+    trend?: string;
   }[] = [
     {
       label: "Avg Sleep",
+      info: STAT_INFO.avg_sleep,
+      trend: TREND_7D,
       // The average rests on sleep_data nights (the web's number over the same
       // window), not on the subset of days daily_health_summary carries (#743).
       value: sleepSum?.stats?.avg_hours != null ? fmt1(sleepSum.stats.avg_hours, "h") : fmt1(sleep?.summary.current_avg, "h"),
@@ -178,6 +183,8 @@ export default function SleepScreen() {
     },
     {
       label: "Resting HR",
+      info: STAT_INFO.rhr,
+      trend: TREND_7D_LOWER,
       value: fmt0(rhr?.summary.current_avg, " bpm"),
       sub:
         rhrDelta == null
@@ -213,6 +220,8 @@ export default function SleepScreen() {
     ? [
         {
           label: "Avg Score",
+          info: STAT_INFO.sleep_score,
+          trend: TREND_7D,
           value: fmt0(st.avg_score),
           sub: "out of 100",
           cls: "text-indigo",
@@ -220,6 +229,8 @@ export default function SleepScreen() {
         },
         {
           label: "Avg Deep",
+          info: STAT_INFO.deep_sleep,
+          trend: TREND_7D,
           value: fmt0(st.avg_deep_pct, "%"),
           sub: st.avg_rem_pct != null ? `REM ${Math.round(st.avg_rem_pct)}%` : "of sleep",
           cls: "text-teal",
@@ -228,6 +239,8 @@ export default function SleepScreen() {
         },
         {
           label: "Avg Sleep HR",
+          info: STAT_INFO.sleep_hr,
+          trend: TREND_7D_LOWER,
           value: fmt0(st.avg_sleep_hr, " bpm"),
           sub: st.avg_spo2 != null ? `SpO₂ ${Math.round(st.avg_spo2)}%` : "during sleep",
           cls: "text-danger",
@@ -285,11 +298,14 @@ export default function SleepScreen() {
                 key={s.label}
                 className="min-w-[46%] flex-1"
                 disabled={!tappable}
-                onPress={() => s.spark && setStatDetail({ label: s.label, value: s.value, sub: s.sub, spark: s.spark.data, color: s.spark.color, unit: s.unit, metric: s.metric })}
+                onPress={() => s.spark && setStatDetail({ label: s.label, value: s.value, sub: s.sub, spark: s.spark.data, color: s.spark.color, unit: s.unit, metric: s.metric, info: s.info })}
               >
                 <Card className="gap-1">
                   <View className="flex-row items-center justify-between">
-                    <Text variant="eyebrow">{s.label}</Text>
+                    <View className="flex-row items-center gap-1.5">
+                      <Text variant="eyebrow">{s.label}</Text>
+                      {s.info ? <InfoHint title={s.label} text={s.info} trend={s.trend} /> : null}
+                    </View>
                     <View className="flex-row items-center gap-1.5">
                       {s.spark ? <TrendArrow series={s.spark.data} inverted={s.inverted} /> : null}
                       {tappable ? <Text variant="micro" className="text-text-muted">›</Text> : null}

--- a/universal/src/components/info-hint.tsx
+++ b/universal/src/components/info-hint.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { Pressable, View } from "react-native";
+import { Text, Modal } from "soma-style";
+
+/** Press-to-reveal "ⓘ" for a stat card, the phone form of web's StatCard hover tooltip
+ *  (soma#758). Tapping opens a small sheet with the same text web shows; `trend`
+ *  adds the trend-window sentence web keeps in the badge's title attribute. */
+export function InfoHint({ title, text, trend, testID }: { title: string; text: string; trend?: string; testID?: string }) {
+  const [open, setOpen] = useState(false);
+  const id = testID ?? `info-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
+  return (
+    <>
+      <Pressable
+        onPress={(e) => { e.stopPropagation(); setOpen(true); }}
+        hitSlop={10}
+        accessibilityRole="button"
+        accessibilityLabel={`About ${title}`}
+        testID={id}
+        className="h-4 w-4 items-center justify-center rounded-full"
+        style={{ borderWidth: 1, borderColor: "#3a5563" }}
+      >
+        <Text variant="micro" style={{ color: "#8fa8b8", fontSize: 9, lineHeight: 11, fontWeight: "700" }}>i</Text>
+      </Pressable>
+      <Modal visible={open} onClose={() => setOpen(false)} title={title}>
+        <View className="gap-2" testID="info-sheet">
+          <Text variant="body" className="text-text-secondary">{text}</Text>
+          {trend ? <Text variant="micro" className="text-text-muted">Trend: {trend}</Text> : null}
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+/** Web's stat-card tooltip texts, verbatim (web/app/page.tsx, web/app/sleep/page.tsx). */
+export const STAT_INFO: Record<string, string> = {
+  steps: "Daily step count from your Garmin watch",
+  calories: "Calories burned above your BMR through activity",
+  rhr: "Lower resting HR generally indicates better cardiovascular fitness. Elite athletes: 40-50 bpm",
+  vo2max: "Maximum oxygen uptake. Higher is better. Excellent: 50+ ml/kg/min",
+  sleep: "Total sleep time from Garmin sleep tracking. Recommended: 7-9 hours",
+  stress: "Garmin stress score (0-100). Lower is better. 0-25 = Rest, 26-50 = Low, 51-75 = Medium, 76-100 = High",
+  activities: "Total tracked activities across all sports in this period",
+  avg_sleep: "Average total sleep time per night. Recommended: 7-9 hours",
+  sleep_score: "Garmin sleep score (0-100) based on duration, quality, and restoration. 80+ = Excellent",
+  deep_sleep: "Percentage of sleep in deep (slow-wave) stage. Ideal: 15-25%. Critical for physical recovery",
+  sleep_hr: "Average heart rate during sleep. Lower values indicate better recovery and cardiovascular health",
+};
+export const TREND_7D = "7-day avg vs prior week";
+export const TREND_7D_LOWER = "7-day avg vs prior week (lower is better)";

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -165,21 +165,29 @@ export function LineChart(props: LineChartProps) {
               ) : null,
             )}
             {/* reference-line labels (web parity: "10K goal", "avg 52", "180 spm" …) */}
-            {[...(refLine ? [refLine] : []), ...(refLines ?? [])].map((r, ri) => {
-              if (!r.label || r.y < loL || r.y > hiL) return null;
-              // Sit above the line, or just below it when the line hugs the top edge; keep
-              // clear of the right-axis labels on dual-axis charts by using the left edge.
+            {(() => {
+              // Labels sit above their line (below it when it hugs the top edge), on the right,
+              // or on the left on dual-axis charts; neighbours closer than a text line alternate
+              // sides so "1.3" and "1.5 high" never overprint (soma#756).
+              const labelled = [...(refLine ? [refLine] : []), ...(refLines ?? [])]
+                .filter((r) => r.label && r.y >= loL && r.y <= hiL)
+                .sort((a, b) => yAtL(a.y) - yAtL(b.y));
+              let lastY = -100; let lastRight = rightS.length !== 0;
+              return labelled.map((r, ri) => {
               const ly = yAtL(r.y);
               const ty = ly < 14 ? ly + 10 : ly - 3;
-              const tw = r.label.length * 4.4 + 4;
-              const atRight = rightS.length === 0;
+              const tw = r.label!.length * 4.4 + 4;
+              let atRight = rightS.length === 0;
+              if (Math.abs(ly - lastY) < 11) atRight = !lastRight;
+              lastY = ly; lastRight = atRight;
               return (
                 <Fragment key={`rt-${ri}`}>
                   <Rect x={atRight ? VBW - 2 - tw : 2} y={ty - 8} width={tw} height={10} rx={2} fill="#0c1519" fillOpacity={0.8} />
                   <SvgText x={atRight ? VBW - 4 : 4} y={ty} fontSize={8} fill={r.color ?? "#3a5563"} textAnchor={atRight ? "end" : "start"} opacity={0.95}>{r.label}</SvgText>
                 </Fragment>
               );
-            })}
+              });
+            })()}
             {series.map((s, si) => {
               if (s.mode === "dots") {
                 return s.values.map((v, i) =>

--- a/universal/src/components/stat-detail-modal.tsx
+++ b/universal/src/components/stat-detail-modal.tsx
@@ -14,6 +14,8 @@ export interface StatDetail {
   unit?: string;
   /** If set, the modal fetches /api/stats/[metric] for a range toggle + previous-period overlay. */
   metric?: string;
+  /** Web's stat-card tooltip text, shown under the value (soma#758). */
+  info?: string;
   /** Pre-supplied dated timeline (e.g. per-workout duration/calories); renders a dated chart with tap-to-read. */
   timeline?: { date: string; value: number; label?: string }[];
   /** How to draw the timeline: connected line (cumulative/monthly) or scatter dots (per-workout). */
@@ -90,6 +92,7 @@ export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; on
             <Text variant="display" className="tabular-nums" style={{ color: stat.color }}>{stat.value}</Text>
             <Text variant="body" className="mb-1 text-text-muted">{stat.sub}</Text>
           </View>
+          {stat.info ? <Text variant="caption" className="text-text-secondary">{stat.info}</Text> : null}
           {pts.length >= 2 ? (
             <View className="gap-1">
               <Text variant="eyebrow" className="text-text-muted">{pts.length} {stat.timelineNoun ?? "workouts"}</Text>
@@ -135,6 +138,7 @@ export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; on
             <Text variant="display" className="tabular-nums" style={{ color: stat.color }}>{stat.value}</Text>
             <Text variant="body" className="mb-1 text-text-muted">{stat.sub}</Text>
           </View>
+          {stat.info ? <Text variant="caption" className="text-text-secondary">{stat.info}</Text> : null}
           <SegmentedControl options={RANGES} value={range} onChange={(v) => setRange(v as Range)} />
           {loading && !data ? (
             <Text variant="body" className="text-text-muted">Loading…</Text>
@@ -191,6 +195,7 @@ export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; on
           <Text variant="display" className="tabular-nums" style={{ color: stat.color }}>{stat.value}</Text>
           <Text variant="body" className="mb-1 text-text-muted">{stat.sub}</Text>
         </View>
+        {stat.info ? <Text variant="caption" className="text-text-secondary">{stat.info}</Text> : null}
         {s.length >= 2 ? (
           <View className="gap-1">
             <Text variant="eyebrow" className="text-text-muted">Trend · last {s.length} days</Text>

--- a/universal/src/components/trend-arrow.tsx
+++ b/universal/src/components/trend-arrow.tsx
@@ -5,15 +5,23 @@ import { Text } from "soma-style";
  *  colored by whether the change is an improvement. `inverted` = lower-is-better
  *  (resting HR, stress), so a decrease reads as green. Matches the web StatCard
  *  trend badge. Renders nothing when there isn't enough data. */
-export function TrendArrow({ series, inverted }: { series?: (number | null)[]; inverted?: boolean }) {
+/** Percent change of the last 7 points vs the 7 before (web's "7-day avg vs prior week")
+ *  when the series has at least 14 points; shorter series fall back to halves. Null when
+ *  there is not enough data. */
+export function trendPct(series?: (number | null)[]): number | null {
   const vals = (series ?? []).filter((v): v is number => typeof v === "number" && isFinite(v));
   if (vals.length < 4) return null;
-  const half = Math.floor(vals.length / 2);
   const mean = (a: number[]) => a.reduce((s, v) => s + v, 0) / a.length;
-  const prior = mean(vals.slice(0, half));
-  const recent = mean(vals.slice(vals.length - half));
+  const win = vals.length >= 14 ? 7 : Math.floor(vals.length / 2);
+  const prior = mean(vals.slice(vals.length - 2 * win, vals.length - win));
+  const recent = mean(vals.slice(vals.length - win));
   if (!prior) return null;
-  const pct = ((recent - prior) / Math.abs(prior)) * 100;
+  return ((recent - prior) / Math.abs(prior)) * 100;
+}
+
+export function TrendArrow({ series, inverted }: { series?: (number | null)[]; inverted?: boolean }) {
+  const pct = trendPct(series);
+  if (pct == null) return null;
   const flat = Math.abs(pct) < 1;
   const up = pct > 0;
   const improving = inverted ? !up : up;


### PR DESCRIPTION
S3 of #578 shipped the trend arrows; a card-by-card pass against web (ledger on #758) found the info tooltips had no phone form at all, the overview Sleep card was a passive tile, Total activities was all-time with a dead tap, and the trend window drifted with the range selector on the sleep screen.

**App**
- `InfoHint`: press-to-reveal ⓘ on every stat card that has a tooltip on web (7 on overview, 4 on sleep), with web's exact texts; the same text shows under the value in the stat modal; the hint also carries web's trend-window sentence ("7-day avg vs prior week", "(lower is better)").
- Overview Sleep tile is now a real stat card: info hint, 7-day trend arrow, tap → sleep stat modal.
- Total activities matches web's count: every Garmin activity plus Hevy workouts in the range (the app's activity feed excludes runs and gym, so runs come from the running stats and workouts from the summary; 26 + 39 + 61 = 126 for 6M, web shows 126), with web's "279 km running" subtitle, and it opens the daily-activities chart.
- `TrendArrow` compares the last 7 points with the 7 before whenever the series has 14+ points (web's window); shorter series still halve.
- S2 leftovers riding along: reference-line labels closer than a text line alternate sides ("1.3" / "1.5 high" no longer overprint); `verify-chart-fidelity.yaml` cold-opens Running for its final marker (a warm deep link keeps the scroll position).

Documented, unchanged: the app keeps the true sign on inverted metrics (web negates it); "Avg Deep" vs web's "Avg Deep Sleep"; the four sleep cards keep their app-only trend + tap.

**Verification**
- `universal/.maestro/verify-stat-info.yaml` through `verify-device.sh`: Overview → ⓘ on Sleep → "Recommended: 7-9 hours"; ⓘ on Steps → "Daily step count from your Garmin watch"; Sleep → ⓘ on Avg Score → "80+ = Excellent"; live marker on Overview. Plus the range-scoped activities subtitle as a live marker. Release APK from this branch on the emulator.
- tsc + vitest green in `universal` (37); web untouched.

Closes #758
