### PR TITLE
feat(app): training Model Computation node detail, What-if shadow pace, per-step editor (#794)

### DIFF
--- a/universal/.maestro/verify-training-dag.yaml
+++ b/universal/.maestro/verify-training-dag.yaml
@@ -1,0 +1,57 @@
+# Soma verify flow: Model Computation node detail (soma#794): tap a DAG node → detail sheet with
+# value, explanation, formula, inputs. The What-if shadow and the step editor need a live plan
+# (their branches are conditional). Run via
+# universal/scripts/verify-device.sh training --flow .maestro/verify-training-dag.yaml --marker "Plan is dormant"
+appId: dev.gkos.soma
+name: Soma verify training dag
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://training
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 45000
+- scrollUntilVisible:
+    element:
+      id: "dag-node-readiness_factor"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-training-dag-nodes
+- tapOn:
+    id: "dag-node-readiness_factor"
+- extendedWaitUntil:
+    visible:
+      id: "dag-node-detail"
+    timeout: 10000
+- takeScreenshot: verify-training-dag-detail
+- back
+- tapOn:
+    id: "dag-node-adjusted_pace"
+- extendedWaitUntil:
+    visible:
+      id: "dag-node-detail"
+    timeout: 10000
+- takeScreenshot: verify-training-dag-detail-output
+- back
+# Live-plan branches (optional): What-if shadow, step editor.
+- runFlow:
+    when:
+      visible:
+        id: "dag-shadow"
+    commands:
+      - takeScreenshot: verify-training-dag-shadow
+- stopApp
+- openLink: universal://training
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      text: "${MARKER}"
+    timeout: 20000
+- takeScreenshot: verify-${SCREEN}

--- a/universal/src/app/(main)/training.tsx
+++ b/universal/src/app/(main)/training.tsx
@@ -10,6 +10,7 @@ import {
   useActivityMatches,
   setDayCompletion,
   toggleCalibration,
+  saveWorkoutSteps,
   applyIntensity,
   fetchJson,
   usePullRefresh,
@@ -23,6 +24,7 @@ import { TrainingPaces } from "../../components/training-paces";
 import { RaceProtocol } from "../../components/race-protocol";
 import { TrainingTrends } from "../../components/training-trends";
 import { TrajectoryChart } from "../../components/trajectory-chart";
+import { StepEditorSheet } from "../../components/step-editor-sheet";
 import { ReferencePanel, type RefMetric } from "../../components/reference-panel";
 import { PaceComputation } from "../../components/pace-computation";
 import { estimateHMSeconds } from "../../lib/vdot-utils";
@@ -93,6 +95,7 @@ export default function TrainingScreen() {
   const readiness = data?.readiness;
   const vdot = fit?.vdot_adjusted ?? sim?.fitness?.vdotAdjusted ?? null;
   const [whatIfFactor, setWhatIfFactor] = useState(1.0);
+  const [editDay, setEditDay] = useState<PlanDay | null>(null);
   // Re-run the forward simulation live as the what-if slider moves (no save).
   const projected = useMemo(() => projectDays(sim, whatIfFactor), [sim, whatIfFactor]);
   const vo2Trend = useVo2Trend();
@@ -257,8 +260,12 @@ export default function TrainingScreen() {
             vdot={vdot}
             projected={projected}
             onToggleComplete={onToggleComplete}
+            onEditSteps={setEditDay}
           />
         ) : null}
+
+        {/* Web's per-step editor: edit a planned day's steps, save through the delta endpoint (soma#794) */}
+        <StepEditorSheet day={editDay} onClose={() => setEditDay(null)} onSave={async (dayId, steps) => { const ok = await saveWorkoutSteps(dayId, steps); if (ok) refetchSim(); return ok; }} />
 
         {/* What-if intensity — preview scaling upcoming workouts + apply */}
         {planDays.length ? (
@@ -295,7 +302,7 @@ export default function TrainingScreen() {
         <TrainingPaces vdot={vdot} />
 
         {/* Pace computation breakdown — mobile replacement for the web DAG */}
-        <PaceComputation nodes={graphNodes} edges={graphEdges} />
+        <PaceComputation nodes={graphNodes} edges={graphEdges} sliderFactor={whatIfFactor} />
 
         {/* Fitness trajectory — the centerpiece: model vs Garmin across
             Fitness (VDOT) / Readiness / Load. Replaces the flat VO2 sparkline. */}

--- a/universal/src/components/pace-computation.tsx
+++ b/universal/src/components/pace-computation.tsx
@@ -1,6 +1,7 @@
-import { View } from "react-native";
+import { useState } from "react";
+import { View, Pressable } from "react-native";
 import Svg, { Polyline, Circle } from "react-native-svg";
-import { Text, Card } from "soma-style";
+import { Text, Card, Modal } from "soma-style";
 import type { GraphNode, GraphEdge } from "../lib/api";
 import { paceStr } from "../lib/vdot";
 
@@ -43,7 +44,22 @@ function ResponseCurve({ points, cx, cy, color, label }: {
  * readiness drivers (each signal's z-value + its weight into the readiness
  * factor — the graph edges).
  */
-export function PaceComputation({ nodes, edges = [] }: { nodes: Record<string, GraphNode>; edges?: GraphEdge[] }) {
+const COLUMNS: { key: string; label: string }[] = [
+  { key: "raw", label: "Signals" }, { key: "zscore", label: "Streams" }, { key: "pmc", label: "Fatigue" },
+  { key: "merge", label: "Factors" }, { key: "output", label: "Output" },
+];
+function fmtNodeValue(n: GraphNode): string {
+  if (n.value == null || !isFinite(Number(n.value))) return "no data";
+  const v = Number(n.value);
+  if (n.id === "adjusted_pace" || n.unit === "s/km") return `${paceStr(v)}/km`;
+  if (n.unit === "×") return `×${v.toFixed(3)}`;
+  const s = Math.abs(v) >= 100 ? v.toFixed(0) : Math.abs(v) >= 10 ? v.toFixed(1) : v.toFixed(2);
+  return n.unit && n.unit !== "×" ? `${s} ${n.unit}` : s;
+}
+
+export function PaceComputation({ nodes, edges = [], sliderFactor = 1 }: { nodes: Record<string, GraphNode>; edges?: GraphEdge[]; sliderFactor?: number }) {
+  // Web's DAG shows a tooltip per node on hover/tap (value, formula, source, inputs) (soma#794).
+  const [detail, setDetail] = useState<GraphNode | null>(null);
   const val = (id: string): number | null => {
     const v = nodes[id]?.value;
     return v == null || !isFinite(Number(v)) ? null : Number(v);
@@ -78,6 +94,13 @@ export function PaceComputation({ nodes, edges = [] }: { nodes: Record<string, G
 
   if (adjusted == null && !factors.length) return null;
 
+  // Web's shadow graph while the What-if slider moves: adjusted = base × (1 + (rf·ff·wf − 1) × slider).
+  const rf = val("readiness_factor") ?? 1, ff = val("fatigue_factor") ?? 1, wf = val("weight_factor") ?? 1, sf = val("slider_factor") ?? 1;
+  const basePace = adjusted != null && rf * ff * wf * sf !== 0 ? adjusted / (1 + (rf * ff * wf - 1) * sf) : null;
+  const shadow = basePace != null && Math.abs(sliderFactor - 1) > 1e-6 ? basePace * (1 + (rf * ff * wf - 1) * sliderFactor) : null;
+  const byColumn = COLUMNS.map((c) => ({ ...c, items: Object.values(nodes).filter((n) => n.column === c.key) })).filter((c) => c.items.length);
+  const inputsOf = (n: GraphNode) => edges.filter((e) => e.to === n.id).map((e) => ({ node: nodes[e.from], weight: e.weight })).filter((x) => x.node);
+
   return (
     <Card className="gap-3">
       <View className="flex-row items-center justify-between">
@@ -92,6 +115,57 @@ export function PaceComputation({ nodes, edges = [] }: { nodes: Record<string, G
           <Text variant="caption" className="text-text-muted mb-1">/km adjusted</Text>
         </View>
       ) : null}
+      {shadow != null ? (
+        <Text variant="caption" className="tabular-nums text-warm" testID="dag-shadow">
+          What-if ×{sliderFactor.toFixed(2)} → {paceStr(shadow)}/km ({shadow > (adjusted ?? 0) ? "+" : ""}{Math.round(shadow - (adjusted ?? 0))} s/km)
+        </Text>
+      ) : null}
+
+      {/* Web's Model Computation DAG as tappable nodes by column (soma#794) */}
+      {byColumn.length ? (
+        <View className="gap-2 border-t border-border-subtle pt-2.5">
+          <Text variant="micro" className="text-text-muted">MODEL COMPUTATION · tap a node</Text>
+          {byColumn.map((c) => (
+            <View key={c.key} className="gap-1">
+              <Text variant="micro" className="text-text-muted">{c.label.toUpperCase()}</Text>
+              <View className="flex-row flex-wrap gap-1.5">
+                {c.items.map((n) => (
+                  <Pressable key={n.id} onPress={() => setDetail(n)} className="rounded-md border border-border-subtle px-2 py-1" testID={`dag-node-${n.id}`} accessibilityRole="button" accessibilityLabel={`${n.label} ${fmtNodeValue(n)}`}>
+                    <Text variant="micro" className="text-text-secondary">{n.label}</Text>
+                    <Text variant="caption" className="tabular-nums" style={{ color: n.value == null ? "#5a7a8a" : (n.color && n.color.startsWith("#") ? n.color : "#e6f1f5") }}>{fmtNodeValue(n)}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          ))}
+        </View>
+      ) : null}
+      <Modal visible={!!detail} onClose={() => setDetail(null)} title={detail?.label ?? ""}>
+        {detail ? (
+          <View className="gap-2" testID="dag-node-detail">
+            <Text variant="headline" className="tabular-nums text-teal">{fmtNodeValue(detail)}</Text>
+            {detail.tooltip?.short ? <Text variant="caption" className="text-text-secondary">{detail.tooltip.short}</Text> : null}
+            {detail.tooltip?.formula ? (
+              <View className="rounded-md bg-surface-subtle px-2.5 py-1.5">
+                <Text variant="micro" className="text-text-muted">formula</Text>
+                <Text variant="micro" className="tabular-nums text-text">{detail.tooltip.formula}</Text>
+              </View>
+            ) : null}
+            {detail.tooltip?.source ? <Text variant="micro" className="text-text-muted">source · {detail.tooltip.source}</Text> : null}
+            {inputsOf(detail).length ? (
+              <View className="gap-0.5">
+                <Text variant="micro" className="text-text-muted">inputs</Text>
+                {inputsOf(detail).map(({ node, weight }) => (
+                  <View key={node.id} className="flex-row items-center justify-between">
+                    <Text variant="micro" className="text-text-secondary">{node.label}</Text>
+                    <Text variant="micro" className="tabular-nums text-text-muted">{fmtNodeValue(node)}{Math.abs(weight) !== 1 ? ` · w ${weight.toFixed(2)}` : ""}</Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </View>
+        ) : null}
+      </Modal>
 
       {/* multiplicative factors that bend the base pace */}
       <View className="gap-2">

--- a/universal/src/components/step-editor-sheet.tsx
+++ b/universal/src/components/step-editor-sheet.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { View, Pressable, TextInput, ScrollView } from "react-native";
+import { Text, Modal, Button } from "soma-style";
+import type { PlanDay, WorkoutStep } from "../lib/api";
+
+const STEP_TYPES = ["warmup", "run", "interval", "recovery", "cooldown"] as const;
+const DURATION_TYPES = [
+  { key: "distance", label: "km" },
+  { key: "time", label: "min" },
+] as const;
+
+function clone(steps: WorkoutStep[] | null | undefined): WorkoutStep[] {
+  return (steps ?? []).map((s) => ({ ...s }));
+}
+
+/**
+ * Web's per-step editor (workout-step-editor.tsx + step-detail-drawer.tsx) as a sheet: edit a
+ * planned day's steps — type, distance/time, description — add or remove steps, then Save
+ * through the same endpoint web uses (`/api/training/delta/save`, `updatedWorkouts[].workoutSteps`).
+ * Only the user's own plan is touched; nothing is pushed to Garmin here (the plan-push cron
+ * does that on its own schedule, as on web) (soma#794).
+ */
+export function StepEditorSheet({ day, onClose, onSave }: { day: PlanDay | null; onClose: () => void; onSave: (dayId: number, steps: WorkoutStep[]) => Promise<boolean> }) {
+  const [steps, setSteps] = useState<WorkoutStep[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [result, setResult] = useState<"idle" | "saved" | "error">("idle");
+  useEffect(() => { setSteps(clone(day?.workoutSteps)); setResult("idle"); }, [day]);
+  if (!day) return null;
+
+  const update = (i: number, patch: Partial<WorkoutStep>) => setSteps((prev) => prev.map((s, k) => (k === i ? { ...s, ...patch } : s)));
+  const remove = (i: number) => setSteps((prev) => prev.filter((_, k) => k !== i));
+  const add = () => setSteps((prev) => [...prev, { step_type: "run", duration_type: "distance", duration_value: 1, description: "" }]);
+  const dirty = JSON.stringify(steps) !== JSON.stringify(clone(day.workoutSteps));
+
+  return (
+    <Modal visible={!!day} onClose={onClose} title={`Edit steps · ${day.runTitle || day.runType}`}>
+      <ScrollView className="max-h-[70vh]" contentContainerClassName="gap-3" testID="step-editor">
+        <Text variant="micro" className="text-text-muted">{day.dayDate} · week {day.weekNumber}{day.targetDistanceKm != null ? ` · ${day.targetDistanceKm} km planned` : ""}</Text>
+        {steps.map((s, i) => (
+          <View key={i} className="gap-2 rounded-lg border border-border-subtle p-2.5" testID={`step-editor-row-${i}`}>
+            <View className="flex-row flex-wrap gap-1.5">
+              {STEP_TYPES.map((t) => (
+                <Pressable key={t} onPress={() => update(i, { step_type: t })} className={`rounded-full px-2.5 py-1 ${s.step_type === t ? "bg-teal" : "bg-surface-subtle"}`} accessibilityRole="button">
+                  <Text variant="micro" className={s.step_type === t ? "text-base" : "text-text-secondary"}>{t}</Text>
+                </Pressable>
+              ))}
+            </View>
+            <View className="flex-row items-center gap-2">
+              <TextInput
+                value={s.duration_value != null ? String(s.duration_value) : ""}
+                onChangeText={(v) => update(i, { duration_value: v.trim() === "" ? null : Number(v.replace(",", ".")) })}
+                keyboardType="decimal-pad"
+                placeholder="0"
+                placeholderTextColor="#5a7a8a"
+                className="w-20 rounded-md border border-border-subtle px-2 py-1.5 text-text"
+                testID={`step-editor-value-${i}`}
+              />
+              {DURATION_TYPES.map((d) => (
+                <Pressable key={d.key} onPress={() => update(i, { duration_type: d.key })} className={`rounded-full px-2.5 py-1 ${(s.duration_type ?? "distance") === d.key ? "bg-teal" : "bg-surface-subtle"}`} accessibilityRole="button">
+                  <Text variant="micro" className={(s.duration_type ?? "distance") === d.key ? "text-base" : "text-text-secondary"}>{d.label}</Text>
+                </Pressable>
+              ))}
+              <View className="flex-1" />
+              <Pressable onPress={() => remove(i)} hitSlop={6} accessibilityLabel="Remove step" testID={`step-editor-remove-${i}`}>
+                <Text variant="micro" className="text-danger">remove</Text>
+              </Pressable>
+            </View>
+            <TextInput
+              value={s.description ?? ""}
+              onChangeText={(v) => update(i, { description: v })}
+              placeholder="description (optional)"
+              placeholderTextColor="#5a7a8a"
+              className="rounded-md border border-border-subtle px-2 py-1.5 text-text"
+            />
+          </View>
+        ))}
+        <Pressable onPress={add} className="self-start rounded-full border border-border-subtle px-3 py-1" accessibilityRole="button" testID="step-editor-add">
+          <Text variant="micro" className="text-teal">+ Add step</Text>
+        </Pressable>
+        <View className="flex-row items-center justify-end gap-2">
+          {result === "saved" ? <Text variant="micro" className="text-success">Saved</Text> : result === "error" ? <Text variant="micro" className="text-danger">Save failed</Text> : null}
+          <Button variant="ghost" size="sm" label="Cancel" onPress={onClose} />
+          <Button variant="secondary" size="sm" label={saving ? "Saving…" : "Save"} disabled={!dirty || saving} onPress={async () => {
+            setSaving(true);
+            const ok = await onSave(day.id, steps);
+            setSaving(false); setResult(ok ? "saved" : "error");
+            if (ok) setTimeout(onClose, 800);
+          }} />
+        </View>
+      </ScrollView>
+    </Modal>
+  );
+}

--- a/universal/src/components/training-schedule.tsx
+++ b/universal/src/components/training-schedule.tsx
@@ -22,6 +22,8 @@ const RUN_COLOR: Record<string, string> = {
 };
 const runColor = (t: string) => RUN_COLOR[t?.toLowerCase()] ?? "#77c8d1";
 
+/** Local calendar day (the plan's dayDate is a local date string). */
+function localToday(): string { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`; }
 function shortDate(iso: string): string {
   const [y, m, d] = iso.split("-").map(Number);
   const dt = new Date(y, (m ?? 1) - 1, d ?? 1);
@@ -58,6 +60,7 @@ function DayRow({
   proj,
   onToggleComplete,
   onOpenMatch,
+  onEditSteps,
 }: {
   day: PlanDay;
   isToday: boolean;
@@ -66,6 +69,7 @@ function DayRow({
   proj?: ProjectedDay;
   onToggleComplete: (day: PlanDay) => void;
   onOpenMatch?: (day: PlanDay, match: ActivityMatch) => void;
+  onEditSteps?: (day: PlanDay) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [pushOverride, setPushOverride] = useState<string | null>(null);
@@ -194,6 +198,11 @@ function DayRow({
             </View>
           ))}
           {day.gymNotes ? <Text variant="micro" className="text-text-muted mt-1">Gym: {day.gymNotes}</Text> : null}
+          {onEditSteps && !day.completed && day.dayDate >= localToday() && day.runType?.toLowerCase() !== "rest" ? (
+            <Pressable onPress={() => onEditSteps(day)} className="self-start mt-1" hitSlop={6} accessibilityRole="button" testID={`edit-steps-${day.id}`}>
+              <Text variant="micro" className="text-teal">✎ Edit steps</Text>
+            </Pressable>
+          ) : null}
           {/* Pace-adjustment waterfall (upcoming days only — past days aren't re-adjusted):
               base pace × readiness × fatigue × weight = adjusted */}
           {proj && !day.completed && proj.adjustedPace != null && day.runType?.toLowerCase() !== "rest" ? (
@@ -246,6 +255,7 @@ export function TrainingSchedule({
   vdot = null,
   projected,
   onToggleComplete,
+  onEditSteps,
 }: {
   planDays: PlanDay[];
   today: string;
@@ -253,6 +263,7 @@ export function TrainingSchedule({
   vdot?: number | null;
   projected?: Map<number, ProjectedDay> | null;
   onToggleComplete: (day: PlanDay) => void;
+  onEditSteps?: (day: PlanDay) => void;
 }) {
   // group by week
   const weeks = useMemo(() => {
@@ -314,7 +325,7 @@ export function TrainingSchedule({
             {isOpen ? (
               <View className="mt-1">
                 {days.map((d) => (
-                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} match={matches?.[d.id]} vdot={vdot} proj={projected?.get(d.id)} onToggleComplete={onToggleComplete}
+                  <DayRow key={d.id} day={d} isToday={d.dayDate === today} match={matches?.[d.id]} vdot={vdot} proj={projected?.get(d.id)} onToggleComplete={onToggleComplete} onEditSteps={onEditSteps}
                     onOpenMatch={(day, match) => setOpenMatch({ day, match })} />
                 ))}
               </View>

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -251,6 +251,17 @@ export function useCalibration(date: string) {
 }
 
 /** Toggle readiness weighting between adaptive and force-equal. Returns true on success. */
+/** Save edited workout steps for one planned day (web's per-step editor → POST
+ *  /api/training/delta/save, `updatedWorkouts[].workoutSteps`). Returns true on success. */
+export async function saveWorkoutSteps(dayId: number, steps: WorkoutStep[]): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/training/delta/save`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify({ sliderFactor: 1.0, updatedWorkouts: [{ dayId, workoutSteps: steps }] }),
+  });
+  return res.ok;
+}
+
 export async function toggleCalibration(forceEqual: boolean): Promise<boolean> {
   const res = await fetch(`${API_BASE}/api/training/calibration/toggle`, {
     method: "POST",
@@ -862,7 +873,13 @@ export function useWeekdayWeekend(range: string) {
 }
 
 // ---- Training computation graph (nodes → the mobile pace-computation breakdown) ----
-export interface GraphNode { id: string; label: string; value: number | null }
+export interface GraphNode {
+  id: string; label: string; value: number | null;
+  /** Web's graph carries these too (soma#794): the column the node sits in, its unit, and the
+   *  tooltip text (short explanation, formula, source) the DAG shows on hover/tap. */
+  column?: string; unit?: string; color?: string;
+  tooltip?: { short: string; formula?: string; source?: string; inputs?: string[] };
+}
 /** A weighted edge in the readiness/pace computation graph (signal → factor). */
 export interface GraphEdge { from: string; to: string; weight: number }
 /** A hard readiness override (sleep < 5h, Body Battery < 25, HRV/majority flags). */


### PR DESCRIPTION
## Phase 4 · Item 2 · training Model Computation + step editor

Closes #794

Gap ledger on the issue. What changes in the app:

- **Model Computation nodes** (`dag-node-<id>`): web's graph nodes by column with their values; a tap opens the detail (`dag-node-detail`) web shows as a tooltip — value + unit, explanation, formula, source, weighted inputs. The graph API already carried `column`, `unit` and `tooltip`; the app now types and uses them.
- **What-if shadow** (`dag-shadow`): the shadow adjusted pace web's shadow graph recomputes while the slider moves.
- **Per-step editor** (`step-editor-sheet.tsx`, `edit-steps-<dayId>`): edit a planned day's steps (type chips, km/min value, description), add/remove, Save → `POST /api/training/delta/save` with `updatedWorkouts[].workoutSteps`, then the sim refetches. Only the user's own plan; nothing is pushed to Garmin here (the plan-push cron does that as on web).
- The DAG layout, node dragging and hover-by-date stay web-only.

Honest limitation: the only plan is dormant, so `planDays` is empty today — the schedule, the What-if slider and therefore the shadow and the editor are not mounted on device; those two branches in the flow are conditional and will prove themselves when a plan is live. Device proof today = node grid + detail sheets.

Verification: release APK from this branch on the dedicated emulator-5556 with the real account (`verify-device.sh training --flow .maestro/verify-training-dag.yaml --marker "Plan is dormant"`), screenshots read back and posted on #794. tsc + vitest green in `universal`; `web` untouched.
