### PR TITLE
feat(app): connections write paths and pipeline operations (parity, #795)

### DIFF
--- a/universal/.maestro/verify-connections-write.yaml
+++ b/universal/.maestro/verify-connections-write.yaml
@@ -1,0 +1,108 @@
+# Soma verify flow: Connections write paths (soma#795) with REVERSIBLE actions only — a throwaway
+# kite rule created, toggled off, deleted; Pipeline operations tabs read; disconnect / settings
+# controls asserted present, never tapped. Run via
+# universal/scripts/verify-device.sh connections --flow .maestro/verify-connections-write.yaml --marker "4,186"
+appId: dev.gkos.soma
+name: Soma verify connections write paths
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://connections
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "+ Add rule"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    text: "+ Add rule"
+- extendedWaitUntil:
+    visible:
+      id: "rule-activity-types"
+    timeout: 10000
+- tapOn:
+    id: "rule-src-garmin"
+- tapOn:
+    id: "rule-type-kite"
+- tapOn:
+    id: "rule-dest-telegram"
+- takeScreenshot: verify-connections-rule-form
+- tapOn:
+    text: "Create rule"
+- extendedWaitUntil:
+    visible:
+      id: "rule-row-new"
+    timeout: 20000
+- takeScreenshot: verify-connections-rule-created
+- tapOn:
+    id: "rule-toggle-new"
+- extendedWaitUntil:
+    visible:
+      id: "rule-off-new"
+    timeout: 15000
+- takeScreenshot: verify-connections-rule-off
+- tapOn:
+    id: "rule-delete-new"
+- extendedWaitUntil:
+    notVisible:
+      id: "rule-row-new"
+    timeout: 15000
+- takeScreenshot: verify-connections-rule-deleted
+- scrollUntilVisible:
+    element:
+      id: "tab-backfill"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- tapOn:
+    id: "tab-backfill"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: verify-connections-backfill
+- tapOn:
+    id: "tab-duplicates"
+- extendedWaitUntil:
+    visible:
+      id: "duplicates-list"
+    timeout: 60000
+- takeScreenshot: verify-connections-duplicates
+- tapOn:
+    id: "tab-coverage"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: verify-connections-coverage
+- stopApp
+- openLink: universal://connections
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "platform-garmin-detail"
+    timeout: 60000
+- scrollUntilVisible:
+    element:
+      id: "disconnect-strava"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- assertVisible:
+    id: "settings-hevy"
+- takeScreenshot: verify-connections-platform-actions
+- stopApp
+- openLink: universal://connections
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-${SCREEN}

--- a/universal/.maestro/verify-maps.yaml
+++ b/universal/.maestro/verify-maps.yaml
@@ -24,8 +24,18 @@ tags:
 - waitForAnimationToEnd:
     timeout: 8000
 - takeScreenshot: verify-maps-thumbs
+# Re-find right before tapping: late-arriving production data can re-lay the gallery out
+# between the scroll and the tap (post-merge run on 2026-09-08 lost the element that way).
+- scrollUntilVisible:
+    element:
+      id: "route-thumb-0"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
 - tapOn:
     id: "route-thumb-0"
+    retryTapIfNoChange: true
 - extendedWaitUntil:
     visible:
       id: "route-map-expand"

--- a/universal/src/app/(main)/connections.tsx
+++ b/universal/src/app/(main)/connections.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
-import { ScrollView, View, RefreshControl, Pressable } from "react-native";
+import { ScrollView, View, RefreshControl, Pressable, Alert, Linking } from "react-native";
 import { Text, Card, Badge, Button, type BadgeTone } from "soma-style";
-import { fetchJson, usePullRefresh, setRuleEnabled, triggerSync, deleteSyncRule, createSyncRule } from "../../lib/api";
+import { fetchJson, usePullRefresh, setRuleEnabled, triggerSync, deleteSyncRule, createSyncRule, disconnectPlatform, useDuplicates, syncActivityTo, API_BASE } from "../../lib/api";
 import { SyncFlowDiagram, type FlowPlatform, type FlowRule } from "../../components/sync-flow-diagram";
 import { CredentialsDialog } from "../../components/credentials-dialog";
 import { PushNotificationsCard } from "../../components/push-notifications-card";
+import { TabStrip } from "../../components/tab-strip";
 
 // ---- Types (subset of the web /connections page, from fetchable endpoints) ----
 
@@ -31,13 +32,16 @@ interface SyncRule {
 }
 
 interface SpotifyStatus { tracks: number; artists: number; last_sync: string | null }
-interface StravaActivity { name: string | null; date: string; type_key: string | null; onStrava: boolean }
+interface StravaActivity { name: string | null; date: string; type_key: string | null; onStrava: boolean; activity_id?: string | null }
 interface StravaCoverage { total: number; onStrava: number; recent: StravaActivity[] }
+/** Web's Backfill tab rows (backfill_progress). */
+interface BackfillRow { source: string; oldest_date_done: string | null; last_page: number; total_items: number; items_completed: number; status: string; updated_at: string }
 interface ConnectionsResponse {
   platforms: PlatformStatus[];
   rules: SyncRule[];
   spotify?: SpotifyStatus | null;
   stravaCoverage?: StravaCoverage | null;
+  backfill?: BackfillRow[];
 }
 
 interface SourceStatus {
@@ -161,28 +165,45 @@ function statusBadge(
   return { label: "Disconnected", tone: "danger" };
 }
 
+/** Hermes' Date() rejects Postgres' text timestamps ("2026-02-21 04:43:07.647075+00"); normalise
+ *  them to ISO (T separator, millisecond fraction, "+00:00" offset) before parsing. */
+function parseTs(v: string): Date {
+  const d = new Date(v);
+  if (!Number.isNaN(d.getTime())) return d;
+  const m = v.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.(\d+))?(Z|[+-]\d{2}(?::?\d{2})?)?$/);
+  if (!m) return d;
+  const frac = m[3] ? `.${m[3].slice(0, 3).padEnd(3, "0")}` : "";
+  let tz = m[4] ?? "Z";
+  if (/^[+-]\d{2}$/.test(tz)) tz = `${tz}:00`;
+  else if (/^[+-]\d{4}$/.test(tz)) tz = `${tz.slice(0, 3)}:${tz.slice(3)}`;
+  return new Date(`${m[1]}T${m[2]}${frac}${tz}`);
+}
 function fmtDate(iso: string | null | undefined): string {
   if (!iso) return "—";
-  const d = new Date(iso);
+  const d = parseTs(iso);
   if (Number.isNaN(d.getTime())) return "—";
   return d.toLocaleDateString();
 }
 
 function fmtDateTime(iso: string | null | undefined): string {
   if (!iso) return "No syncs yet";
-  const d = new Date(iso);
+  const d = parseTs(iso);
   if (Number.isNaN(d.getTime())) return "No syncs yet";
   return d.toLocaleString();
 }
 
 /** Inline "add sync rule" form: pick a source + destination, then create. */
