### PR TITLE
feat(app): sign-in, privacy and status screens (parity, #796)

### DIFF
--- a/universal/.maestro/verify-login.yaml
+++ b/universal/.maestro/verify-login.yaml
@@ -1,0 +1,46 @@
+# Soma verify flow: Sign-in screen (soma#796). Enters a WRONG token and tests the connection so the
+# rejected path is proven; never saves, never types the real token. Run via
+# universal/scripts/verify-device.sh login --flow .maestro/verify-login.yaml --marker "Sign in"
+appId: dev.gkos.soma
+name: Soma verify sign-in screen
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://login
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "login-source"
+    timeout: 60000
+- takeScreenshot: verify-login-initial
+- tapOn:
+    id: "login-token"
+- inputText: "not-a-real-token"
+- hideKeyboard
+- tapOn:
+    id: "login-test"
+- extendedWaitUntil:
+    visible:
+      id: "login-result"
+    timeout: 60000
+- assertVisible:
+    text: "Rejected.*"
+- takeScreenshot: verify-login-rejected
+- tapOn:
+    id: "login-token"
+- eraseText: 40
+- hideKeyboard
+- stopApp
+- openLink: universal://login
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-${SCREEN}

--- a/universal/.maestro/verify-privacy.yaml
+++ b/universal/.maestro/verify-privacy.yaml
@@ -1,0 +1,48 @@
+# Soma verify flow: Privacy screen (soma#796), web's /privacy text reachable from More. Run via
+# universal/scripts/verify-device.sh privacy --flow .maestro/verify-privacy.yaml --marker "Privacy policy"
+appId: dev.gkos.soma
+name: Soma verify privacy screen
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://privacy
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "privacy-title"
+    timeout: 60000
+- takeScreenshot: verify-privacy-top
+- scrollUntilVisible:
+    element:
+      id: "privacy-contact"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-privacy-contact
+- stopApp
+- openLink: universal://more
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Privacy"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-more-entries
+- stopApp
+- openLink: universal://privacy
+- waitForAnimationToEnd:
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-${SCREEN}

--- a/universal/.maestro/verify-system.yaml
+++ b/universal/.maestro/verify-system.yaml
@@ -1,0 +1,34 @@
+# Soma verify flow: Status screen (soma#796), what web's /status shows through the API. Run via
+# universal/scripts/verify-device.sh system --flow .maestro/verify-system.yaml --marker "Status"
+appId: dev.gkos.soma
+name: Soma verify status screen
+tags:
+  - verify
+---
+- stopApp
+- openLink: universal://system
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "system-platforms"
+    timeout: 60000
+- assertVisible:
+    text: "Reachable"
+- takeScreenshot: verify-system-loaded
+- stopApp
+- openLink: universal://system
+- waitForAnimationToEnd:
+    timeout: 10000
+- extendedWaitUntil:
+    visible:
+      id: "system-platforms"
+    timeout: 60000
+- scrollUntilVisible:
+    element:
+      text: "${MARKER}"
+    direction: DOWN
+    timeout: 60000
+    speed: 40
+    centerElement: true
+- takeScreenshot: verify-${SCREEN}

--- a/universal/app.json
+++ b/universal/app.json
@@ -36,7 +36,8 @@
       "@bacons/apple-targets",
       "./plugins/soma-widget/withSomaWidget",
       "./plugins/emulator-cleartext/withEmulatorCleartext",
-      "expo-sharing"
+      "expo-sharing",
+      "expo-secure-store"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/universal/package-lock.json
+++ b/universal/package-lock.json
@@ -23,6 +23,7 @@
         "expo-image": "~57.0.1",
         "expo-linking": "~57.0.3",
         "expo-router": "~57.0.6",
+        "expo-secure-store": "~57.0.3",
         "expo-sharing": "~57.0.18",
         "expo-splash-screen": "~57.0.4",
         "expo-status-bar": "~57.0.1",
@@ -6085,6 +6086,15 @@
         "react-server-dom-webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-57.0.3.tgz",
+      "integrity": "sha512-w7XkSQeUiYXPoKXo1jSrQqql7pyCSyIzOp2k0apsZZBE+RkoLTQIMjcbqc181y6KgupfNnYxkaKe+4MEg94+SA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {

--- a/universal/package.json
+++ b/universal/package.json
@@ -17,6 +17,7 @@
     "expo-image": "~57.0.1",
     "expo-linking": "~57.0.3",
     "expo-router": "~57.0.6",
+    "expo-secure-store": "~57.0.3",
     "expo-sharing": "~57.0.18",
     "expo-splash-screen": "~57.0.4",
     "expo-status-bar": "~57.0.1",

--- a/universal/src/app/(main)/_layout.tsx
+++ b/universal/src/app/(main)/_layout.tsx
@@ -37,6 +37,9 @@ function TabsNav() {
       <Tabs.Screen name="playlist-builder" options={{ href: null }} />
       <Tabs.Screen name="live-dj" options={{ href: null }} />
       <Tabs.Screen name="connections" options={{ href: null }} />
+      <Tabs.Screen name="system" options={{ href: null }} />
+      <Tabs.Screen name="login" options={{ href: null }} />
+      <Tabs.Screen name="privacy" options={{ href: null }} />
     </Tabs>
   );
 }

