### PR TITLE
feat(app): training signals, race prediction, efficiency factor and weight trend with sparklines (#786)

### DIFF
--- a/universal/.maestro/verify-training-tails2.yaml
+++ b/universal/.maestro/verify-training-tails2.yaml
@@ -1,0 +1,37 @@
+# Soma verify flow: training signals (soma#786): Race prediction, Efficiency factor and Weight
+# trend cards with sparklines among the external signals. Run via
+# universal/scripts/verify-device.sh training --flow .maestro/verify-training-tails2.yaml --marker "Plan is dormant"
+appId: dev.gkos.soma
+name: Soma verify training tails 2
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://training
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- scrollUntilVisible:
+    element:
+      id: "ref-efficiency-factor"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- assertVisible:
+    id: "ref-weight-trend"
+- assertVisible:
+    id: "ref-race-prediction"
+- takeScreenshot: verify-training-signals
+- stopApp
+- openLink: universal://training
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -25,6 +25,7 @@ import { TrainingTrends } from "../../components/training-trends";
 import { TrajectoryChart } from "../../components/trajectory-chart";
 import { ReferencePanel, type RefMetric } from "../../components/reference-panel";
 import { PaceComputation } from "../../components/pace-computation";
+import { estimateHMSeconds } from "../../lib/vdot-utils";
 
 /** VO2max trend (last year, chronological) from the shared stats endpoint. */
 function useVo2Trend() {
@@ -97,6 +98,7 @@ export default function TrainingScreen() {
   const vo2Trend = useVo2Trend();
 
   // External comparison signals (Garmin-side + PMC) with trend sparklines.
+  const hms = (sec: number) => { const s = Math.round(sec); const h = Math.floor(s / 3600), mi = Math.floor((s % 3600) / 60), se = s % 60; return h > 0 ? `${h}:${String(mi).padStart(2, "0")}:${String(se).padStart(2, "0")}` : `${mi}:${String(se).padStart(2, "0")}`; };
   const refMetrics: RefMetric[] = useMemo(() => {
     const c = sim?.comparison;
     const nums = (arr: { [k: string]: number | string }[] | undefined, key: string) =>
@@ -111,16 +113,32 @@ export default function TrainingScreen() {
     if (ctl.length) m.push({ label: "Fitness (CTL)", value: String(Math.round(last(ctl))), spark: ctl, color: "#77c8d1" });
     const atl = nums(c?.load, "atl");
     if (atl.length) m.push({ label: "Fatigue (ATL)", value: String(Math.round(last(atl))), spark: atl, color: "#e0a458" });
+    // Web's External Comparison Signals (training-dashboard.tsx): race prediction, decoupling,
+    // efficiency factor and weight trend, each with its fitness_trajectory sparkline (soma#786).
+    const hist = data?.history ?? [];
+    const series = (key: "efficiency_factor" | "decoupling_pct" | "race_prediction_seconds" | "weight_kg", days?: number) => {
+      const rows = days ? hist.slice(-days) : hist;
+      return rows.map((h) => Number(h[key])).filter((v) => isFinite(v) && v > 0);
+    };
+    // Web: the HM time from the current VDOT (Daniels), else the day's stored prediction; the
+    // sparkline takes each day's stored seconds, else the estimate from that day's VDOT.
+    const rpSpark = hist.map((h) => (h.race_prediction_seconds != null && Number(h.race_prediction_seconds) > 0 ? Number(h.race_prediction_seconds) : Number(h.vdot_adjusted) > 0 ? estimateHMSeconds(Number(h.vdot_adjusted)) : NaN)).filter((v) => isFinite(v) && v > 0);
+    const rp = vdot != null && Number(vdot) > 0 ? estimateHMSeconds(Number(vdot)) : fit?.race_prediction_seconds != null ? Number(fit.race_prediction_seconds) : last(rpSpark);
+    if (rp > 0) m.push({ label: "Race prediction", value: hms(rp), spark: rpSpark, color: "#6ad4a0", note: "HM from current VDOT" });
     const dec = (fit as { decoupling_pct?: number | null } | undefined)?.decoupling_pct;
     if (dec != null) {
       const dv = Number(dec);
       // Aerobic-decoupling thresholds (web parity): <3% tight, >5% high drift.
       const decColor = dv < 3 ? "#6ad4a0" : dv > 5 ? "#e06060" : "#e0a458";
-      const decNote = dv < 3 ? "tight aerobic" : dv > 5 ? "high drift" : "moderate drift";
-      m.push({ label: "Decoupling", value: `${dv.toFixed(1)}%`, spark: [], color: decColor, note: decNote });
+      const decNote = dv < 3 ? "tight aerobic · <3% good" : dv > 5 ? "high drift · >5% caution" : "moderate drift";
+      m.push({ label: "Decoupling", value: `${dv.toFixed(1)}%`, spark: series("decoupling_pct"), color: decColor, note: decNote });
     }
+    const ef = fit?.efficiency_factor != null ? Number(fit.efficiency_factor) : last(series("efficiency_factor"));
+    if (isFinite(ef) && (ef > 0 || series("efficiency_factor").length)) m.push({ label: "Efficiency factor", value: ef.toFixed(2), spark: series("efficiency_factor"), color: "#77c8d1", note: "speed / heart rate · rising = better economy" });
+    const wkg = fit?.weight_kg != null ? Number(fit.weight_kg) : last(series("weight_kg", 14));
+    if (wkg > 0) m.push({ label: "Weight trend", value: `${wkg.toFixed(1)} kg`, spark: series("weight_kg", 14), color: "#e0a458", note: "≈ 1:00–1:15 faster HM per kg of fat" });
     return m;
-  }, [sim, fit]);
+  }, [sim, fit, data, vdot]);
 
   async function onToggleWeighting(mode: "Adaptive" | "Equal") {
     const ok = await toggleCalibration(mode === "Equal");

--- a/universal/src/components/reference-panel.tsx
+++ b/universal/src/components/reference-panel.tsx
@@ -22,11 +22,13 @@ export function ReferencePanel({ metrics }: { metrics: RefMetric[] }) {
       </View>
       <View className="flex-row flex-wrap gap-3">
         {metrics.map((m) => (
-          <View key={m.label} className="min-w-[46%] flex-1 gap-1 rounded-lg border border-border-subtle p-2.5">
+          <View key={m.label} className="min-w-[46%] flex-1 gap-1 rounded-lg border border-border-subtle p-2.5" testID={`ref-${m.label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`}>
             <Text variant="micro" className="text-text-muted">{m.label}</Text>
             <View className="flex-row items-center justify-between gap-2">
-              <Text variant="body" className="tabular-nums" style={{ color: m.color }}>{m.value}</Text>
-              {m.spark.length >= 2 ? <Sparkline data={m.spark} color={m.color} height={20} baseline /> : null}
+              <Text variant="body" className="tabular-nums shrink-0" style={{ color: m.color }}>{m.value}</Text>
+              {/* The sparkline measures its container; give it the remaining width so a wide value
+                  ("1:43:44", "73.2 kg") does not push it past the card edge (soma#786). */}
+              {m.spark.length >= 2 ? <View className="flex-1 min-w-0 overflow-hidden" style={{ minWidth: 36 }}><Sparkline data={m.spark} color={m.color} height={20} baseline /></View> : null}
             </View>
             {m.note ? <Text variant="micro" className="text-text-muted">{m.note}</Text> : null}
           </View>

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -204,7 +204,14 @@ export interface TrainingBreakdown {
     decoupling_pct: number | null;
     weight_kg: number | null;
     vdot_adjusted: number | null;
-  };
+    efficiency_factor?: number | string | null;
+    race_prediction_seconds?: number | string | null;
+  } | null;
+  /** 30-day fitness_trajectory rows for web's external-signal sparklines (soma#786). */
+  history?: {
+    date: string; efficiency_factor: number | string | null; decoupling_pct: number | string | null;
+    race_prediction_seconds: number | string | null; vdot_adjusted: number | string | null; weight_kg: number | string | null;
+  }[];
 }
 
 /** soma's training breakdown: PMC (fitness/fatigue/form), readiness, fitness markers. */

--- a/web/app/api/training/breakdown/route.ts
+++ b/web/app/api/training/breakdown/route.ts
@@ -17,8 +17,17 @@ export async function GET(request: Request) {
     SELECT ctl, atl, tsb FROM pmc_daily WHERE date = ${date}
   `;
   const [fitness] = await sql`
-    SELECT vo2max, decoupling_pct, weight_kg, vdot_adjusted FROM fitness_trajectory WHERE date = ${date}
+    SELECT vo2max, decoupling_pct, weight_kg, vdot_adjusted, efficiency_factor, race_prediction_seconds
+    FROM fitness_trajectory WHERE date = ${date}
   `;
+  // Web's External Comparison Signals draw 30-day sparklines from fitness_trajectory
+  // (efficiency factor, decoupling, race prediction, weight); ship the same rows (soma#786).
+  const history = await sql`
+    SELECT date::text AS date, efficiency_factor, decoupling_pct, race_prediction_seconds, vdot_adjusted, weight_kg
+    FROM fitness_trajectory
+    WHERE date >= ${date}::date - interval '30 days' AND date <= ${date}::date
+    ORDER BY date
+  `.catch(() => []);
 
   return NextResponse.json({
     date,
@@ -29,5 +38,6 @@ export async function GET(request: Request) {
     },
     pmc: pmc || null,
     fitness: fitness || null,
+    history,
   });
 }


### PR DESCRIPTION
## Phase 3 · Item 5 · training signals

Closes #786

Gap ledger and side-by-side are on the issue. What changes:

- **API** `/api/training/breakdown`: `fitness` gains `efficiency_factor` and `race_prediction_seconds`; a new `history` array carries the last 30 days of `fitness_trajectory` (efficiency factor, decoupling, race prediction, VDOT, weight) — the rows web's training page reads for its sparklines.
- **External signals**: Race prediction (`ref-race-prediction`, HM time from current VDOT), Efficiency factor (`ref-efficiency-factor`, speed / HR), Weight trend (`ref-weight-trend`, 14-day sparkline); Decoupling now has its sparkline and web's "<3% good / >5% caution" note. The DAG stays static.

Verification: API exercised against the working-tree server on 3457 (branch APK pointed at 10.0.2.2:3457), then `verify-device.sh training --flow .maestro/verify-training-tails2.yaml --marker "Plan is dormant"` on the dedicated emulator-5556 with the real account, screenshots read back and posted on #786. tsc + vitest green in `universal` and `web`.
