### PR TITLE
feat(app): activities tails, stacked monthly distribution, max-speed chart, list depth

### DIFF
--- a/universal/.maestro/verify-activities-tails.yaml
+++ b/universal/.maestro/verify-activities-tails.yaml
@@ -1,0 +1,63 @@
+# Soma verify flow: activities tails (soma#773): monthly distribution + max-speed progression as
+# shared charts (expand), 20-row pages. Run via universal/scripts/verify-device.sh activities --flow .maestro/verify-activities-tails.yaml
+appId: dev.gkos.soma
+name: Soma verify activities tails
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://activities
+- waitForAnimationToEnd:
+    timeout: 10000
+# Loaded state first, so the scroll does not start on the skeleton (production can be slow).
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- scrollUntilVisible:
+    element:
+      id: "expand-monthly-activity"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "expand-monthly-activity"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Monthly activity · expanded.*"
+    timeout: 10000
+- takeScreenshot: verify-activities-monthly-expanded
+- back
+- scrollUntilVisible:
+    element:
+      id: "expand-max-speed-progression"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "expand-max-speed-progression"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Max speed progression · expanded.*"
+    timeout: 10000
+- takeScreenshot: verify-activities-kite-expanded
+- back
+- scrollUntilVisible:
+    element:
+      text: "(?s).*1–20 of .*"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    visibilityPercentage: 80
+- takeScreenshot: verify-activities-list-page
+- stopApp
+- openLink: universal://activities
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/components/activities-deep.tsx
+++ b/universal/src/components/activities-deep.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import { View, Pressable, TextInput } from "react-native";
-import Svg, { Circle, Polyline } from "react-native-svg";
-import { ExpandableChart } from "./line-chart";
+import { ExpandableChart, LineChart, type LineChartProps } from "./line-chart";
 import { Text, Card } from "soma-style";
 import type { ActivitiesDeep, ActivityRow, KiteSession } from "../lib/api";
 import { ActivityDetailModal } from "./activity-detail-modal";
