### PR TITLE
feat(app): overview trend chart cards and the Activity breakdown drill-in

### DIFF
--- a/universal/.maestro/verify-overview-trends.yaml
+++ b/universal/.maestro/verify-overview-trends.yaml
@@ -1,0 +1,62 @@
+# Soma verify flow: overview trend chart cards + the Activity breakdown drill-in (soma#769).
+# Run via universal/scripts/verify-device.sh overview --flow .maestro/verify-overview-trends.yaml
+appId: dev.gkos.soma
+name: Soma verify overview trends
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://overview
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "expand-daily-steps"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "expand-daily-steps"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Daily Steps · expanded.*"
+    timeout: 10000
+- takeScreenshot: verify-overview-steps-expanded
+- back
+- scrollUntilVisible:
+    element:
+      id: "expand-stress-trend"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-overview-trend-cards
+- scrollUntilVisible:
+    element:
+      id: "expand-activity-breakdown"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "expand-activity-breakdown"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*activities in this range.*"
+    timeout: 10000
+- takeScreenshot: verify-overview-breakdown-expanded
+- back
+- stopApp
+- openLink: universal://overview
+- waitForAnimationToEnd:
+    timeout: 10000
+# Today's steps sit below the fold on a cold-opened overview: scroll to the live marker.
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 40000
+    speed: 40
+    visibilityPercentage: 60
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { TimeRangeSelector } from "../../components/time-range-selector";
 import { useRangePref, rangeToDays, rangeLabel } from "../../lib/time-range";
 import { InfoHint, STAT_INFO, TREND_7D, TREND_7D_LOWER } from "../../components/info-hint";
+import { OverviewTrendCharts } from "../../components/overview-trend-charts";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
 import { LineChart, ChartLegend, ExpandableChart, chartDateLabel } from "../../components/line-chart";
@@ -423,6 +424,9 @@ export default function OverviewScreen() {
             </Pressable>
           ))}
         </View>
