### PR TITLE
feat(app): nutrition Trend tails, stacked burn vs eaten, goal pace, target-date status (#782)

### DIFF
--- a/universal/.maestro/verify-nutrition-trend-tails.yaml
+++ b/universal/.maestro/verify-nutrition-trend-tails.yaml
@@ -1,0 +1,56 @@
+# Soma verify flow: nutrition Trend tails (soma#782): status line, stacked burn vs eaten (expand),
+# cumulative deficit with goal pace. Run via
+# universal/scripts/verify-device.sh nutrition --flow .maestro/verify-nutrition-trend-tails.yaml --marker "<today's burn>"
+appId: dev.gkos.soma
+name: Soma verify nutrition trend tails
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://nutrition
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- tapOn:
+    text: "Trend"
+- extendedWaitUntil:
+    visible:
+      id: "bodycomp-status"
+    timeout: 45000
+- takeScreenshot: verify-nutrition-trend-status
+- scrollUntilVisible:
+    element:
+      id: "expand-cumulative-deficit"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-nutrition-trend-cumulative
+- scrollUntilVisible:
+    element:
+      id: "expand-burn-vs-eaten"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-nutrition-trend-burn
+- tapOn:
+    id: "expand-burn-vs-eaten"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Burn vs eaten · expanded.*"
+    timeout: 10000
+- takeScreenshot: verify-nutrition-trend-burn-expanded
+- back
+- stopApp
+- openLink: universal://nutrition
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/components/body-comp-chart.tsx
+++ b/universal/src/components/body-comp-chart.tsx
@@ -1,7 +1,8 @@
 import { View } from "react-native";
 import { Text, Card, Badge } from "soma-style";
 import { useBodyComp, type BodyComp } from "../lib/api";
-import { LineChart, ChartLegend } from "./line-chart";
+import { LineChart, ChartLegend, ExpandableChart, type LineChartProps } from "./line-chart";
+import { goalPaceSeries } from "../lib/body-comp-pace";
 
 const C = {
   actual: "#a9e4ec", // light teal — raw weigh-ins (dots)
@@ -9,12 +10,23 @@ const C = {
   trend: "#77c8d1", // teal dashed — projection
   goal: "#e0a458", // warm — goal line
   deficit: "#6ad4a0", // green — cumulative deficit
+  pace: "#e0a458", // warm — goal pace (web's orange)
+  // Web's burn components (stacked bars): BMR slate, daily activity teal, run blue, gym orange.
+  bmr: "#94a3b8",
+  activity: "#14b8a6",
+  run: "#3b82f6",
+  gym: "#f97316",
+  eaten: "#77c8d1",
+  goalLine: "#ffffff",
 };
 
 const dayMs = 86400000;
 function toDate(iso: string): number {
   const [y, m, d] = iso.split("-").map(Number);
   return Date.UTC(y, (m ?? 1) - 1, d ?? 1);
+}
+function isoOf(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
 }
 function shortLabel(iso: string): string {
   const [, m, d] = iso.split("-").map(Number);
@@ -52,6 +64,26 @@ function kg(v: number | null | undefined): string {
   return v == null ? "–" : `${v.toFixed(1)} kg`;
 }
 
+/** Web's trajectory status line (body-comp-chart.tsx statusText): the target-date verdict
+ *  with the goal date, or the date the current rate reaches the goal (soma#782). */
+function statusLine(p: BodyComp["profile"]): { text: string; tone: "danger" | "success" | "warm"; hint?: string } {
+  const slope = p.trendSlope ?? 0;
+  const actualRate = Math.abs(slope);
+  const rateRatio = (p.weeklyRate ?? 0) > 0 ? actualRate / (p.weeklyRate as number) : 0;
+  const onTrack = slope < 0 && rateRatio >= 0.8;
+  const behind = slope < 0 && rateRatio >= 0.3 && rateRatio < 0.8;
+  const goal = p.targetDate ? shortLabel(p.targetDate) : null;
+  if (p.targetDatePassed) {
+    return { text: "Target date passed — adjust goal", tone: "danger", hint: "Consider extending your target date or adjusting your goal" };
+  }
+  if (onTrack) return { text: `On track${goal ? ` · goal ${goal}` : ""}${p.daysRemaining != null ? ` (${p.daysRemaining}d)` : ""}`, tone: "success" };
+  if (actualRate > 0 && p.fatToLose != null && p.fatToLose > 0) {
+    const predicted = shortLabel(isoOf(Date.now() + Math.round((p.fatToLose / actualRate) * 7) * dayMs));
+    return { text: `Behind pace${goal ? ` · goal ${goal}` : ""} · at current rate: ${predicted}`, tone: behind ? "warm" : "danger" };
+  }
+  return { text: `Behind pace${goal ? ` · goal ${goal}` : ""}${p.daysRemaining != null ? ` (${p.daysRemaining}d)` : ""}`, tone: "danger" };
+}
+
 function StatusCard({ p }: { p: BodyComp["profile"] }) {
   const slope = p.trendSlope ?? 0;
   const losing = slope < 0;
@@ -64,6 +96,8 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
     : onTrack ? { label: "On track", tone: "success" as const }
     : behind ? { label: "Behind pace", tone: "warm" as const }
     : { label: "Off pace", tone: "danger" as const };
+  const status = p.trendSlope != null || p.targetDatePassed ? statusLine(p) : null;
+  const toneClass = status?.tone === "success" ? "text-success" : status?.tone === "warm" ? "text-warm" : "text-danger";
   return (
     <Card className="gap-2">
       <View className="flex-row items-center justify-between">
@@ -74,6 +108,12 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
         <Text variant="display" className="tabular-nums">{kg(p.latestActualWeight ?? p.currentWeight)}</Text>
         <Text variant="body" className="text-text-muted mb-1">→ {kg(p.targetWeight)}</Text>
       </View>
+      {status ? (
+        <View testID="bodycomp-status">
+          <Text variant="caption" className={toneClass}>{status.text}</Text>
+          {status.hint ? <Text variant="micro" className="text-text-muted">{status.hint}</Text> : null}
+        </View>
+      ) : null}
       <View className="flex-row flex-wrap gap-x-5 gap-y-1">
         <View>
           <Text variant="micro" className="text-text-muted">Body fat</Text>
@@ -94,7 +134,8 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
             {p.window ? <Text variant="micro" className="text-text-muted">{p.window.label}</Text> : null}
           </View>
         ) : null}
-        {p.daysRemaining != null ? (
+        {/* Web shows the days-left count only while the target date is still ahead. */}
+        {p.daysRemaining != null && !p.targetDatePassed ? (
           <View>
             <Text variant="micro" className="text-text-muted">Days left</Text>
             <Text variant="caption" className="tabular-nums">{p.daysRemaining}</Text>
@@ -104,6 +145,12 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
           <View>
             <Text variant="micro" className="text-text-muted">Fat to lose</Text>
             <Text variant="caption" className="tabular-nums">{p.fatToLose.toFixed(1)} kg</Text>
+          </View>
+        ) : null}
+        {p.weeklyRate != null && p.weeklyRate > 0 ? (
+          <View>
+            <Text variant="micro" className="text-text-muted">Goal rate</Text>
+            <Text variant="caption" className="tabular-nums">{p.weeklyRate.toFixed(1)} kg/wk</Text>
           </View>
         ) : null}
         {p.avgActualDeficit != null && (!p.window || p.window.active) ? (
@@ -131,7 +178,7 @@ function StatusCard({ p }: { p: BodyComp["profile"] }) {
 }
 
 /** Full body-composition trajectory for the nutrition Trend tab: a status
- *  card + Weight, Body-Fat%, and Cumulative-Deficit charts. */
+ *  card + Weight, Body-Fat%, Cumulative-Deficit and Burn-vs-Eaten charts. */
 export function BodyCompChart({ visible }: { visible: boolean }) {
   const { data, loading } = useBodyComp(visible);
   if (!visible) return null;
@@ -152,15 +199,49 @@ export function BodyCompChart({ visible }: { visible: boolean }) {
   const bfTrend = alignBy(wAxis, trendPrediction, "bf");
   const bfGoal = interpLine(wAxis, goalLine, "bf");
 
+  // Cumulative deficit on a daily axis extended by web's goal-pace line.
   const dAxis = dailyDeficits.map((d) => d.date);
+  const counted = dailyDeficits.filter((d) => d.cumulative != null);
+  const firstCounted = counted.length ? counted[0].date : null;
+  const { axis: cAxis, pace: goalPace } = goalPaceSeries(dAxis, profile, goalDeficit, firstCounted);
+  const cLabels = cAxis.map(shortLabel);
+  const cumulative = alignBy(cAxis, dailyDeficits.filter((d) => d.cumulative != null), "cumulative");
+  const countedDays = profile.window?.countedDays ?? counted.length;
+  const cumulativeChart: LineChartProps = {
+    labels: cLabels,
+    xTicks: 4,
+    yFormat: (v) => (Math.abs(v) >= 1000 ? `${Math.round(v / 1000)}k` : `${Math.round(v)}`),
+    series: [
+      { values: goalPace, color: C.pace, dashed: true, width: 1.5, label: "Goal pace" },
+      { values: cumulative, color: C.deficit, width: 2.2, label: "Actual" },
+    ],
+  };
+
+  // Burn vs eaten: web stacks the burn components (BMR + daily activity + run + gym) per day,
+  // draws the eaten calories as dots, and a stepped goal line (burn − daily deficit goal).
+  // Days outside the current window are faded, not summed.
   const dLabels = dAxis.map(shortLabel);
-  const cumulative = dailyDeficits.map((d) => d.cumulative);
-  const goalPace = dailyDeficits.map((d) => d.goalPace);
-  // Burn-vs-eaten: total burn (BMR + steps + runs + gym) against calories eaten;
-  // the gap is the day's deficit.
-  const burn = dailyDeficits.map((d) => (d.totalBurn != null ? d.totalBurn : null));
+  const has = (k: "bmr" | "dailyActivity" | "runCal" | "gymCal") => dailyDeficits.some((d) => d[k] != null);
+  const comp = (k: "bmr" | "dailyActivity" | "runCal" | "gymCal") => dailyDeficits.map((d) => (d[k] != null ? (d[k] as number) : d.totalBurn != null && k === "bmr" && !has("dailyActivity") ? d.totalBurn : null));
   const eaten = dailyDeficits.map((d) => (d.consumed != null ? d.consumed : null));
+  const burnGoal = dailyDeficits.map((d) => (d.totalBurn != null ? Math.max(0, d.totalBurn - goalDeficit) : null));
+  const opacities = dailyDeficits.map((d) => (d.inWindow === false ? 0.3 : 0.85));
+  const faded = dailyDeficits.filter((d) => d.inWindow === false).length;
   const hasBurn = dailyDeficits.some((d) => d.totalBurn != null && d.consumed != null);
+  const burnChart: LineChartProps = {
+    labels: dLabels,
+    xTicks: 4,
+    yMin: 0,
+    yFormat: (v) => (v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${Math.round(v)}`),
+    series: [
+      { values: comp("bmr"), color: C.bmr, mode: "bars", stack: "burn", opacities, label: "BMR" },
+      { values: comp("dailyActivity"), color: C.activity, mode: "bars", stack: "burn", opacities, label: "Daily activity" },
+      { values: comp("runCal"), color: C.run, mode: "bars", stack: "burn", opacities, label: "Run" },
+      { values: comp("gymCal"), color: C.gym, mode: "bars", stack: "burn", opacities, label: "Gym" },
+      { values: burnGoal, color: C.goalLine, dashed: true, width: 1.4, label: "Goal" },
+      { values: eaten, color: C.eaten, mode: "dots", width: 3, label: "Eaten" },
+    ],
+  };
 
   const legend = [
     { color: C.actual, label: "Weigh-in" },
@@ -207,53 +288,47 @@ export function BodyCompChart({ visible }: { visible: boolean }) {
 
       {dailyDeficits.length >= 2 ? (
         <Card className="gap-2">
-          <View className="flex-row items-center justify-between">
-            <Text variant="eyebrow">Cumulative deficit</Text>
+          <ExpandableChart title="Cumulative deficit" chart={cumulativeChart}>
             <Text variant="micro" className="text-text-muted tabular-nums">goal {Math.round(goalDeficit)}/day</Text>
-          </View>
-          {profile.window ? (
-            <Text variant="micro" className="text-text-muted" testID="bodycomp-cumulative-window">
-              {profile.window.active ? `Summed ${profile.window.label}` : `${profile.window.label} · line ends at the last window`}
-            </Text>
-          ) : null}
-          <LineChart
-            height={130}
-            labels={dLabels}
-            yFormat={(v) => `${Math.round(v / 1000)}k`}
-            series={[
-              { values: goalPace, color: "#3a5563", dashed: true, width: 1.5 },
-              { values: cumulative, color: C.deficit, width: 2.2 },
-            ]}
-          />
+            {profile.window ? (
+              <Text variant="micro" className="text-text-muted" testID="bodycomp-cumulative-window">
+                {profile.window.active ? `Summed ${profile.window.label}` : `${profile.window.label} · line ends at the last window`}
+              </Text>
+            ) : null}
+            {countedDays < 2 ? (
+              <Text variant="micro" className="text-warm" testID="bodycomp-cumulative-sparse">
+                {countedDays === 1 ? "Only one counted day in the last window — a single point, no line yet." : "No counted day yet — nothing to sum."}
+              </Text>
+            ) : null}
+            <LineChart height={130} interactive {...cumulativeChart} />
+          </ExpandableChart>
           <ChartLegend items={[
             { color: C.deficit, label: "Actual" },
-            { color: "#3a5563", label: "Goal pace", dashed: true },
+            { color: C.pace, label: `Goal pace (−${Math.round(goalDeficit)}/day)`, dashed: true },
           ]} />
         </Card>
       ) : null}
 
       {hasBurn && dailyDeficits.length >= 2 ? (
         <Card className="gap-2">
-          <Text variant="eyebrow">Burn vs eaten</Text>
-          {profile.window ? (
-            <Text variant="micro" className="text-text-muted">
-              {profile.window.active ? `Counted ${profile.window.label}` : profile.window.label} · days outside the window are context, not a sum
-            </Text>
-          ) : null}
-          <LineChart
-            height={140}
-            labels={dLabels}
-            yFormat={(v) => `${Math.round(v).toLocaleString()}`}
-            series={[
-              { values: burn, color: C.goal, width: 2.2, label: "Burn" },
-              { values: eaten, color: C.smooth, mode: "dots", width: 3, label: "Eaten" },
-            ]}
-          />
+          <ExpandableChart title="Burn vs eaten" chart={burnChart}>
+            {profile.window ? (
+              <Text variant="micro" className="text-text-muted">
+                {profile.window.active ? `Counted ${profile.window.label}` : profile.window.label}
+                {faded > 0 ? ` · ${faded} faded day${faded === 1 ? "" : "s"} outside the current window` : ""}
+              </Text>
+            ) : null}
+            <LineChart height={150} interactive {...burnChart} />
+          </ExpandableChart>
           <ChartLegend items={[
-            { color: C.goal, label: "Total burn" },
-            { color: C.smooth, label: "Eaten" },
+            { color: C.bmr, label: "BMR" },
+            { color: C.activity, label: "Daily activity" },
+            { color: C.run, label: "Run" },
+            { color: C.gym, label: "Gym" },
+            { color: C.eaten, label: "Eaten" },
+            { color: C.goalLine, label: "Goal", dashed: true },
           ]} />
-          <Text variant="micro" className="text-text-muted">The gap is the day&apos;s deficit — burn from BMR + steps + runs + gym.</Text>
+          <Text variant="micro" className="text-text-muted">The gap between the bar and the dot is the day&apos;s deficit; the goal line is burn minus the daily deficit goal.</Text>
         </Card>
       ) : null}
     </View>

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -22,6 +22,8 @@ export interface ChartSeries {
   area?: boolean;
   /** Bar series with the same stack key pile up per x index (web's stacked BarChart). */
   stack?: string;
+  /** Per-index fill opacity for bars (web fades days outside the current window, soma#782). */
+  opacities?: (number | null)[];
 }
 
 export interface LineChartProps {
@@ -104,8 +106,15 @@ export function LineChart(props: LineChartProps) {
     );
   }
 
-  const loL = yMin != null ? yMin : Math.min(...lAll);
-  const hiL = yMax != null ? yMax : Math.max(...lAll);
+  let loL = yMin != null ? yMin : Math.min(...lAll);
+  let hiL = yMax != null ? yMax : Math.max(...lAll);
+  if (hiL === loL) {
+    // A flat or single-valued series would collapse the axis to one label ("-1k / -1k");
+    // pad it so the value sits mid-plot and the two ticks differ (soma#782).
+    const pad = Math.abs(hiL) * 0.1 || 1;
+    if (yMin == null) loL -= pad;
+    if (yMax == null) hiL += pad;
+  }
   const rangeL = hiL - loL || 1;
   const loR = rAll.length ? Math.min(...rAll) : 0;
   const hiR = rAll.length ? Math.max(...rAll) : 1;
@@ -239,7 +248,7 @@ export function LineChart(props: LineChartProps) {
                   if (v == null || !isFinite(v) || v <= 0) return null;
                   const b = base[i] ?? 0; const y0 = yOf(s, b + (s.stack ? 0 : 0)); const yTop = yOf(s, b + v);
                   const bottom = s.stack ? yOf(s, b) : floorY;
-                  return <Rect key={`${si}-${i}`} x={xAt(i) - bw / 2} y={Math.min(yTop, bottom)} width={bw} height={Math.max(0.5, Math.abs(bottom - yTop))} fill={s.color} fillOpacity={0.85} rx={s.stack ? 0 : 1} />;
+                  return <Rect key={`${si}-${i}`} x={xAt(i) - bw / 2} y={Math.min(yTop, bottom)} width={bw} height={Math.max(0.5, Math.abs(bottom - yTop))} fill={s.color} fillOpacity={s.opacities?.[i] ?? 0.85} rx={s.stack ? 0 : 1} />;
                 });
               }
               if (s.mode === "dots") {
@@ -257,7 +266,16 @@ export function LineChart(props: LineChartProps) {
               });
               if (cur.length) segs.push(cur.join(" "));
               const floor = padTop + plotH;
-              return segs.map((pts, gi) => {
+              // A point with no drawable neighbour would vanish from a polyline; draw it as a dot
+              // so a one-day window still shows its value (soma#782).
+              const lone = s.values.map((v, i) => {
+                if (v == null || !isFinite(v)) return null;
+                const prev = s.values[i - 1], next = s.values[i + 1];
+                const hasPrev = prev != null && isFinite(prev), hasNext = next != null && isFinite(next);
+                return !hasPrev && !hasNext ? <Circle key={`${si}-lone-${i}`} cx={xAt(i)} cy={yOf(s, v)} r={2.6} fill={s.color} /> : null;
+              });
+              if (!segs.some((p) => p.includes(" "))) return lone;
+              return [...lone, ...segs.map((pts, gi) => {
                 const first = pts.split(" ")[0]?.split(",")[0]; const last = pts.split(" ").at(-1)?.split(",")[0];
                 return (
                   <Fragment key={`${si}-${gi}`}>
@@ -265,7 +283,7 @@ export function LineChart(props: LineChartProps) {
                     <Polyline points={pts} fill="none" stroke={s.color} strokeWidth={s.width ?? 2} strokeDasharray={s.dashed ? "5 4" : undefined} strokeLinejoin="round" strokeLinecap="round" />
                   </Fragment>
                 );
-              });
+              })];
             })}
             {/* interactive cursor */}
             {callout != null ? (

--- a/universal/src/lib/body-comp-pace.test.ts
+++ b/universal/src/lib/body-comp-pace.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { goalPaceSeries } from "./body-comp-pace";
+
+describe("goalPaceSeries (soma#782, web's cumulative-deficit goal pace)", () => {
+  it("runs daily from the window start to its end when the window is closed", () => {
+    const r = goalPaceSeries(["2026-05-27", "2026-05-29"], { window: { active: false, start: "2026-05-27", end: "2026-05-29", countedDays: 1, label: "x" } as never }, 800, "2026-05-29");
+    expect(r.axis).toEqual(["2026-05-27", "2026-05-28", "2026-05-29"]);
+    expect(r.pace).toEqual([0, -800, -1600]);
+  });
+  it("extends 14 days past the last day while the window is active", () => {
+    const r = goalPaceSeries(["2026-09-01"], { window: { active: true, start: "2026-09-01", end: "2026-09-01", countedDays: 1, label: "x" } as never }, 500, "2026-09-01");
+    expect(r.axis.length).toBe(15);
+    expect(r.pace[14]).toBe(-7000);
+  });
+  it("falls back to the first counted day when the API sends no window, and is empty-safe", () => {
+    const r = goalPaceSeries(["2026-03-01", "2026-03-03"], { window: undefined } as never, 800, "2026-03-01");
+    expect(r.pace[0]).toBe(0);
+    expect(r.pace[r.pace.length - 1]).toBeLessThan(0);
+    expect(goalPaceSeries([], { window: undefined } as never, 800, null)).toEqual({ axis: [], pace: [] });
+  });
+});

--- a/universal/src/lib/body-comp-pace.ts
+++ b/universal/src/lib/body-comp-pace.ts
@@ -1,0 +1,32 @@
+/** Web's cumulative-deficit goal pace as pure data (soma#782): a straight line from the
+ *  window's first counted day, sampled daily, to its last day (+14 days while the window is
+ *  still active) (#728). Lives outside the component so vitest can cover it without RN. */
+const dayMs = 86400000;
+function toDate(iso: string): number { const [y, m, d] = iso.split("-").map(Number); return Date.UTC(y, (m ?? 1) - 1, d ?? 1); }
+function isoOf(ms: number): string { return new Date(ms).toISOString().slice(0, 10); }
+
+export interface PaceWindow { active: boolean; start?: string | null; end?: string | null; countedDays?: number; label?: string }
+
+export function goalPaceSeries(
+  axisDates: string[],
+  profile: { window?: PaceWindow | null },
+  goalDeficit: number,
+  firstCounted: string | null,
+): { axis: string[]; pace: (number | null)[] } {
+  const winStart = profile.window?.start ?? firstCounted;
+  const lastData = axisDates.length ? axisDates[axisDates.length - 1] : null;
+  const winEnd = profile.window?.end ?? lastData;
+  if (!winStart || !winEnd) return { axis: axisDates, pace: axisDates.map(() => null) };
+  const startMs = toDate(winStart);
+  const endMs = toDate(winEnd) + (profile.window && !profile.window.active ? 0 : 14) * dayMs;
+  const set = new Set(axisDates);
+  for (let ms = startMs; ms <= endMs; ms += dayMs) set.add(isoOf(ms));
+  const axis = [...set].sort();
+  const pace = axis.map((d) => {
+    const t = toDate(d);
+    if (t < startMs || t > endMs) return null;
+    return Math.round(-goalDeficit * ((t - startMs) / dayMs)) || 0;
+  });
+  return { axis, pace };
+}
+


### PR DESCRIPTION
## Phase 3 · Item 1 · nutrition Trend tails

Closes #782

Gap ledger and side-by-side are on the issue. What changes in the app:

- **Burn vs eaten**: stacked BMR / daily activity / run / gym bars per day (shared chart `stack`), days outside the current window faded (new per-bar `opacities`), eaten dots, the goal line (burn − daily deficit goal), "N faded days outside the current window" note, expand + tap-to-read.
- **Cumulative deficit**: web's goal-pace line over the window, +14 days while active (`lib/body-comp-pace.ts`, unit-tested); a one-counted-day window is named as such; expand + tap-to-read. The shared chart pads a flat y-range (no more "-1k / -1k" axis) and draws isolated points as dots.
- **Status card**: web's verdict line — "Target date passed — adjust goal · Consider extending your target date or adjusting your goal", or on-track / behind-pace with the goal date and the date the current rate reaches it; days-left hidden once the date has passed; goal rate shown.

Verification: release APK from this branch on the dedicated emulator-5556 with the real account (`verify-device.sh nutrition --flow .maestro/verify-nutrition-trend-tails.yaml`), screenshots read back and posted on #782. tsc + vitest green in `universal` (3 new tests); `web` untouched.