@@ -47,27 +46,21 @@ export function ActivitiesMonthly({ monthly }: { monthly: ActivitiesDeep["monthl
   const max = Math.max(...totals) || 1;
   const sports = [...new Set(data.flatMap((m) => Object.keys(m.sports)))];
 
-  const bars = (height: number) => (
-    <View className="flex-row items-end gap-1" style={{ height }}>
-      {data.map((m, i) => {
-        const total = totals[i];
-        return (
-          <View key={m.month} className="flex-1 items-center justify-end self-stretch gap-0.5">
-            <View className="w-full overflow-hidden rounded-t-sm" style={{ height: `${Math.max(3, (total / max) * 100)}%` }}>
-              {Object.entries(m.sports).map(([s, c]) => (
-                <View key={s} style={{ height: `${(c / total) * 100}%`, backgroundColor: sportColor(s) }} />
-              ))}
-            </View>
-            <Text variant="micro" className="text-text-muted" style={{ fontSize: 8 }}>{i % labelStep === 0 || i === data.length - 1 ? shortMonth(m.month) : ""}</Text>
-          </View>
-        );
-      })}
-    </View>
-  );
+  // Web's stacked BarChart through the shared chart: one bar series per sport on one stack,
+  // a count axis, month ticks and tap-to-read listing every sport's count (soma#773).
+  void max; void labelStep;
+  const chart: LineChartProps = {
+    labels: data.map((m) => shortMonth(m.month)),
+    xTicks: Math.min(data.length, 6),
+    yMin: 0,
+    yFormat: (v) => `${Math.round(v)}`,
+    series: sports.map((s) => ({ values: data.map((m) => m.sports[s] ?? null), color: sportColor(s), mode: "bars" as const, stack: "sports", label: s })),
+  };
   return (
     <Card className="gap-2">
-      <ExpandableChart title="Monthly activity" renderExpanded={() => bars(240)}>
-        {bars(112)}
+      <ExpandableChart title="Monthly activity" chart={chart}>
+        <Text variant="micro" className="text-text-muted">sessions per month · {totals.reduce((a, b) => a + b, 0)} in range</Text>
+        <LineChart height={120} interactive {...chart} />
       </ExpandableChart>
       <View className="flex-row flex-wrap gap-x-3 gap-y-1">
         {sports.map((s) => (
@@ -104,18 +97,17 @@ export function KiteDeepDive({ sessions }: { sessions: KiteSession[] }) {
     return slice.reduce((a, b) => a + b, 0) / slice.length;
   });
   const minS = Math.min(...speeds), maxS = Math.max(...speeds), rS = maxS - minS || 1;
-  const H = 90;
-  const x = (i: number) => (i / Math.max(1, speeds.length - 1)) * 96 + 2;
-  const speedSvg = (h: number) => {
-    const y = (v: number) => h - ((v - minS) / rS) * (h - 10) - 5;
-    return (
-      <Svg width="100%" height={h} viewBox={`0 0 100 ${h}`} preserveAspectRatio="none">
-        <Polyline points={ma.map((v, i) => `${x(i)},${y(v)}`).join(" ")} fill="none" stroke="#22d3ee" strokeWidth={1.4} opacity={0.9} />
-        {speeds.map((v, i) => (
-          <Circle key={i} cx={x(i)} cy={y(v)} r={2} fill="#22d3ee" fillOpacity={0.5} />
-        ))}
-      </Svg>
-    );
+  void minS; void rS;
+  // Web's Max Speed Progression (scatter + moving average) through the shared chart:
+  // dots per session, a line for the moving average, a knots axis, dated ticks, tap-to-read.
+  const speedChart: LineChartProps = {
+    labels: withSpeed.map((s) => s.date),
+    xTicks: Math.min(withSpeed.length, 4),
+    yFormat: (v) => `${v.toFixed(0)} kt`,
+    series: [
+      { values: speeds, color: "#22d3ee", mode: "dots", width: 3, label: "Max speed" },
+      { values: ma, color: "#22d3ee", width: 1.4, label: "Moving avg" },
+    ],
   };
 
   return (
@@ -127,8 +119,8 @@ export function KiteDeepDive({ sessions }: { sessions: KiteSession[] }) {
 
       {speeds.length >= 3 ? (
         <View className="gap-1">
-          <ExpandableChart title="Max speed progression" renderExpanded={() => speedSvg(240)}>
-            {speedSvg(H)}
+          <ExpandableChart title="Max speed progression" chart={speedChart}>
+            <LineChart height={110} interactive {...speedChart} />
           </ExpandableChart>
           <Text variant="micro" className="text-text-muted">max speed per session · line = moving avg</Text>
         </View>
@@ -282,7 +274,7 @@ export function SnowDeepDive({ all }: { all: ActivityRow[] }) {
   );
 }
 
-const PAGE = 12;
+const PAGE = 20; // web pages 20 rows
 type SortKey = "date" | "distance_km" | "duration_min" | "avg_hr" | "calories" | "elev_gain";
 const SORTS: { key: SortKey; label: string }[] = [
   { key: "date", label: "Date" }, { key: "distance_km", label: "Dist" }, { key: "duration_min", label: "Time" },
@@ -330,7 +322,7 @@ export function ActivitiesList({ all }: { all: ActivityRow[] }) {
     <Card className="gap-2">
       <View className="flex-row items-center justify-between">
         <Text variant="eyebrow">All activities</Text>
-        <Text variant="micro" className="tabular-nums text-text-muted">{filtered.length} total</Text>
+        <Text variant="micro" className="tabular-nums text-text-muted">{filtered.length ? `${cur * PAGE + 1}–${Math.min((cur + 1) * PAGE, filtered.length)} of ${filtered.length}` : "0 activities"}</Text>
       </View>
 
       <TextInput

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -20,6 +20,8 @@ export interface ChartSeries {
   sizes?: (number | null)[];
   /** Fill under the line down to the plot floor (web's elevation Area). */
   area?: boolean;
+  /** Bar series with the same stack key pile up per x index (web's stacked BarChart). */
+  stack?: string;
 }
 
 export interface LineChartProps {
@@ -80,6 +82,14 @@ export function LineChart(props: LineChartProps) {
     return all;
   };
   const lExtra: number[] = [];
+  // Stacked bars: the axis must reach the summed height per index.
+  const stackTops = new Map<string, number[]>();
+  for (const s of series) if (s.mode === "bars" && s.stack) {
+    const acc = stackTops.get(s.stack) ?? [];
+    s.values.forEach((v, i) => { acc[i] = (acc[i] ?? 0) + (v != null && isFinite(v) ? v : 0); });
+    stackTops.set(s.stack, acc);
+  }
+  for (const tops of stackTops.values()) for (const t of tops) if (t != null && isFinite(t)) lExtra.push(t);
   if (refLine && isFinite(refLine.y)) lExtra.push(refLine.y);
   if (refLines) for (const r of refLines) if (isFinite(r.y)) lExtra.push(r.y);
   if (refAreas) for (const a of refAreas) { if (isFinite(a.y1)) lExtra.push(a.y1); if (isFinite(a.y2)) lExtra.push(a.y2); }
@@ -222,11 +232,15 @@ export function LineChart(props: LineChartProps) {
               if (s.mode === "bars") {
                 const bw = n > 1 ? Math.max(1.5, (VBW / (n - 1)) * 0.7) : 8;
                 const floorY = padTop + plotH;
-                return s.values.map((v, i) =>
-                  v == null || !isFinite(v) ? null : (
-                    <Rect key={`${si}-${i}`} x={xAt(i) - bw / 2} y={Math.min(yOf(s, v), floorY)} width={bw} height={Math.max(0.5, Math.abs(floorY - yOf(s, v)))} fill={s.color} fillOpacity={0.85} rx={1} />
-                  ),
-                );
+                // Stacked: this series starts where the earlier series of the same stack ended.
+                const base: number[] = [];
+                if (s.stack) for (let k = 0; k < si; k++) { const o = series[k]; if (o.mode === "bars" && o.stack === s.stack) o.values.forEach((v, i) => { base[i] = (base[i] ?? 0) + (v != null && isFinite(v) ? v : 0); }); }
+                return s.values.map((v, i) => {
+                  if (v == null || !isFinite(v) || v <= 0) return null;
+                  const b = base[i] ?? 0; const y0 = yOf(s, b + (s.stack ? 0 : 0)); const yTop = yOf(s, b + v);
+                  const bottom = s.stack ? yOf(s, b) : floorY;
+                  return <Rect key={`${si}-${i}`} x={xAt(i) - bw / 2} y={Math.min(yTop, bottom)} width={bw} height={Math.max(0.5, Math.abs(bottom - yTop))} fill={s.color} fillOpacity={0.85} rx={s.stack ? 0 : 1} />;
+                });
               }
               if (s.mode === "dots") {
                 return s.values.map((v, i) =>


### PR DESCRIPTION
## Phase 2 · Item 4 · activities tails

Closes #773

Gap ledger and side-by-side are on the issue. What changes in the app:

- **Monthly Activity Distribution** as a stacked bar chart on the shared `LineChart` (bar series gain a `stack` key with cumulative bases), one colour per sport, tap-to-read.
- **Max Speed Progression** as a shared chart: per-session dots plus the moving average, tap-to-read, expandable.
- **All Activities list depth**: twenty rows per page with a `1–20 of N` pager, matching web.

Verification: release APK from this branch on emulator-5554 with the real account (`verify-device.sh activities --flow .maestro/verify-activities-tails.yaml`), screenshots read back and posted on #773. tsc + vitest green in `universal`; `web` untouched.
