### PR TITLE
fix(bridge): retry the Strava photo fetch and surface NO_PHOTO in the run result

### DIFF
--- a/bridge/src/main.ts
+++ b/bridge/src/main.ts
@@ -48,16 +48,33 @@ async function missed(db: Pool, activities: GarminActivitySummary[]): Promise<Ga
   return findMissed(activities, bridged, externalIdsJoined);
 }
 
-async function imagePathFor(db: Pool, gid: number): Promise<string | null> {
+/** The workout card (Hevy-enriched) or the activity card for the Strava photo. A miss used to
+ *  be silent — the 2026-09-07 "Upper" push reached Strava without its photo and the log said
+ *  only "pushed". Now: three attempts (the card render on Vercel can cold-start past a single
+ *  fetch), and the outcome is logged and surfaced in the RESULT line as NO_PHOTO. */
+async function imagePathFor(db: Pool, gid: number): Promise<{ path: string | null; note: string }> {
   const r = await db.query("SELECT hevy_id FROM workout_enrichment WHERE garmin_activity_id=$1 ORDER BY processed_at DESC LIMIT 1", [gid]);
   const url = r.rows[0]?.hevy_id ? `${SOMA}/api/workout/${r.rows[0].hevy_id}/image` : `${SOMA}/api/activity/${gid}/image`;
-  try {
-    const resp = await fetch(url);
-    if (!resp.ok) return null;
-    const path = `/tmp/bridge_${gid}.png`;
-    await require("node:fs/promises").writeFile(path, Buffer.from(await resp.arrayBuffer()));
-    return path;
-  } catch { return null; }
+  let note = "";
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const resp = await fetch(url, { signal: AbortSignal.timeout(60_000) });
+      if (!resp.ok) { note = `image http ${resp.status}`; }
+      else {
+        const buf = Buffer.from(await resp.arrayBuffer());
+        if (buf.length < 1000) { note = `image too small (${buf.length} B)`; }
+        else {
+          const path = `/tmp/bridge_${gid}.png`;
+          await require("node:fs/promises").writeFile(path, buf);
+          console.log(`image ok for ${gid}: ${buf.length} B from ${url} (attempt ${attempt})`);
+          return { path, note: "" };
+        }
+      }
+    } catch (e) { note = `image fetch failed: ${(e as Error).message.slice(0, 60)}`; }
+    console.log(`image attempt ${attempt} for ${gid}: ${note}`);
+    if (attempt < 3) await new Promise((r) => setTimeout(r, 5000 * attempt));
+  }
+  return { path: null, note };
 }
 
 async function recordUpload(db: Pool, gid: number, sid: number): Promise<void> {
@@ -110,7 +127,7 @@ async function main(): Promise<void> {
     try {
       const summary = await getActivity(garmin, gid);
       const desc = String(summary.description || "");
-      const img = await imagePathFor(db, gid);
+      const { path: img, note: imgNote } = await imagePathFor(db, gid);
       const fit = await downloadFit(garmin, gid);
       const before = await ownActivityIds(page);
       await uploadFit(token, fit, `bridge_${gid}.fit`); // facterino forwards to Strava
@@ -124,8 +141,9 @@ async function main(): Promise<void> {
       if (!newId) { issues.push(`${name}: forward not seen in ${(FORWARD_TRIES * FORWARD_POLL_MS) / 60000}min`); continue; }
       await recordUpload(db, gid, Number(newId)); // record BEFORE finalize → never a duplicate
       await setActivityDetails(page, Number(newId), { title: name, description: desc, imagePath: img, replacePhoto: true });
-      pushed.push(`${name}->strava/${newId}`);
-      console.log(`pushed ${name} (${gid}) -> strava/${newId}`);
+      pushed.push(`${name}->strava/${newId}${img ? "" : " NO_PHOTO"}`);
+      if (!img) issues.push(`${name}: NO_PHOTO (${imgNote || "no image"}) — re-finalize with the refinalize-strava workflow`);
+      console.log(`pushed ${name} (${gid}) -> strava/${newId}${img ? " with photo" : ` WITHOUT photo (${imgNote})`}`);
     } catch (e) { issues.push(`${name}: ${(e as Error).message.slice(0, 60)}`); }
   }
   await browser.close();


### PR DESCRIPTION
## Bridge: never lose a Strava photo silently

The 2026-09-07 "Upper" workout was forwarded to Strava (run 34164500125) without its workout card, and the log only said `pushed Upper -> strava/20080495691`. `imagePathFor` returned `null` on a transient failure with no trace; both image endpoints answer 200 today.

- `imagePathFor`: three attempts with a 60 s timeout and a size sanity check; each attempt's outcome is logged.
- A push without a photo is marked `NO_PHOTO` in the `RESULT:` line and listed as an issue with the re-finalize hint, so the notify step surfaces it instead of reporting a clean push.
- The missed activity was re-finalized with the `refinalize-strava` workflow (run 34190832891).

`bridge` tsc + vitest green (12 tests).
