### PR TITLE
feat(app): workouts tails, 20 tappable PRs, gym taps open the workout modal

### DIFF
--- a/universal/.maestro/verify-workouts-tails.yaml
+++ b/universal/.maestro/verify-workouts-tails.yaml
@@ -1,0 +1,83 @@
+# Soma verify flow: workouts tails (soma#775): 20 tappable PRs → exercise detail; overview
+# last-gym-session + feed gym rows → workout modal. Run via
+# universal/scripts/verify-device.sh workouts --flow .maestro/verify-workouts-tails.yaml
+appId: dev.gkos.soma
+name: Soma verify workouts tails
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://workouts
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- scrollUntilVisible:
+    element:
+      id: "pr-19"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-workouts-prs-20
+- scrollUntilVisible:
+    element:
+      id: "pr-0"
+    direction: UP
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "pr-0"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*sessions.*"
+    timeout: 15000
+- takeScreenshot: verify-workouts-exercise-modal
+- back
+- stopApp
+- openLink: universal://overview
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "last-gym-session"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "last-gym-session"
+- extendedWaitUntil:
+    visible:
+      id: "tab-hr"
+    timeout: 20000
+- takeScreenshot: verify-overview-last-gym-modal
+- back
+- scrollUntilVisible:
+    element:
+      id: "feed-workout-.*"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "feed-workout-.*"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: "tab-hr"
+    timeout: 20000
+- takeScreenshot: verify-overview-feed-gym-modal
+- back
+- stopApp
+- openLink: universal://workouts
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/scripts/verify-device.sh
+++ b/universal/scripts/verify-device.sh
@@ -171,10 +171,19 @@ if [ -n "$FLOW_OVERRIDE" ]; then case "$FLOW_OVERRIDE" in /*) FLOW="$FLOW_OVERRI
 # reconnects on its own), so drop it again right before Maestro starts.
 $ADB devices 2>/dev/null | awk 'NR>1 && $2=="offline"{print $1}' | while read -r stale; do $ADB disconnect "$stale" >/dev/null 2>&1 || true; done
 set +e
-( cd "$HERE" && "$MAESTRO" --device "$DEV" test \
-    -e ROUTE="universal://$SCREEN" -e MARKER="$MARKER_RE" -e SCREEN="$SCREEN" ${EXTRA_ENV[@]+"${EXTRA_ENV[@]}"} \
-    "$FLOW" ) > "$OUT/$SCREEN.maestro.log" 2>&1
-RC=$?
+# The bridge can re-register its offline entry in the milliseconds between the drop above and
+# Maestro's device listing ("Device X was requested, but it is not connected"); that is a
+# harness race, not a result, so drop again and retry up to three times before giving up.
+for attempt in 1 2 3; do
+  ( cd "$HERE" && "$MAESTRO" --device "$DEV" test \
+      -e ROUTE="universal://$SCREEN" -e MARKER="$MARKER_RE" -e SCREEN="$SCREEN" ${EXTRA_ENV[@]+"${EXTRA_ENV[@]}"} \
+      "$FLOW" ) > "$OUT/$SCREEN.maestro.log" 2>&1
+  RC=$?
+  grep -q "was requested, but it is not connected" "$OUT/$SCREEN.maestro.log" || break
+  echo "note: stale offline adb entry raced Maestro (attempt $attempt) — dropping it and retrying"
+  $ADB devices 2>/dev/null | awk 'NR>1 && $2=="offline"{print $1}' | while read -r stale; do $ADB disconnect "$stale" >/dev/null 2>&1 || true; done
+  sleep 2
+done
 set -e
 
 # 4. Keep the evidence regardless of outcome.

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -3,6 +3,7 @@ import { TimeRangeSelector } from "../../components/time-range-selector";
 import { useRangePref, rangeToDays, rangeLabel } from "../../lib/time-range";
 import { InfoHint, STAT_INFO, TREND_7D, TREND_7D_LOWER } from "../../components/info-hint";
 import { OverviewTrendCharts } from "../../components/overview-trend-charts";
+import { WorkoutDetailModal } from "../../components/workout-detail-modal";
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
 import { Text, Card, Badge, Sparkline } from "soma-style";
 import { LineChart, ChartLegend, ExpandableChart, chartDateLabel } from "../../components/line-chart";
@@ -170,6 +171,7 @@ export default function OverviewScreen() {
 
   const [statDetail, setStatDetail] = useState<StatDetail | null>(null);
   const [selActivity, setSelActivity] = useState<ActivityRow | null>(null);
+  const [selWorkout, setSelWorkout] = useState<{ id: string; title: string } | null>(null);
   const readiness = training?.readiness;
   const tsb = training?.pmc?.tsb ?? null;
 
@@ -433,9 +435,9 @@ export default function OverviewScreen() {
           <>
             <Text variant="eyebrow" className="text-text-muted mt-1">Activity</Text>
             <ActivityHeatmap activities={activitiesDeep.all} />
-            <LastGymSession activities={activitiesDeep.all} onSelect={setSelActivity} />
+            <LastGymSession activities={activitiesDeep.all} workouts={wkSum?.recent} onSelect={setSelActivity} onSelectWorkout={setSelWorkout} />
             <GymFrequency activities={activitiesDeep.all} />
-            <RecentActivityFeed activities={activitiesDeep.all} onSelect={setSelActivity} />
+            <RecentActivityFeed activities={activitiesDeep.all} workouts={wkSum?.recent} onSelect={setSelActivity} onSelectWorkout={setSelWorkout} />
             <ActivityBreakdown monthly={activitiesDeep.monthly ?? []} />
           </>
         ) : null}
@@ -443,6 +445,7 @@ export default function OverviewScreen() {
 
       <StatDetailModal stat={statDetail} onClose={() => setStatDetail(null)} />
       <ActivityDetailModal activity={selActivity} onClose={() => setSelActivity(null)} />
+      <WorkoutDetailModal id={selWorkout?.id ?? null} title={selWorkout?.title} unit="kg" onClose={() => setSelWorkout(null)} />
     </ScrollView>
   );
 }

--- a/universal/src/components/activity-content.tsx
+++ b/universal/src/components/activity-content.tsx
@@ -130,15 +130,38 @@ export function ActivityHeatmap({ activities }: { activities: ActivityRow[] }) {
 }
 
 /** Recent activity feed: the latest N activities, tap for detail. */
