### PR TITLE
chore(universal): soma-style ^1.3.1

### DIFF
--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -43,7 +43,7 @@
         "react-native-web": "~0.21.0",
         "react-native-webview": "13.16.1",
         "react-native-worklets": "0.10.0",
-        "soma-style": "^1.3.0"
+        "soma-style": "^1.3.1"
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
@@ -10396,9 +10396,9 @@
       }
     },
     "node_modules/soma-style": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-1.3.0.tgz",
-      "integrity": "sha512-v/m0M98eRB71tEYko9jqR//nEiGvbK4kbQQ9s+TluDqEVizKnX1I/3/ouNIH677JpUz47NDliplV3ESoeQmU+A==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/soma-style/-/soma-style-1.3.1.tgz",
+      "integrity": "sha512-xiJEjssLyjQOF/PfRpeg+HDrVDIWtoutyFxUNXR389NpNIhBdDvf3vS41F1xo2oh5cuLX6FB/EWOAA1Io6/bkw==",
       "license": "MIT",
       "peerDependencies": {
         "nativewind": ">=4.0.0",

--- a/universal/package.json
+++ b/universal/package.json
@@ -37,7 +37,7 @@
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.16.1",
     "react-native-worklets": "0.10.0",
-    "soma-style": "^1.3.0"
+    "soma-style": "^1.3.1"
   },
   "devDependencies": {
     "@types/react": "~19.2.2",


### PR DESCRIPTION
`universal` pinned `soma-style` at `^1.3.0` while `web` and the published package are on 1.3.1. Aligned the pin and refreshed the lockfile.

Closes #763
Closes #764
Closes #765
