### PR TITLE
feat(app): interactive maps, fullscreen pan/zoom for routes and the heatmap, mini-map thumbnails (#793)

### DIFF
--- a/universal/.maestro/verify-maps.yaml
+++ b/universal/.maestro/verify-maps.yaml
@@ -1,0 +1,79 @@
+# Soma verify flow: interactive maps (soma#793): mini-map route thumbnails, the activity map's
+# fullscreen pan/zoom modal, the heatmap's fullscreen modal. Run via
+# universal/scripts/verify-device.sh running --flow .maestro/verify-maps.yaml --marker "last 6M"
+appId: dev.gkos.soma
+name: Soma verify maps
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- scrollUntilVisible:
+    element:
+      id: "route-thumb-0"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- waitForAnimationToEnd:
+    timeout: 8000
+- takeScreenshot: verify-maps-thumbs
+- tapOn:
+    id: "route-thumb-0"
+- extendedWaitUntil:
+    visible:
+      id: "route-map-expand"
+    timeout: 45000
+- waitForAnimationToEnd:
+    timeout: 8000
+- takeScreenshot: verify-maps-activity-map
+- tapOn:
+    id: "route-map-expand"
+- extendedWaitUntil:
+    visible:
+      id: "route-map-fullscreen"
+    timeout: 15000
+- waitForAnimationToEnd:
+    timeout: 8000
+- swipe:
+    start: 50%, 60%
+    end: 70%, 40%
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: verify-maps-activity-fullscreen
+- tapOn:
+    id: "route-map-fullscreen-close"
+- back
+- scrollUntilVisible:
+    element:
+      id: "heatmap-expand"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "heatmap-expand"
+- extendedWaitUntil:
+    visible:
+      id: "heatmap-fullscreen"
+    timeout: 15000
+- waitForAnimationToEnd:
+    timeout: 8000
+- takeScreenshot: verify-maps-heatmap-fullscreen
+- tapOn:
+    id: "heatmap-fullscreen-close"
+- stopApp
+- openLink: universal://running
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -383,7 +383,7 @@ export function ActivityDetailModal({ activity, onClose }: { activity: ActivityR
             </View>
           ) : tab === "Map" ? (
             <View className="gap-2">
-              <RouteMap points={routePts} height={340} />
+              <RouteMap points={routePts} height={340} title={activity?.name || "Route"} />
               <RouteProfile gps={data?.gps_route ?? []} />
             </View>
           ) : tab === "Charts" ? (

--- a/universal/src/components/map-fullscreen.native.tsx
+++ b/universal/src/components/map-fullscreen.native.tsx
@@ -1,0 +1,72 @@
+import { useState, type ReactNode } from "react";
+import { Modal, View, Pressable } from "react-native";
+import { Text } from "soma-style";
+import { Map, Camera } from "@maplibre/maplibre-react-native";
+
+/** OpenFreeMap dark vector basemap — free, OSM data, no API key (the same style the inline maps use). */
+export const DARK_STYLE = "https://tiles.openfreemap.org/styles/dark";
+
+/**
+ * Fullscreen, pannable and zoomable MapLibre view (soma#793). The inline maps stay static
+ * like web's `interactive={false}` maps (a pannable map inside a ScrollView traps vertical
+ * drags); tapping their ⤢ opens this modal with drag, pinch and double-tap zoom enabled.
+ * Children are the GeoJSON sources/layers to draw; `bounds` fits the camera.
+ */
+export function MapFullscreen({
+  visible,
+  onClose,
+  title,
+  bounds,
+  children,
+  legend,
+  testID = "map-fullscreen",
+}: {
+  visible: boolean;
+  onClose: () => void;
+  title: string;
+  bounds: [number, number, number, number];
+  children: ReactNode;
+  legend?: ReactNode;
+  testID?: string;
+}) {
+  // The Camera fits `bounds` when the Map mounts; inside a Modal that is still animating in,
+  // the view can measure 0×0 and the fit lands zoomed far out (the heatmap opened on a whole
+  // state). Mount the Map only once the container has a real size.
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose} statusBarTranslucent>
+      <View className="flex-1 bg-base" testID={testID}>
+        <View className="flex-row items-center justify-between px-4 pb-2 pt-12">
+          <Text variant="body" className="text-text flex-1" numberOfLines={1}>{title}</Text>
+          <Pressable onPress={onClose} hitSlop={10} accessibilityRole="button" accessibilityLabel="Close map" testID={`${testID}-close`} className="rounded-full bg-surface-subtle px-3 py-1.5">
+            <Text variant="caption" className="text-teal">Close</Text>
+          </Pressable>
+        </View>
+        <View className="flex-1" onLayout={(e) => setSize({ w: e.nativeEvent.layout.width, h: e.nativeEvent.layout.height })}>
+          {size.w > 0 && size.h > 0 ? (
+          <Map
+            style={{ flex: 1 }}
+            mapStyle={DARK_STYLE}
+            attribution={false}
+            logo={false}
+            dragPan
+            touchZoom
+            doubleTapZoom
+            doubleTapHoldZoom
+            touchRotate={false}
+            touchPitch={false}
+          >
+            <Camera bounds={bounds} padding={{ top: 40, bottom: 40, left: 40, right: 40 }} />
+            {children}
+          </Map>
+          ) : null}
+          {legend ? <View className="absolute bottom-3 left-3">{legend}</View> : null}
+        </View>
+        {/* Sits above the gesture handle. */}
+        <Text variant="micro" className="text-text-muted px-4 pt-2 pb-8" style={{ fontSize: 9 }}>
+          © OpenFreeMap · © OpenStreetMap contributors · drag to pan, pinch or double-tap to zoom
+        </Text>
+      </View>
+    </Modal>
+  );
+}

--- a/universal/src/components/map-fullscreen.tsx
+++ b/universal/src/components/map-fullscreen.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode } from "react";
+import { Modal, View, Pressable } from "react-native";
+import { Text } from "soma-style";
+
+export const DARK_STYLE = "https://tiles.openfreemap.org/styles/dark";
+
+/** Expo web fallback for the fullscreen map (soma#793): no native MapLibre view here, so the
+ *  modal only carries the title, the legend and a note. The .native.tsx twin draws the map. */
+export function MapFullscreen({
+  visible,
+  onClose,
+  title,
+  legend,
+  testID = "map-fullscreen",
+}: {
+  visible: boolean;
+  onClose: () => void;
+  title: string;
+  bounds: [number, number, number, number];
+  children?: ReactNode;
+  legend?: ReactNode;
+  testID?: string;
+}) {
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 bg-base p-4 gap-3" testID={testID}>
+        <View className="flex-row items-center justify-between">
+          <Text variant="body" className="text-text flex-1" numberOfLines={1}>{title}</Text>
+          <Pressable onPress={onClose} hitSlop={10} accessibilityRole="button" accessibilityLabel="Close map" testID={`${testID}-close`}>
+            <Text variant="caption" className="text-teal">Close</Text>
+          </Pressable>
+        </View>
+        <Text variant="micro" className="text-text-muted">The pannable map renders in the native app.</Text>
+        {legend}
+      </View>
+    </Modal>
+  );
+}