-export function RecentActivityFeed({ activities, onSelect }: { activities: ActivityRow[]; onSelect: (a: ActivityRow) => void }) {
-  const recent = useMemo(() =>
-    [...activities].sort((a, b) => (b.date || "").localeCompare(a.date || "")).slice(0, 8),
-    [activities]);
+type FeedWorkout = { id: string; title: string; start_time: string; exercise_count: number; duration_min: number | null; volume: number };
+type FeedItem = { kind: "activity"; date: string; a: ActivityRow } | { kind: "workout"; date: string; w: FeedWorkout };
+/** Web's recent feed lists Garmin activities AND Hevy workouts and routes each to its own
+ *  dialog (soma#775). The activity feed here excludes gym, so the Hevy workouts from the
+ *  range summary fill that role and open the workout modal. */
+export function RecentActivityFeed({ activities, workouts, onSelect, onSelectWorkout }: { activities: ActivityRow[]; workouts?: FeedWorkout[]; onSelect: (a: ActivityRow) => void; onSelectWorkout?: (w: { id: string; title: string }) => void }) {
+  const recent = useMemo(() => {
+    const items: FeedItem[] = [
+      ...activities.map((a) => ({ kind: "activity" as const, date: a.date || "", a })),
+      ...(workouts ?? []).map((w) => ({ kind: "workout" as const, date: w.start_time || "", w })),
+    ];
+    return items.sort((x, y) => y.date.localeCompare(x.date)).slice(0, 8);
+  }, [activities, workouts]);
   if (!recent.length) return null;
   return (
     <Card className="gap-1">
       <Text variant="eyebrow" className="mb-1">Recent activity</Text>
-      {recent.map((a, i) => {
+      {recent.map((it, i) => {
+        if (it.kind === "workout") {
+          const w = it.w;
+          return (
+            <Pressable key={`w-${w.id}-${i}`} onPress={() => onSelectWorkout?.({ id: w.id, title: w.title })} className="flex-row items-center gap-2 border-b border-border-subtle py-2" testID={`feed-workout-${w.id}`}>
+              <Text variant="body">🏋️</Text>
+              <View className="flex-1">
+                <Text variant="caption" className="text-text" numberOfLines={1}>{w.title || "Workout"}</Text>
+                <Text variant="micro" className="text-text-muted tabular-nums">{w.exercise_count} exercises{w.duration_min ? ` · ${w.duration_min} min` : ""}{w.volume > 0 ? ` · ${w.volume >= 1000 ? `${(w.volume / 1000).toFixed(1)}k` : Math.round(w.volume)} kg` : ""}</Text>
+              </View>
+              <Text variant="micro" className="text-text-muted">{relativeDate(w.start_time)}</Text>
+            </Pressable>
+          );
+        }
+        const a = it.a;
         const m = meta(a.type_key);
         return (
           <Pressable key={`${a.activity_id}-${i}`} onPress={() => onSelect(a)} className="flex-row items-center gap-2 border-b border-border-subtle py-2">
@@ -156,11 +179,27 @@ export function RecentActivityFeed({ activities, onSelect }: { activities: Activ
 }
 
 /** The most recent gym/strength session, tap for detail. */
-export function LastGymSession({ activities, onSelect }: { activities: ActivityRow[]; onSelect: (a: ActivityRow) => void }) {
+export function LastGymSession({ activities, workouts, onSelect, onSelectWorkout }: { activities: ActivityRow[]; workouts?: FeedWorkout[]; onSelect: (a: ActivityRow) => void; onSelectWorkout?: (w: { id: string; title: string }) => void }) {
   const last = useMemo(
     () => [...activities].filter((a) => isGym(a.type_key)).sort((a, b) => (b.date || "").localeCompare(a.date || ""))[0] ?? null,
     [activities],
   );
+  // Web's "Last Workout" is the newest Hevy workout and opens the workout dialog (soma#775).
+  const lastW = useMemo(() => [...(workouts ?? [])].sort((a, b) => (b.start_time || "").localeCompare(a.start_time || ""))[0] ?? null, [workouts]);
+  if (lastW && (!last || (lastW.start_time || "") >= (last.date || ""))) {
+    return (
+      <Pressable onPress={() => onSelectWorkout?.({ id: lastW.id, title: lastW.title })} testID="last-gym-session">
+        <Card className="gap-1">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Last gym session</Text>
+            <Text variant="micro" className="text-text-muted">{relativeDate(lastW.start_time)}</Text>
+          </View>
+          <Text variant="title" numberOfLines={1}>🏋️ {lastW.title || "Workout"}</Text>
+          <Text variant="caption" className="text-text-muted tabular-nums">{lastW.exercise_count} exercises{lastW.duration_min ? ` · ${lastW.duration_min} min` : ""}{lastW.volume > 0 ? ` · ${lastW.volume >= 1000 ? `${(lastW.volume / 1000).toFixed(1)}k` : Math.round(lastW.volume)} kg` : ""}</Text>
+        </Card>
+      </Pressable>
+    );
+  }
   if (!last) return null;
   return (
     <Pressable onPress={() => onSelect(last)}>

--- a/universal/src/components/workout-strength.tsx
+++ b/universal/src/components/workout-strength.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { View, Pressable, ScrollView } from "react-native";
 import { Text, Card } from "soma-style";
 import { LineChart, ExpandableChart } from "./line-chart";
+import { ExerciseDetailModal } from "./exercise-detail-modal";
 import { fetchJson } from "../lib/api";
 import type { WorkoutInsights } from "../lib/api";
 
@@ -54,6 +55,8 @@ function StrengthProgression({ names, unit }: { names: string[]; unit: "kg" | "l
 
 /** Strength progression + PR grid + program split (web parity, #427). */
 export function WorkoutStrength({ insights, unit }: { insights: WorkoutInsights | null | undefined; unit: "kg" | "lb" }) {
+  // Web's PR cards open the exercise dialog; keep the hook above the early return.
+  const [prName, setPrName] = useState<string | null>(null);
   if (!insights) return null;
   const w = (kg: number) => `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10} ${unit}`;
   const names = (insights.topExercises ?? []).map((e) => e.exercise).slice(0, 8);
@@ -67,16 +70,20 @@ export function WorkoutStrength({ insights, unit }: { insights: WorkoutInsights 
 
       {prs.length ? (
         <Card className="gap-2">
-          <Text variant="eyebrow">Personal records</Text>
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Personal records</Text>
+            <Text variant="micro" className="text-text-muted">{Math.min(prs.length, 20)} of {prs.length} · tap for detail</Text>
+          </View>
           <View className="flex-row flex-wrap gap-3">
-            {prs.slice(0, 8).map((p) => (
-              <View key={p.exercise} className="min-w-[46%] flex-1 gap-0.5">
+            {prs.slice(0, 20).map((p, i) => (
+              <Pressable key={p.exercise} onPress={() => setPrName(p.exercise)} className="min-w-[46%] flex-1 gap-0.5 rounded-md bg-surface-subtle px-2 py-1.5" testID={`pr-${i}`} accessibilityRole="button" accessibilityLabel={`${p.exercise} personal record`}>
                 <Text variant="micro" className="text-text-secondary" numberOfLines={1}>{p.exercise}</Text>
                 <Text variant="title" className="text-lime">{w(num(p.pr_weight))}</Text>
                 {p.reps_at_pr != null ? <Text variant="micro" className="text-text-muted">{num(p.reps_at_pr)} reps</Text> : null}
-              </View>
+              </Pressable>
             ))}
           </View>
+          <ExerciseDetailModal name={prName} unit={unit} onClose={() => setPrName(null)} />
         </Card>
       ) : null}
 


### PR DESCRIPTION
## Phase 2 · Item 5 · workouts tails

Closes #775

Gap ledger and side-by-side are on the issue. What changes in the app:

- **Personal records twenty deep**, each tile tappable (`pr-<i>`) into the exercise detail modal.
- **Overview gym taps route to the workout modal.** The Last gym session card (`last-gym-session`) and the Hevy workouts merged into the Recent activity feed (`feed-workout-<id>`) open `WorkoutDetailModal`. The matched Hevy workout id was already in the workouts summary the overview fetches, so the API is unchanged.

Verification: release APK from this branch on emulator-5554 with the real account (`verify-device.sh workouts --flow .maestro/verify-workouts-tails.yaml`), screenshots read back and posted on #775. tsc + vitest green in `universal`; `web` untouched.
