### PR TITLE
feat(app): running tails — Monthly mileage as the shared bar chart, axis ticks on the HR-vs-pace scatter

### DIFF
--- a/universal/.maestro/verify-running-tails.yaml
+++ b/universal/.maestro/verify-running-tails.yaml
@@ -1,0 +1,50 @@
+# Soma verify flow: running tails (soma#771): Monthly mileage as the shared chart (expand),
+# HR-vs-pace axis ticks. Run via universal/scripts/verify-device.sh running --flow .maestro/verify-running-tails.yaml
+appId: dev.gkos.soma
+name: Soma verify running tails
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "expand-monthly-mileage"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "expand-monthly-mileage"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Monthly mileage · expanded.*"
+    timeout: 10000
+- takeScreenshot: verify-running-mileage-expanded
+- back
+- scrollUntilVisible:
+    element:
+      text: "(?i)heart rate vs pace"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- scrollUntilVisible:
+    element:
+      text: "(?s).*slower .*→.*"
+    direction: DOWN
+    timeout: 30000
+    speed: 30
+    visibilityPercentage: 80
+- takeScreenshot: verify-running-hrpace
+- stopApp
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/components/running-hr-pace.tsx
+++ b/universal/src/components/running-hr-pace.tsx
@@ -61,7 +61,14 @@ export function RunningHrPace({ data }: { data: { points: HrPacePoint[] } | null
         <Text variant="micro" className="text-text-muted">tap a dot to read a run</Text>
       )}
 
