### PR TITLE
feat(app): training trajectory density, goal zones, tier lines, taper and race markers

### DIFF
--- a/universal/.maestro/verify-training-tails.yaml
+++ b/universal/.maestro/verify-training-tails.yaml
@@ -1,0 +1,47 @@
+# Soma verify flow: training tails (soma#776): the trajectory card still renders (and, once a
+# plan is live, expands with the annotated chart). Run via
+# universal/scripts/verify-device.sh training --flow .maestro/verify-training-tails.yaml
+appId: dev.gkos.soma
+name: Soma verify training tails
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://training
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- scrollUntilVisible:
+    element:
+      text: "(?i)fitness trajectory"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-training-trajectory-card
+# Live-plan branch (optional): the annotated chart expands when the endpoint has points.
+- runFlow:
+    when:
+      visible:
+        id: "expand-trajectory-to-race"
+    commands:
+      - tapOn:
+          id: "expand-trajectory-to-race"
+      - extendedWaitUntil:
+          visible:
+            text: "(?s).*Trajectory to race · expanded.*"
+          timeout: 10000
+      - takeScreenshot: verify-training-trajectory-expanded
+      - back
+- stopApp
+- openLink: universal://training
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/components/trajectory-chart.tsx
+++ b/universal/src/components/trajectory-chart.tsx
@@ -1,7 +1,9 @@
 import { useState, useMemo } from "react";
 import { View, Pressable } from "react-native";
 import { Text, Card, SegmentedControl } from "soma-style";
-import { LineChart, ChartLegend, chartDateLabel } from "./line-chart";
+import { LineChart, ChartLegend, ExpandableChart, chartDateLabel, type LineChartProps } from "./line-chart";
+import { todayKey } from "../lib/freshness";
+import { trajectoryAnnotations } from "../lib/trajectory-annotations";
 import { getHMPrediction } from "../lib/vdot-pace-zones";
 import type { ForwardSim, TrajectoryData } from "../lib/api";
 
