### PR TITLE
feat(app): sleep tails, schedule band, hours axis, resting HR card

### DIFF
--- a/universal/.maestro/verify-running-tails.yaml
+++ b/universal/.maestro/verify-running-tails.yaml
@@ -9,6 +9,12 @@ tags:
 - openLink: universal://running
 - waitForAnimationToEnd:
     timeout: 10000
+# Wait for the loaded state (header stats) before scrolling: against production the data can
+# arrive after the animation settles, and a scroll that starts on the skeleton runs off the end.
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
 - scrollUntilVisible:
     element:
       id: "expand-monthly-mileage"

--- a/universal/.maestro/verify-sleep-tails.yaml
+++ b/universal/.maestro/verify-sleep-tails.yaml
@@ -1,0 +1,56 @@
+# Soma verify flow: sleep tails (soma#772): schedule band + expand, stages hours axis, RHR card.
+# Run via universal/scripts/verify-device.sh sleep --flow .maestro/verify-sleep-tails.yaml
+appId: dev.gkos.soma
+name: Soma verify sleep tails
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://sleep
+- waitForAnimationToEnd:
+    timeout: 10000
+# Loaded state first (header stat), so the scroll does not start on the skeleton.
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- scrollUntilVisible:
+    element:
+      id: "expand-resting-heart-rate"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-sleep-rhr-card
+- scrollUntilVisible:
+    element:
+      text: "SLEEP STAGES"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-sleep-stages-axis
+- scrollUntilVisible:
+    element:
+      id: "expand-sleep-schedule"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "expand-sleep-schedule"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Sleep schedule · expanded.*"
+    timeout: 10000
+- takeScreenshot: verify-sleep-schedule-expanded
+- back
+- stopApp
+- openLink: universal://sleep
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -355,6 +355,30 @@ export default function SleepScreen() {
           </Card>
         ) : null}
 
