### PR TITLE
feat(app): workout detail modal at web parity (HR gantt, muscle map, tabs, Image tab)

### DIFF
--- a/universal/.maestro/verify-workout-detail.yaml
+++ b/universal/.maestro/verify-workout-detail.yaml
@@ -1,0 +1,57 @@
+# Soma verify flow: the workout detail modal (soma#761, S5 of #578).
+# Opens the newest workout from the Workouts screen: HR tab (block strip + avg label),
+# Summary (muscle map + working sets), Image (save / share).
+# Run via universal/scripts/verify-device.sh workouts --flow .maestro/verify-workout-detail.yaml
+appId: dev.gkos.soma
+name: Soma verify workout detail
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://workouts
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "RECENT WORKOUTS"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "workout-row-0"
+- extendedWaitUntil:
+    visible:
+      id: "tab-hr"
+    timeout: 20000
+- tapOn:
+    id: "tab-hr"
+- extendedWaitUntil:
+    visible:
+      id: "block-0"
+    timeout: 15000
+- takeScreenshot: verify-workout-hr
+- tapOn:
+    id: "tab-summary"
+- extendedWaitUntil:
+    visible:
+      text: "WORKING SETS"
+    timeout: 10000
+- takeScreenshot: verify-workout-summary
+- tapOn:
+    id: "tab-image"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*share PNG.*"
+    timeout: 10000
+- takeScreenshot: verify-workout-image
+- back
+- stopApp
+- openLink: universal://workouts
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/scripts/verify-device.sh
+++ b/universal/scripts/verify-device.sh
@@ -167,6 +167,9 @@ echo "verify $SCREEN on $DEV — expecting live marker: '$MARKER'  (from $EXPO_P
 # 3. Drive the device: open the screen, wait for the marker to be visible.
 if [ -n "$FLOW_OVERRIDE" ]; then case "$FLOW_OVERRIDE" in /*) FLOW="$FLOW_OVERRIDE";; *) FLOW="$HERE/$FLOW_OVERRIDE";; esac; fi
 [ -f "$FLOW" ] || { echo "FAIL: flow not found: $FLOW"; exit 2; }
+# The stale entry can come back between step 0 and here (an ssh-forwarded adb bridge
+# reconnects on its own), so drop it again right before Maestro starts.
+$ADB devices 2>/dev/null | awk 'NR>1 && $2=="offline"{print $1}' | while read -r stale; do $ADB disconnect "$stale" >/dev/null 2>&1 || true; done
 set +e
 ( cd "$HERE" && "$MAESTRO" --device "$DEV" test \
     -e ROUTE="universal://$SCREEN" -e MARKER="$MARKER_RE" -e SCREEN="$SCREEN" ${EXTRA_ENV[@]+"${EXTRA_ENV[@]}"} \

--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -5,6 +5,7 @@ import * as Sharing from "expo-sharing";
 import { Text, Modal, Badge, Button, Sparkline } from "soma-style";
 import { LineChart, type ChartSeries } from "./line-chart";
 import { RouteMap } from "./route-map";
+import { TabStrip } from "./tab-strip";
 import { fetchJson, activityImageSource, uploadActivityPhotoToStrava, type ActivityRow } from "../lib/api";
 
 interface TSPoint { elapsed_sec: number; hr?: number | null; speed?: number | null; elevation?: number | null; cadence?: number | null; power?: number | null; respiration?: number | null; stride?: number | null }
@@ -50,25 +51,6 @@ function longDate(iso: string | null | undefined): string { if (!iso) return "";
 function prettyKey(k: string): string { return k.replace(/([A-Z])/g, " $1").replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase()).trim(); }
 function fmtVal(v: number | string | boolean): string { return typeof v === "number" ? (Number.isInteger(v) ? String(v) : v.toFixed(2)) : String(v); }
 const mmss = (v: number) => `${Math.floor(v / 60)}:${String(Math.round(v % 60)).padStart(2, "0")}`;
-
-/** Horizontal pill tab strip: six tabs never wrap (the segmented control did), a tab can be
- *  shown disabled like web keeps "Splits" visible without laps (soma#760). */
-function TabStrip({ tabs, value, onChange }: { tabs: { key: string; disabled?: boolean }[]; value: string; onChange: (k: string) => void }) {
-  return (
-    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-1 py-0.5 pr-2">
-      {tabs.map((t) => {
-        const active = t.key === value;
-        return (
-          <Pressable key={t.key} disabled={t.disabled} onPress={() => onChange(t.key)} hitSlop={4} accessibilityRole="tab" accessibilityState={{ selected: active, disabled: !!t.disabled }} testID={`tab-${t.key.toLowerCase()}`}>
-            <View className="rounded-full px-2 py-1" style={{ backgroundColor: active ? "#77c8d1" : "#152232", borderWidth: 1, borderColor: active ? "#77c8d1" : "#1a3040", opacity: t.disabled ? 0.4 : 1 }}>
-              <Text variant="micro" style={{ color: active ? "#0a1720" : "#a0b4c0", fontWeight: active ? "700" : "500", fontSize: 11.5, lineHeight: 15 }}>{t.key}</Text>
-            </View>
-          </Pressable>
-        );
-      })}
-    </ScrollView>
-  );
-}
 
 /* ---- Charts tab: web's activity-performance-chart (7 metrics, overlay, reversed pace axis) ---- */
 const PERF_METRICS = ["Pace", "HR", "Elevation", "Cadence", "Power", "Breathing", "Stride"] as const;

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -44,6 +44,10 @@ export interface LineChartProps {
   interactive?: boolean;
   /** Flip the left axis so smaller values sit higher (web's reversed pace axis). */
   invertY?: boolean;
+  /** Vertical bands between two x indices, drawn under the series (web's ReferenceArea per exercise block). */
+  xBands?: { i0: number; i1: number; color: string; opacity?: number }[];
+  /** Vertical guide lines at an x index (exercise / set boundaries). */
+  xLines?: { i: number; color?: string; dashed?: boolean }[];
 }
 
 const VBW = 320;
@@ -57,7 +61,7 @@ export function chartDateLabel(iso: string): string {
 /** A compact react-native-svg line/scatter chart with y-axis labels, dated x
  *  ticks, an optional right axis, and optional tap-to-read cursor + callout. */
 export function LineChart(props: LineChartProps) {
-  const { series, labels, height = 120, yFormat, yFormatRight, refLine, refLines, refAreas, yMin, yMax, xTicks, interactive, invertY } = props;
+  const { series, labels, height = 120, yFormat, yFormatRight, refLine, refLines, refAreas, yMin, yMax, xTicks, interactive, invertY, xBands, xLines } = props;
   const fmtL = yFormat ?? ((v: number) => String(Math.round(v)));
   const fmtR = yFormatRight ?? fmtL;
   const [active, setActive] = useState<number | null>(null);
@@ -158,6 +162,13 @@ export function LineChart(props: LineChartProps) {
               const yTop = yAtL(hi);
               return <Rect key={`ra-${ai}`} x={0} y={yTop} width={VBW} height={Math.max(0, yAtL(lo) - yTop)} fill={a.color} fillOpacity={a.opacity ?? 0.12} />;
             })}
