### PR TITLE
feat(app): connections read side, Hevy managed-by-sync status, sport tabs on Strava coverage (#785)

### DIFF
--- a/universal/.maestro/verify-connections-tails.yaml
+++ b/universal/.maestro/verify-connections-tails.yaml
@@ -1,0 +1,50 @@
+# Soma verify flow: connections read side (soma#785): Hevy managed-by-sync-service status, sport
+# filter tabs on the Strava coverage list. Run via
+# universal/scripts/verify-device.sh connections --flow .maestro/verify-connections-tails.yaml --marker "<spotify tracks>"
+appId: dev.gkos.soma
+name: Soma verify connections tails
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://connections
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "platform-hevy-detail"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-connections-hevy
+- scrollUntilVisible:
+    element:
+      id: "coverage-tab-strength"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-connections-coverage-all
+- tapOn:
+    id: "coverage-tab-strength"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: verify-connections-coverage-strength
+- tapOn:
+    id: "coverage-tab-running"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: verify-connections-coverage-running
+- stopApp
+- openLink: universal://connections
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -15,6 +15,9 @@ interface PlatformStatus {
   athlete_name: string | null;
   auth_type: string;
   can_connect: boolean;
+  /** Sync-service platforms: raw data present + newest synced_at (web's "Managed by sync service", soma#785). */
+  has_data?: boolean;
+  last_sync?: string | null;
 }
 
 interface SyncRule {
@@ -127,8 +130,23 @@ const PLATFORM_META: Record<
 
 const PLATFORM_ORDER = ["garmin", "hevy", "strava", "telegram", "surfr"];
 
+/** Web's Activity Sync Manager tabs: All / Running / Strength / Cycling, by Garmin type key. */
+type CoverageTab = "all" | "running" | "strength" | "cycling";
+const COVERAGE_TABS: { key: CoverageTab; label: string }[] = [
+  { key: "all", label: "All" }, { key: "running", label: "Running" }, { key: "strength", label: "Strength" }, { key: "cycling", label: "Cycling" },
+];
+function sportOf(typeKey: string | null): CoverageTab | "other" {
+  const k = (typeKey || "").toLowerCase();
+  if (k.includes("running") || k.includes("treadmill")) return "running";
+  if (k.includes("strength")) return "strength";
+  if (k.includes("cycling") || k.includes("biking") || k.includes("bike")) return "cycling";
+  return "other";
+}
+
 function isConnected(p: PlatformStatus | undefined): boolean {
-  return p?.status === "active" || p?.status === "connected";
+  // Web's rule for sync-service platforms: data in the raw table means the service manages it,
+  // whether or not a credentials row exists (Hevy never has one on this install).
+  return p?.status === "active" || p?.status === "connected" || p?.has_data === true;
 }
 
 function statusBadge(
@@ -221,6 +239,7 @@ export default function ConnectionsScreen() {
   const platforms = conn?.platforms ?? [];
   // optimistic enable/disable overrides so the toggle flips instantly
   const [ruleOverride, setRuleOverride] = useState<Record<number, boolean>>({});
+  const [coverageTab, setCoverageTab] = useState<CoverageTab>("all");
   const [dialogPlatform, setDialogPlatform] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
@@ -376,7 +395,9 @@ export default function ConnectionsScreen() {
                 ? "Not yet available"
                 : connected
                   ? meta.kind === "sync-service"
-                    ? `${who}Last synced ${fmtDate(sync?.lastSync ?? null)}`
+                    // The platform's own newest raw row (web's MAX(synced_at)) when the API sends it,
+                    // else the pipeline's last run.
+                    ? `${who}Last synced ${fmtDate(cred?.last_sync ?? sync?.lastSync ?? null)}`
                     : `${who}Connected ${fmtDate(cred?.connected_at)}`
                   : "Not connected";
 
@@ -392,7 +413,7 @@ export default function ConnectionsScreen() {
                   <Badge label={badge.label} tone={badge.tone} />
                 </View>
                 <View className="flex-row items-center justify-between">
-                  <Text variant="micro" className="text-text-secondary flex-1 pr-2">
+                  <Text variant="micro" className="text-text-secondary flex-1 pr-2" testID={`platform-${platform}-detail`}>
                     {detail}
                   </Text>
                   {meta.kind !== "planned" ? (
@@ -559,8 +580,21 @@ export default function ConnectionsScreen() {
             <View className="h-2 overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
               <View style={{ width: `${Math.round((conn.stravaCoverage.onStrava / conn.stravaCoverage.total) * 100)}%`, height: "100%", backgroundColor: "#fc5200" }} />
             </View>
+            {/* Web's Activity Sync Manager filters the list by sport with counts (soma#785). */}
+            <View className="flex-row flex-wrap gap-1.5">
+              {COVERAGE_TABS.map((t) => {
+                const rows = conn?.stravaCoverage?.recent ?? [];
+                const n = t.key === "all" ? rows.length : rows.filter((a) => sportOf(a.type_key) === t.key).length;
+                const on = coverageTab === t.key;
+                return (
+                  <Pressable key={t.key} onPress={() => setCoverageTab(t.key)} className={`rounded-full px-3 py-1 ${on ? "bg-teal" : "bg-surface-subtle"}`} testID={`coverage-tab-${t.key}`} accessibilityRole="button">
+                    <Text variant="micro" className={on ? "text-base" : "text-text-secondary"}>{t.label} {n}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
             <View className="gap-0.5">
-              {conn.stravaCoverage.recent.map((a, i) => {
+              {conn.stravaCoverage.recent.filter((a) => coverageTab === "all" || sportOf(a.type_key) === coverageTab).map((a, i) => {
                 const sport = (a.type_key || "").replace(/_v2$/, "").replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
                 return (
                   <View key={`${a.date}-${i}`} className="flex-row items-center justify-between border-b border-border-subtle py-1.5">

--- a/web/app/api/connections/route.ts
+++ b/web/app/api/connections/route.ts
@@ -20,6 +20,20 @@ export async function GET() {
       ORDER BY priority DESC, id
     `;
 
+    // Sync-service platforms (Garmin, Hevy) hold no row in platform_credentials on a
+    // self-hosted install; the web Sync Hub calls them "Managed by sync service" whenever their
+    // raw table has data, dated by the newest synced_at. Expose the same facts (soma#785).
+    const syncService = await sql`
+      SELECT 'garmin' AS platform,
+             EXISTS(SELECT 1 FROM garmin_raw_data LIMIT 1) AS has_data,
+             (SELECT MAX(synced_at) FROM garmin_raw_data) AS last_sync
+      UNION ALL
+      SELECT 'hevy' AS platform,
+             EXISTS(SELECT 1 FROM hevy_raw_data LIMIT 1) AS has_data,
+             (SELECT MAX(synced_at) FROM hevy_raw_data) AS last_sync
+    `.catch(() => [] as { platform: string; has_data: boolean; last_sync: string | null }[]);
+    const syncMap = Object.fromEntries((syncService as any[]).map((r: any) => [r.platform, r]));
+
     // Spotify library status (features cached for tempo-matched playlists).
     // The demo database has no spotify tables: no Spotify block, not a 500 (this
     // endpoint had been 500 on the demo since the counts landed).
@@ -96,6 +110,8 @@ export async function GET() {
             ? "api_key"
             : "oauth2"),
       can_connect: p === "strava",
+      has_data: syncMap[p]?.has_data === true,
+      last_sync: (syncMap[p]?.last_sync as string | null) ?? null,
     }));
 
     return NextResponse.json({ platforms: status, rules, spotify, stravaCoverage });


### PR DESCRIPTION
## Phase 3 · Item 4 · connections (read side)

Closes #785

Gap ledger and side-by-side are on the issue. What changes:

- **API** `/api/connections`: each platform row gains `has_data` and `last_sync` for the sync-service platforms (Garmin, Hevy) from their raw tables — the rule web's Sync Hub already applies ("Managed by sync service" whenever the raw table has data, dated by the newest `synced_at`). Wrapped in a catch so a database without those tables still answers.
- **App Hevy card**: "Sync service · Last synced 9/1/2026" (`platform-hevy-detail`) instead of "DISCONNECTED · Not connected"; Garmin likewise dates itself by its raw table.
- **Strava coverage**: All / Running / Strength / Cycling tabs with counts (`coverage-tab-<key>`) filtering the list, like web's Activity Sync Manager.

Write paths (rules, backfill, duplicates, disconnect) stay out of scope by decision.

Verification: API exercised against the working-tree server on 3457 (branch APK pointed at 10.0.2.2:3457), then the flow on the dedicated emulator-5556 with the real account (`verify-device.sh connections --flow .maestro/verify-connections-tails.yaml --marker "4,186"`), screenshots read back and posted on #785. tsc + vitest green in `universal` and `web`.