+
+        {/* Web's four page-level trend charts, scoped to the selected range (soma#769) */}
+        <OverviewTrendCharts range={range} />
 
         {/* Activity content — calendar heatmap, recent feed, breakdown */}
         {activitiesDeep?.all?.length ? (

--- a/universal/src/components/activity-content.tsx
+++ b/universal/src/components/activity-content.tsx
@@ -230,23 +230,32 @@ export function ActivityBreakdown({ monthly }: { monthly: MonthSports[] }) {
   }, [monthly]);
   if (!totals.length) return null;
   const max = Math.max(...totals.map(([, n]) => n), 1);
-  return (
-    <Card className="gap-2">
-      <Text variant="eyebrow">Activity breakdown</Text>
+  const sum = totals.reduce((a, [, n]) => a + n, 0) || 1;
+  // Web's Activity Breakdown dialog: the same bars, taller, with each sport's share of the total.
+  const bars = (expanded: boolean) => (
+    <View className={expanded ? "gap-2" : "gap-1.5"}>
       {totals.map(([sport, n]) => {
         const m = meta(sport);
         return (
           <View key={sport} className="gap-0.5">
             <View className="flex-row justify-between">
               <Text variant="caption" className="text-text-secondary">{m.emoji} {m.label}</Text>
-              <Text variant="caption" className="tabular-nums text-text-muted">{n}</Text>
+              <Text variant="caption" className="tabular-nums text-text-muted">{n}{expanded ? ` · ${((n / sum) * 100).toFixed(1)}%` : ""}</Text>
             </View>
-            <View className="h-2 overflow-hidden rounded-full" style={{ backgroundColor: "#16242c" }}>
-              <View className="h-full rounded-full" style={{ width: `${(n / max) * 100}%`, backgroundColor: m.color }} />
+            <View className={expanded ? "h-4 overflow-hidden rounded-md" : "h-2 overflow-hidden rounded-full"} style={{ backgroundColor: "#16242c" }}>
+              <View className="h-full" style={{ width: `${(n / max) * 100}%`, backgroundColor: m.color, borderRadius: expanded ? 4 : 999 }} />
             </View>
           </View>
         );
       })}
+      {expanded ? <Text variant="micro" className="text-text-muted">{sum} activities in this range</Text> : null}
+    </View>
+  );
+  return (
+    <Card className="gap-2">
+      <ExpandableChart title="Activity breakdown" renderExpanded={() => bars(true)}>
+        {bars(false)}
+      </ExpandableChart>
     </Card>
   );
 }

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -14,7 +14,7 @@ export interface ChartSeries {
   color: string;
   width?: number;
   dashed?: boolean;
-  mode?: "line" | "dots";
+  mode?: "line" | "dots" | "bars";
   label?: string;
   axis?: "left" | "right";
   sizes?: (number | null)[];
@@ -204,6 +204,15 @@ export function LineChart(props: LineChartProps) {
               });
             })()}
             {series.map((s, si) => {
+              if (s.mode === "bars") {
+                const bw = n > 1 ? Math.max(1.5, (VBW / (n - 1)) * 0.7) : 8;
+                const floorY = padTop + plotH;
+                return s.values.map((v, i) =>
+                  v == null || !isFinite(v) ? null : (
+                    <Rect key={`${si}-${i}`} x={xAt(i) - bw / 2} y={Math.min(yOf(s, v), floorY)} width={bw} height={Math.max(0.5, Math.abs(floorY - yOf(s, v)))} fill={s.color} fillOpacity={0.85} rx={1} />
+                  ),
+                );
+              }
               if (s.mode === "dots") {
                 return s.values.map((v, i) =>
                   v == null || !isFinite(v) ? null : (

--- a/universal/src/components/overview-trend-charts.tsx
+++ b/universal/src/components/overview-trend-charts.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { View } from "react-native";
+import { Text, Card } from "soma-style";
+import { LineChart, ChartLegend, ExpandableChart, chartDateLabel, type LineChartProps } from "./line-chart";
+import { fetchJson } from "../lib/api";
+
+interface StatPoint { date: string; value: number | null; value2?: number | null }
+interface StatSeries { current: StatPoint[]; summary: { current_avg: number | null } }
+type Metric = "steps" | "calories" | "rhr" | "stress";
+const METRICS: Metric[] = ["steps", "calories", "rhr", "stress"];
+
+const fin = (v: number | null | undefined): number | null => (v != null && isFinite(Number(v)) ? Number(v) : null);
+const mean = (xs: (number | null)[]): number | null => { const v = xs.filter((x): x is number => x != null); return v.length ? v.reduce((a, b) => a + b, 0) / v.length : null; };
+
+/** Web's four page-level trend cards (Daily Steps / Daily Calories / Resting Heart Rate /
+ *  Stress Trend), range-scoped through /api/stats, each expandable (soma#769). */
+export function OverviewTrendCharts({ range }: { range: string }) {
+  const [data, setData] = useState<Partial<Record<Metric, StatSeries>>>({});
+  useEffect(() => {
+    let alive = true;
+    Promise.all(METRICS.map((m) => fetchJson<StatSeries>(`/api/stats/${m}?range=${range}`).then((d) => [m, d] as const).catch(() => [m, null] as const)))
+      .then((pairs) => { if (!alive) return; const next: Partial<Record<Metric, StatSeries>> = {}; for (const [m, d] of pairs) if (d) next[m] = d; setData(next); });
+    return () => { alive = false; };
+  }, [range]);
+
+  const series = (m: Metric) => (data[m]?.current ?? []).filter((p) => p.value != null);
+  const labels = (pts: StatPoint[]) => pts.map((p) => chartDateLabel(p.date));
+  const last7 = (pts: StatPoint[]) => mean(pts.slice(-7).map((p) => fin(p.value)));
+
+  const steps = series("steps"); const cal = series("calories"); const rhr = series("rhr"); const stress = series("stress");
+  if (!steps.length && !cal.length && !rhr.length && !stress.length) return null;
+
+  const cards: { key: string; title: string; subtitle: string; chart: LineChartProps; legend?: { color: string; label: string; dashed?: boolean }[] }[] = [];
+  if (steps.length >= 2) {
+    const avg7 = last7(steps);
+    cards.push({
+      key: "steps", title: "Daily Steps", subtitle: avg7 != null ? `7-day avg: ${Math.round(avg7).toLocaleString()}` : "",
+      chart: { labels: labels(steps), xTicks: 4, yMin: 0, yFormat: (v) => `${Math.round(v / 1000)}k`, refLine: { y: 10000, color: "#77c8d1", label: "10K goal" }, series: [{ values: steps.map((p) => fin(p.value)), color: "#77c8d1", mode: "bars", label: "Steps" }] },
+    });
+  }
+  if (cal.length >= 2) {
+    const active = cal.map((p) => fin(p.value)); const bmr = cal.map((p) => fin(p.value2)); const bmrAvg = mean(bmr); const avg7 = last7(cal);
+    cards.push({
+      key: "calories", title: "Daily Calories", subtitle: avg7 != null ? `7-day active avg: ${Math.round(avg7).toLocaleString()} kcal` : "",
+      chart: { labels: labels(cal), xTicks: 4, yMin: 0, yFormat: (v) => `${Math.round(v).toLocaleString()}`, refLine: bmrAvg != null ? { y: bmrAvg, color: "#8fa8b8", label: `BMR ~${Math.round(bmrAvg).toLocaleString()}` } : undefined, series: [{ values: active, color: "#e0a458", width: 2.2, label: "Active" }, ...(bmr.some((v) => v != null) ? [{ values: bmr, color: "#5a7a8a", width: 1.4, dashed: true, label: "BMR" }] : [])] },
+      legend: [{ color: "#e0a458", label: "Active" }, { color: "#5a7a8a", label: "BMR", dashed: true }],
+    });
+  }
+  if (rhr.length >= 2) {
+    const vals = rhr.map((p) => fin(p.value)); const latest = vals.filter((v): v is number => v != null).at(-1); const avg7 = last7(rhr);
+    cards.push({
+      key: "rhr", title: "Resting Heart Rate", subtitle: latest != null && avg7 != null ? `${Math.round(latest)} bpm · avg ${Math.round(avg7)}` : "",
+      chart: { labels: labels(rhr), xTicks: 4, yFormat: (v) => `${Math.round(v)}`, refLine: avg7 != null ? { y: avg7, color: "#e06060", label: `avg ${Math.round(avg7)}` } : undefined, series: [{ values: vals, color: "#e06060", width: 2.2, label: "RHR" }] },
+    });
+  }
+  if (stress.length >= 2) {
+    const avg = stress.map((p) => fin(p.value)); const max = stress.map((p) => fin(p.value2)); const latest = avg.filter((v): v is number => v != null).at(-1); const avg7 = last7(stress);
+    cards.push({
+      key: "stress", title: "Stress Trend", subtitle: latest != null && avg7 != null ? `Today: ${Math.round(latest)} · avg ${Math.round(avg7)}` : "",
+      chart: { labels: labels(stress), xTicks: 4, yMin: 0, yMax: 100, yFormat: (v) => `${Math.round(v)}`, refLines: [{ y: 25, color: "#6ad4a0", label: "low" }, { y: 50, color: "#e0c458", label: "med" }, { y: 75, color: "#e06060", label: "high" }], series: [...(max.some((v) => v != null) ? [{ values: max, color: "#e06060", width: 1.4, dashed: true, label: "Max" }] : []), { values: avg, color: "#e0c458", width: 2.2, label: "Avg" }] },
+      legend: [{ color: "#e0c458", label: "Avg" }, { color: "#e06060", label: "Max", dashed: true }],
+    });
+  }
+  if (!cards.length) return null;
+  return (
+    <View className="gap-3">
+      <Text variant="eyebrow" className="text-text-muted mt-1">Trends</Text>
+      {cards.map((c) => (
+        <Card key={c.key} className="gap-2">
+          <ExpandableChart title={c.title} chart={c.chart}>
+            {c.subtitle ? <Text variant="micro" className="text-text-muted">{c.subtitle}</Text> : null}
+            <LineChart height={130} interactive {...c.chart} />
+          </ExpandableChart>
+          {c.legend ? <ChartLegend items={c.legend} /> : null}
+        </Card>
+      ))}
+    </View>
+  );
+}


### PR DESCRIPTION
Item 1 of the Phase 2 umbrella #768 (overview tails). Ledger and evidence on #769.

- `OverviewTrendCharts`: web's four page-level trend cards after Today's metrics — Daily Steps (bars, "10K goal" line, "7-day avg" subtitle), Daily Calories (active + BMR series, "BMR ~x" line), Resting Heart Rate (line + "avg x"), Stress Trend (avg + max, low/med/high lines) — scoped to the selected range through `/api/stats/{steps,calories,rhr,stress}`, each expandable.
- `LineChart` gains a `bars` series mode (steps).
- Activity breakdown expands into web's dialog: taller bars with each sport's share of the total and the range count.

Verification: `universal/.maestro/verify-overview-trends.yaml` through `verify-device.sh` (Daily Steps expand → modal stamp; trend cards visible; breakdown expand → share list; cold open live marker). Release APK from this branch on the emulator. tsc + vitest green in `universal` (37); web untouched.

Closes #769
