### PR TITLE
feat(app): workouts tails, unit toggle width, top ten with recency, kcal/HR rows, pickable progression (#784)

### DIFF
--- a/universal/.maestro/verify-workouts-tails2.yaml
+++ b/universal/.maestro/verify-workouts-tails2.yaml
@@ -1,0 +1,76 @@
+# Soma verify flow: workouts tails, Phase 3 (soma#784): unit toggle, top exercises ten deep with
+# recency, recent rows with kcal/HR + Show all, pickable strength-progression exercises. Run via
+# universal/scripts/verify-device.sh workouts --flow .maestro/verify-workouts-tails2.yaml
+appId: dev.gkos.soma
+name: Soma verify workouts tails 2
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://workouts
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- scrollUntilVisible:
+    element:
+      id: "unit-toggle"
+    direction: DOWN
+    timeout: 30000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-workouts-unit-toggle
+- scrollUntilVisible:
+    element:
+      id: "top-exercise-9"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-workouts-top-ten
+- scrollUntilVisible:
+    element:
+      id: "workouts-show-all"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-workouts-recent-rows
+- tapOn:
+    id: "workouts-show-all"
+- extendedWaitUntil:
+    visible:
+      id: "workout-row-12"
+    timeout: 10000
+- takeScreenshot: verify-workouts-recent-all
+- scrollUntilVisible:
+    element:
+      id: "strength-add"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-workouts-strength-chips
+- tapOn:
+    id: "strength-add"
+- extendedWaitUntil:
+    visible:
+      id: "strength-pick-0"
+    timeout: 10000
+- takeScreenshot: verify-workouts-strength-picker
+- tapOn:
+    id: "strength-pick-0"
+- waitForAnimationToEnd:
+    timeout: 5000
+- takeScreenshot: verify-workouts-strength-added
+- stopApp
+- openLink: universal://workouts
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,5 +1,5 @@
 import { ScrollView, View, RefreshControl, Pressable } from "react-native";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Text, Card, Badge, ProgressBar, SegmentedControl, Sparkline } from "soma-style";
 import { TimeRangeSelector } from "../../components/time-range-selector";
 import { useRangePref } from "../../lib/time-range";
@@ -50,6 +50,14 @@ function useWorkouts() {
   return { data, error, refetch: () => setReload((n) => n + 1) };
 }
 
+/** ISO timestamp → local calendar day (Hevy start times are UTC; the day is what web joins on). */
+function localDayOf(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return String(iso).slice(0, 10);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+export { localDayOf };
+
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr);
   if (Number.isNaN(d.getTime())) return dateStr;
@@ -85,6 +93,15 @@ export default function WorkoutsScreen() {
   })();
 
   const recent = data?.recent ?? [];
+  // Web's Recent Workouts rows carry Garmin calories and avg HR; the sync list has the kcal and
+  // the insights HR trend has the HR, both keyed by local day + title (soma#784).
+  const enrich = useMemo(() => {
+    const m = new Map<string, { kcal?: number; hr?: number }>();
+    const key = (iso: string, title: string) => `${localDayOf(iso)}|${(title || "").trim().toLowerCase()}`;
+    for (const w of recent) if (w.kcal > 0) m.set(key(w.date, w.title), { ...(m.get(key(w.date, w.title)) ?? {}), kcal: w.kcal });
+    for (const h of insights?.hrTrend ?? []) { const hr = Number(h.avg_hr); if (isFinite(hr) && hr > 0) { const k = key(h.date, h.title); m.set(k, { ...(m.get(k) ?? {}), hr: Math.round(hr) }); } }
+    return m;
+  }, [recent, insights]);
   const totalSynced = data?.totalSynced ?? 0;
   const syncedThisWeek = data?.syncedThisWeek ?? 0;
   const syncedCount = recent.filter((w) => w.synced).length;