-function QuickAddRule({ sources, onCreate }: { sources: string[]; onCreate: (source: string, dest: string) => Promise<boolean> }) {
+/** Web's Add Rule form: source, activity type (* / strength / running / cycling / kite) and
+ *  destination (strava / garmin / telegram) — the app used to allow source + destination only (soma#795). */
+const ACTIVITY_TYPES = [{ value: "*", label: "All" }, { value: "strength", label: "Strength" }, { value: "running", label: "Running" }, { value: "cycling", label: "Cycling" }, { value: "kite", label: "Kite" }];
+function QuickAddRule({ sources, onCreate }: { sources: string[]; onCreate: (source: string, dest: string, activityType: string) => Promise<boolean> }) {
   const [open, setOpen] = useState(false);
   const [source, setSource] = useState<string | null>(null);
   const [dest, setDest] = useState<string | null>(null);
+  const [activityType, setActivityType] = useState<string>("*");
   const [busy, setBusy] = useState(false);
   const srcOptions = sources.length ? sources : ["garmin", "hevy"];
-  const destOptions = ["strava", "telegram"];
+  const destOptions = ["strava", "garmin", "telegram"];
 
   if (!open) {
     return (
@@ -191,8 +212,8 @@ function QuickAddRule({ sources, onCreate }: { sources: string[]; onCreate: (sou
       </Pressable>
     );
   }
-  const Pill = ({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) => (
-    <Pressable onPress={onPress} hitSlop={4}>
+  const Pill = ({ label, active, onPress, testID }: { label: string; active: boolean; onPress: () => void; testID?: string }) => (
+    <Pressable onPress={onPress} hitSlop={4} testID={testID} accessibilityRole="radio" accessibilityState={{ selected: active }}>
       <View className="rounded-full px-2.5 py-1" style={{ backgroundColor: active ? "#77c8d133" : "#142530" }}>
         <Text variant="micro" style={{ color: active ? "#77c8d1" : "#8aa0ac" }}>{label}</Text>
       </View>
@@ -202,11 +223,15 @@ function QuickAddRule({ sources, onCreate }: { sources: string[]; onCreate: (sou
     <View className="gap-2 border-t border-border-subtle pt-2">
       <Text variant="micro" className="text-text-muted">Source</Text>
       <View className="flex-row flex-wrap gap-2">
-        {srcOptions.map((s) => <Pill key={s} label={s} active={source === s} onPress={() => setSource(s)} />)}
+        {srcOptions.map((s) => <Pill key={s} label={s} active={source === s} onPress={() => setSource(s)} testID={`rule-src-${s}`} />)}
+      </View>
+      <Text variant="micro" className="text-text-muted">Activity type</Text>
+      <View className="flex-row flex-wrap gap-2" testID="rule-activity-types">
+        {ACTIVITY_TYPES.map((t) => <Pill key={t.value} label={t.label} active={activityType === t.value} onPress={() => setActivityType(t.value)} testID={`rule-type-${t.value === "*" ? "all" : t.value}`} />)}
       </View>
       <Text variant="micro" className="text-text-muted">Destination</Text>
       <View className="flex-row flex-wrap gap-2">
-        {destOptions.map((d) => <Pill key={d} label={d} active={dest === d} onPress={() => setDest(d)} />)}
+        {destOptions.map((d) => <Pill key={d} label={d} active={dest === d} onPress={() => setDest(d)} testID={`rule-dest-${d}`} />)}
       </View>
       <View className="flex-row gap-2">
         <Button
@@ -217,7 +242,7 @@ function QuickAddRule({ sources, onCreate }: { sources: string[]; onCreate: (sou
           onPress={async () => {
             if (!source || !dest) return;
             setBusy(true);
-            const ok = await onCreate(source, dest);
+            const ok = await onCreate(source, dest, activityType);
             setBusy(false);
             if (ok) { setOpen(false); setSource(null); setDest(null); }
           }}
@@ -244,6 +269,36 @@ export default function ConnectionsScreen() {
   const [syncing, setSyncing] = useState(false);
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
   const [deletedRules, setDeletedRules] = useState<Set<number>>(new Set());
+  // The rule the user just created gets stable "new" test ids so a device flow can toggle and
+  // delete exactly it (soma#795) — no other row is touched by the verify flow.
+  const [lastCreatedId, setLastCreatedId] = useState<number | null>(null);
+  const [opsTab, setOpsTab] = useState<"Coverage" | "Backfill" | "Duplicates">("Coverage");
+  const [actionMsg, setActionMsg] = useState<string | null>(null);
+  const duplicates = useDuplicates(opsTab === "Duplicates");
+  function confirmDisconnect(platform: string, label: string) {
+    Alert.alert(`Disconnect ${label}?`, `Soma keeps the data already synced; the ${label} link is removed and can be re-connected on the web dashboard.`, [
+      { text: "Cancel", style: "cancel" },
+      { text: "Disconnect", style: "destructive", onPress: async () => {
+        const ok = await disconnectPlatform(platform);
+        setActionMsg(ok ? `${label} disconnected.` : `Couldn't disconnect ${label}.`);
+        if (ok) refetchConn();
+      } },
+    ]);
+  }
+  function confirmSyncToStrava(a: StravaActivity) {
+    if (!a.activity_id) return;
+    Alert.alert("Sync to Strava?", `Forward "${a.name || "this activity"}" from Garmin to Strava now.`, [
+      { text: "Cancel", style: "cancel" },
+      { text: "Sync", onPress: async () => {
+        const ok = await syncActivityTo("garmin", String(a.activity_id), "strava");
+        setActionMsg(ok ? "Queued for Strava. Pull to refresh in a moment." : "Couldn't queue the sync.");
+        if (ok) refetchConn();
+      } },
+    ]);
+  }
+  function openWebSettings(section: string) {
+    Linking.openURL(`${API_BASE}/connections#${section}`).catch(() => setActionMsg("Couldn't open the web dashboard."));
+  }
 
   async function onSyncNow() {
     setSyncing(true); setSyncMsg(null);
@@ -297,13 +352,15 @@ export default function ConnectionsScreen() {
     const groups = new Map<string, SyncRule[]>();
     for (const r of rules) {
       const dest = Object.keys(r.destinations ?? {}).join(", ") || r.activity_type;
-      const key = `${r.source_platform}→${dest}`;
+      const type = r.activity_type && r.activity_type !== "all" ? r.activity_type : "*";
+      const key = `${r.source_platform}→${dest}·${type}`;
       const arr = groups.get(key);
       if (arr) arr.push(r);
       else groups.set(key, [r]);
     }
     return [...groups.entries()].map(([key, rs]) => {
-      const [source, dest] = key.split("→");
+      const [source, destType] = key.split("→");
+      const dest = destType.split("·")[0];
       const effective = [...rs].sort(
         (a, b) => Number(b.enabled) - Number(a.enabled) || b.priority - a.priority || a.id - b.id,
       )[0];
@@ -417,12 +474,24 @@ export default function ConnectionsScreen() {
                     {detail}
                   </Text>
                   {meta.kind !== "planned" ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onPress={() => setDialogPlatform(platform)}
-                      label={connected ? "Configure" : "Connect"}
-                    />
+                    <View className="flex-row items-center gap-1">
+                      {connected && meta.kind === "sync-service" ? (
+                        <Pressable onPress={() => openWebSettings(platform)} hitSlop={8} testID={`settings-${platform}`} accessibilityRole="link" accessibilityLabel={`${meta.label} settings on the web dashboard`} className="rounded-full px-2 py-1">
+                          <Text variant="micro" className="text-text-secondary">Settings ↗</Text>
+                        </Pressable>
+                      ) : null}
+                      {connected && meta.kind === "oauth" ? (
+                        <Pressable onPress={() => confirmDisconnect(platform, meta.label)} hitSlop={8} testID={`disconnect-${platform}`} accessibilityRole="button" accessibilityLabel={`Disconnect ${meta.label}`} className="rounded-full px-2 py-1">
+                          <Text variant="micro" className="text-danger">Disconnect</Text>
+                        </Pressable>
+                      ) : null}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onPress={() => setDialogPlatform(platform)}
+                        label={connected ? "Configure" : "Connect"}
+                      />
+                    </View>
                   ) : null}
                 </View>
               </Card>
@@ -436,9 +505,13 @@ export default function ConnectionsScreen() {
           {groupedRules.length === 0 ? (
             <Text variant="micro">No sync rules configured.</Text>
           ) : (
-            groupedRules.map((g) => (
+            groupedRules.map((g) => {
+              const isNew = g.effective.id === lastCreatedId;
+              const idSuffix = isNew ? "new" : String(g.effective.id);
+              return (
               <View
                 key={g.key}
+                testID={`rule-row-${idSuffix}`}
                 className="flex-row items-center justify-between border-b border-border-subtle py-2 last:border-0"
               >
                 <View className="flex-1 gap-0.5 pr-2">
@@ -465,25 +538,28 @@ export default function ConnectionsScreen() {
                   </Text>
                 </View>
                 <View className="flex-row items-center gap-3">
-                  <Pressable onPress={() => toggleRule(g.effective.id, g.effective.enabled)} hitSlop={8}>
-                    <Badge
-                      label={g.effective.enabled ? "On" : "Off"}
-                      tone={g.effective.enabled ? "success" : "neutral"}
-                    />
+                  <Pressable onPress={() => toggleRule(g.effective.id, g.effective.enabled)} hitSlop={8} testID={`rule-toggle-${idSuffix}`} accessibilityRole="switch" accessibilityState={{ checked: g.effective.enabled }}>
+                    <View testID={`rule-${g.effective.enabled ? "on" : "off"}-${idSuffix}`}>
+                      <Badge
+                        label={g.effective.enabled ? "On" : "Off"}
+                        tone={g.effective.enabled ? "success" : "neutral"}
+                      />
+                    </View>
                   </Pressable>
-                  <Pressable onPress={() => onDeleteRule(g.effective.id)} hitSlop={8}>
+                  <Pressable onPress={() => onDeleteRule(g.effective.id)} hitSlop={8} testID={`rule-delete-${idSuffix}`} accessibilityRole="button" accessibilityLabel="Delete rule">
                     <Text variant="micro" className="text-danger">Delete</Text>
                   </Pressable>
                 </View>
               </View>
-            ))
+              );
+            })
           )}
           <QuickAddRule
             sources={[...new Set((conn?.rules ?? []).map((r) => r.source_platform))]}
-            onCreate={async (source, dest) => {
-              const ok = await createSyncRule({ source_platform: source, activity_type: "all", destinations: { [dest]: true } });
-              if (ok) refetchConn();
-              return ok;
+            onCreate={async (source, dest, activityType) => {
+              const id = await createSyncRule({ source_platform: source, activity_type: activityType, destinations: { [dest]: { enabled: true } } });
+              if (id != null) { setLastCreatedId(id); refetchConn(); }
+              return id != null;
             }}
           />
         </Card>
@@ -535,10 +611,72 @@ export default function ConnectionsScreen() {
           )}
         </Card>
 
-        {/* Data pipeline — table coverage + recent runs */}
-        {sync && ((sync.tables?.length ?? 0) > 0 || (sync.history?.length ?? 0) > 0) ? (
-          <Card className="gap-3">
-            <Text variant="eyebrow">Data pipeline</Text>
+        {/* Pipeline operations — web's Backfill / Duplicates / Data Coverage tabs (soma#795).
+            Backfill and duplicates are READ here: web's backfill trigger and duplicate resolver
+            both act on Garmin (resolve deletes the duplicate there), so they stay web-only. */}
+        <Card className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Pipeline operations</Text>
+            {actionMsg ? <Text variant="micro" className="text-text-muted flex-1 pl-3 text-right" numberOfLines={2}>{actionMsg}</Text> : null}
+          </View>
+          <TabStrip
+            tabs={[{ key: "Coverage" }, { key: "Backfill" }, { key: "Duplicates" }]}
+            value={opsTab}
+            onChange={(k) => setOpsTab(k as typeof opsTab)}
+          />
+          {opsTab === "Backfill" ? (
+            <View className="gap-2" testID="backfill-list">
+              {(conn?.backfill ?? []).length === 0 ? (
+                <Text variant="micro" className="text-text-muted">No backfill has run yet.</Text>
+              ) : (conn?.backfill ?? []).map((b) => {
+                const pct = b.total_items > 0 ? Math.min(100, Math.round((b.items_completed / b.total_items) * 100)) : 0;
+                const tone: BadgeTone = b.status === "complete" || b.status === "done" ? "success" : b.status === "error" ? "danger" : "warm";
+                return (
+                  <View key={b.source} className="gap-1 border-b border-border-subtle py-1.5">
+                    <View className="flex-row items-center justify-between">
+                      <Text variant="caption" className="text-text">{b.source}</Text>
+                      <Badge label={b.status} tone={tone} />
+                    </View>
+                    <View className="h-1.5 overflow-hidden rounded-full" style={{ backgroundColor: "#142530" }}>
+                      <View style={{ width: `${pct}%`, height: "100%", backgroundColor: "#5ec8c2" }} />
+                    </View>
+                    <Text variant="micro" className="text-text-muted tabular-nums">
+                      {b.items_completed.toLocaleString()}/{b.total_items.toLocaleString()} · page {b.last_page}{b.oldest_date_done ? ` · back to ${fmtDate(b.oldest_date_done)}` : ""} · {fmtDateTime(b.updated_at)}
+                    </Text>
+                  </View>
+                );
+              })}
+              <Text variant="micro" className="text-text-muted">Start or resume a backfill from the web dashboard. It reads your Garmin history page by page.</Text>
+            </View>
+          ) : null}
+          {opsTab === "Duplicates" ? (
+            <View className="gap-2" testID={duplicates.data ? "duplicates-list" : "duplicates-loading"}>
+              {!duplicates.data ? (
+                <Text variant="micro" className="text-text-muted">Scanning Garmin activities for duplicates…</Text>
+              ) : duplicates.data.error ? (
+                <Text variant="micro" className="text-warning">Duplicate scan unavailable right now.</Text>
+              ) : duplicates.data.pairs.length === 0 ? (
+                <Text variant="micro" className="text-text-muted">No duplicate activities found.</Text>
+              ) : duplicates.data.pairs.map((p, i) => (
+                <View key={`${p.a.id}-${p.b.id}`} className="gap-1 border-b border-border-subtle py-1.5" testID={`duplicate-pair-${i}`}>
+                  {[p.a, p.b].map((s) => (
+                    <View key={s.id} className="flex-row items-center justify-between">
+                      <View className="flex-1 pr-2">
+                        <Text variant="caption" className="text-text" numberOfLines={1}>{s.name}</Text>
+                        <Text variant="micro" className="text-text-muted">{fmtDateTime(s.startTime)} · {s.type.replace(/_/g, " ")}</Text>
+                      </View>
+                      <Text variant="micro" className="text-text-secondary tabular-nums">{Math.round(s.duration / 60)} min{s.distance > 0 ? ` · ${(s.distance / 1000).toFixed(1)} km` : ""}</Text>
+                    </View>
+                  ))}
+                </View>
+              ))}
+              {duplicates.data && duplicates.data.pairs.length > 0 ? (
+                <Text variant="micro" className="text-text-muted">Resolving deletes the duplicate on Garmin, so that stays on the web dashboard.</Text>
+              ) : null}
+            </View>
+          ) : null}
+          {opsTab === "Coverage" && sync && ((sync.tables?.length ?? 0) > 0 || (sync.history?.length ?? 0) > 0) ? (
+            <>
             {sync.tables?.length ? (
               <View className="flex-row flex-wrap gap-x-6 gap-y-2">
                 {sync.tables.map((t) => (
@@ -564,8 +702,12 @@ export default function ConnectionsScreen() {
                 ))}
               </View>
             ) : null}
-          </Card>
-        ) : null}
+            </>
+          ) : null}
+          {opsTab === "Coverage" && !(sync && ((sync.tables?.length ?? 0) > 0 || (sync.history?.length ?? 0) > 0)) ? (
+            <Text variant="micro" className="text-text-muted">Pipeline coverage is unavailable right now.</Text>
+          ) : null}
+        </Card>
 
         {/* Strava coverage — how many recent Garmin activities reached Strava */}
         {conn?.stravaCoverage && conn.stravaCoverage.total > 0 ? (
@@ -604,7 +746,13 @@ export default function ConnectionsScreen() {
                     </View>
                     {a.onStrava
                       ? <Badge label="On Strava" tone="warm" />
-                      : <Text variant="micro" className="text-text-muted">not synced</Text>}
+                      : a.activity_id
+                        ? (
+                          <Pressable onPress={() => confirmSyncToStrava(a)} hitSlop={8} testID={`sync-row-${i}`} accessibilityRole="button" accessibilityLabel="Sync to Strava" className="rounded-full bg-surface-subtle px-2.5 py-1">
+                            <Text variant="micro" className="text-teal">Sync to Strava</Text>
+                          </Pressable>
+                        )
+                        : <Text variant="micro" className="text-text-muted">not synced</Text>}
                   </View>
                 );
               })}
@@ -619,7 +767,14 @@ export default function ConnectionsScreen() {
               <Text variant="eyebrow">Spotify</Text>
               <Text variant="micro" className="text-text-muted">Tempo-matched running playlists</Text>
             </View>
-            <Badge label={conn?.spotify ? "Connected" : "Web sign-in"} tone={conn?.spotify ? "success" : "neutral"} />
+            <View className="flex-row items-center gap-2">
+              {conn?.spotify ? (
+                <Pressable onPress={() => confirmDisconnect("spotify", "Spotify")} hitSlop={8} testID="disconnect-spotify" accessibilityRole="button" accessibilityLabel="Disconnect Spotify">
+                  <Text variant="micro" className="text-danger">Disconnect</Text>
+                </Pressable>
+              ) : null}
+              <Badge label={conn?.spotify ? "Connected" : "Web sign-in"} tone={conn?.spotify ? "success" : "neutral"} />
+            </View>
           </View>
           {conn?.spotify ? (
             <>

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -438,12 +438,47 @@ export async function triggerSync(source?: string): Promise<boolean> {
 
 /** Create a sync rule (POST /api/connections/rules). Returns true on success. */
 export async function createSyncRule(rule: {
-  source_platform: string; activity_type: string; destinations: Record<string, unknown>; enabled?: boolean;
-}): Promise<boolean> {
+  source_platform: string; activity_type: string; destinations: Record<string, unknown>; enabled?: boolean; preprocessing?: string[]; priority?: number;
+}): Promise<number | null> {
   const res = await fetch(`${API_BASE}/api/connections/rules`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
     body: JSON.stringify({ enabled: true, ...rule }),
+  });
+  if (!res.ok) return null;
+  const body = (await res.json().catch(() => null)) as { rule?: { id?: number } } | null;
+  return typeof body?.rule?.id === "number" ? body.rule.id : -1;
+}
+
+/** Web's Connections → Disconnect (DELETE /api/connections/[platform] marks the credentials
+ *  disconnected; Spotify has its own POST /api/playlist/spotify/disconnect). Destructive for the
+ *  user's link: callers confirm first, and the device flows never tap it (soma#795). */
+export async function disconnectPlatform(platform: string): Promise<boolean> {
+  const res = platform === "spotify"
+    ? await fetch(`${API_BASE}/api/playlist/spotify/disconnect`, { method: "POST", headers: { ...AUTH_HEADERS } })
+    : await fetch(`${API_BASE}/api/connections/${encodeURIComponent(platform)}`, { method: "DELETE", headers: { ...AUTH_HEADERS } });
+  return res.ok;
+}
+/** Web's Duplicates tab (GET /api/duplicates): candidate pairs of Garmin activities. */
+export interface DuplicateSide { id: number; name: string; type: string; startTime: string; duration: number; distance: number; calories: number | null; avgHr: number | null; maxHr: number | null; detailEndpoints: number }
+export interface DuplicatePairs { pairs: { a: DuplicateSide; b: DuplicateSide }[]; count: number; error?: string }
+export function useDuplicates(enabled: boolean) {
+  const [data, setData] = useState<DuplicatePairs | null>(null);
+  const [loading, setLoading] = useState(false);
+  useEffect(() => {
+    if (!enabled || data) return;
+    let alive = true; setLoading(true);
+    fetchJson<DuplicatePairs>("/api/duplicates").then((d) => alive && setData(d)).catch(() => alive && setData({ pairs: [], count: 0, error: "unavailable" })).finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [enabled, data]);
+  return { data, loading };
+}
+/** Web's Activity Sync Manager "Sync" action (POST /api/sync/activity): forward one activity to a
+ *  destination. An outward write (Strava); the device flows never trigger it (soma#795). */
+export async function syncActivityTo(source_platform: string, source_id: string, destination: string): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/api/sync/activity`, {
+    method: "POST", headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    body: JSON.stringify({ source_platform, source_id, destination }),
   });
   return res.ok;
 }

--- a/web/app/api/connections/route.ts
+++ b/web/app/api/connections/route.ts
@@ -34,6 +34,13 @@ export async function GET() {
     `.catch(() => [] as { platform: string; has_data: boolean; last_sync: string | null }[]);
     const syncMap = Object.fromEntries((syncService as any[]).map((r: any) => [r.platform, r]));
 
+    // Web's Pipeline Operations → Backfill tab reads backfill_progress on the server; the app
+    // needs it from the API (soma#795). Absent table → empty list, never a 500.
+    const backfill = await sql`
+      SELECT source, oldest_date_done::text AS oldest_date_done, last_page, total_items, items_completed, status, updated_at
+      FROM backfill_progress ORDER BY source
+    `.catch(() => [] as unknown[]);
+
     // Spotify library status (features cached for tempo-matched playlists).
     // The demo database has no spotify tables: no Spotify block, not a 500 (this
     // endpoint had been 500 on the demo since the counts landed).
@@ -51,14 +58,15 @@ export async function GET() {
     // Strava coverage: of recent Garmin activities, how many are on Strava,
     // via soma's own sync (activity_sync_log) OR the Garmin→Strava bridge
     // (strava_bridge_uploads), which is what actually runs today (#736).
-    type StravaRow = { name: string | null; date: string; type_key: string | null; strava_id: string | null };
+    type StravaRow = { name: string | null; date: string; type_key: string | null; strava_id: string | null; activity_id: string | null };
     // The demo database is a subset without strava_bridge_uploads: fall back to
     // activity_sync_log alone rather than 500 the whole endpoint (#748 follow-up).
     const stravaRows = (await sql`
       SELECT g.raw_json->>'activityName' AS name,
         (g.raw_json->>'startTimeLocal')::date::text AS date,
         g.raw_json->'activityType'->>'typeKey' AS type_key,
-        COALESCE(sl.destination_id, sbu.strava_activity_id::text) AS strava_id
+        COALESCE(sl.destination_id, sbu.strava_activity_id::text) AS strava_id,
+        g.activity_id::text AS activity_id
       FROM garmin_activity_raw g
       LEFT JOIN activity_sync_log sl
         ON sl.source_id = g.activity_id::text AND sl.destination = 'strava' AND sl.status IN ('sent', 'external')
@@ -72,7 +80,8 @@ export async function GET() {
       SELECT g.raw_json->>'activityName' AS name,
         (g.raw_json->>'startTimeLocal')::date::text AS date,
         g.raw_json->'activityType'->>'typeKey' AS type_key,
-        sl.destination_id AS strava_id
+        sl.destination_id AS strava_id,
+        g.activity_id::text AS activity_id
       FROM garmin_activity_raw g
       LEFT JOIN activity_sync_log sl
         ON sl.source_id = g.activity_id::text AND sl.destination = 'strava' AND sl.status IN ('sent', 'external')
@@ -87,7 +96,7 @@ export async function GET() {
       ? {
           total: stravaTotal,
           onStrava: stravaOn,
-          recent: stravaRows.slice(0, 10).map((r) => ({ name: r.name, date: r.date, type_key: r.type_key, onStrava: r.strava_id != null })),
+          recent: stravaRows.slice(0, 10).map((r) => ({ name: r.name, date: r.date, type_key: r.type_key, onStrava: r.strava_id != null, activity_id: r.activity_id })),
         }
       : null;
 
@@ -114,7 +123,7 @@ export async function GET() {
       last_sync: (syncMap[p]?.last_sync as string | null) ?? null,
     }));
 
-    return NextResponse.json({ platforms: status, rules, spotify, stravaCoverage });
+    return NextResponse.json({ platforms: status, rules, spotify, stravaCoverage, backfill });
   } catch (err) {
     console.error("Error fetching connections status:", err);
     return NextResponse.json(

--- a/web/app/api/sync/status/route.ts
+++ b/web/app/api/sync/status/route.ts
@@ -84,7 +84,7 @@ export async function GET() {
 
     // Recent run history + per-table data counts (pipeline operations detail).
     const historyRows = await sql`
-      SELECT sync_type, status, records_synced, started_at::text AS started_at
+      SELECT sync_type, status, records_synced, started_at
       FROM sync_log
       ORDER BY started_at DESC
       LIMIT 8
@@ -93,7 +93,7 @@ export async function GET() {
       type: String(r.sync_type),
       status: String(r.status),
       records: Number(r.records_synced) || 0,
-      at: String(r.started_at),
+      at: new Date(r.started_at as string | Date).toISOString(), // ISO so the app's Date() parses it (the ::text form did not)
     }));
 
     const countRows = await sql`


### PR DESCRIPTION
## Summary

Item 3 of the Phase 4 parity track (#792): the Connections screen gains web's Sync Hub write paths, all through the existing web APIs.

- Add rule form takes web's full shape: source, activity type (all, strength, running, cycling, kite) and destination (strava, garmin, telegram). The POST response id is kept so the new row carries stable `rule-row-new` / `rule-toggle-new` / `rule-delete-new` test ids.
- Rule rows are grouped per source, destination and activity type. A type-specific rule is its own row, as on web. Before this, a garmin to telegram kite rule collapsed into the all-activities row and its toggle flipped the wrong rule.
- New Pipeline operations card with web's tabs: Coverage (the former Data pipeline content), Backfill (`backfill_progress` rows, now included in `/api/connections`) and Duplicates (`/api/duplicates` pairs with both sides). Starting a backfill and resolving a duplicate stay web-only because both act on Garmin; the app says so under each tab.
- Disconnect for Strava and Spotify behind a confirm dialog (`DELETE /api/connections/strava`, `POST /api/playlist/spotify/disconnect`). Settings links for Garmin, Hevy and Telegram open the web dashboard.
- Coverage rows not on Strava get a "Sync to Strava" action behind a confirm (`POST /api/sync/activity`); the API now sends the Garmin activity id per row.
- `/api/connections` sends `backfill_progress.updated_at` and `/api/sync/status` sends each history row's `at` as ISO timestamps. Their Postgres text form (`2026-09-08 05:34:45.662+00`) does not parse under Hermes, so every recent-run time read "No syncs yet" on device (caught in the first flow run; the recent-runs case predates this PR). The app also normalises that text form before parsing, so older servers still show times.
- `verify-maps.yaml` re-scrolls to the first route thumbnail before tapping it (the screen resets after the first scroll on a cold open; caught in Item 1's post-merge run).

## Verification

- `universal`: tsc clean, vitest 44 passing. `web`: tsc clean, vitest 378 passing.
- Working-tree server on 3457: `/api/connections` returns `backfill` (3 sources) and `activity_id` on every coverage row; `/api/duplicates` returns 2 pairs.
- Device (emulator-5556, real account, branch release APK against 10.0.2.2:3457), flow `verify-connections-write.yaml`: throwaway garmin to telegram kite rule created, toggled off, deleted; Backfill, Duplicates and Coverage tabs read; `disconnect-strava` and `settings-hevy` asserted present and never tapped. No disconnect, no backfill start, no duplicate resolve, no Strava forward was triggered.
- All ten recent coverage rows are on Strava in the real account, so the "Sync to Strava" control is not visible on device; it is covered by the type and the API field only.

Closes #795
