### PR TITLE
feat(app): overview tails, empty-week card, recovery row, Hevy gym frequency, 20-row feed (#783)

### DIFF
--- a/universal/.maestro/verify-overview-tails.yaml
+++ b/universal/.maestro/verify-overview-tails.yaml
@@ -1,0 +1,62 @@
+# Soma verify flow: overview tails (soma#783): empty-week This Week card, recovery row on the
+# readiness hero, Gym frequency from Hevy (expand), 20-row recent feed. Run via
+# universal/scripts/verify-device.sh overview --flow .maestro/verify-overview-tails.yaml
+appId: dev.gkos.soma
+name: Soma verify overview tails
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://overview
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "overview-recovery-row"
+    timeout: 45000
+- takeScreenshot: verify-overview-recovery-row
+- scrollUntilVisible:
+    element:
+      id: "this-week-empty"
+    direction: DOWN
+    timeout: 30000
+    speed: 40
+    centerElement: true
+    optional: true
+- takeScreenshot: verify-overview-this-week
+- scrollUntilVisible:
+    element:
+      id: "expand-gym-frequency"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-overview-gym-frequency
+- tapOn:
+    id: "expand-gym-frequency"
+- extendedWaitUntil:
+    visible:
+      text: "(?s).*Gym frequency · expanded.*"
+    timeout: 10000
+- takeScreenshot: verify-overview-gym-frequency-expanded
+- back
+- scrollUntilVisible:
+    element:
+      id: "feed-row-19"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-overview-feed-20
+- stopApp
+- openLink: universal://overview
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -19,6 +19,7 @@ import {
   useRecoverySummary,
   useActivitiesDeep,
   useWorkoutsSummary,
+  useWorkoutInsights,
   fetchJson,
   usePullRefresh,
   todayLocal,
@@ -116,6 +117,27 @@ function useVo2max(range: string) {
 }
 
 /** This-week vs last-week training totals + streak for the This Week card. */
+/** Today's body battery (charged / drained) from the stats series — web's Recovery Status shows
+ *  "Body Battery · <date> +45 −44 drained" next to the readiness score (soma#783). */
+type BbPoint = { date: string; value: number | null; value2?: number | null };
+/** An ISO timestamp as the LOCAL calendar day (web's "since 2026-08-21", not the UTC 21:00 of the day before). */
+function localDay(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso.slice(0, 10);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+function useBodyBattery() {
+  const [bb, setBb] = useState<BbPoint | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetchJson<{ current: BbPoint[] }>("/api/stats/body_battery?range=7d")
+      .then((d) => { const pts = (d.current ?? []).filter((p) => p.value != null); if (alive) setBb(pts.length ? pts[pts.length - 1] : null); })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+  return bb;
+}
+
 function useWeeklyTraining() {
   const [w, setW] = useState<WeeklyTraining | null>(null);
   useEffect(() => {
@@ -162,6 +184,8 @@ export default function OverviewScreen() {
   const recovery = useRecoverySummary("30d");
   const { data: activitiesDeep } = useActivitiesDeep(range);
   const { data: wkSum } = useWorkoutsSummary(range);
+  const { data: wkIns } = useWorkoutInsights(range);
+  const bb = useBodyBattery();
   const fitness = useOverviewFitness();
   const { refreshing, onRefresh } = usePullRefresh(() => {
     refetch();
@@ -200,6 +224,7 @@ export default function OverviewScreen() {
   const sleepAvg = sleep?.summary?.current_avg ?? null;
 
   const hrvLatest = recovery.data?.hrv?.latest ?? null;
+  const garminReadiness = recovery.data?.readiness?.latest?.score ?? null;
   const hrvSpark = (recovery.data?.hrv?.trend ?? []).map((p) => Number(p.weekly_avg)).filter((v) => isFinite(v));
   // An HRV reading older than two days is not today's metric (#731).
   const hrvFresh = freshness(hrvLatest?.date ?? null, todayKey());
@@ -271,6 +296,25 @@ export default function OverviewScreen() {
                 <Text variant="micro" className="text-text-secondary">
                   Form {tsb >= 0 ? "+" : ""}{tsb.toFixed(0)} · {formDescriptor(tsb)}
                 </Text>
+              ) : null}
+              {/* Web's Recovery Status row: Garmin's readiness as the comparison, today's body
+                  battery charged/drained, and the HRV reading with its freshness (soma#783). */}
+              {(garminReadiness != null || bb || hrvLatest) ? (
+                <View className="flex-row flex-wrap gap-x-3 gap-y-0.5 mt-0.5" testID="overview-recovery-row">
+                  {garminReadiness != null ? <Text variant="micro" className="text-text-secondary tabular-nums">Garmin {garminReadiness}</Text> : null}
+                  {bb ? (
+                    <Text variant="micro" className="text-text-secondary tabular-nums">
+                      Body Battery{bb.date !== todayKey() ? ` · ${chartDateLabel(bb.date)}` : ""} +{Math.round(bb.value ?? 0)}{bb.value2 != null ? ` / −${Math.round(bb.value2)} drained` : ""}
+                    </Text>
+                  ) : null}
+                  {hrvLatest ? (
+                    <Text variant="micro" className="text-text-secondary tabular-nums">
+                      {hrvFresh.stale
+                        ? `No HRV reading since ${localDay(hrvLatest.date)} · last ${hrvLatest.last_night_avg ?? hrvLatest.weekly_avg ?? "—"} ms`
+                        : `HRV ${hrvLatest.weekly_avg ?? "—"} ms weekly${hrvLatest.last_night_avg != null ? ` · last night ${hrvLatest.last_night_avg}` : ""}`}
+                    </Text>
+                  ) : null}
+                </View>
               ) : null}
             </View>
           </Card>
@@ -436,7 +480,7 @@ export default function OverviewScreen() {
             <Text variant="eyebrow" className="text-text-muted mt-1">Activity</Text>
             <ActivityHeatmap activities={activitiesDeep.all} />
             <LastGymSession activities={activitiesDeep.all} workouts={wkSum?.recent} onSelect={setSelActivity} onSelectWorkout={setSelWorkout} />
-            <GymFrequency activities={activitiesDeep.all} />
+            <GymFrequency days={wkIns?.calendar ?? []} sinceDays={rangeToDays(range)} rangeLabel={rangeLabel(range)} />
             <RecentActivityFeed activities={activitiesDeep.all} workouts={wkSum?.recent} onSelect={setSelActivity} onSelectWorkout={setSelWorkout} />
             <ActivityBreakdown monthly={activitiesDeep.monthly ?? []} />
           </>

--- a/universal/src/components/activity-content.tsx
+++ b/universal/src/components/activity-content.tsx
@@ -141,7 +141,7 @@ export function RecentActivityFeed({ activities, workouts, onSelect, onSelectWor
       ...activities.map((a) => ({ kind: "activity" as const, date: a.date || "", a })),
       ...(workouts ?? []).map((w) => ({ kind: "workout" as const, date: w.start_time || "", w })),
     ];
-    return items.sort((x, y) => y.date.localeCompare(x.date)).slice(0, 8);
+    return items.sort((x, y) => y.date.localeCompare(x.date)).slice(0, 20); // web lists twenty (soma#783)
   }, [activities, workouts]);
   if (!recent.length) return null;
   return (
@@ -164,7 +164,7 @@ export function RecentActivityFeed({ activities, workouts, onSelect, onSelectWor
         const a = it.a;
         const m = meta(a.type_key);
         return (
-          <Pressable key={`${a.activity_id}-${i}`} onPress={() => onSelect(a)} className="flex-row items-center gap-2 border-b border-border-subtle py-2">
+          <Pressable key={`${a.activity_id}-${i}`} onPress={() => onSelect(a)} className="flex-row items-center gap-2 border-b border-border-subtle py-2" testID={`feed-row-${i}`}>
             <Text variant="body">{m.emoji}</Text>
             <View className="flex-1">
               <Text variant="caption" className="text-text" numberOfLines={1}>{a.name || m.label}</Text>
@@ -216,46 +216,52 @@ export function LastGymSession({ activities, workouts, onSelect, onSelectWorkout
 }
 
 /** Gym sessions per week over the last 12 weeks. */
-export function GymFrequency({ activities }: { activities: ActivityRow[] }) {
-  const { weeks, labels } = useMemo(() => {
-    const gym = activities.filter((a) => isGym(a.type_key));
+export function GymFrequency({ days, sinceDays, rangeLabel }: { days: { day: string }[]; sinceDays?: number; rangeLabel?: string }) {
+  // Web's Gym Frequency reads hevy_raw_data for the range: "N workouts · M this week" over
+  // monthly bars. The deep activity feed excludes strength, so the source is the Hevy calendar
+  // from the workout insights (one row per workout day) (soma#783).
+  const { months, labels, total, thisWeek } = useMemo(() => {
     const today = new Date();
-    const dow = today.getDay();
-    const daysToMon = dow === 0 ? 6 : dow - 1;
-    const thisMon = new Date(today);
-    thisMon.setDate(today.getDate() - daysToMon);
-    const w: number[] = [];
-    const l: string[] = [];
-    for (let i = 11; i >= 0; i--) {
-      const ws = new Date(thisMon);
-      ws.setDate(thisMon.getDate() - i * 7);
-      const we = new Date(ws);
-      we.setDate(ws.getDate() + 7);
-      const wsS = ymd(ws), weS = ymd(we);
-      w.push(gym.filter((a) => { const d = (a.date || "").slice(0, 10); return d >= wsS && d < weS; }).length);
-      l.push(niceDate(wsS).replace(/^\w+, /, ""));
+    // Web scopes the headline to the range (the calendar itself comes back unscoped) and counts
+    // "this week" as the last 7 days (NOW - INTERVAL '7 days'), not since Monday.
+    const cutoff = sinceDays ? ymd(new Date(today.getTime() - sinceDays * 86400000)) : "";
+    const ds = days.map((d) => (d.day || "").slice(0, 10)).filter((d) => d && d >= cutoff).sort();
+    const weekAgo = new Date(today); weekAgo.setDate(today.getDate() - 7);
+    const monS = ymd(weekAgo);
+    const byMonth = new Map<string, number>();
+    for (const d of ds) byMonth.set(d.slice(0, 7), (byMonth.get(d.slice(0, 7)) ?? 0) + 1);
+    // Fill the months between the first and the last workout so a quiet month shows as zero.
+    const keys: string[] = [];
+    if (ds.length) {
+      const [y0, m0] = ds[0].slice(0, 7).split("-").map(Number); const [y1, m1] = ds[ds.length - 1].slice(0, 7).split("-").map(Number);
+      for (let y = y0, m = m0; y < y1 || (y === y1 && m <= m1); m++) { if (m > 12) { m = 1; y++; } keys.push(`${y}-${String(m).padStart(2, "0")}`); }
     }
-    return { weeks: w, labels: l };
-  }, [activities]);
-  if (weeks.every((v) => v === 0)) return null;
-  // Web's expanded gym-frequency dialog draws a moving average over the bars; a
-  // 4-week window is the weekly-series equivalent of its 3-month line (soma#756).
-  const ma = weeks.map((_, i) => { const from = Math.max(0, i - 3); const slice = weeks.slice(from, i + 1); return slice.reduce((a, b) => a + b, 0) / slice.length; });
+    const MON = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    return {
+      months: keys.map((k) => byMonth.get(k) ?? 0),
+      labels: keys.map((k) => `${MON[Number(k.slice(5, 7)) - 1]} '${k.slice(2, 4)}`),
+      total: ds.length,
+      thisWeek: ds.filter((d) => d >= monS).length,
+    };
+  }, [days, sinceDays]);
+  if (!total) return null;
   const chart = {
     labels,
-    xTicks: 4,
+    xTicks: Math.min(4, labels.length),
     yFormat: (v: number) => String(Math.round(v)),
-    series: [
-      { values: weeks, color: "#e0a458", width: 2.2, label: "Sessions" },
-      { values: ma, color: "#5a7a8a", width: 1.4, dashed: true, label: "4-wk avg" },
-    ],
+    yMin: 0,
+    series: [{ values: months, color: "#e0a458", mode: "bars" as const, label: "Workouts" }],
   };
   return (
     <Card className="gap-2">
       <ExpandableChart title="Gym frequency" chart={chart}>
+        <View className="flex-row items-end gap-2" testID="gym-frequency-headline">
+          <Text variant="headline" className="tabular-nums">{total}</Text>
+          <Text variant="micro" className="text-text-muted mb-0.5">workouts{rangeLabel ? ` · ${rangeLabel}` : ""} · {thisWeek} this week</Text>
+        </View>
         <LineChart height={110} interactive {...chart} />
       </ExpandableChart>
-      <ChartLegend items={[{ color: "#e0a458", label: "sessions / week · last 12 weeks" }, { color: "#5a7a8a", label: "4-wk avg", dashed: true }]} />
+      <ChartLegend items={[{ color: "#e0a458", label: "workouts per month" }]} />
     </Card>
   );
 }

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -179,6 +179,7 @@ export function LineChart(props: LineChartProps) {
           onResponderGrant={onTouch}
           onResponderMove={onTouch}
           onResponderRelease={() => interactive && setActive(null)}
+          onResponderTerminate={() => interactive && setActive(null)}
         >
           <Svg width="100%" height={height} viewBox={`0 0 ${VBW} ${height}`}>
             {/* reference bands (drawn under everything) */}

--- a/universal/src/components/this-week-card.tsx
+++ b/universal/src/components/this-week-card.tsx
@@ -40,9 +40,23 @@ export function ThisWeekCard({ data }: { data: WeeklyTraining | null }) {
   const [open, setOpen] = useState(false);
   const [dayMetric, setDayMetric] = useState<DayMetric>("Sessions");
   const { data: comparison } = useWeeklyComparison(open);
-  if (!data || !data.this_week) return null;
-  const tw = num(data.this_week);
+  if (!data) return null;
   const lw = data.last_week ? num(data.last_week) : null;
+  if (!data.this_week) {
+    // Web keeps the card and says so ("No training this week yet"); last week stays as context (soma#783).
+    return (
+      <Card className="gap-1" testID="this-week-empty">
+        <Text variant="eyebrow">This week</Text>
+        <Text variant="caption" className="text-text-secondary">No training this week yet</Text>
+        {lw ? (
+          <Text variant="micro" className="text-text-muted tabular-nums">
+            last week · {lw.sessions} session{lw.sessions === 1 ? "" : "s"} · {lw.total_hours.toFixed(1)} h · {Math.round(lw.total_km)} km · {Math.round(lw.total_cal).toLocaleString()} kcal
+          </Text>
+        ) : null}
+      </Card>
+    );
+  }
+  const tw = num(data.this_week);
 
   const cmpCfg = DAY_CFG[dayMetric];
   const twDays = comparison?.this_week ?? [];


### PR DESCRIPTION
## Phase 3 · Item 2 · overview tails

Closes #783

Gap ledger (and its correction after reading the code) are on the issue. What changes in the app:

- **This Week**: the card no longer vanishes on an empty week; it shows web's "No training this week yet" with last week's totals as context (`this-week-empty`).
- **Recovery row on the readiness hero** (`overview-recovery-row`): "Garmin 82" (Garmin training readiness), "Body Battery +45 / −44 drained" (today's stats series, dated when stale), and the HRV line ("HRV 71 ms weekly · last night 76", or "No HRV reading since <date> · last <x> ms" when stale).
- **Gym frequency** now works: fed from the Hevy workout calendar instead of the strength-less deep feed, with web's monthly bars and the "N workouts · M this week" headline; expands.
- **Recent activity**: twenty rows (`feed-row-<i>`), as on web.
- **Shared chart**: the tap-to-read callout is cleared when the ScrollView takes the gesture over (`onResponderTerminate`); a scroll that started on a chart used to leave its cursor stuck.

Verification: release APK from this branch on the dedicated emulator-5556 with the real account (`verify-device.sh overview --flow .maestro/verify-overview-tails.yaml`), screenshots read back and posted on #783. tsc + vitest green in `universal`; `web` untouched.