@@ -218,11 +235,12 @@ export default function WorkoutsScreen() {
 
         {/* Workout data — volume, stats, top exercises, recent (new /api/workouts/summary) */}
         <View className="flex-row items-center justify-end gap-3">
-          <View className="w-24">
+          {/* 96 px wrapped "kg" into "k / g" on a Pixel 7 (soma#784): give the two pills room. */}
+          <View className="w-36" testID="unit-toggle">
             <SegmentedControl options={["kg", "lb"] as const} value={unit} onChange={(v) => setUnit(v as "kg" | "lb")} />
           </View>
         </View>
-        <WorkoutsDashboard summary={wkSum} unit={unit} topRich={insights?.topExercises} />
+        <WorkoutsDashboard summary={wkSum} unit={unit} topRich={insights?.topExercises} enrich={enrich} />
 
         {/* Anatomical muscle activation map + 4-metric toggle (new /api/workouts/bodymap) */}
         <MuscleBodyMapSection data={bodyMap} />

--- a/universal/src/components/workout-strength.tsx
+++ b/universal/src/components/workout-strength.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { View, Pressable, ScrollView } from "react-native";
-import { Text, Card } from "soma-style";
+import { Text, Card, Modal } from "soma-style";
 import { LineChart, ExpandableChart } from "./line-chart";
 import { ExerciseDetailModal } from "./exercise-detail-modal";
 import { fetchJson } from "../lib/api";
@@ -14,6 +14,10 @@ interface ProgResp { progression: { date: string; maxWeight: number; estimated1R
 /** Configurable per-exercise strength progression: pick an exercise pill, load
  *  its max-weight-over-time line from /api/workouts/exercise. */
 function StrengthProgression({ names, unit }: { names: string[]; unit: "kg" | "lb" }) {
+  // Web tracks a chosen set of exercises (chips with ✕) and offers "+ Add exercise…" from the
+  // top list; the first three are the default set (soma#784). Local state only.
+  const [tracked, setTracked] = useState<string[]>(names.slice(0, 3));
+  const [picking, setPicking] = useState(false);
   const [sel, setSel] = useState<string | null>(names[0] ?? null);
   const [prog, setProg] = useState<ProgResp["progression"]>([]);
   const [loading, setLoading] = useState(false);
@@ -36,12 +40,35 @@ function StrengthProgression({ names, unit }: { names: string[]; unit: "kg" | "l
       <View />
       </ExpandableChart>
       <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-2 pr-2">
-        {names.map((n) => (
-          <Pressable key={n} onPress={() => setSel(n)} className={`rounded-full px-3 py-1 ${sel === n ? "bg-teal" : "bg-surface-subtle"}`}>
-            <Text variant="micro" className={sel === n ? "text-base" : "text-text-secondary"}>{n}</Text>
-          </Pressable>
+        {tracked.map((n) => (
+          <View key={n} className={`flex-row items-center rounded-full pl-3 pr-1 py-1 ${sel === n ? "bg-teal" : "bg-surface-subtle"}`}>
+            <Pressable onPress={() => setSel(n)} hitSlop={4}>
+              <Text variant="micro" className={sel === n ? "text-base" : "text-text-secondary"}>{n}</Text>
+            </Pressable>
+            {tracked.length > 1 ? (
+              <Pressable onPress={() => { const next = tracked.filter((t) => t !== n); setTracked(next); if (sel === n) setSel(next[0] ?? null); }} hitSlop={6} accessibilityLabel={`Remove ${n}`} className="px-1.5">
+                <Text variant="micro" className={sel === n ? "text-base" : "text-text-muted"}>✕</Text>
+              </Pressable>
+            ) : null}
+          </View>
         ))}
       </ScrollView>
+      {/* Its own row, not the end of the chip strip: three tracked names already overflow the
+          width on a phone, which pushed the affordance off-screen (device screenshot, soma#784). */}
+      {names.some((n) => !tracked.includes(n)) ? (
+        <Pressable onPress={() => setPicking(true)} className="self-start rounded-full border border-border-subtle px-3 py-1" testID="strength-add" accessibilityRole="button">
+          <Text variant="micro" className="text-teal">+ Add exercise…</Text>
+        </Pressable>
+      ) : null}
+      <Modal visible={picking} onClose={() => setPicking(false)} title="Add exercise">
+        <View className="gap-1">
+          {names.filter((n) => !tracked.includes(n)).map((n, i) => (
+            <Pressable key={n} onPress={() => { setTracked([n, ...tracked]); setSel(n); setPicking(false); }} className="border-b border-border-subtle py-2" testID={`strength-pick-${i}`}>
+              <Text variant="body" className="text-text">{n}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </Modal>
       {loading && !vals.length ? (
         <Text variant="micro" className="text-text-muted">Loading…</Text>
       ) : vals.length >= 2 ? (
@@ -59,7 +86,7 @@ export function WorkoutStrength({ insights, unit }: { insights: WorkoutInsights 
   const [prName, setPrName] = useState<string | null>(null);
   if (!insights) return null;
   const w = (kg: number) => `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10} ${unit}`;
-  const names = (insights.topExercises ?? []).map((e) => e.exercise).slice(0, 8);
+  const names = (insights.topExercises ?? []).map((e) => e.exercise).slice(0, 20);
   const prs = insights.prs ?? [];
   const split = insights.programSplit ?? [];
   const maxSessions = Math.max(1, ...split.map((p) => num(p.sessions)));

--- a/universal/src/components/workouts-dashboard.tsx
+++ b/universal/src/components/workouts-dashboard.tsx
@@ -16,6 +16,17 @@ function shortDate(iso: string): string {
   const d = new Date(iso);
   return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
+/** Web's "1w ago" / "3w ago" / "2mo ago" recency on the Top Exercises rows. */
+function relativeAgo(iso: string): string {
+  const d = new Date(iso); if (Number.isNaN(d.getTime())) return "";
+  const days = Math.max(0, Math.round((Date.now() - d.getTime()) / 86400000));
+  if (days < 1) return "today"; if (days < 7) return `${days}d ago`; if (days < 30) return `${Math.round(days / 7)}w ago`;
+  if (days < 365) return `${Math.round(days / 30.4)}mo ago`; return `${Math.round(days / 365)}y ago`;
+}
+function localDay(iso: string): string {
+  const d = new Date(iso); if (Number.isNaN(d.getTime())) return String(iso).slice(0, 10);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
 function kvol(v: number): string {
   return v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${v}`;
 }
@@ -39,10 +50,16 @@ function volumeChart(weeks: WorkoutSummary["weeklyVolume"]): LineChartProps | nu
 
 /** Workouts dashboard: summary stats + weekly volume + top exercises (+ optional
     recent list — hidden on the workouts screen, which has its own sync-status list). */
-export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", topRich }: { summary: WorkoutSummary | null | undefined; showRecent?: boolean; unit?: "kg" | "lb"; topRich?: TopExerciseRich[] }) {
+export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", topRich, enrich }: { summary: WorkoutSummary | null | undefined; showRecent?: boolean; unit?: "kg" | "lb"; topRich?: TopExerciseRich[]; enrich?: Map<string, { kcal?: number; hr?: number }> }) {
   const [exName, setExName] = useState<string | null>(null);
   const [wkId, setWkId] = useState<{ id: string; title: string } | null>(null);
+  const [showAll, setShowAll] = useState(false);
   if (!summary) return null;
+  // Web lists ten top exercises with when each was last done; the rich insights list carries
+  // both (the summary's own list stops at eight and has no recency) (soma#784).
+  const top = (topRich?.length ? topRich.map((t) => ({ name: t.exercise, sessions: num(t.workout_count), last: t.last_performed })) : summary.topExercises.map((e) => ({ name: e.name, sessions: e.sessions, last: null as string | null }))).slice(0, 10);
+  const recentRows = showAll ? summary.recent : summary.recent.slice(0, 10);
+  const more = summary.recent.length - 10;
   const richByName = new Map((topRich ?? []).map((t) => [t.exercise, t]));
   const bestW = (kg: number | null) => (kg == null ? null : `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10} ${unit}`);
   const s = summary.stats;
@@ -81,19 +98,22 @@ export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", top
         </Card>
       ) : null}
 
-      {summary.topExercises.length ? (
+      {top.length ? (
         <Card className="gap-2">
           <Text variant="eyebrow">Top exercises</Text>
-          {summary.topExercises.map((e, i) => {
+          {top.map((e, i) => {
             const r = richByName.get(e.name);
             const spark = (r?.recent_weights ?? []).map((x) => Number(x)).filter((x) => isFinite(x));
             const best = r?.best_weight != null ? bestW(Number(r.best_weight)) : null;
             return (
-              <Pressable key={e.name} onPress={() => setExName(e.name)} className="border-b border-border-subtle py-1.5">
+              <Pressable key={e.name} onPress={() => setExName(e.name)} className="border-b border-border-subtle py-1.5" testID={`top-exercise-${i}`}>
                 <View className="flex-row items-center justify-between">
                   <View className="flex-row items-center gap-2 flex-1">
                     <Text variant="micro" className="tabular-nums text-text-muted w-5">{i + 1}</Text>
-                    <Text variant="body" className="text-text-secondary flex-1" numberOfLines={1}>{e.name}</Text>
+                    <View className="flex-1">
+                      <Text variant="body" className="text-text-secondary" numberOfLines={1}>{e.name}</Text>
+                      {e.last ? <Text variant="micro" className="text-text-muted">{relativeAgo(e.last)}</Text> : null}
+                    </View>
                   </View>
                   <View className="flex-row items-center gap-1.5 ml-2">
                     {best ? <Text variant="micro" className="tabular-nums text-lime">{best}</Text> : null}
@@ -114,8 +134,13 @@ export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", top
 
       {showRecent && summary.recent.length ? (
         <Card className="gap-2">
-          <Text variant="eyebrow">Recent workouts</Text>
-          {summary.recent.slice(0, 10).map((w, i) => (
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Recent workouts</Text>
+            <Text variant="micro" className="text-text-muted tabular-nums">{summary.recent.length} in range</Text>
+          </View>
+          {recentRows.map((w, i) => {
+            const x = enrich?.get(`${localDay(w.start_time)}|${(w.title || "").trim().toLowerCase()}`);
+            return (
             <Pressable key={w.id} onPress={() => setWkId({ id: w.id, title: w.title || "Workout" })} className="border-b border-border-subtle py-2" testID={`workout-row-${i}`}>
               <View className="flex-row items-center justify-between">
                 <Text variant="body" className="text-text flex-1" numberOfLines={1}>{w.title || "Workout"}</Text>
@@ -125,10 +150,16 @@ export function WorkoutsDashboard({ summary, showRecent = true, unit = "kg", top
                 </View>
               </View>
               <Text variant="micro" className="text-text-muted">
-                {w.exercise_count} exercises{w.duration_min ? ` · ${w.duration_min} min` : ""}{w.volume > 0 ? ` · ${kvol(w.volume)} kg` : ""}
+                {w.exercise_count} exercises{w.duration_min ? ` · ${w.duration_min} min` : ""}{w.volume > 0 ? ` · ${kvol(w.volume)} kg` : ""}{x?.kcal ? ` · ${x.kcal} kcal` : ""}{x?.hr ? ` · ${x.hr} bpm` : ""}
               </Text>
             </Pressable>
-          ))}
+            );
+          })}
+          {more > 0 ? (
+            <Pressable onPress={() => setShowAll((v) => !v)} className="py-1.5" testID="workouts-show-all" accessibilityRole="button">
+              <Text variant="caption" className="text-teal">{showAll ? "Show fewer" : `Show all (${more} more)`}</Text>
+            </Pressable>
+          ) : null}
         </Card>
       ) : null}
 


### PR DESCRIPTION
## Phase 3 · Item 3 · workouts tails

Closes #784

Gap ledger and side-by-side are on the issue. What changes in the app:

- **Unit toggle defect**: the kg/lb control was 96 px wide and wrapped "kg" into "k / g" on a Pixel 7 (Android 15); it now has room (`unit-toggle`).
- **Top exercises**: ten rows (`top-exercise-<i>`) with web's recency ("1w ago", "3w ago", "2mo ago") from the rich insights list.
- **Recent workouts**: rows carry Garmin kcal and average HR when known, ten at a time with "Show all (N more)" (`workouts-show-all`), like web's list.
- **Strength progression**: a tracked set of exercises (chips with ✕) and "+ Add exercise…" (`strength-add`) picking from the top twenty (`strength-pick-<i>`); local state, no server write.

Verification: release APK from this branch on the dedicated emulator-5556 with the real account (`verify-device.sh workouts --flow .maestro/verify-workouts-tails2.yaml`), screenshots read back and posted on #784. tsc + vitest green in `universal`; `web` untouched.