--- a/universal/src/components/route-map.native.tsx
+++ b/universal/src/components/route-map.native.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from "react";
-import { View } from "react-native";
+import { useMemo, useState } from "react";
+import { View, Pressable } from "react-native";
 import { Text } from "soma-style";
 import { Map, Camera, GeoJSONSource, Layer } from "@maplibre/maplibre-react-native";
+import { MapFullscreen } from "./map-fullscreen";
 import Svg, { Defs, LinearGradient, Stop, Rect as SvgRect } from "react-native-svg";
 
 /** One GPS sample of a run/ride. lat+lng required; speed drives pace colour. */
@@ -28,7 +29,9 @@ type PointF = { type: "Feature"; properties: { markerType: "start" | "end" }; ge
  * subtle glow and green/red start/end dots. Camera fits the route. The web SVG
  * fallback (route-map.tsx) is used on Expo web. Fed by /api/activity/[id].gps_route.
  */
-export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; height?: number }) {
+export function RouteMap({ points, height = 300, title = "Route" }: { points: RoutePoint[]; height?: number; title?: string }) {
+  // Fullscreen pan/zoom (soma#793); hooks stay above the early return below.
+  const [open, setOpen] = useState(false);
   const { routes, ends, bounds } = useMemo(() => {
     const pts = (points ?? []).filter((p) => p && isFinite(p.lat) && isFinite(p.lng));
     if (pts.length < 2) return { routes: null as null | { type: "FeatureCollection"; features: LineF[] }, ends: null as null | { type: "FeatureCollection"; features: PointF[] }, bounds: null as null | [number, number, number, number] };
@@ -82,6 +85,10 @@ export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; heigh
             </GeoJSONSource>
           ) : null}
         </Map>
+        {/* ⤢ opens the same route in a pannable, zoomable fullscreen map (soma#793). */}
+        <Pressable onPress={() => setOpen(true)} hitSlop={8} accessibilityRole="button" accessibilityLabel="Expand map" testID="route-map-expand" className="absolute top-2 right-2 rounded-md px-2 py-1" style={{ backgroundColor: "rgba(15,20,26,0.8)" }}>
+          <Text variant="micro" className="text-teal">⤢ expand</Text>
+        </Pressable>
         {/* Pace legend */}
         <View className="absolute bottom-2 left-2 rounded-md px-2 py-1" style={{ backgroundColor: "rgba(15,20,26,0.8)" }}>
           <Text variant="micro" className="text-text-muted">Pace</Text>
@@ -103,6 +110,24 @@ export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; heigh
       </View>
       <Text variant="micro" className="text-text-muted" style={{ fontSize: 8, marginTop: 2 }}>© OpenFreeMap · © OpenStreetMap contributors</Text>
       <Text variant="micro" className="text-text-muted">GPS route · green start, red finish · colour = pace.</Text>
+      <MapFullscreen visible={open} onClose={() => setOpen(false)} title={title} bounds={bounds} testID="route-map-fullscreen"
+        legend={<View className="rounded-md px-2 py-1" style={{ backgroundColor: "rgba(15,20,26,0.8)" }}><Text variant="micro" className="text-text-muted">red = fast · cyan = slow · green start · red finish</Text></View>}>
+          <GeoJSONSource id="route-fs" data={routes}>
+            {/* Two-layer glow + core, matching web run-map.tsx exactly. */}
+            <Layer id="route-fs-glow-outer" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 10, "line-opacity": 0.06, "line-blur": 6 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+            <Layer id="route-fs-glow-mid" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 4, "line-opacity": 0.22, "line-blur": 2 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+            <Layer id="route-fs-core" type="line" paint={{ "line-color": PACE_COLOR, "line-width": 2.5, "line-opacity": 1 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+          </GeoJSONSource>
+          {ends ? (
+            <GeoJSONSource id="route-fs-ends" data={ends}>
+              <Layer id="route-fs-end-dots" type="circle" paint={{
+                "circle-radius": 5,
+                "circle-color": END_COLOR,
+                "circle-stroke-width": 2, "circle-stroke-color": "#ffffff", "circle-opacity": 0.95,
+              }} />
+            </GeoJSONSource>
+          ) : null}
+      </MapFullscreen>
     </View>
   );
 }

--- a/universal/src/components/route-map.tsx
+++ b/universal/src/components/route-map.tsx
@@ -30,7 +30,7 @@ function paceColor(pace: number | null): string {
  * with green/red start/end dots. No map library (native gets the real MapLibre
  * basemap). Fed by /api/activity/[id].gps_route.
  */
-export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; height?: number }) {
+export function RouteMap({ points, height = 300 }: { points: RoutePoint[]; height?: number; title?: string }) {
   const pts = (points ?? []).filter((p) => p && isFinite(p.lat) && isFinite(p.lng));
   if (pts.length < 2) return null;
 

--- a/universal/src/components/route-thumb.native.tsx
+++ b/universal/src/components/route-thumb.native.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { View } from "react-native";
+import { Map, Camera, GeoJSONSource, Layer } from "@maplibre/maplibre-react-native";
+import type { RoutePoint } from "../lib/api";
+import { DARK_STYLE } from "./map-fullscreen";
+
+/** Static mini MapLibre map of one route — web's Recent Routes gallery draws a real map per
+ *  card (RunMap, non-interactive); the SVG polyline stays as the web fallback (soma#793).
+ *  Gestures locked so the thumbnail is a plain tap target inside the gallery. */
+export function RouteThumb({ points }: { points: RoutePoint[]; stroke?: number }) {
+  const { geojson, bounds } = useMemo(() => {
+    const pts = (points ?? []).filter((p) => p && isFinite(p.lat) && isFinite(p.lng));
+    if (pts.length < 2) return { geojson: null, bounds: null as [number, number, number, number] | null };
+    const step = Math.max(1, Math.floor(pts.length / 120));
+    const s = pts.filter((_, i) => i % step === 0);
+    let w = Infinity, so = Infinity, e = -Infinity, n = -Infinity;
+    for (const p of s) { if (p.lng < w) w = p.lng; if (p.lng > e) e = p.lng; if (p.lat < so) so = p.lat; if (p.lat > n) n = p.lat; }
+    return {
+      geojson: { type: "FeatureCollection" as const, features: [{ type: "Feature" as const, properties: {}, geometry: { type: "LineString" as const, coordinates: s.map((p) => [p.lng, p.lat] as [number, number]) } }] },
+      bounds: [w, so, e, n] as [number, number, number, number],
+    };
+  }, [points]);
+  if (!geojson || !bounds) return <View className="h-24 rounded-lg bg-surface-subtle" />;
+  return (
+    <View className="h-24 rounded-lg overflow-hidden" pointerEvents="none">
+      <Map style={{ flex: 1 }} mapStyle={DARK_STYLE} attribution={false} logo={false}
+        dragPan={false} touchZoom={false} doubleTapZoom={false} doubleTapHoldZoom={false} touchRotate={false} touchPitch={false}>
+        <Camera bounds={bounds} padding={{ top: 10, bottom: 10, left: 10, right: 10 }} />
+        <GeoJSONSource id="thumb" data={geojson}>
+          <Layer id="thumb-line" type="line" paint={{ "line-color": "#77c8d1", "line-width": 2.2, "line-opacity": 0.95 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+        </GeoJSONSource>
+      </Map>
+    </View>
+  );
+}

--- a/universal/src/components/route-thumb.tsx
+++ b/universal/src/components/route-thumb.tsx
@@ -1,0 +1,26 @@
+import { View } from "react-native";
+import Svg, { Polyline } from "react-native-svg";
+import type { RoutePoint } from "../lib/api";
+
+/** One route's GPS path as a normalized SVG polyline (north up), no map tiles — the Expo web
+ *  fallback; the .native.tsx twin draws a static MapLibre mini map like web's gallery (soma#793). */
+export function RouteThumb({ points, stroke = 2 }: { points: RoutePoint[]; stroke?: number }) {
+  const pts = points.filter((p) => isFinite(p.lat) && isFinite(p.lng));
+  const step = Math.max(1, Math.floor(pts.length / 80));
+  const s = pts.filter((_, i) => i % step === 0);
+  if (s.length < 2) return <View className="h-24 rounded-lg bg-surface-subtle" />;
+  const lats = s.map((p) => p.lat), lngs = s.map((p) => p.lng);
+  const minLa = Math.min(...lats), maxLa = Math.max(...lats);
+  const minLo = Math.min(...lngs), maxLo = Math.max(...lngs);
+  const rLa = maxLa - minLa || 1e-6, rLo = maxLo - minLo || 1e-6;
+  const poly = s
+    .map((p) => `${((p.lng - minLo) / rLo) * 92 + 4},${(1 - (p.lat - minLa) / rLa) * 92 + 4}`)
+    .join(" ");
+  return (
+    <View className="h-24 rounded-lg bg-surface-subtle overflow-hidden">
+      <Svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
+        <Polyline points={poly} fill="none" stroke="#77c8d1" strokeWidth={stroke} strokeLinejoin="round" strokeLinecap="round" />
+      </Svg>
+    </View>
+  );
+}

--- a/universal/src/components/run-heatmap.native.tsx
+++ b/universal/src/components/run-heatmap.native.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from "react";
-import { View } from "react-native";
+import { useMemo, useState } from "react";
+import { View, Pressable } from "react-native";
 import { Text, Card } from "soma-style";
 import { Map, Camera, GeoJSONSource, Layer } from "@maplibre/maplibre-react-native";
+import { MapFullscreen } from "./map-fullscreen";
 import type { HeatRoute } from "../lib/api";
 
 /** OpenFreeMap dark vector basemap — free, no API key, beautiful streets/labels. */
@@ -17,6 +18,7 @@ type Feature = { type: "Feature"; geometry: { type: "LineString"; coordinates: [
  * /api/running/heatmap.
  */
 export function RunHeatmap({ routes }: { routes: HeatRoute[] }) {
+  const [open, setOpen] = useState(false); // fullscreen pan/zoom (soma#793), above the early return
   const valid = (routes ?? []).filter((r) => Array.isArray(r) && r.length >= 2);
 
   const { geojson, bounds, count } = useMemo(() => {
@@ -63,7 +65,12 @@ export function RunHeatmap({ routes }: { routes: HeatRoute[] }) {
     <Card className="gap-2">
       <View className="flex-row items-center justify-between">
         <Text variant="eyebrow">Route heatmap</Text>
-        <Text variant="micro" className="text-text-muted">{count} routes · last 12 mo</Text>
+        <View className="flex-row items-center gap-3">
+          <Text variant="micro" className="text-text-muted">{count} routes · last 12 mo</Text>
+          <Pressable onPress={() => setOpen(true)} hitSlop={8} accessibilityRole="button" accessibilityLabel="Expand heatmap" testID="heatmap-expand">
+            <Text variant="micro" className="text-teal">⤢ expand</Text>
+          </Pressable>
+        </View>
       </View>
       <View className="rounded-lg overflow-hidden" style={{ aspectRatio: 1 }}>
         {/* Gestures locked to match web run-heatmap (interactive={false}); the
@@ -84,6 +91,11 @@ export function RunHeatmap({ routes }: { routes: HeatRoute[] }) {
         </Map>
       </View>
       <Text variant="micro" className="text-text-muted">Brighter lines = roads you run most.</Text>
+      <MapFullscreen visible={open} onClose={() => setOpen(false)} title={`Route heatmap · ${count} routes`} bounds={bounds} testID="heatmap-fullscreen">
+        <GeoJSONSource id="routes-fs" data={geojson}>
+          <Layer id="routeLines-fs" type="line" paint={{ "line-color": "#77c8d1", "line-width": 2, "line-opacity": 0.4 }} layout={{ "line-cap": "round", "line-join": "round" }} />
+        </GeoJSONSource>
+      </MapFullscreen>
     </Card>
   );
 }

--- a/universal/src/components/running-routes.tsx
+++ b/universal/src/components/running-routes.tsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
 import { View, Pressable } from "react-native";
-import Svg, { Polyline } from "react-native-svg";
 import { Text, Card } from "soma-style";
+import { RouteThumb } from "./route-thumb";
 import { ActivityDetailModal } from "./activity-detail-modal";
 import type { RouteItem, RoutePoint, ActivityRow } from "../lib/api";
 
+/** Web's gallery caption pace (mm:ss /km from distance + duration). */
+function formatPace(distanceKm: number | null, durationS: number | null): string {
+  if (!distanceKm || !durationS) return "";
+  const secPerKm = Math.round(durationS / distanceKm);
+  return `${Math.floor(secPerKm / 60)}:${String(secPerKm % 60).padStart(2, "0")}`;
+}
 function shortDate(iso: string): string {
   const d = new Date(iso);
   return isNaN(d.getTime()) ? "" : d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
@@ -27,28 +33,6 @@ function toActivityRow(r: RouteItem): ActivityRow {
   };
 }
 
-/** One route's GPS path as a normalized SVG polyline (north up), no map tiles. */
-function RouteThumb({ points, stroke = 2 }: { points: RoutePoint[]; stroke?: number }) {
-  const pts = points.filter((p) => isFinite(p.lat) && isFinite(p.lng));
-  const step = Math.max(1, Math.floor(pts.length / 80));
-  const s = pts.filter((_, i) => i % step === 0);
-  if (s.length < 2) return <View className="h-24 rounded-lg bg-surface-subtle" />;
-  const lats = s.map((p) => p.lat), lngs = s.map((p) => p.lng);
-  const minLa = Math.min(...lats), maxLa = Math.max(...lats);
-  const minLo = Math.min(...lngs), maxLo = Math.max(...lngs);
-  const rLa = maxLa - minLa || 1e-6, rLo = maxLo - minLo || 1e-6;
-  const poly = s
-    .map((p) => `${((p.lng - minLo) / rLo) * 92 + 4},${(1 - (p.lat - minLa) / rLa) * 92 + 4}`)
-    .join(" ");
-  return (
-    <View className="h-24 rounded-lg bg-surface-subtle overflow-hidden">
-      <Svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet">
-        <Polyline points={poly} fill="none" stroke="#77c8d1" strokeWidth={stroke} strokeLinejoin="round" strokeLinecap="round" />
-      </Svg>
-    </View>
-  );
-}
-
 /** Recent-runs route gallery (SVG route shapes), fed by /api/running/recent-routes. */
 export function RunningRoutes({ routes }: { routes: RouteItem[] }) {
   const [showAll, setShowAll] = useState(false);
@@ -64,12 +48,12 @@ export function RunningRoutes({ routes }: { routes: RouteItem[] }) {
         <Text variant="micro" className="text-text-muted">{withGps.length} routes · tap to open</Text>
       </View>
       <View className="flex-row flex-wrap gap-3">
-        {shown.map((r) => (
-          <Pressable key={r.activity_id} className="min-w-[46%] flex-1 gap-1" onPress={() => setSelected(r)}>
+        {shown.map((r, i) => (
+          <Pressable key={r.activity_id} className="min-w-[46%] flex-1 gap-1" onPress={() => setSelected(r)} testID={`route-thumb-${i}`}>
             <RouteThumb points={r.gps_points} />
             <Text variant="micro" className="text-text-secondary" numberOfLines={1}>{r.name || "Run"}</Text>
             <Text variant="micro" className="text-text-muted">
-              {shortDate(r.date)}{r.distance_km != null ? ` · ${r.distance_km.toFixed(1)} km` : ""}
+              {shortDate(r.date)}{r.distance_km != null ? ` · ${r.distance_km.toFixed(1)} km` : ""}{formatPace(r.distance_km, r.duration_s) ? ` · ${formatPace(r.distance_km, r.duration_s)} /km` : ""}
             </Text>
           </Pressable>
         ))}


### PR DESCRIPTION
## Phase 4 · Item 1 · interactive route maps (S6)

Closes #793

Gap ledger on the issue. What changes in the app:

- **Fullscreen pan/zoom** (`map-fullscreen.native.tsx`): the activity Map tab (`route-map-expand` → `route-map-fullscreen`) and the running Route heatmap (`heatmap-expand` → `heatmap-fullscreen`) open a fullscreen MapLibre view with drag, pinch and double-tap zoom, attribution and a close control. The inline maps stay static like web's `interactive={false}` maps, so a scroll never fights a pan.
- **Recent Routes thumbnails**: static mini MapLibre maps (`route-thumb.native.tsx`) on the same OpenFreeMap dark style, like web's gallery of `RunMap` cards; SVG polylines stay as the web fallback; captions gain the pace.
- Basemap: the app's existing OpenFreeMap vector style (OSM data, free, no key). Nothing installed.

Verification: release APK from this branch on the dedicated emulator-5556 with the real account (`verify-device.sh running --flow .maestro/verify-maps.yaml --marker "last 6M"`), screenshots read back and posted on #793. tsc + vitest green in `universal`; `web` untouched.