--- a/universal/src/app/(main)/login.tsx
+++ b/universal/src/app/(main)/login.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import { ScrollView, View, TextInput, Pressable } from "react-native";
+import { Text, Card, Badge, Button } from "soma-style";
+import { API_BASE, DEFAULT_API_BASE, AUTH_SOURCE, AUTH_HEADERS, EMBEDDED_TOKEN, applyAuth, hostOf, type AuthSource } from "../../lib/api";
+import { saveStoredAuth, clearStoredAuth } from "../../lib/auth-store";
+
+const SOURCE_LABEL: Record<AuthSource, string> = {
+  embedded: "Embedded build token",
+  stored: "Stored on this device",
+  none: "No token",
+};
+
+/**
+ * Sign-in for installs without the embedded token build (soma#796): an API base URL and a bearer
+ * token, kept in the device keychain / keystore. The embedded-token flow is untouched: with nothing
+ * stored, the app keeps using EXPO_PUBLIC_API_URL and EXPO_PUBLIC_API_TOKEN, and "Use the build's
+ * token" returns to it. Web's equivalent is the GitHub sign-in on soma.gkos.dev; the personal API
+ * token is what this native client uses instead of a session.
+ */
+export default function LoginScreen() {
+  const [url, setUrl] = useState(API_BASE);
+  const [token, setToken] = useState("");
+  const [source, setSource] = useState<AuthSource>(AUTH_SOURCE);
+  const [testing, setTesting] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; text: string } | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  const base = url.trim().replace(/\/+$/, "");
+  const validUrl = /^https?:\/\/[^\s/]+/.test(base);
+
+  async function testConnection() {
+    if (!validUrl) { setResult({ ok: false, text: "Enter a URL that starts with http:// or https://" }); return; }
+    setTesting(true); setResult(null);
+    const headers: Record<string, string> = token.trim()
+      ? { Authorization: `Bearer ${token.trim()}` }
+      : { ...AUTH_HEADERS };
+    try {
+      // soma's API answers a rejected or missing token with a redirect to the login page, which
+      // fetch follows: a real answer is JSON, the login page is HTML.
+      const res = await fetch(`${base}/api/health/today`, { headers });
+      const type = res.headers.get("content-type") ?? "";
+      if (res.ok && type.includes("json")) {
+        setResult({ ok: true, text: `Connected. ${hostOf(base)} answered with today's health${token.trim() ? " for the token you entered" : ""}.` });
+      } else if (res.status === 401 || res.status === 403 || type.includes("html")) {
+        const why = type.includes("html") ? "it answered with the sign-in page" : `HTTP ${res.status}`;
+        setResult({ ok: false, text: `Rejected. ${hostOf(base)} did not accept ${token.trim() ? "that token" : "the current token"} (${why}).` });
+      } else {
+        setResult({ ok: false, text: `Unexpected reply from ${hostOf(base)} (HTTP ${res.status}).` });
+      }
+    } catch {
+      setResult({ ok: false, text: `Unreachable. Could not reach ${hostOf(base)} from this device.` });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function save() {
+    if (!validUrl) { setNote("Enter a valid URL first."); return; }
+    if (!token.trim() && source !== "embedded") { setNote("Enter the personal API token from Settings on the web dashboard."); return; }
+    try {
+      await saveStoredAuth({ baseUrl: base, token: token.trim() });
+      applyAuth(base, token.trim() || null, token.trim() ? "stored" : source);
+      setSource(token.trim() ? "stored" : source);
+      setToken("");
+      setNote(`Saved. Screens now use ${hostOf(base)}.`);
+    } catch {
+      setNote("Couldn't store the credentials on this device.");
+    }
+  }
+
+  async function useBuildToken() {
+    try {
+      await clearStoredAuth();
+      applyAuth(DEFAULT_API_BASE, null, EMBEDDED_TOKEN ? "embedded" : "none");
+      setSource(EMBEDDED_TOKEN ? "embedded" : "none");
+      setUrl(DEFAULT_API_BASE);
+      setToken("");
+      setResult(null);
+      setNote(EMBEDDED_TOKEN ? "Back to the build's embedded token." : "Stored credentials removed.");
+    } catch {
+      setNote("Couldn't clear the stored credentials.");
+    }
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6" keyboardShouldPersistTaps="handled">
+      <View className="w-full max-w-2xl gap-4">
+        <View className="gap-1">
+          <Text variant="headline">Sign in</Text>
+          <Text variant="caption" className="text-text-secondary">
+            Point the app at your soma server with a personal API token
+          </Text>
+        </View>
+
+        <Card className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Current access</Text>
+            <View testID="login-source">
+              <Badge label={SOURCE_LABEL[source]} tone={source === "none" ? "neutral" : "success"} />
+            </View>
+          </View>
+          <Text variant="micro" className="text-text-muted" testID="login-current-host">
+            Server: {hostOf(API_BASE)}
+          </Text>
+          <Text variant="micro" className="text-text-muted">
+            {EMBEDDED_TOKEN
+              ? "This build carries its own token. Saving a token here overrides it on this device only; \"Use the build's token\" switches back."
+              : "This build has no token. Save one here to use the app; it stays in the device keychain."}
+          </Text>
+        </Card>
+
+        <Card className="gap-3">
+          <Text variant="eyebrow">Server</Text>
+          <Text variant="micro" className="text-text-muted">API base URL</Text>
+          <TextInput
+            value={url}
+            onChangeText={setUrl}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+            placeholder="https://soma.example.com"
+            placeholderTextColor="#5a7a8a"
+            testID="login-url"
+            accessibilityLabel="API base URL"
+            className="rounded-xl border border-border-subtle bg-surface-subtle px-3 py-2.5 text-text"
+            style={{ fontSize: 14 }}
+          />
+          <Text variant="micro" className="text-text-muted">Personal API token</Text>
+          <TextInput
+            value={token}
+            onChangeText={setToken}
+            autoCapitalize="none"
+            autoCorrect={false}
+            secureTextEntry
+            placeholder={source === "embedded" ? "Leave empty to keep the build's token" : "Paste the token from the web dashboard"}
+            placeholderTextColor="#5a7a8a"
+            testID="login-token"
+            accessibilityLabel="Personal API token"
+            className="rounded-xl border border-border-subtle bg-surface-subtle px-3 py-2.5 text-text"
+            style={{ fontSize: 14 }}
+          />
+          <View className="flex-row flex-wrap items-center gap-2">
+            <Button variant="secondary" size="sm" label={testing ? "Testing…" : "Test connection"} onPress={testConnection} disabled={testing} testID="login-test" />
+            <Button variant="primary" size="sm" label="Save" onPress={save} testID="login-save" />
+          </View>
+          {result ? (
+            <Text variant="caption" className={result.ok ? "text-success" : "text-warning"} testID="login-result">
+              {result.text}
+            </Text>
+          ) : null}
+          {note ? <Text variant="micro" className="text-text-secondary" testID="login-note">{note}</Text> : null}
+        </Card>
+
+        {source === "stored" || (EMBEDDED_TOKEN && url !== DEFAULT_API_BASE) ? (
+          <Pressable onPress={useBuildToken} className="items-center py-2" testID="login-clear" accessibilityRole="button">
+            <Text variant="caption" className="text-teal">{EMBEDDED_TOKEN ? "Use the build's token" : "Remove stored credentials"}</Text>
+          </Pressable>
+        ) : null}
+
+        <Text variant="micro" className="text-text-muted">
+          The token is created on the web dashboard under Settings and grants full access to your data. It is stored with the platform keychain on iOS and the keystore on Android, never in plain files.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}

--- a/universal/src/app/(main)/more.tsx
+++ b/universal/src/app/(main)/more.tsx
@@ -14,6 +14,11 @@ const SECTIONS: { key: string; label: string; hint: string; icon: IconName }[] =
   { key: "sleep", label: "Sleep", hint: "Stages, HRV, respiration", icon: "moon-outline" },
   { key: "playlist", label: "Playlist", hint: "BPM-matched running playlists", icon: "musical-notes-outline" },
   { key: "connections", label: "Sync", hint: "Integrations, sync rules & pipeline status", icon: "sync-outline" },
+  // Web's /status, /login and /privacy as screens (soma#796). "system" not "status": Expo web
+  // reserves the /status route for Metro.
+  { key: "system", label: "Status", hint: "Server, sync pipeline & linked platforms", icon: "pulse-outline" },
+  { key: "login", label: "Sign in", hint: "API URL & token for installs without the built-in token", icon: "key-outline" },
+  { key: "privacy", label: "Privacy", hint: "What Soma stores and why", icon: "shield-checkmark-outline" },
 ];
 
 export default function MoreScreen() {

--- a/universal/src/app/(main)/privacy.tsx
+++ b/universal/src/app/(main)/privacy.tsx
@@ -1,0 +1,88 @@
+import { ScrollView, View, Pressable, Linking } from "react-native";
+import { Text, Card } from "soma-style";
+
+/** Web's /privacy page (soma#796), same wording, as sections the More tab can reach. */
+const SECTIONS: { title: string; body?: string; items?: string[] }[] = [
+  {
+    title: "Overview",
+    body: "Soma Health (\"we\", \"us\", \"our\") is a personal health intelligence platform that integrates data from wearable devices and fitness services to provide nutrition tracking, training plan management, and body composition analysis.",
+  },
+  {
+    title: "Data we collect",
+    items: [
+      "Garmin Connect data: activity summaries, daily health metrics (heart rate, sleep, steps, stress), body composition, and workout data synced from your Garmin wearable device.",
+      "Hevy data: strength training workout data including exercises, sets, reps, and duration.",
+      "Strava data: activity data synced for cross-platform tracking.",
+      "User-entered data: nutrition logs, meal plans, body measurements, and profile information.",
+    ],
+  },
+  {
+    title: "How we use your data",
+    items: [
+      "Calculate daily energy expenditure and calorie targets",
+      "Generate and manage training plans",
+      "Track body composition progress toward goals",
+      "Provide sleep-adjusted nutrition recommendations",
+      "Sync structured workouts to your Garmin device",
+    ],
+  },
+  {
+    title: "Data storage and security",
+    body: "Your data is stored securely in a Neon PostgreSQL database. We use HTTPS for all data transmission. Authentication is handled via GitHub OAuth with NextAuth.js on the web and a personal API token in this app. We do not sell, share, or distribute your personal data to any third parties.",
+  },
+  {
+    title: "Third-party services",
+    body: "We integrate with Garmin Connect, Hevy, and Strava to sync your fitness data. Each service has its own privacy policy. We only access data you explicitly authorize through OAuth consent flows.",
+  },
+  {
+    title: "Data retention",
+    body: "Your data is retained as long as your account is active. You may request deletion of your data at any time by contacting us.",
+  },
+  {
+    title: "Your rights",
+    items: [
+      "Access your personal data",
+      "Request correction of inaccurate data",
+      "Request deletion of your data",
+      "Revoke access to connected services at any time",
+    ],
+  },
+];
+
+const CONTACT = "kostas@gkos.dev";
+
+export default function PrivacyScreen() {
+  return (
+    <ScrollView className="flex-1 bg-base" contentContainerClassName="items-center px-5 py-6">
+      <View className="w-full max-w-2xl gap-4">
+        <View className="gap-1">
+          <Text variant="headline" testID="privacy-title">Privacy policy</Text>
+          <Text variant="caption" className="text-text-secondary">Last updated: March 17, 2026</Text>
+        </View>
+        {SECTIONS.map((s) => (
+          <Card key={s.title} className="gap-2">
+            <Text variant="eyebrow">{s.title}</Text>
+            {s.body ? <Text variant="caption" className="text-text-secondary">{s.body}</Text> : null}
+            {s.items ? (
+              <View className="gap-1.5">
+                {s.items.map((it) => (
+                  <View key={it} className="flex-row gap-2">
+                    <Text variant="caption" className="text-text-muted">•</Text>
+                    <Text variant="caption" className="text-text-secondary flex-1">{it}</Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </Card>
+        ))}
+        <Card className="gap-2">
+          <Text variant="eyebrow">Contact</Text>
+          <Text variant="caption" className="text-text-secondary">For privacy inquiries, contact us at</Text>
+          <Pressable onPress={() => Linking.openURL(`mailto:${CONTACT}`).catch(() => {})} accessibilityRole="link" testID="privacy-contact">
+            <Text variant="caption" className="text-teal">{CONTACT}</Text>
+          </Pressable>
+        </Card>
+      </View>
+    </ScrollView>
+  );
+}

--- a/universal/src/app/(main)/system.tsx
+++ b/universal/src/app/(main)/system.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import { ScrollView, View, RefreshControl } from "react-native";
+import Constants from "expo-constants";
+import { Text, Card, Badge, type BadgeTone } from "soma-style";
+import { API_BASE, AUTH_SOURCE, AUTH_HEADERS, DAEMON_HOST, fetchJson, usePullRefresh, hostOf } from "../../lib/api";
+
+/** What web's /status (which is the Connections page) shows, through the API (soma#796):
+ *  sync status per source, table coverage, platform links, plus this client's own facts. */
+interface SyncStatusResponse {
+  lastSync: string | null;
+  status: string;
+  recordsSynced: number;
+  error: string | null;
+  sources: Record<string, { status: string; lastSync: string | null; records: number; error: string | null }>;
+  history?: { type: string; status: string; records: number; at: string }[];
+  tables?: { label: string; count: number }[];
+}
+interface PlatformRow { platform: string; status: string; connected_at?: string | null; has_data?: boolean; last_sync?: string | null }
+interface ConnectionsResponse { platforms: PlatformRow[]; rules: { id: number; enabled: boolean }[]; spotify?: { tracks: number } | null }
+
+const LABELS: Record<string, string> = { garmin: "Garmin Connect", hevy: "Hevy", strava: "Strava", telegram: "Telegram", surfr: "Surfr" };
+const SOURCE_LABEL: Record<string, string> = { embedded: "Embedded build token", stored: "Stored on this device", none: "No token" };
+
+function fmt(iso: string | null | undefined): string {
+  if (!iso) return "never";
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? "never" : d.toLocaleString();
+}
+function ago(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  const m = Math.round(ms / 60000);
+  if (m < 60) return `${m} min ago`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h} h ago`;
+  return `${Math.round(h / 24)} d ago`;
+}
+function toneFor(status: string): BadgeTone {
+  return status === "success" || status === "active" || status === "connected" ? "success" : status === "error" ? "danger" : "neutral";
+}
+
+export default function SystemScreen() {
+  const [sync, setSync] = useState<SyncStatusResponse | null>(null);
+  const [conn, setConn] = useState<ConnectionsResponse | null>(null);
+  const [health, setHealth] = useState<"checking" | "ok" | "rejected" | "unreachable">("checking");
+  const [error, setError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
+  const { refreshing, onRefresh } = usePullRefresh(() => setReload((n) => n + 1));
+
+  useEffect(() => {
+    let alive = true;
+    setHealth("checking");
+    fetch(`${API_BASE}/api/health/today`, { headers: { ...AUTH_HEADERS } })
+      .then((r) => { if (!alive) return; setHealth(r.ok && (r.headers.get("content-type") ?? "").includes("json") ? "ok" : "rejected"); })
+      .catch(() => alive && setHealth("unreachable"));
+    fetchJson<SyncStatusResponse>("/api/sync/status").then((d) => alive && setSync(d)).catch((e) => alive && setError(String(e?.message ?? e)));
+    fetchJson<ConnectionsResponse>("/api/connections").then((d) => alive && setConn(d)).catch(() => {});
+    return () => { alive = false; };
+  }, [reload]);
+
+  const version = Constants.expoConfig?.version ?? "dev";
+  const sources = Object.entries(sync?.sources ?? {});
+  const platforms = (conn?.platforms ?? []).filter((p) => p.platform !== "surfr");
+  const healthLabel = health === "ok" ? "Reachable" : health === "rejected" ? "Token rejected" : health === "unreachable" ? "Unreachable" : "Checking…";
+
+  return (
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" />}
+    >
+      <View className="w-full max-w-2xl gap-4">
+        <View className="gap-1">
+          <Text variant="headline">Status</Text>
+          <Text variant="caption" className="text-text-secondary">This app, its server and the sync pipeline</Text>
+        </View>
+
+        <Card className="gap-2" testID="system-api">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">API</Text>
+            <Badge label={healthLabel} tone={health === "ok" ? "success" : health === "checking" ? "neutral" : "danger"} />
+          </View>
+          <Row label="Server" value={hostOf(API_BASE)} />
+          <Row label="Daemon host" value={DAEMON_HOST} />
+          <Row label="Access" value={SOURCE_LABEL[AUTH_SOURCE] ?? AUTH_SOURCE} />
+          <Row label="App version" value={version} />
+        </Card>
+
+        <Card className="gap-2" testID="system-sync">
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Sync pipeline</Text>
+            {sync ? <Badge label={sync.status} tone={toneFor(sync.status)} /> : null}
+          </View>
+          {error ? <Text variant="micro" className="text-warning">{error}</Text> : null}
+          {sync ? (
+            <>
+              <Row label="Last sync" value={`${fmt(sync.lastSync)}${ago(sync.lastSync) ? ` · ${ago(sync.lastSync)}` : ""}`} />
+              <Row label="Records" value={sync.recordsSynced.toLocaleString()} />
+              {sync.error ? <Row label="Error" value={sync.error} /> : null}
+              {sources.length ? (
+                <View className="gap-1 border-t border-border-subtle pt-2">
+                  {sources.map(([name, s]) => (
+                    <View key={name} className="flex-row items-center justify-between">
+                      <Text variant="micro" className="text-text-secondary">{name.replace(/_/g, " ")}</Text>
+                      <View className="flex-row items-center gap-2">
+                        <Text variant="micro" className="tabular-nums text-text-muted">{s.records.toLocaleString()} rec · {ago(s.lastSync) || fmt(s.lastSync)}</Text>
+                        <Badge label={s.status} tone={toneFor(s.status)} />
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              ) : null}
+              {sync.tables?.length ? (
+                <View className="flex-row flex-wrap gap-x-6 gap-y-2 border-t border-border-subtle pt-2">
+                  {sync.tables.map((t) => (
+                    <View key={t.label} className="gap-0.5">
+                      <Text variant="micro" className="text-text-muted">{t.label}</Text>
+                      <Text variant="title" className="text-teal tabular-nums">{t.count.toLocaleString()}</Text>
+                    </View>
+                  ))}
+                </View>
+              ) : null}
+            </>
+          ) : !error ? <Text variant="micro" className="text-text-muted">Loading…</Text> : null}
+        </Card>
+
+        <Card className="gap-2" testID={conn ? "system-platforms" : "system-platforms-loading"}>
+          <View className="flex-row items-center justify-between">
+            <Text variant="eyebrow">Platforms</Text>
+            {conn ? <Text variant="micro" className="text-text-muted">{conn.rules.filter((r) => r.enabled).length} rules on</Text> : null}
+          </View>
+          {platforms.map((p) => {
+            const linked = p.status === "active" || p.status === "connected" || p.has_data === true;
+            return (
+              <View key={p.platform} className="flex-row items-center justify-between">
+                <Text variant="caption" className="text-text">{LABELS[p.platform] ?? p.platform}</Text>
+                <View className="flex-row items-center gap-2">
+                  <Text variant="micro" className="text-text-muted">{p.last_sync ? `synced ${ago(p.last_sync) || fmt(p.last_sync)}` : p.connected_at ? `since ${fmt(p.connected_at).split(",")[0]}` : ""}</Text>
+                  <Badge label={linked ? "Linked" : "Not linked"} tone={linked ? "success" : "neutral"} />
+                </View>
+              </View>
+            );
+          })}
+          {conn ? (
+            <View className="flex-row items-center justify-between">
+              <Text variant="caption" className="text-text">Spotify</Text>
+              <Badge label={conn.spotify ? "Linked" : "Not linked"} tone={conn.spotify ? "success" : "neutral"} />
+            </View>
+          ) : <Text variant="micro" className="text-text-muted">Loading…</Text>}
+        </Card>
+      </View>
+    </ScrollView>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <View className="flex-row items-start justify-between gap-3">
+      <Text variant="micro" className="text-text-muted">{label}</Text>
+      <Text variant="micro" className="text-text-secondary flex-1 text-right" numberOfLines={2}>{value}</Text>
+    </View>
+  );
+}

--- a/universal/src/app/_layout.tsx
+++ b/universal/src/app/_layout.tsx
@@ -5,11 +5,13 @@ import { StatusBar } from "expo-status-bar";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { useEffect, useState } from "react";
 import { hydrateRangePref } from "../lib/time-range";
+import { applyStoredAuth } from "../lib/api";
 
 export default function RootLayout() {
   // Read the persisted time range once before any screen fetches with it (soma#754).
   const [ready, setReady] = useState(false);
-  useEffect(() => { hydrateRangePref().finally(() => setReady(true)); }, []);
+  // Also apply stored sign-in credentials (soma#796) so no screen fetches with the wrong server.
+  useEffect(() => { Promise.all([hydrateRangePref(), applyStoredAuth()]).finally(() => setReady(true)); }, []);
   if (!ready) return <View className="flex-1 bg-base" />;
   return (
     <SafeAreaProvider>

--- a/universal/src/components/ChatSheet.tsx
+++ b/universal/src/components/ChatSheet.tsx
@@ -14,7 +14,7 @@ import { Text, Card, Badge, type BadgeTone } from "soma-style";
 import { useChat as useChatSheet } from "./ChatContext";
 import { MarkdownText } from "./MarkdownText";
 
-const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { API_BASE } from "../lib/api";
 
 /* First-pass React Native port of the web chat-widget. Talks to the same
    /api/chat SSE endpoint (a local `claude -p` subprocess on the Mac, or the

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -1,19 +1,53 @@
 import { useCallback, useEffect, useState } from "react";
 
-export const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+import { getStoredAuth } from "./auth-store";
+
+/** The build's API base (EXPO_PUBLIC_API_URL). `API_BASE` starts here and can be redirected by
+ *  the sign-in screen for installs without an embedded token (soma#796). */
+export const DEFAULT_API_BASE = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3456";
+export let API_BASE = DEFAULT_API_BASE;
+export function hostOf(base: string): string {
+  return base.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+}
 
 /** Daemon-class routes (Live DJ today, chat next) run on the Mac behind `tailscale serve`,
  *  never on Vercel: the DJ is a detached process with local status files. EXPO_PUBLIC_DAEMON_URL
  *  points the app there (e.g. https://gkos-mac.taile2630d.ts.net:8448); unset → same host as
  *  the API, which is right for local dev and honest for prod (the call then fails visibly). */
-export const DAEMON_BASE = process.env.EXPO_PUBLIC_DAEMON_URL ?? API_BASE;
+export let DAEMON_BASE = process.env.EXPO_PUBLIC_DAEMON_URL ?? API_BASE;
 /** Host shown on the Live DJ screen so it is never a mystery where the DJ runs. */
-export const DAEMON_HOST = DAEMON_BASE.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+export let DAEMON_HOST = hostOf(DAEMON_BASE);
 
 /** Personal API token for prod (soma.gkos.dev gates /api/* behind a session;
     the token bypasses that for this native client). Empty in local dev. */
 const API_TOKEN = process.env.EXPO_PUBLIC_API_TOKEN;
+/** True for the embedded-token build; false for a store or side-loaded install that signs in. */
+export const EMBEDDED_TOKEN = Boolean(API_TOKEN);
 export const AUTH_HEADERS: Record<string, string> = API_TOKEN ? { Authorization: `Bearer ${API_TOKEN}` } : {};
+export type AuthSource = "embedded" | "stored" | "none";
+/** Where the current bearer comes from; the Status and Sign-in screens show it. */
+export let AUTH_SOURCE: AuthSource = API_TOKEN ? "embedded" : "none";
+
+/** Redirect every fetch to `baseUrl` with `token` (soma#796). Module bindings are live, so the
+ *  screens that read `API_BASE` or spread `AUTH_HEADERS` at call time pick the change up at once.
+ *  A null token with source "embedded" restores the build's token; "none" clears the header. */
+export function applyAuth(baseUrl: string | null, token: string | null, source: AuthSource): void {
+  if (baseUrl) {
+    API_BASE = baseUrl.replace(/\/+$/, "");
+    if (!process.env.EXPO_PUBLIC_DAEMON_URL) { DAEMON_BASE = API_BASE; DAEMON_HOST = hostOf(API_BASE); }
+  }
+  if (token) AUTH_HEADERS.Authorization = `Bearer ${token}`;
+  else if (source === "embedded" && API_TOKEN) AUTH_HEADERS.Authorization = `Bearer ${API_TOKEN}`;
+  else delete AUTH_HEADERS.Authorization;
+  AUTH_SOURCE = source;
+}
+/** Startup: apply credentials the sign-in screen stored earlier. A no-op when nothing is stored,
+ *  which keeps the embedded-token build exactly as before. */
+export async function applyStoredAuth(): Promise<void> {
+  const stored = await getStoredAuth().catch(() => null);
+  if (!stored) return;
+  applyAuth(stored.baseUrl || null, stored.token || null, stored.token ? "stored" : AUTH_SOURCE);
+}
 
 /** Image source for an activity's generated share card. Includes the auth
  *  header (React Native <Image> forwards `headers` on native; prod gates /api/*). */

--- a/universal/src/lib/auth-store.ts
+++ b/universal/src/lib/auth-store.ts
@@ -1,0 +1,42 @@
+import * as SecureStore from "expo-secure-store";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+/**
+ * Where a self-hosted install keeps its API base URL and bearer token (soma#796). Native uses
+ * the platform keychain / keystore through expo-secure-store; Expo web has no secure store, so it
+ * falls back to localStorage via AsyncStorage (the token is then only as private as the browser).
+ * The embedded-token build never writes here: with nothing stored, `applyStoredAuth` is a no-op.
+ */
+export interface StoredAuth { baseUrl: string; token: string }
+
+const KEY_URL = "soma_api_base_url";
+const KEY_TOKEN = "soma_api_token";
+// process.env.EXPO_OS is inlined by Expo at build time; react-native itself is not imported here
+// so lib/api stays importable under vitest (react-native ships Flow sources).
+const secure = process.env.EXPO_OS !== "web";
+
+async function read(key: string): Promise<string | null> {
+  return secure ? SecureStore.getItemAsync(key) : AsyncStorage.getItem(key);
+}
+async function write(key: string, value: string): Promise<void> {
+  return secure ? SecureStore.setItemAsync(key, value) : AsyncStorage.setItem(key, value);
+}
+async function remove(key: string): Promise<void> {
+  return secure ? SecureStore.deleteItemAsync(key) : AsyncStorage.removeItem(key);
+}
+
+export async function getStoredAuth(): Promise<StoredAuth | null> {
+  const [baseUrl, token] = await Promise.all([read(KEY_URL), read(KEY_TOKEN)]);
+  if (!baseUrl && !token) return null;
+  return { baseUrl: baseUrl ?? "", token: token ?? "" };
+}
+
+export async function saveStoredAuth(auth: StoredAuth): Promise<void> {
+  await write(KEY_URL, auth.baseUrl);
+  if (auth.token) await write(KEY_TOKEN, auth.token);
+  else await remove(KEY_TOKEN);
+}
+
+export async function clearStoredAuth(): Promise<void> {
+  await Promise.all([remove(KEY_URL), remove(KEY_TOKEN)]);
+}

--- a/universal/src/test/expo-secure-store.stub.ts
+++ b/universal/src/test/expo-secure-store.stub.ts
@@ -1,0 +1,7 @@
+/** In-memory stand-in for expo-secure-store under vitest (the real module pulls react-native's
+ *  Flow sources through expo-modules-core, which Vite cannot parse). Aliased in vitest.config.ts. */
+const store = new Map<string, string>();
+export async function getItemAsync(key: string): Promise<string | null> { return store.get(key) ?? null; }
+export async function setItemAsync(key: string, value: string): Promise<void> { store.set(key, value); }
+export async function deleteItemAsync(key: string): Promise<void> { store.delete(key); }
+export async function isAvailableAsync(): Promise<boolean> { return true; }

--- a/universal/vitest.config.ts
+++ b/universal/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    // expo-secure-store imports react-native Flow sources via expo-modules-core; Vite cannot
+    // parse those, so tests get an in-memory stand-in (soma#796).
+    alias: {
+      "expo-secure-store": path.resolve(__dirname, "src/test/expo-secure-store.stub.ts"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Item 4 of the Phase 4 parity track (#792): web's login, privacy and status pages become app screens reachable from More.

- **Sign in** (`login`): API base URL and personal API token for people who install the app without the embedded-token build. Stored through `expo-secure-store` (keychain on iOS, keystore on Android; localStorage via AsyncStorage on Expo web). "Test connection" probes `/api/health/today` and distinguishes connected, rejected (the API redirects a bad token to the login page, so a JSON answer means accepted) and unreachable. "Save" applies the pair at once: `API_BASE`, `AUTH_HEADERS`, `DAEMON_BASE` and `DAEMON_HOST` are live module bindings that every fetch reads at call time. "Use the build's token" clears the stored pair. With nothing stored, `applyStoredAuth` is a no-op and the embedded-token flow is unchanged. `ChatSheet` now imports `API_BASE` from `lib/api` instead of keeping its own env copy, so chat follows the signed-in server too.
- **Privacy** (`privacy`): web's `/privacy` text with the same wording, as sections. The contact address opens mail.
- **Status** (`system`, because Expo web reserves the `/status` route for Metro): server host, daemon host, access source, app version and reachability, then the sync pipeline from `/api/sync/status` (status, last sync, per-source rows, table counts) and linked platforms plus Spotify from `/api/connections`. Web's `/status` redirects to `/connections`, so these are the facts that page shows.
- Three hidden tab routes, three More entries, three Maestro flows.
- `expo-secure-store` is a native module and `react-native` ships Flow sources, so `lib/api` stays importable under vitest through two measures: `auth-store` decides native vs web with the build-time `process.env.EXPO_OS` instead of importing `react-native`, and `vitest.config.ts` aliases `expo-secure-store` to an in-memory stand-in under `src/test/`.

## Verification

- `universal`: tsc clean, vitest 44 passing (6 files). `web`: tsc clean, vitest 378 passing.
- Device (emulator-5556, real account, branch release APK against 10.0.2.2:3457): `verify-system.yaml` (API card "Reachable", sync pipeline rows, platforms linked), `verify-login.yaml` (types a wrong token, "Test connection" shows the rejected path, never saves, the real token is never typed), `verify-privacy.yaml` (top, contact, and the three new More entries). Screenshots read back.
- The success path of "Test connection" runs with the build's embedded token when the token field is empty; the flow proves the rejected path only, so no credential is written on device.

Closes #796