-      <View style={{ position: "relative", height: H }}>
+      <View className="flex-row">
+      {/* HR axis ticks (web's YAxis) */}
+      <View className="w-8 justify-between" style={{ height: H }}>
+        <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(maxH)}</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{Math.round((minH + maxH) / 2)}</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(minH)}</Text>
+      </View>
+      <View className="flex-1" style={{ position: "relative", height: H }} accessibilityLabel={`HR ${Math.round(minH)} to ${Math.round(maxH)} bpm, pace ${pace(minP)} to ${pace(maxP)} per km`}>
         <Svg width="100%" height={H} viewBox={`0 0 100 ${H}`} preserveAspectRatio="none">
           {visible.map((p, i) => {
             const cx = ((p.pace as number) - minP) / rP * 96 + 2;
@@ -98,10 +105,15 @@ export function RunningHrPace({ data }: { data: { points: HrPacePoint[] } | null
           })}
         </View>
       </View>
+      </View>
 
-      <View className="flex-row items-center justify-between">
-        <Text variant="micro" className="text-text-muted">← {pace(minP)} faster</Text>
-        <Text variant="micro" className="text-text-muted">slower {pace(maxP)} →</Text>
+      {/* pace axis ticks (web's XAxis): faster on the left */}
+      <View className="flex-row justify-between pl-8">
+        <Text variant="micro" className="tabular-nums text-text-muted">← {pace(minP)} faster</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{pace(minP + rP * 0.25)}</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{pace(minP + rP * 0.5)}</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{pace(minP + rP * 0.75)}</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">slower {pace(maxP)} →</Text>
       </View>
       <Text variant="micro" className="text-text-muted">HR {Math.round(minH)}–{Math.round(maxH)} bpm (up = higher) · dot = distance</Text>
 

--- a/universal/src/components/running-mileage.tsx
+++ b/universal/src/components/running-mileage.tsx
@@ -1,6 +1,6 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
-import { ExpandableChart } from "./line-chart";
+import { LineChart, ExpandableChart, type LineChartProps } from "./line-chart";
 
 interface MileageMonth { month: string; km: number; runs: number }
 
@@ -10,26 +10,9 @@ function monthLabel(ym: string): string {
   return MONTHS[(m ?? 1) - 1] ?? ym;
 }
 
-/** Monthly mileage bar chart (last N months), peak month highlighted. When the
-    dated detail is available each bar is labelled with its month + run count
-    (web parity); otherwise it falls back to the value-only series. Expands
-    into a taller copy like web's ExpandableChartCard (soma#756). */
-function MileageBars({ values, maxIdx, height }: { values: number[]; maxIdx: number; height: number }) {
-  const max = Math.max(...values) || 1;
-  return (
-    <View className="flex-row items-end gap-1" style={{ height }}>
-      {values.map((m, i) => (
-        <View key={i} className="flex-1 items-center justify-end self-stretch">
-          <View
-            className="w-full rounded-t-sm"
-            style={{ height: `${Math.max(3, (m / max) * 100)}%`, backgroundColor: i === maxIdx ? "#77c8d1" : "#2f4a58" }}
-          />
-        </View>
-      ))}
-    </View>
-  );
-}
-
+/** Monthly mileage as web's bar chart: km axis, month ticks, tap-to-read, expandable
+    (soma#771). With the dated detail each month also lists its run count; without it
+    the value-only series is drawn. Peak month highlighted in the footer. */
 export function RunningMileage({ mileage, months }: { mileage?: number[] | null; months?: MileageMonth[] | null }) {
   const detail = (months ?? []).filter((m) => isFinite(m.km));
   const useDetail = detail.length >= 2;
@@ -38,26 +21,33 @@ export function RunningMileage({ mileage, months }: { mileage?: number[] | null;
   const max = Math.max(...values) || 1;
   const maxIdx = values.indexOf(max);
   const total = values.reduce((a, b) => a + b, 0);
-  const labelsRow = useDetail ? (
-    <View className="flex-row gap-1">
-      {detail.map((m, i) => (
-        <View key={i} className="flex-1 items-center">
-          <Text variant="micro" className="text-text-muted">{monthLabel(m.month)}</Text>
-          <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(m.km)}·{m.runs}</Text>
-        </View>
-      ))}
-    </View>
-  ) : null;
+  const labels = useDetail ? detail.map((m) => monthLabel(m.month)) : values.map((_, i) => `${i + 1}`);
+  const chart: LineChartProps = {
+    labels,
+    xTicks: Math.min(values.length, 6),
+    yMin: 0,
+    yFormat: (v) => `${Math.round(v)}`,
+    series: [{ values, color: "#77c8d1", mode: "bars", label: "km" }],
+  };
 
   return (
     <Card className="gap-2">
-      <ExpandableChart title="Monthly mileage" renderExpanded={() => <View className="gap-2"><MileageBars values={values} maxIdx={maxIdx} height={220} />{labelsRow}</View>}>
-        <MileageBars values={values} maxIdx={maxIdx} height={96} />
+      <ExpandableChart title="Monthly mileage" chart={chart}>
+        <Text variant="micro" className="text-text-muted">km per month</Text>
+        <LineChart height={120} interactive {...chart} />
       </ExpandableChart>
-      {labelsRow}
+      {useDetail ? (
+        <View className="flex-row gap-1">
+          {detail.map((m, i) => (
+            <View key={i} className="flex-1 items-center">
+              <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(m.km)}·{m.runs}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
       <View className="flex-row justify-between">
         <Text variant="micro" className="text-text-muted">
-          peak {Math.round(max)} km{useDetail ? ` · ${MONTHS.length && detail[maxIdx] ? monthLabel(detail[maxIdx].month) : ""}` : ""} · last {values.length} mo
+          peak {Math.round(max)} km{useDetail && detail[maxIdx] ? ` · ${monthLabel(detail[maxIdx].month)}` : ""} · last {values.length} mo{useDetail ? " · km·runs" : ""}
         </Text>
         <Text variant="micro" className="tabular-nums text-text-muted">
           {Math.round(total)} km{useDetail ? ` · ${detail.reduce((a, b) => a + b.runs, 0)} runs` : " total"}


### PR DESCRIPTION
Item 2 of the Phase 2 umbrella #768 (running tails). Ledger and evidence on #771. Shoes and the six personal records were already at parity, so the tails are the two bespoke charts:

- Monthly mileage: web's bar chart through the shared chart (km axis, month ticks, tap-to-read, expand); the runs-per-month row and the peak/total footer stay.
- Heart rate vs pace: the scatter stays bespoke (its x axis is pace, not time) and gains web's axis ticks: pace along the bottom (faster on the left), HR on the left; the tap-a-dot read-out and year chips remain.

Verification: `universal/.maestro/verify-running-tails.yaml` through `verify-device.sh` (mileage expand → modal stamp; HR-vs-pace ticks; cold open live marker). Release APK from this branch on the emulator. tsc + vitest green in `universal` (37); web untouched.

Closes #771