@@ -57,12 +59,15 @@ export function TrajectoryChart({ comparison, trajectory }: { comparison: Forwar
     for (let i = optimal.length - 1; i >= 0; i--) if (optimal[i] != null) { lastOptimal = optimal[i]; break; }
     const projHM = lastOptimal != null ? getHMPrediction(lastOptimal) : null;
     const goalHM = trajectory?.goalVdot != null ? getHMPrediction(trajectory.goalVdot) : null;
+    // Web's annotations (soma#776) from the pure helper (unit-tested; no plan is live today).
+    const ann = trajectoryAnnotations(t, { goalVdot: trajectory?.goalVdot ?? null, raceDate: trajectory?.raceDate ?? null, today: todayKey(), hmTime: (v) => timeStr(getHMPrediction(v)) });
     return {
       labels: t.map((p) => chartDateLabel(p.date)),
       optimal, actual,
       hereDot: actual.map((v, i) => (i === hereIdx ? v : null)),
       cur: hereIdx >= 0 ? actual[hereIdx] : null,
       projHM, goalHM,
+      ...ann,
     };
   }, [trajectory]);
   const src = useMemo(() => {
@@ -108,23 +113,34 @@ export function TrajectoryChart({ comparison, trajectory }: { comparison: Forwar
       </View>
       {useTraj ? (
         <>
-          <LineChart
-            height={175}
-            interactive
-            xTicks={4}
-            labels={traj.labels}
-            yFormat={(v) => v.toFixed(1)}
-            refLine={trajectory?.goalVdot != null ? { y: trajectory.goalVdot, color: "#e0c458" } : undefined}
-            series={[
-              { values: traj.optimal, color: "#77c8d1", width: 1.6, dashed: true, label: "Optimal" },
-              { values: traj.actual, color: "#6ad4a0", width: 2.4, label: "Actual" },
-              { values: traj.hereDot, color: "#ffffff", mode: "dots" as const, width: 3 },
-            ]}
-          />
+          {(() => {
+            const chart: LineChartProps = {
+              xTicks: 4,
+              labels: traj.labels,
+              yFormat: (v: number) => v.toFixed(1),
+              refAreas: traj.refAreas,
+              refLines: traj.refLines,
+              xLines: traj.xLines,
+              xBands: traj.xBands,
+              series: [
+                { values: traj.optimal, color: "#77c8d1", width: 1.6, dashed: true, label: "Optimal" },
+                { values: traj.actual, color: "#6ad4a0", width: 2.4, label: "Actual" },
+                { values: traj.hereDot, color: "#ffffff", mode: "dots" as const, width: 3 },
+              ],
+            };
+            return (
+              <ExpandableChart title="Trajectory to race" chart={chart}>
+                <LineChart height={175} interactive {...chart} />
+              </ExpandableChart>
+            );
+          })()}
           <ChartLegend items={[
             { color: "#6ad4a0", label: "Actual VDOT" },
             { color: "#77c8d1", label: "Optimal (to race)", dashed: true },
-            ...(trajectory?.goalVdot != null ? [{ color: "#e0c458", label: `Goal ${trajectory.goalVdot.toFixed(1)}`, dashed: true }] : []),
+            ...(trajectory?.goalVdot != null ? [{ color: "#6ad4a0", label: "A goal zone" }, { color: "#e0c458", label: "B goal zone" }] : []),
+            ...(traj.hasToday ? [{ color: "#e0c458", label: "Today" }] : []),
+            ...(traj.hasRace ? [{ color: "#c084fc", label: "Race", dashed: true }] : []),
+            ...(traj.hasTaper ? [{ color: "#8b9df0", label: "Taper (12 d)" }] : []),
           ]} />
           {traj.projHM != null ? (
             <View className="mt-1 flex-row items-center justify-between rounded-lg px-3 py-2" style={{ backgroundColor: "#16241b" }}>

--- a/universal/src/lib/trajectory-annotations.test.ts
+++ b/universal/src/lib/trajectory-annotations.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { trajectoryAnnotations } from "./trajectory-annotations";
+
+const days = (from: string, n: number) => Array.from({ length: n }, (_, i) => ({ date: new Date(new Date(from).getTime() + i * 86400000).toISOString().slice(0, 10) }));
+const hm = (v: number) => `${v.toFixed(1)}v`;
+
+describe("trajectoryAnnotations (#776)", () => {
+  it("draws A/B goal zones and A/B/C tier lines from the goal VDOT", () => {
+    const a = trajectoryAnnotations(days("2026-03-01", 30), { goalVdot: 52, raceDate: null, today: "2026-03-10", hmTime: hm });
+    expect(a.refAreas.map((r) => [r.y1, r.y2])).toEqual([[50, 52], [48.5, 50]]);
+    expect(a.refLines.map((l) => [l.y, l.label])).toEqual([[52, "A (52.0v)"], [50, "B (50.0v)"], [48.5, "C (48.5v)"]]);
+    expect(a.hasRace).toBe(false); expect(a.xBands).toEqual([]);
+  });
+  it("places Today and Race on the date index and the 12-day taper band before the race", () => {
+    const a = trajectoryAnnotations(days("2026-03-01", 45), { goalVdot: null, raceDate: "2026-04-12", today: "2026-03-20", hmTime: hm });
+    expect(a.xLines).toEqual([{ i: 19, color: "#e0c458" }, { i: 42, color: "#c084fc", dashed: true }]);
+    expect(a.xBands).toEqual([{ i0: 30, i1: 42, color: "#8b9df0", opacity: 0.12 }]);
+    expect(a.hasTaper).toBe(true); expect(a.refLines).toEqual([]);
+  });
+  it("is empty-safe: no plan, no points → nothing to draw", () => {
+    const a = trajectoryAnnotations([], { goalVdot: null, raceDate: null, today: "2026-09-07", hmTime: hm });
+    expect(a).toEqual({ refAreas: [], refLines: [], xLines: [], xBands: [], hasToday: false, hasRace: false, hasTaper: false });
+  });
+  it("skips the race line when the race is beyond the trajectory window", () => {
+    const a = trajectoryAnnotations(days("2026-03-01", 10), { goalVdot: 50, raceDate: "2026-06-01", today: "2026-03-05", hmTime: hm });
+    expect(a.hasRace).toBe(false); expect(a.xLines).toEqual([{ i: 4, color: "#e0c458" }]);
+  });
+});

--- a/universal/src/lib/trajectory-annotations.ts
+++ b/universal/src/lib/trajectory-annotations.ts
@@ -1,0 +1,42 @@
+/** Web's trajectory-chart annotations as pure data (soma#776): goal-zone bands and tier
+ *  lines (A = goal, B = goal − 2, C = goal − 3.5 VDOT), the Today and Race lines and the
+ *  12-day taper band, all expressed against the trajectory's date index so the shared
+ *  chart can draw them. Pure so it can be unit-tested while no plan is live. */
+export interface TrajectoryPointLike { date: string }
+export interface TrajectoryAnnotations {
+  refAreas: { y1: number; y2: number; color: string; opacity?: number }[];
+  refLines: { y: number; color?: string; dashed?: boolean; label?: string }[];
+  xLines: { i: number; color?: string; dashed?: boolean }[];
+  xBands: { i0: number; i1: number; color: string; opacity?: number }[];
+  hasToday: boolean; hasRace: boolean; hasTaper: boolean;
+}
+export const TAPER_DAYS = 12;
+
+export function trajectoryAnnotations(
+  points: TrajectoryPointLike[],
+  opts: { goalVdot: number | null; raceDate: string | null; today: string; hmTime: (vdot: number) => string },
+): TrajectoryAnnotations {
+  const dates = points.map((p) => p.date.slice(0, 10));
+  const idxOf = (d: string | null | undefined) => (d ? dates.findIndex((x) => x >= d) : -1);
+  const todayIdx = idxOf(opts.today);
+  const race = opts.raceDate ? opts.raceDate.slice(0, 10) : null;
+  const raceIdx = idxOf(race);
+  const taperStart = race ? new Date(new Date(race).getTime() - TAPER_DAYS * 86400000).toISOString().slice(0, 10) : null;
+  const taperIdx = idxOf(taperStart);
+  const g = opts.goalVdot;
+  const tiers = g != null && isFinite(g)
+    ? [
+        { y: g, color: "#6ad4a0", label: `A (${opts.hmTime(g)})` },
+        { y: g - 2, color: "#8b9df0", label: `B (${opts.hmTime(g - 2)})` },
+        { y: g - 3.5, color: "#e0c458", label: `C (${opts.hmTime(g - 3.5)})` },
+      ]
+    : [];
+  const hasTaper = taperIdx >= 0 && raceIdx > taperIdx;
+  return {
+    refAreas: g != null && isFinite(g) ? [{ y1: g - 2, y2: g, color: "#6ad4a0", opacity: 0.08 }, { y1: g - 3.5, y2: g - 2, color: "#e0c458", opacity: 0.07 }] : [],
+    refLines: tiers,
+    xLines: [...(todayIdx >= 0 ? [{ i: todayIdx, color: "#e0c458" }] : []), ...(raceIdx >= 0 ? [{ i: raceIdx, color: "#c084fc", dashed: true }] : [])],
+    xBands: hasTaper ? [{ i0: taperIdx, i1: raceIdx, color: "#8b9df0", opacity: 0.12 }] : [],
+    hasToday: todayIdx >= 0, hasRace: raceIdx >= 0, hasTaper,
+  };
+}


### PR DESCRIPTION
## Phase 2 · Item 6 · training tails

Closes #776

Gap ledger and the verification note are on the issue. What changes in the app:

- **Trajectory annotations** from `lib/trajectory-annotations.ts` (pure, unit-tested): A/B goal-zone bands, A/B/C tier reference lines labelled with the predicted HM time, Today and Race vertical lines, the 12-day taper band. Drawn with the Phase 1 `refAreas` / `refLines` / `xLines` / `xBands` chart props.
- **Expandable trajectory card.** The computation DAG stays static.

Honest limitation: the only plan is dormant, so `/api/training/trajectory` returns no points and neither web nor the app renders the trajectory today. The device check proves the Fitness trajectory card (the model-vs-Garmin fallback) still renders and expands; the annotated chart will appear the day a plan is live again.

Verification: release APK from this branch on emulator-5554 with the real account (`verify-device.sh training --flow .maestro/verify-training-tails.yaml`), screenshots read back and posted on #776. tsc + vitest green in `universal` (4 new tests); `web` untouched.