+        {(rhr?.current?.length ?? 0) >= 2 ? (
+          <Card className="gap-2">
+            {(() => {
+              const vals = rhr!.current.map((p) => finiteOrNull(p.value));
+              const nn = vals.filter((v): v is number => v != null);
+              const avg = nn.length ? nn.reduce((a, b) => a + b, 0) / nn.length : null;
+              const latest = nn.at(-1);
+              const rhrChart = {
+                labels: rhr!.current.map((p) => chartLabel(p.date)),
+                xTicks: 4,
+                yFormat: (v: number) => String(Math.round(v)),
+                refLine: avg != null ? { y: avg, color: "#e06060", label: `avg ${Math.round(avg)}` } : undefined,
+                series: [{ values: vals, color: "#e06060", width: 2.2, label: "RHR" }],
+              };
+              return (
+                <ExpandableChart title="Resting heart rate" chart={rhrChart}>
+                  {latest != null && avg != null ? <Text variant="micro" className="text-text-muted tabular-nums">{Math.round(latest)} bpm · avg {Math.round(avg)}</Text> : null}
+                  <LineChart height={130} interactive {...rhrChart} />
+                </ExpandableChart>
+              );
+            })()}
+          </Card>
+        ) : null}
+
         {(battery?.current?.length ?? 0) >= 2 ? (
           <Card className="gap-2">
             {(() => {

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -40,6 +40,9 @@ export interface LineChartProps {
   yMax?: number;
   /** Number of evenly-spaced x labels to draw (default 2 = first + last). */
   xTicks?: number;
+  /** Number of evenly spaced left-axis labels (default 2 = the two ends). Web's charts label
+   *  intermediate ticks; a clock axis with only its two ends reads as a two-hour window. */
+  yTicks?: number;
   /** Enable tap/drag to read the exact value(s) at a point. */
   interactive?: boolean;
   /** Flip the left axis so smaller values sit higher (web's reversed pace axis). */
@@ -48,6 +51,8 @@ export interface LineChartProps {
   xBands?: { i0: number; i1: number; color: string; opacity?: number }[];
   /** Vertical guide lines at an x index (exercise / set boundaries). */
   xLines?: { i: number; color?: string; dashed?: boolean }[];
+  /** Fill between two series (by index) — web's bedtime→wake band (soma#772). */
+  bands?: { a: number; b: number; color: string; opacity?: number }[];
 }
 
 const VBW = 320;
@@ -61,7 +66,7 @@ export function chartDateLabel(iso: string): string {
 /** A compact react-native-svg line/scatter chart with y-axis labels, dated x
  *  ticks, an optional right axis, and optional tap-to-read cursor + callout. */
 export function LineChart(props: LineChartProps) {
-  const { series, labels, height = 120, yFormat, yFormatRight, refLine, refLines, refAreas, yMin, yMax, xTicks, interactive, invertY, xBands, xLines } = props;
+  const { series, labels, height = 120, yFormat, yFormatRight, refLine, refLines, refAreas, yMin, yMax, xTicks, yTicks, interactive, invertY, xBands, xLines, bands } = props;
   const fmtL = yFormat ?? ((v: number) => String(Math.round(v)));
   const fmtR = yFormatRight ?? fmtL;
   const [active, setActive] = useState<number | null>(null);
@@ -138,8 +143,11 @@ export function LineChart(props: LineChartProps) {
       <View className="flex-row">
         {/* left axis labels */}
         <View className="w-9 justify-between" style={{ height, paddingVertical: padTop }}>
-          <Text variant="micro" className="text-text-muted tabular-nums">{fmtL(invertY ? loL : hiL)}</Text>
-          <Text variant="micro" className="text-text-muted tabular-nums">{fmtL(invertY ? hiL : loL)}</Text>
+          {Array.from({ length: Math.max(2, yTicks ?? 2) }, (_: unknown, i: number) => {
+            const t = i / (Math.max(2, yTicks ?? 2) - 1); // 0 = top of the axis
+            const v = invertY ? loL + (hiL - loL) * t : hiL - (hiL - loL) * t;
+            return <Text key={`yt-${i}`} variant="micro" className="text-text-muted tabular-nums">{fmtL(v)}</Text>;
+          })}
         </View>
 
         <View
@@ -169,6 +177,13 @@ export function LineChart(props: LineChartProps) {
             {xLines?.map((l, li) => (
               <Line key={`xl-${li}`} x1={xAt(Math.max(0, Math.min(n - 1, l.i)))} y1={padTop} x2={xAt(Math.max(0, Math.min(n - 1, l.i)))} y2={padTop + plotH} stroke={l.color ?? "#ffffff"} strokeWidth={1} strokeOpacity={l.dashed ? 0.35 : 0.6} strokeDasharray={l.dashed ? "3 3" : undefined} />
             ))}
+            {bands?.map((bd, bi) => {
+              const sa = series[bd.a]; const sb = series[bd.b];
+              if (!sa || !sb) return null;
+              const fwd: string[] = []; const back: string[] = [];
+              sa.values.forEach((v, i) => { const w = sb.values[i]; if (v != null && isFinite(v) && w != null && isFinite(w)) { fwd.push(`${xAt(i)},${yOf(sa, v)}`); back.push(`${xAt(i)},${yOf(sb, w)}`); } });
+              return fwd.length >= 2 ? <Polygon key={`bd-${bi}`} points={[...fwd, ...back.reverse()].join(" ")} fill={bd.color} fillOpacity={bd.opacity ?? 0.18} /> : null;
+            })}
             <Line x1={0} y1={yAtL(hiL)} x2={VBW} y2={yAtL(hiL)} stroke="#1e2f38" strokeWidth={1} />
             <Line x1={0} y1={yAtL(loL)} x2={VBW} y2={yAtL(loL)} stroke="#1e2f38" strokeWidth={1} />
             {refLine && refLine.y >= loL && refLine.y <= hiL ? (

--- a/universal/src/components/sleep-dashboard.tsx
+++ b/universal/src/components/sleep-dashboard.tsx
@@ -51,8 +51,15 @@ function StagesTrend({ nights, height = 112 }: { nights: SleepNight[]; height?: 
   if (data.length < 2) return null;
   // Keep the 9h target inside the plot even on short-sleep months.
   const maxTotal = Math.max(...data.map((n) => n.total ?? 0), 9 * 3600) || 1;
+  const maxH = maxTotal / 3600;
   return (
-    <View style={{ height }}>
+    <View className="flex-row">
+    <View className="w-7 justify-between" style={{ height }}>
+      <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(maxH)}h</Text>
+      <Text variant="micro" className="tabular-nums text-text-muted">{Math.round(maxH / 2)}h</Text>
+      <Text variant="micro" className="tabular-nums text-text-muted">0h</Text>
+    </View>
+    <View className="flex-1" style={{ height }}>
       {SLEEP_GUIDES.map((g) => {
         const pct = ((g.h * 3600) / maxTotal) * 100;
         return pct > 0 && pct < 100 ? (
@@ -79,6 +86,7 @@ function StagesTrend({ nights, height = 112 }: { nights: SleepNight[]; height?: 
           </View>
         );
       })}
+    </View>
     </View>
     </View>
   );

--- a/universal/src/components/sleep-schedule-chart.tsx
+++ b/universal/src/components/sleep-schedule-chart.tsx
@@ -1,6 +1,6 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
-import { LineChart, ChartLegend } from "./line-chart";
+import { LineChart, ChartLegend, ExpandableChart, type LineChartProps } from "./line-chart";
 import type { SchedulePoint } from "../lib/api";
 
 const BED = "#8b7fe0"; // bedtime line (indigo)
@@ -13,7 +13,8 @@ function fmtHour(h: number): string {
   const mins = Math.round((actual - whole) * 60);
   const ampm = whole >= 12 ? "PM" : "AM";
   const h12 = whole % 12 === 0 ? 12 : whole % 12;
-  return `${h12}:${String(mins).padStart(2, "0")} ${ampm}`;
+  // Whole hours (the axis ticks) stay compact so they fit the axis column; readouts keep minutes.
+  return mins === 0 ? `${h12} ${ampm}` : `${h12}:${String(mins).padStart(2, "0")} ${ampm}`;
 }
 
 const chartLabel = (iso: string) => {
@@ -44,25 +45,38 @@ export function SleepScheduleChart({ schedule }: { schedule: SchedulePoint[] | u
   const avgBed = last7.reduce((s, p) => s + norm(p.bedtimeHour), 0) / last7.length;
   const avgWake = last7.reduce((s, p) => s + p.wakeHour, 0) / last7.length;
 
+  // Web's domain: whole hours around the data (floor−1 … ceil+1, clamped 0…33, ≥6 h span),
+  // on a REVERSED axis so the earlier clock time sits at the top (wake above bedtime).
+  const all = [...bedtimes, ...wakes];
+  let lo = Math.max(0, Math.floor(Math.min(...all)) - 1);
+  let hi = Math.min(33, Math.ceil(Math.max(...all)) + 1);
+  if (hi - lo < 6) { const mid = (lo + hi) / 2; lo = Math.floor(mid - 3); hi = Math.ceil(mid + 3); }
+  // Five whole-hour ticks: stretch the span to a multiple of 4 h (downwards, the top is the wake side).
+  const Y_TICKS = 5;
+  lo = hi - Math.ceil((hi - lo) / (Y_TICKS - 1)) * (Y_TICKS - 1);
+
+  // Web draws bedtime and wake as two stacked Areas, so the night reads as one filled band.
+  const chart: LineChartProps = {
+    labels,
+    xTicks: 4,
+    yMin: lo,
+    yMax: hi,
+    yTicks: Y_TICKS,
+    invertY: true,
+    yFormat: (v) => fmtHour(v),
+    bands: [{ a: 0, b: 1, color: BED, opacity: 0.22 }],
+    series: [
+      { values: bedtimes, color: BED, width: 2.2, label: "Bedtime" },
+      { values: wakes, color: WAKE, width: 2.2, label: "Wake" },
+    ],
+  };
   return (
     <Card className="gap-2">
-      <View className="flex-row items-center justify-between">
-        <Text variant="eyebrow">Sleep schedule</Text>
-        <Text variant="micro" className="text-text-muted tabular-nums">
-          {fmtHour(avgBed)} → {fmtHour(avgWake)}
-        </Text>
-      </View>
-      <LineChart
-        height={150}
-        interactive
-        labels={labels}
-        yFormat={(v) => fmtHour(v)}
-        series={[
-          { values: bedtimes, color: BED, width: 2.2 },
-          { values: wakes, color: WAKE, width: 2.2 },
-        ]}
-      />
-      <ChartLegend items={[{ color: BED, label: "Bedtime" }, { color: WAKE, label: "Wake" }]} />
+      <ExpandableChart title="Sleep schedule" chart={chart}>
+        <Text variant="micro" className="text-text-muted tabular-nums">{fmtHour(avgBed)} → {fmtHour(avgWake)} · last 7 nights</Text>
+        <LineChart height={150} interactive {...chart} />
+      </ExpandableChart>
+      <ChartLegend items={[{ color: BED, label: "Bedtime" }, { color: WAKE, label: "Wake" }, { color: BED, label: "asleep (band)" }]} />
     </Card>
   );
 }


### PR DESCRIPTION
## Phase 2 · Item 3 · sleep tails

Closes #772

Gap ledger and side-by-side are on the issue. What changes in the app:

- **Sleep schedule as a filled band.** `LineChart` gets a `bands` prop (polygon between two series); the schedule card fills bedtime→wake, expands, and captions the last 7 nights.
- **Hours axis on the stages chart.** The stages trend shows `max h / half / 0h` ticks instead of an unlabelled stack.
- **Resting heart rate card.** New expandable trend card on the sleep page, mirroring web's dedicated RHR chart.
- **Harness.** `verify-running-tails.yaml` waits for the loaded state before scrolling (the post-merge check against production scrolled past the card while data was still loading).

Verification: release APK from this branch on emulator-5554 with the real account (`verify-device.sh sleep --flow .maestro/verify-sleep-tails.yaml`), screenshots read back and posted on #772. tsc + vitest green in `universal`; `web` untouched.