+            {xBands?.map((b, bi) => {
+              const x0 = xAt(Math.max(0, Math.min(n - 1, b.i0))); const x1 = xAt(Math.max(0, Math.min(n - 1, b.i1)));
+              return x1 > x0 ? <Rect key={`xb-${bi}`} x={x0} y={padTop} width={x1 - x0} height={plotH} fill={b.color} fillOpacity={b.opacity ?? 0.22} /> : null;
+            })}
+            {xLines?.map((l, li) => (
+              <Line key={`xl-${li}`} x1={xAt(Math.max(0, Math.min(n - 1, l.i)))} y1={padTop} x2={xAt(Math.max(0, Math.min(n - 1, l.i)))} y2={padTop + plotH} stroke={l.color ?? "#ffffff"} strokeWidth={1} strokeOpacity={l.dashed ? 0.35 : 0.6} strokeDasharray={l.dashed ? "3 3" : undefined} />
+            ))}
             <Line x1={0} y1={yAtL(hiL)} x2={VBW} y2={yAtL(hiL)} stroke="#1e2f38" strokeWidth={1} />
             <Line x1={0} y1={yAtL(loL)} x2={VBW} y2={yAtL(loL)} stroke="#1e2f38" strokeWidth={1} />
             {refLine && refLine.y >= loL && refLine.y <= hiL ? (

--- a/universal/src/components/tab-strip.tsx
+++ b/universal/src/components/tab-strip.tsx
@@ -1,0 +1,21 @@
+import { ScrollView, Pressable, View } from "react-native";
+import { Text } from "soma-style";
+
+/** Horizontal pill tab strip: six tabs never wrap, a tab can be shown disabled like web
+ *  keeps "Splits" visible without laps (soma#760, shared with the workout modal in #761). */
+export function TabStrip({ tabs, value, onChange }: { tabs: { key: string; disabled?: boolean }[]; value: string; onChange: (k: string) => void }) {
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-1 py-0.5 pr-2">
+      {tabs.map((t) => {
+        const active = t.key === value;
+        return (
+          <Pressable key={t.key} disabled={t.disabled} onPress={() => onChange(t.key)} hitSlop={4} accessibilityRole="tab" accessibilityState={{ selected: active, disabled: !!t.disabled }} testID={`tab-${t.key.toLowerCase()}`}>
+            <View className="rounded-full px-2 py-1" style={{ backgroundColor: active ? "#77c8d1" : "#152232", borderWidth: 1, borderColor: active ? "#77c8d1" : "#1a3040", opacity: t.disabled ? 0.4 : 1 }}>
+              <Text variant="micro" style={{ color: active ? "#0a1720" : "#a0b4c0", fontWeight: active ? "700" : "500", fontSize: 11.5, lineHeight: 15 }}>{t.key}</Text>
+            </View>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}

--- a/universal/src/components/workout-detail-modal.tsx
+++ b/universal/src/components/workout-detail-modal.tsx
@@ -1,12 +1,18 @@
-import { useEffect, useState } from "react";
-import { View, Image, Share } from "react-native";
-import { Text, Modal, Button } from "soma-style";
+import { useEffect, useMemo, useState } from "react";
+import { View, Image, ScrollView, Pressable } from "react-native";
+import { Text, Modal, Button, Badge } from "soma-style";
 import { LineChart } from "./line-chart";
+import { TabStrip } from "./tab-strip";
+import { MuscleBodyMap } from "./muscle-body-map";
 import { fetchJson, workoutImageSource } from "../lib/api";
+import { aggregateWorkoutMuscles, MUSCLE_LABELS, ALL_MUSCLE_GROUPS, type MuscleGroup } from "../lib/muscle-groups";
+import { shareImageFile } from "../lib/share-image";
 
 interface WSet { weight_kg: number | null; reps: number | null; type?: string; avg_hr?: number }
-interface WExercise { title: string; sets: WSet[] }
+interface WExercise { title: string; sets: WSet[]; notes?: string | null; muscle_group?: string | null }
 interface HrZone { zone: number; seconds: number; low: number; high: number }
+/** Exercise timing overlay the API synthesises from the Hevy sets (web's gantt source). */
+interface ExerciseSet { exercise: string | null; start_sec: number; duration_sec: number; reps: number; weight: number; set_type: string }
 interface WorkoutDetail {
   id: string; title?: string; start_time?: string; end_time?: string;
   exercises: WExercise[];
@@ -14,11 +20,16 @@ interface WorkoutDetail {
     avg_hr: number | null; max_hr: number | null; min_hr?: number | null; calories: number | null;
     hr_zones?: HrZone[] | null;
     hr_timeline?: { elapsed_sec: number; hr: number }[];
+    exercise_sets?: ExerciseSet[] | null;
+    activity_id?: string | null;
   } | null;
 }
 
-// Zone 1..5 palette (easy → max).
+// Zone 1..5 palette (easy → max) and web's zone names.
 const ZONE_COLORS = ["#5a7a8a", "#77c8d1", "#6ad4a0", "#e0a458", "#e06060"];
+const ZONE_NAMES = ["Warm Up", "Easy", "Aerobic", "Threshold", "Max"];
+// Per-exercise block colours (web's exerciseColorMap palette).
+const BLOCK_COLORS = ["#3b82f6", "#f97316", "#22c55e", "#ec4899", "#a855f7", "#eab308", "#06b6d4", "#ef4444"];
 // Distinct set types get a badge; "normal" is left plain.
 const SET_TYPE: Record<string, { label: string; color: string }> = {
   warmup: { label: "W", color: "#8aa0ac" },
@@ -30,26 +41,155 @@ const KG_TO_LB = 2.20462;
 function longDate(iso: string | undefined): string {
   if (!iso) return "";
   const d = new Date(iso);
-  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric", year: "numeric" });
+  return isNaN(d.getTime()) ? "" : d.toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric", year: "numeric" });
 }
 function durationMin(w: WorkoutDetail): number | null {
   if (!w.start_time || !w.end_time) return null;
   const a = new Date(w.start_time).getTime(), b = new Date(w.end_time).getTime();
   return isFinite(a) && isFinite(b) && b > a ? Math.round((b - a) / 60000) : null;
 }
+const kvol = (v: number) => (v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${Math.round(v)}`);
+const isWorking = (s: WSet) => (s.type ?? "normal") === "normal" && (s.weight_kg ?? 0) > 0 && (s.reps ?? 0) > 0;
+
+function Box({ label, value, sub, color }: { label: string; value: string; sub?: string; color?: string }) {
+  return (
+    <View className="min-w-[30%] flex-1">
+      <Text variant="eyebrow" className="text-text-muted">{label}</Text>
+      <Text variant="title" style={color ? { color } : undefined} className={color ? undefined : "text-text"}>{value}</Text>
+      {sub ? <Text variant="micro" className="text-text-muted">{sub}</Text> : null}
+    </View>
+  );
+}
+
+/* ---- HR tab: web's WorkoutHrTimeline (exercise blocks over the HR line + block strip) ---- */
+interface Block { exercise: string; color: string; startSec: number; endSec: number; fillEnd: number; sets: ExerciseSet[]; avgHr: number | null }
+function groupBlocks(sets: ExerciseSet[], totalSec: number, timeline: { elapsed_sec: number; hr: number }[]): Block[] {
+  const names: string[] = [];
+  const blocks: Omit<Block, "fillEnd" | "avgHr">[] = [];
+  let cur: Omit<Block, "fillEnd" | "avgHr"> | null = null;
+  for (const s of sets) {
+    if (s.set_type === "REST") continue;
+    const name = s.exercise || "Unknown";
+    if (!names.includes(name)) names.push(name);
+    if (cur && cur.exercise === name) { cur.endSec = s.start_sec + s.duration_sec; cur.sets.push(s); }
+    else { if (cur) blocks.push(cur); cur = { exercise: name, color: BLOCK_COLORS[names.indexOf(name) % BLOCK_COLORS.length], startSec: s.start_sec, endSec: s.start_sec + s.duration_sec, sets: [s] }; }
+  }
+  if (cur) blocks.push(cur);
+  return blocks.map((b, i) => {
+    const fillEnd = i < blocks.length - 1 ? blocks[i + 1].startSec : totalSec;
+    const inside = timeline.filter((p) => p.elapsed_sec >= b.startSec && p.elapsed_sec < fillEnd).map((p) => p.hr);
+    return { ...b, fillEnd, avgHr: inside.length ? inside.reduce((a, c) => a + c, 0) / inside.length : null };
+  });
+}
+
+function HrTab({ g, title }: { g: NonNullable<WorkoutDetail["garmin"]>; title: string }) {
+  const tl = g.hr_timeline ?? [];
+  const [selected, setSelected] = useState<number | null>(null);
+  const total = tl.length ? tl[tl.length - 1].elapsed_sec : 0;
+  const blocks = useMemo(() => groupBlocks(g.exercise_sets ?? [], total, tl), [g.exercise_sets, total, tl]);
+  const idxAt = (sec: number) => { if (!tl.length) return 0; let best = 0; for (let i = 0; i < tl.length; i++) if (tl[i].elapsed_sec <= sec) best = i; else break; return best; };
+  const hrs = tl.map((p) => p.hr);
+  const avg = hrs.length ? hrs.reduce((a, b) => a + b, 0) / hrs.length : null;
+  const zones = (g.hr_zones ?? []).filter((z) => z.seconds > 0);
+  const zTotal = zones.reduce((a, z) => a + z.seconds, 0);
+  if (tl.length < 2) {
+    return (
+      <View className="items-center gap-1 py-6">
+        <Text variant="body" className="text-text-muted">No heart rate data</Text>
+        <Text variant="micro" className="text-text-muted">No matching Garmin activity found for {title}.</Text>
+      </View>
+    );
+  }
+  const xBands = blocks.map((b, i) => ({ i0: idxAt(b.startSec), i1: idxAt(b.fillEnd), color: b.color, opacity: selected == null ? 0.22 : selected === i ? 0.4 : 0.08 }));
+  const xLines = [
+    ...blocks.slice(1).map((b) => ({ i: idxAt(b.startSec), color: "#ffffff" })),
+    ...blocks.flatMap((b) => b.sets.slice(1).map((s) => ({ i: idxAt(s.start_sec), color: "#ffffff", dashed: true }))),
+  ];
+  return (
+    <View className="gap-3">
+      <View className="flex-row flex-wrap gap-3">
+        <Box label="Avg HR" value={g.avg_hr != null ? `${Math.round(g.avg_hr)}` : "—"} sub="bpm" color="#e06060" />
+        <Box label="Max HR" value={g.max_hr != null ? `${Math.round(g.max_hr)}` : "—"} sub="bpm" />
+        <Box label="Min HR" value={g.min_hr != null ? `${Math.round(g.min_hr)}` : "—"} sub="bpm" />
+        <Box label="Calories" value={g.calories != null ? `${Math.round(g.calories)}` : "—"} sub="kcal" color="#e0a458" />
+      </View>
+      <LineChart
+        height={170}
+        interactive
+        xTicks={4}
+        labels={tl.map((p) => `${Math.round(p.elapsed_sec / 60)}m`)}
+        yFormat={(v) => `${Math.round(v)}`}
+        refLine={avg != null ? { y: avg, color: "#9fb3c0", label: "avg" } : undefined}
+        xBands={xBands}
+        xLines={xLines}
+        series={[{ values: hrs, color: "#e6edf3", width: 1.8, label: "HR" }]}
+      />
+      {blocks.length ? (
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-2 pr-2">
+          {blocks.map((b, i) => (
+            <Pressable key={`${b.exercise}-${i}`} onPress={() => setSelected(selected === i ? null : i)} testID={`block-${i}`} accessibilityRole="button" accessibilityLabel={`${b.exercise}, ${b.sets.length} sets`}>
+              <View className="rounded-lg px-2 py-1.5" style={{ backgroundColor: selected === i ? "#1c2d3a" : "#0f1c26", borderWidth: 1, borderColor: selected === i ? b.color : "#1a3040", minWidth: 96, opacity: selected == null || selected === i ? 1 : 0.55 }}>
+                <View className="flex-row items-center gap-1.5">
+                  <View className="h-2 w-2 rounded-full" style={{ backgroundColor: b.color }} />
+                  <Text variant="micro" className="text-text" numberOfLines={1} style={{ maxWidth: 110 }}>{b.exercise}</Text>
+                </View>
+                <Text variant="micro" className="text-text-muted">{b.sets.length} sets{b.avgHr != null ? ` · ${Math.round(b.avgHr)} bpm` : ""}</Text>
+              </View>
+            </Pressable>
+          ))}
+        </ScrollView>
+      ) : null}
+      {selected != null && blocks[selected] ? (
+        <View className="rounded-md px-2 py-1.5" style={{ backgroundColor: "#0f1c26", borderWidth: 1, borderColor: blocks[selected].color }}>
+          <Text variant="micro" className="text-text">{blocks[selected].exercise}</Text>
+          <Text variant="micro" className="text-text-muted">
+            {blocks[selected].sets.map((s, k) => `Set ${k + 1}/${blocks[selected].sets.length}: ${s.weight > 0 ? `${s.weight} kg × ` : "BW × "}${s.reps}${s.set_type === "WARMUP" ? " (warmup)" : ""}`).join(" · ")}
+          </Text>
+        </View>
+      ) : null}
+      {zones.length && zTotal > 0 ? (
+        <View className="gap-1.5">
+          <Text variant="eyebrow" className="text-text-muted">Time in zones</Text>
+          {zones.map((z) => {
+            const pct = (z.seconds / zTotal) * 100;
+            const color = ZONE_COLORS[Math.min(Math.max(z.zone - 1, 0), 4)];
+            return (
+              <View key={z.zone} className="flex-row items-center gap-2">
+                <Text variant="micro" className="w-24 text-text-secondary" numberOfLines={1}>Z{z.zone} {ZONE_NAMES[z.zone - 1] ?? ""}</Text>
+                <View className="h-2.5 flex-1 overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
+                  <View style={{ width: `${Math.max(pct, 2)}%`, height: "100%", backgroundColor: color }} />
+                </View>
+                <Text variant="micro" className="w-20 text-right text-text-muted tabular-nums">{Math.round(pct)}% · {z.low}–{z.high}</Text>
+              </View>
+            );
+          })}
+        </View>
+      ) : null}
+      {g.activity_id ? (
+        <View className="flex-row items-center gap-2">
+          <Badge label="Garmin" tone="success" />
+          <Text variant="micro" className="text-text-muted">Matched from Garmin strength training activity</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
 
 /**
- * Single-workout detail (web parity, #429): per-exercise sets (weight × reps),
- * total volume + set count, and the Garmin HR / calories overlay. Fetches
- * /api/workout/[id] on open. Weight unit follows the screen toggle.
+ * Single-workout detail (web parity, #429 / #761): Exercises, Summary (with the
+ * per-workout muscle map), HR (exercise blocks over the Garmin HR line) and Image
+ * tabs. Fetches /api/workout/[id] on open. Weight unit follows the screen toggle.
  */
 export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | null; title?: string; unit: "kg" | "lb"; onClose: () => void }) {
   const [data, setData] = useState<WorkoutDetail | null>(null);
   const [loading, setLoading] = useState(false);
+  const [tab, setTab] = useState<string>("Exercises");
+  const [imgState, setImgState] = useState<"loading" | "ready" | "error">("loading");
+  const [saving, setSaving] = useState(false);
   useEffect(() => {
     if (!id) { setData(null); return; }
     let alive = true;
-    setLoading(true);
+    setLoading(true); setTab("Exercises"); setImgState("loading");
     fetchJson<WorkoutDetail>(`/api/workout/${encodeURIComponent(id)}`)
       .then((d) => alive && setData(d))
       .catch(() => alive && setData(null))
@@ -57,20 +197,26 @@ export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | 
     return () => { alive = false; };
   }, [id]);
 
+  // Hooks stay above the early return (a hook after it changes the hook count when `id` flips).
+  const exercises = data?.exercises ?? [];
+  const muscles = useMemo(() => aggregateWorkoutMuscles(exercises), [exercises]);
   if (!id) return null;
   const w = (kg: number | null | undefined) => (kg == null ? "—" : `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10}`);
-  const exercises = data?.exercises ?? [];
-  let volumeKg = 0, setCount = 0;
-  for (const ex of exercises) for (const s of ex.sets) {
-    if (s.weight_kg != null && s.reps != null) volumeKg += s.weight_kg * s.reps;
-    setCount++;
-  }
+  // Web's totals: working sets only (normal, with weight and reps).
+  let volumeKg = 0, workingSets = 0, totalReps = 0, allSets = 0;
+  for (const ex of exercises) for (const s of ex.sets) { allSets++; if (isWorking(s)) { workingSets++; totalReps += s.reps as number; volumeKg += (s.weight_kg as number) * (s.reps as number); } }
   const vol = unit === "lb" ? volumeKg * KG_TO_LB : volumeKg;
   const dur = data ? durationMin(data) : null;
+  const muscleRows = ALL_MUSCLE_GROUPS.map((mg) => [mg, muscles[mg]?.total ?? 0] as [MuscleGroup, number]).filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1]);
+  const muscleMax = muscleRows.length ? muscleRows[0][1] : 1;
+  const img = workoutImageSource(id);
+  const name = data?.title || title || "Workout";
+  const hasHr = (data?.garmin?.hr_timeline?.length ?? 0) > 1;
+  const tabs = [{ key: "Exercises" }, { key: "Summary" }, { key: "HR" }, { key: "Image" }];
 
   return (
-    <Modal visible={!!id} onClose={onClose} title={data?.title || title || "Workout"}>
-      <View className="gap-3">
+    <Modal visible={!!id} onClose={onClose} title={name}>
+      <View className="gap-3" style={{ maxHeight: 560 }}>
         {loading && !data ? (
           <Text variant="body" className="text-text-muted">Loading…</Text>
         ) : !data ? (
@@ -78,125 +224,113 @@ export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | 
         ) : (
           <>
             <Text variant="micro" className="text-text-muted">{longDate(data.start_time)}</Text>
-            <View className="flex-row flex-wrap gap-3">
-              <View className="min-w-[30%] flex-1">
-                <Text variant="eyebrow" className="text-text-muted">Volume</Text>
-                <Text variant="title" className="text-teal">{vol >= 1000 ? `${(vol / 1000).toFixed(1)}k` : Math.round(vol)}</Text>
-                <Text variant="micro" className="text-text-muted">{unit} · {setCount} sets</Text>
-              </View>
-              {dur != null ? (
-                <View className="min-w-[30%] flex-1">
-                  <Text variant="eyebrow" className="text-text-muted">Duration</Text>
-                  <Text variant="title" className="text-lime">{dur}</Text>
-                  <Text variant="micro" className="text-text-muted">min</Text>
-                </View>
-              ) : null}
-              {data.garmin?.calories != null ? (
-                <View className="min-w-[30%] flex-1">
-                  <Text variant="eyebrow" className="text-text-muted">Calories</Text>
-                  <Text variant="title" className="text-warm">{Math.round(data.garmin.calories)}</Text>
-                  <Text variant="micro" className="text-text-muted">kcal · Garmin</Text>
-                </View>
-              ) : null}
-              {data.garmin?.avg_hr != null ? (
-                <View className="min-w-[30%] flex-1">
-                  <Text variant="eyebrow" className="text-text-muted">Avg HR</Text>
-                  <Text variant="title" className="text-danger">{Math.round(data.garmin.avg_hr)}</Text>
-                  <Text variant="micro" className="text-text-muted">
-                    {data.garmin.min_hr != null ? `${Math.round(data.garmin.min_hr)}–` : ""}{data.garmin.max_hr != null ? `${Math.round(data.garmin.max_hr)} bpm` : "bpm"}
-                  </Text>
-                </View>
-              ) : null}
-            </View>
-
-            {/* Garmin HR over the session (from enrichment hr_samples) */}
-            {(() => {
-              const tl = data.garmin?.hr_timeline ?? [];
-              if (tl.length < 2) return null;
-              const hrs = tl.map((p) => p.hr);
-              const labels = tl.map((p) => `${Math.round(p.elapsed_sec / 60)}m`);
-              return (
-                <View className="gap-1">
-                  <Text variant="eyebrow" className="text-text-muted">Heart rate</Text>
-                  <LineChart height={130} interactive xTicks={4} labels={labels}
-                    yFormat={(v) => `${Math.round(v)}`}
-                    series={[{ values: hrs, color: "#e06060", width: 2 }]} />
-                </View>
-              );
-            })()}
-
-            {/* Time in HR zones (only for workouts matched to a Garmin cardio activity) */}
-            {data.garmin?.hr_zones && data.garmin.hr_zones.length > 0 ? (() => {
-              const zones = data.garmin!.hr_zones!;
-              const maxSec = Math.max(...zones.map((z) => z.seconds), 1);
-              return (
-                <View className="gap-1.5">
-                  <Text variant="eyebrow" className="text-text-muted">Time in zones</Text>
-                  {zones.map((z) => {
-                    const mins = z.seconds / 60;
-                    const color = ZONE_COLORS[Math.min(Math.max(z.zone - 1, 0), 4)];
+            <TabStrip tabs={tabs} value={tab} onChange={setTab} />
+            <ScrollView style={{ maxHeight: 460 }} showsVerticalScrollIndicator={false}>
+              {tab === "Exercises" ? (
+                <View className="gap-2">
+                  {exercises.map((ex, ei) => {
+                    // Top set = heaviest WEIGHT among working sets (web parity); mark every
+                    // set at that weight, and suppress when all working sets already match.
+                    const workWeights = ex.sets.filter((s) => s.type !== "warmup" && s.weight_kg != null && s.weight_kg > 0).map((s) => s.weight_kg as number);
+                    const maxWeight = workWeights.length ? Math.max(...workWeights) : 0;
+                    const normalCount = ex.sets.filter((s) => s.type !== "warmup").length;
+                    const atMaxCount = ex.sets.filter((s) => s.type !== "warmup" && s.weight_kg === maxWeight).length;
+                    const showTop = maxWeight > 0 && atMaxCount < normalCount;
+                    let exVol = 0; ex.sets.forEach((s) => { if (isWorking(s)) exVol += (s.weight_kg as number) * (s.reps as number); });
+                    const exVolDisp = unit === "lb" ? exVol * KG_TO_LB : exVol;
+                    let ordinal = 0;
                     return (
-                      <View key={z.zone} className="flex-row items-center gap-2">
-                        <Text variant="micro" className="w-14 text-text-secondary tabular-nums">Z{z.zone} · {z.low}+</Text>
-                        <View className="h-2.5 flex-1 overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
-                          <View style={{ width: `${Math.max((z.seconds / maxSec) * 100, 2)}%`, height: "100%", backgroundColor: color }} />
+                      <View key={ei} className={`gap-1 ${ei ? "border-t border-border-subtle pt-2" : ""}`}>
+                        <View className="flex-row items-center justify-between gap-2">
+                          <View className="flex-row items-center gap-1.5 flex-shrink">
+                            <Text variant="body" className="text-text flex-shrink" numberOfLines={1}>{ex.title || "Exercise"}</Text>
+                            {ex.muscle_group ? <Badge label={ex.muscle_group} tone="neutral" /> : null}
+                          </View>
+                          {exVol > 0 ? <Text variant="micro" className="text-text-muted tabular-nums">{kvol(exVolDisp)} {unit}</Text> : null}
                         </View>
-                        <Text variant="micro" className="w-12 text-right text-text-muted tabular-nums">{mins >= 1 ? `${Math.round(mins)}m` : `${Math.round(z.seconds)}s`}</Text>
+                        <View className="flex-row flex-wrap gap-1.5">
+                          {ex.sets.map((s, si) => {
+                            const badge = s.type && s.type !== "normal" ? SET_TYPE[s.type] : undefined;
+                            const isTop = showTop && s.weight_kg === maxWeight && s.type !== "warmup";
+                            const num = s.type === "warmup" ? "W" : String(++ordinal);
+                            return (
+                              <View key={si} className="flex-row items-center gap-1 rounded-md bg-surface-subtle px-2 py-1" style={isTop ? { borderWidth: 1, borderColor: "#77c8d1" } : undefined}>
+                                <Text variant="micro" className="text-text-muted tabular-nums">{num}</Text>
+                                {isTop ? <Text variant="micro" style={{ color: "#77c8d1" }}>▲</Text> : null}
+                                {badge && s.type !== "warmup" ? <Text variant="micro" style={{ color: badge.color }}>{badge.label}</Text> : null}
+                                <Text variant="micro" className="tabular-nums text-text-secondary">
+                                  {s.weight_kg != null && s.weight_kg > 0 ? `${w(s.weight_kg)} × ` : (s.reps != null ? "BW × " : "")}{s.reps ?? "—"}
+                                </Text>
+                                {s.avg_hr != null ? <Text variant="micro" className="tabular-nums" style={{ color: "#e06060" }}>♥{Math.round(s.avg_hr)}</Text> : null}
+                              </View>
+                            );
+                          })}
+                        </View>
+                        {ex.notes ? <Text variant="micro" className="text-text-muted" style={{ fontStyle: "italic" }}>{ex.notes}</Text> : null}
                       </View>
                     );
                   })}
                 </View>
-              );
-            })() : null}
-
-            <View className="gap-2">
-              {exercises.map((ex, ei) => {
-                // Top set = heaviest WEIGHT among working sets (web parity); mark every
-                // set at that weight, and suppress when all working sets already match.
-                let exVol = 0;
-                const workWeights = ex.sets.filter((s) => s.type !== "warmup" && s.weight_kg != null && s.weight_kg > 0).map((s) => s.weight_kg as number);
-                const maxWeight = workWeights.length ? Math.max(...workWeights) : 0;
-                const normalCount = ex.sets.filter((s) => s.type !== "warmup").length;
-                const atMaxCount = ex.sets.filter((s) => s.type !== "warmup" && s.weight_kg === maxWeight).length;
-                const showTop = maxWeight > 0 && atMaxCount < normalCount;
-                ex.sets.forEach((s) => { if (s.weight_kg != null && s.reps != null) exVol += s.weight_kg * s.reps; });
-                const exVolDisp = unit === "lb" ? exVol * KG_TO_LB : exVol;
-                return (
-                  <View key={ei} className="gap-1 border-t border-border-subtle pt-2">
-                    <View className="flex-row items-center justify-between">
-                      <Text variant="body" className="flex-shrink text-text" numberOfLines={1}>{ex.title || "Exercise"}</Text>
-                      {exVol > 0 ? (
-                        <Text variant="micro" className="text-text-muted tabular-nums">
-                          {exVolDisp >= 1000 ? `${(exVolDisp / 1000).toFixed(1)}k` : Math.round(exVolDisp)} {unit}
-                        </Text>
-                      ) : null}
-                    </View>
-                    <View className="flex-row flex-wrap gap-1.5">
-                      {ex.sets.map((s, si) => {
-                        const badge = s.type && s.type !== "normal" ? SET_TYPE[s.type] : undefined;
-                        const isTop = showTop && s.weight_kg === maxWeight && s.type !== "warmup";
-                        return (
-                          <View key={si} className="flex-row items-center gap-1 rounded-md bg-surface-subtle px-2 py-1" style={isTop ? { borderWidth: 1, borderColor: "#77c8d1" } : undefined}>
-                            {isTop ? <Text variant="micro" style={{ color: "#77c8d1" }}>▲</Text> : null}
-                            {badge ? <Text variant="micro" style={{ color: badge.color }}>{badge.label}</Text> : null}
-                            <Text variant="micro" className="tabular-nums text-text-secondary">
-                              {s.weight_kg != null && s.weight_kg > 0 ? `${w(s.weight_kg)} × ` : (s.reps != null ? "BW × " : "")}{s.reps ?? "—"}
-                            </Text>
-                            {s.avg_hr != null ? <Text variant="micro" className="tabular-nums" style={{ color: "#e06060" }}>♥{Math.round(s.avg_hr)}</Text> : null}
-                          </View>
-                        );
-                      })}
-                    </View>
+              ) : tab === "Summary" ? (
+                <View className="gap-3">
+                  <View className="flex-row flex-wrap gap-3">
+                    <Box label="Duration" value={dur != null ? `${dur}` : "—"} sub="min" color="#cbe896" />
+                    <Box label="Exercises" value={`${exercises.length}`} sub={`${allSets} sets`} />
+                    <Box label="Working sets" value={`${workingSets}`} sub="weight × reps" />
+                    <Box label="Total reps" value={`${totalReps}`} />
+                    <Box label="Total volume" value={kvol(vol)} sub={unit} color="#77c8d1" />
+                    {data.garmin?.calories != null
+                      ? <Box label="Calories" value={`${Math.round(data.garmin.calories)}`} sub="kcal · Garmin" color="#e0a458" />
+                      : <Box label="Avg volume / set" value={workingSets ? kvol(vol / workingSets) : "—"} sub={unit} />}
                   </View>
-                );
-              })}
-            </View>
-
-            {/* Shareable summary image */}
-            <View className="items-center gap-2 border-t border-border-subtle pt-3">
-              <Image source={workoutImageSource(id)} style={{ width: "100%", aspectRatio: 4 / 3, borderRadius: 12, backgroundColor: "#0e1a22" }} resizeMode="contain" />
-              <Button label="Share workout" variant="secondary" size="sm" onPress={() => { Share.share({ url: workoutImageSource(id).uri, message: data.title || title || "Workout" }).catch(() => {}); }} />
-            </View>
+                  {muscleRows.length ? (
+                    <View className="gap-2 border-t border-border-subtle pt-2">
+                      <Text variant="eyebrow" className="text-text-muted">Muscles worked</Text>
+                      <MuscleBodyMap volumes={muscles} selected={null} onSelect={() => {}} scale={0.8} />
+                      <View className="gap-1" testID="muscle-list">
+                        {muscleRows.slice(0, 6).map(([mg, v]) => (
+                          <View key={mg} className="flex-row items-center gap-2">
+                            <Text variant="micro" className="w-20 text-text-secondary">{MUSCLE_LABELS[mg]}</Text>
+                            <View className="h-2 flex-1 overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
+                              <View style={{ width: `${Math.max(2, (v / muscleMax) * 100)}%`, height: "100%", backgroundColor: "#77c8d1" }} />
+                            </View>
+                            <Text variant="micro" className="w-10 text-right text-text-muted tabular-nums">{Math.round((v / (muscleRows.reduce((a, [, x]) => a + x, 0) || 1)) * 100)}%</Text>
+                          </View>
+                        ))}
+                      </View>
+                    </View>
+                  ) : null}
+                  <View className="gap-1 border-t border-border-subtle pt-2">
+                    <Text variant="eyebrow" className="text-text-muted">Volume by exercise</Text>
+                    {exercises.map((ex, i) => { let v = 0; ex.sets.forEach((s) => { if (isWorking(s)) v += (s.weight_kg as number) * (s.reps as number); }); return v > 0 ? (
+                      <View key={i} className="flex-row justify-between gap-3">
+                        <Text variant="micro" className="text-text-secondary flex-1" numberOfLines={1}>{ex.title}</Text>
+                        <Text variant="micro" className="text-text-muted tabular-nums">{kvol(unit === "lb" ? v * KG_TO_LB : v)} {unit}</Text>
+                      </View>) : null; })}
+                  </View>
+                </View>
+              ) : tab === "HR" ? (
+                data.garmin && hasHr ? <HrTab g={data.garmin} title={name} /> : (
+                  <View className="items-center gap-1 py-6">
+                    <Text variant="body" className="text-text-muted">No heart rate data</Text>
+                    <Text variant="micro" className="text-text-muted">No matching Garmin activity found.</Text>
+                  </View>
+                )
+              ) : (
+                <View className="items-center gap-3">
+                  <View style={{ width: "100%", aspectRatio: 4 / 3, borderRadius: 12, backgroundColor: "#0e1a22", overflow: "hidden" }}>
+                    <Image source={img} style={{ width: "100%", height: "100%" }} resizeMode="contain" onLoadStart={() => setImgState("loading")} onLoad={() => setImgState("ready")} onError={() => setImgState("error")} />
+                    {imgState !== "ready" ? (
+                      <View className="absolute inset-0 items-center justify-center" pointerEvents="none">
+                        <Text variant="caption" className="text-text-muted">{imgState === "error" ? "The card could not be rendered." : "Rendering the card…"}</Text>
+                      </View>
+                    ) : null}
+                  </View>
+                  <Button label={saving ? "Preparing…" : "Save / share PNG"} disabled={saving || imgState !== "ready"} onPress={async () => { setSaving(true); try { await shareImageFile(img, `${name.replace(/\s+/g, "-").toLowerCase()}.png`, name); } catch { /* dismissed */ } finally { setSaving(false); } }} />
+                  <Text variant="micro" className="text-center text-text-muted">The same summary card web renders.</Text>
+                </View>
+              )}
+            </ScrollView>
           </>
         )}
       </View>

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -115,8 +115,8 @@ export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", top
       {showRecent && summary.recent.length ? (
         <Card className="gap-2">
           <Text variant="eyebrow">Recent workouts</Text>
-          {summary.recent.slice(0, 10).map((w) => (
-            <Pressable key={w.id} onPress={() => setWkId({ id: w.id, title: w.title || "Workout" })} className="border-b border-border-subtle py-2">
+          {summary.recent.slice(0, 10).map((w, i) => (
+            <Pressable key={w.id} onPress={() => setWkId({ id: w.id, title: w.title || "Workout" })} className="border-b border-border-subtle py-2" testID={`workout-row-${i}`}>
               <View className="flex-row items-center justify-between">
                 <Text variant="body" className="text-text flex-1" numberOfLines={1}>{w.title || "Workout"}</Text>
                 <View className="flex-row items-center gap-1.5 ml-2">

--- a/universal/src/lib/muscle-groups.ts
+++ b/universal/src/lib/muscle-groups.ts
@@ -47,6 +47,166 @@ export const SLUG_TO_MUSCLE: Record<string, MuscleGroup> = (() => {
   return r;
 })();
 
+export interface MuscleMapping {
+  primary: MuscleGroup[];
+  secondary: MuscleGroup[];
+}
+
+// Exact match mapping for all known exercises
+const EXERCISE_MAP: Record<string, MuscleMapping> = {
+  // --- CHEST ---
+  "Bench Press (Barbell)":          { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+  "Incline Bench Press (Barbell)":  { primary: ["chest"], secondary: ["shoulders", "triceps"] },
+  "Chest Dip":                      { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+  "Chest Dip (Weighted)":           { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+  "Chest Dip (Assisted)":           { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+  "Chest Fly (Machine)":            { primary: ["chest"], secondary: [] },
+  "Chest Fly (Band)":               { primary: ["chest"], secondary: [] },
+  "Push Up (Weighted)":             { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+
+  // --- BACK ---
+  "Iso-Lateral Row (Machine)":      { primary: ["back"], secondary: ["biceps"] },
+  "Iso-Lateral Low Row":            { primary: ["back"], secondary: ["biceps"] },
+  "Pull Up":                        { primary: ["back"], secondary: ["biceps"] },
+  "Pull Up (Assisted)":             { primary: ["back"], secondary: ["biceps"] },
+  "Pull Up (Weighted)":             { primary: ["back"], secondary: ["biceps"] },
+  "Bent Over Row (Barbell)":        { primary: ["back"], secondary: ["biceps", "core"] },
+  "Chest Supported Incline Row (Dumbbell)": { primary: ["back"], secondary: ["biceps"] },
+  "Lat Pulldown (Cable)":           { primary: ["back"], secondary: ["biceps"] },
+  "Lat Pulldown (Machine)":         { primary: ["back"], secondary: ["biceps"] },
+  "Reverse Grip Lat Pulldown (Cable)": { primary: ["back"], secondary: ["biceps"] },
+  "Seated Cable Row - V Grip (Cable)": { primary: ["back"], secondary: ["biceps"] },
+  "Straight Arm Lat Pulldown (Cable)": { primary: ["back"], secondary: [] },
+  "Deadlift (Barbell)":             { primary: ["back", "hamstrings"], secondary: ["glutes", "core", "forearms"] },
+  "Back Extension (Weighted Hyperextension)": { primary: ["back"], secondary: ["glutes", "hamstrings"] },
+  "Back Extension (Hyperextension)": { primary: ["back"], secondary: ["glutes", "hamstrings"] },
+
+  // --- SHOULDERS ---
+  "Overhead Press (Barbell)":       { primary: ["shoulders"], secondary: ["triceps", "core"] },
+  "Seated Overhead Press (Barbell)": { primary: ["shoulders"], secondary: ["triceps"] },
+  "Seated Shoulder Press (Machine)": { primary: ["shoulders"], secondary: ["triceps"] },
+  "Shoulder Press (Dumbbell)":      { primary: ["shoulders"], secondary: ["triceps"] },
+  "Arnold Press (Dumbbell)":        { primary: ["shoulders"], secondary: ["triceps"] },
+  "Lateral Raise (Dumbbell)":       { primary: ["shoulders"], secondary: [] },
+  "Lateral Raise (Machine)":        { primary: ["shoulders"], secondary: [] },
+  "Lateral Raise (Cable)":          { primary: ["shoulders"], secondary: [] },
+  "Front Raise (Dumbbell)":         { primary: ["shoulders"], secondary: [] },
+  "Front Raise (Barbell)":          { primary: ["shoulders"], secondary: [] },
+  "Face Pull":                      { primary: ["shoulders"], secondary: ["back"] },
+  "Rear Deltoid":                   { primary: ["shoulders"], secondary: ["back"] },
+  "Rear Delt Reverse Fly (Machine)": { primary: ["shoulders"], secondary: ["back"] },
+  "Rear Delt Reverse Fly (Cable)":  { primary: ["shoulders"], secondary: ["back"] },
+  "Chest Supported Reverse Fly (Dumbbell)": { primary: ["shoulders"], secondary: ["back"] },
+  "Shoulder Extension":             { primary: ["shoulders"], secondary: [] },
+  "Shrug (Dumbbell)":               { primary: ["shoulders"], secondary: [] },
+
+  // --- BICEPS ---
+  "Hammer Curl (Dumbbell)":         { primary: ["biceps"], secondary: ["forearms"] },
+  "Preacher Curl (Barbell)":        { primary: ["biceps"], secondary: [] },
+  "Concentration Curl":             { primary: ["biceps"], secondary: [] },
+  "Bicep Curl (Barbell)":           { primary: ["biceps"], secondary: [] },
+  "Bicep Curl (Dumbbell)":          { primary: ["biceps"], secondary: [] },
+  "Bicep Curl (Cable)":             { primary: ["biceps"], secondary: [] },
+  "Reverse EZ-Bar Curl":            { primary: ["biceps"], secondary: ["forearms"] },
+
+  // --- TRICEPS ---
+  "Triceps Pushdown":               { primary: ["triceps"], secondary: [] },
+  "Triceps Extension (Cable)":      { primary: ["triceps"], secondary: [] },
+  "One-Arm Cable Cross Body Triceps Extension": { primary: ["triceps"], secondary: [] },
+  "Overhead Triceps Extension (Cable)": { primary: ["triceps"], secondary: [] },
+
+  // --- FOREARMS ---
+  "Seated Palms Up Wrist Curl":     { primary: ["forearms"], secondary: [] },
+
+  // --- QUADS ---
+  "Leg Extension (Machine)":        { primary: ["quads"], secondary: [] },
+  "Leg Press (Machine)":            { primary: ["quads", "glutes"], secondary: ["hamstrings", "calves"] },
+
+  // --- HAMSTRINGS ---
+  "Seated Leg Curl (Machine)":      { primary: ["hamstrings"], secondary: [] },
+  "Lying Leg Curl (Machine)":       { primary: ["hamstrings"], secondary: [] },
+  "Romanian Deadlift (Barbell)":    { primary: ["hamstrings"], secondary: ["glutes", "back"] },
+
+  // --- GLUTES ---
+  "Hip Abduction (Machine)":        { primary: ["glutes"], secondary: [] },
+  "Hip Adduction (Machine)":        { primary: ["glutes"], secondary: [] },
+
+  // --- CALVES ---
+  "Calf Press (Machine)":           { primary: ["calves"], secondary: [] },
+  "Seated Calf Raise":              { primary: ["calves"], secondary: [] },
+
+  // --- CORE ---
+  "Crunch (Weighted)":              { primary: ["core"], secondary: [] },
+  "Crunch":                         { primary: ["core"], secondary: [] },
+  "Crunch (Machine)":               { primary: ["core"], secondary: [] },
+  "Hanging Leg Raise":              { primary: ["core"], secondary: [] },
+  "Leg Raise Parallel Bars":        { primary: ["core"], secondary: [] },
+  "Lying Leg Raise":                { primary: ["core"], secondary: [] },
+  "Side Bend (Dumbbell)":           { primary: ["core"], secondary: [] },
+  "Plank":                          { primary: ["core"], secondary: ["shoulders"] },
+  "Russian Twist (Bodyweight)":     { primary: ["core"], secondary: [] },
+  "Superman":                       { primary: ["core"], secondary: ["back", "glutes"] },
+  "Torso Rotation":                 { primary: ["core"], secondary: [] },
+};
+
+/**
+ * Get primary and secondary muscle groups for an exercise.
+ * Falls back to ILIKE-style pattern matching for unknown exercises.
+ */
+export function getExerciseMuscles(exerciseName: string): MuscleMapping {
+  // Exact match
+  const exact = EXERCISE_MAP[exerciseName];
+  if (exact) return exact;
+
+  // Pattern fallback for unknown exercises
+  const lower = exerciseName.toLowerCase();
+  if (lower.includes("bench") || lower.includes("chest") || lower.includes("push up"))
+    return { primary: ["chest"], secondary: ["triceps"] };
+  if (lower.includes("row") || lower.includes("pull up") || lower.includes("lat ") || lower.includes("pulldown"))
+    return { primary: ["back"], secondary: ["biceps"] };
+  if (lower.includes("shoulder") || lower.includes("overhead press") || lower.includes("lateral raise") || lower.includes("front raise") || lower.includes("face pull") || lower.includes("rear delt") || lower.includes("reverse fly") || lower.includes("shrug"))
+    return { primary: ["shoulders"], secondary: [] };
+  if (lower.includes("curl") || lower.includes("hammer") || lower.includes("preacher") || lower.includes("concentration"))
+    return { primary: ["biceps"], secondary: [] };
+  if (lower.includes("tricep") || lower.includes("pushdown"))
+    return { primary: ["triceps"], secondary: [] };
+  if (lower.includes("deadlift") || lower.includes("back extension"))
+    return { primary: ["back"], secondary: ["hamstrings"] };
+  if (lower.includes("leg press") || lower.includes("leg extension") || lower.includes("squat"))
+    return { primary: ["quads"], secondary: ["glutes"] };
+  if (lower.includes("leg curl") || lower.includes("romanian"))
+    return { primary: ["hamstrings"], secondary: ["glutes"] };
+  if (lower.includes("hip"))
+    return { primary: ["glutes"], secondary: [] };
+  if (lower.includes("calf"))
+    return { primary: ["calves"], secondary: [] };
+  if (lower.includes("crunch") || lower.includes("plank") || lower.includes("leg raise") || lower.includes("twist") || lower.includes("superman") || lower.includes("torso"))
+    return { primary: ["core"], secondary: [] };
+  if (lower.includes("wrist"))
+    return { primary: ["forearms"], secondary: [] };
+  if (lower.includes("dip"))
+    return { primary: ["chest"], secondary: ["triceps", "shoulders"] };
+
+  return { primary: [], secondary: [] };
+}
+
+/** Per-workout muscle volumes for the body map, exactly as web's workout dialog computes
+ *  them: working sets only (weight × reps), primary ×1, secondary ×0.33, bodyweight
+ *  exercises count as 1 so they still light up (soma#761). */
+export function aggregateWorkoutMuscles(exercises: { title?: string | null; sets?: { weight_kg?: number | null; reps?: number | null; type?: string | null }[] | null }[]): Record<string, { primary: number; secondary: number; total: number }> {
+  const out: Record<string, { primary: number; secondary: number; total: number }> = {};
+  for (const mg of ALL_MUSCLE_GROUPS) out[mg] = { primary: 0, secondary: 0, total: 0 };
+  for (const ex of exercises) {
+    const mapping = getExerciseMuscles(ex.title || "");
+    let exVol = 0;
+    for (const st of ex.sets ?? []) if ((st.type ?? "normal") === "normal" && (st.weight_kg ?? 0) > 0 && (st.reps ?? 0) > 0) exVol += (st.weight_kg as number) * (st.reps as number);
+    if (exVol === 0) exVol = 1;
+    for (const mg of mapping.primary) { out[mg].primary += exVol; out[mg].total += exVol; }
+    for (const mg of mapping.secondary) { const c = exVol * 0.33; out[mg].secondary += c; out[mg].total += c; }
+  }
+  return out;
+}
+
 export function hexToRgba(hex: string, alpha: number): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);

--- a/universal/src/lib/share-image.ts
+++ b/universal/src/lib/share-image.ts
@@ -1,0 +1,14 @@
+import { Platform, Share } from "react-native";
+import * as FileSystem from "expo-file-system/legacy";
+import * as Sharing from "expo-sharing";
+
+/** Download a rendered PNG (with the app's auth header) and hand the FILE to the share
+ *  sheet — web offers "Download PNG"; a bare URL would reach the recipient without the
+ *  header and 401 (soma#760, #761). On Expo web falls back to the system share. */
+export async function shareImageFile(img: { uri: string; headers?: Record<string, string> }, fileName: string, title: string): Promise<void> {
+  if (Platform.OS === "web") { await Share.share({ url: img.uri, message: title }).catch(() => {}); return; }
+  const target = `${FileSystem.cacheDirectory ?? ""}${fileName}`;
+  const res = await FileSystem.downloadAsync(img.uri, target, { headers: img.headers });
+  if (await Sharing.isAvailableAsync()) await Sharing.shareAsync(res.uri, { mimeType: "image/png", dialogTitle: title });
+  else await Share.share({ url: res.uri, message: title }).catch(() => {});
+}


### PR DESCRIPTION
S5 of #578 shipped the muscle map and image for the range view; a tab-by-tab pass against web's workout dialog (ledger on #761, screenshots of both) found the per-workout modal itself was a single column with a bare HR line. Now:

**App (`workout-detail-modal.tsx`)**
- Four tabs like web (Exercises / Summary / HR / Image) on the shared pill strip, in a scroll container.
- HR tab: the timeline gantt — exercise blocks over the Garmin HR line from the `exercise_sets[]` the API already sends, solid exercise and dashed set boundaries, the average line, a block strip with sets and per-block average bpm, tap a block to highlight it and read its sets, zone bars normalised by total time with web's zone names, the Garmin provenance badge, and web's "No heart rate data" state.
- Summary tab: web's six boxes (Duration, Exercises, Working sets, Total reps, Total volume, Calories or Avg volume / set) with web's arithmetic (working sets with weight and reps only; the old totals counted warmups), the per-workout muscle body map from the ported exercise → muscle mapping (`getExerciseMuscles`, primary ×1, secondary ×0.33, bodyweight counts 1), a muscle share list and volume by exercise.
- Exercises tab: per-set numbering, exercise notes, muscle-group badge; the app-only failure/dropset badges and inline volume stay.
- Image tab: render state and "Save / share PNG" through the share sheet (the old `Share.share` passed a bare URL that reached the recipient without the auth header).

**Shared**: `LineChart` gains `xBands` / `xLines` (vertical bands and guides); `TabStrip` and `shareImageFile` move to their own files and the activity modal imports them; `lib/muscle-groups.ts` carries web's mapping table verbatim.

Documented, unchanged: overview gym taps still open the Garmin activity modal (the app's rows carry no Hevy id); no zone-coloured gradient stroke.

**Verification**
- `universal/.maestro/verify-workout-detail.yaml` through `verify-device.sh`: newest workout → HR tab (block strip visible) → Summary ("Working sets", muscle map) → Image ("Save / share PNG"); cold open for the live marker. Release APK from this branch on the emulator.
- tsc + vitest green in `universal` (37); web untouched.

Closes #761
