### PR TITLE
fix(web): sidebar sizing model and type legibility (#363, #797)

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -55,7 +55,7 @@ export default function RootLayout({
           )}
           <NavProgress />
           <Sidebar />
-          <main className={`min-h-screen bg-background pb-[env(safe-area-inset-bottom,0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+3rem)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] lg:pl-56 2xl:pl-64 lg:pt-6${isDemo ? " md:pt-8" : ""}`}>
+          <main className={`min-h-screen bg-background pb-[env(safe-area-inset-bottom,0.5rem)] pt-[calc(env(safe-area-inset-top,0px)+3rem)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] lg:pl-16 xl:pl-56 2xl:pl-64 lg:pt-6${isDemo ? " md:pt-8" : ""}`}>
             {children}
           </main>
           <Toaster richColors />

--- a/web/components/demo-banner.tsx
+++ b/web/components/demo-banner.tsx
@@ -2,7 +2,7 @@ export const DEMO_URL = "https://soma-demo.gkos.dev";
 
 export function DemoBanner({ repoUrl }: { repoUrl: string }) {
   return (
-    <div className="fixed left-0 lg:left-56 2xl:left-64 right-0 top-0 z-50 flex items-center justify-center gap-3 bg-primary/10 px-4 py-1.5 text-xs text-primary backdrop-blur-sm border-b border-primary/20">
+    <div className="fixed left-0 lg:left-16 xl:left-56 2xl:left-64 right-0 top-0 z-50 flex items-center justify-center gap-3 bg-primary/10 px-4 py-1.5 text-xs text-primary backdrop-blur-sm border-b border-primary/20">
       <span className="font-medium">Demo</span>
       <span className="text-primary/60">·</span>
       <span className="text-primary/80">sample data — not real health records</span>

--- a/web/components/sidebar.tsx
+++ b/web/components/sidebar.tsx
@@ -102,27 +102,31 @@ export function Sidebar() {
       {/* Slide-out drawer */}
       <aside
         className={cn(
-          "fixed left-0 top-0 z-40 h-screen w-56 2xl:w-64 flex flex-col border-r border-border bg-sidebar transition-transform duration-200 safe-area-pt safe-area-pl safe-area-pb",
+          // Sizing model (soma#363): the slide-out drawer below lg keeps full labels; from lg the
+          // sidebar is always visible as a 4rem icon rail (tablet / narrow desktop), grows to
+          // 14rem with labels from xl and 16rem from 2xl. The content offset in app/layout.tsx and
+          // the demo banner track the same steps.
+          "fixed left-0 top-0 z-40 h-screen w-56 lg:w-16 xl:w-56 2xl:w-64 flex flex-col border-r border-border bg-sidebar transition-[transform,width] duration-200 safe-area-pt safe-area-pl safe-area-pb",
           // Slide-in drawer on mobile; always visible on desktop (lg+).
           drawerOpen ? "translate-x-0" : "-translate-x-full",
           "lg:translate-x-0"
         )}
       >
         {/* Logo + close area */}
-        <div className="flex h-14 items-center gap-3 px-4 border-b border-border">
-          <div className="w-8" /> {/* spacer for hamburger */}
+        <div className="flex h-14 items-center gap-3 px-4 lg:justify-center lg:px-0 xl:justify-start xl:px-4 border-b border-border">
+          <div className="w-8 lg:hidden xl:block" /> {/* spacer for hamburger */}
           <Link
             href="/"
             className="flex items-center gap-2"
             aria-label="Go to home"
           >
             <SomaLogo size={24} />
-            <span className="text-[1rem] font-semibold">Soma</span>
+            <span className="text-[1rem] font-semibold lg:hidden xl:inline">Soma</span>
           </Link>
         </div>
 
         {/* Nav items */}
-        <nav className="flex flex-1 flex-col gap-0.5 p-2 overflow-y-auto">
+        <nav className="flex flex-1 flex-col gap-0.5 p-2 lg:px-1.5 xl:px-2 overflow-y-auto" aria-label="Primary">
           {navItems.map((item) => {
             const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
             const isLoading = navigatingTo === item.href;
@@ -134,8 +138,12 @@ export function Sidebar() {
                 href={item.href}
                 onClick={() => { if (!isActive) setNavigatingTo(item.href); }}
                 aria-current={isActive ? "page" : undefined}
+                aria-label={item.label}
+                title={`${item.label} (⌘${item.shortcut})`}
                 className={cn(
-                  "flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all text-[15px] active:scale-[0.96] active:opacity-70",
+                  // Type: 15px labels (one step above the app's 14px body) and a hint that stays
+                  // readable at 12px / 70% (was 50%, soma#363). On the rail only the icon shows.
+                  "flex items-center gap-3 px-3 py-2.5 lg:justify-center lg:px-0 lg:py-2.5 xl:justify-start xl:px-3 rounded-lg transition-all text-[15px] leading-5 active:scale-[0.96] active:opacity-70",
                   isActive
                     ? "bg-accent text-accent-foreground font-medium"
                     : isLoading
@@ -144,12 +152,12 @@ export function Sidebar() {
                 )}
               >
                 {isLoading ? (
-                  <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                  <Loader2 className="h-4 w-4 lg:h-5 lg:w-5 xl:h-4 xl:w-4 shrink-0 animate-spin" />
                 ) : (
-                  <Icon className="h-4 w-4 shrink-0" />
+                  <Icon className="h-4 w-4 lg:h-5 lg:w-5 xl:h-4 xl:w-4 shrink-0" />
                 )}
-                <span>{item.label}</span>
-                <span className="ml-auto text-xs text-muted-foreground/50 hidden md:inline">
+                <span className="lg:hidden xl:inline">{item.label}</span>
+                <span className="ml-auto text-xs tabular-nums text-muted-foreground/70 hidden xl:inline" aria-hidden="true">
                   ⌘{item.shortcut}
                 </span>
               </Link>
@@ -157,7 +165,7 @@ export function Sidebar() {
           })}
 
           {/* Sync button at bottom */}
-          <div className="mt-auto pt-2 border-t border-border">
+          <div className="mt-auto pt-2 border-t border-border lg:flex lg:justify-center xl:block">
             <SyncButton />
           </div>
         </nav>


### PR DESCRIPTION
## Summary

Closes the sidebar review (#363) as Item 5 of the Phase 4 parity track (#792, sub-issue #797).

**Sizing model.** The desktop sidebar was one fixed 14rem column from `lg` up, so a 1024px tablet or narrow desktop gave 22% of its width to navigation. Now:

| Viewport | Sidebar | Content offset |
|---|---|---|
| below `lg` (phones, small tablets) | slide-out drawer, 14rem, full labels | none |
| `lg` (1024 to 1279) | always-visible 4rem icon rail, `title` tooltips with the shortcut | 4rem |
| `xl` (1280 to 1535) | 14rem with labels and shortcut hints | 14rem |
| `2xl` | 16rem | 16rem |

`app/layout.tsx` (`lg:pl-16 xl:pl-56 2xl:pl-64`) and the demo banner offset track the same steps, so the content and the banner never sit under the sidebar at any width.

**Type and legibility.** Labels stay 15px with a 20px line height. The `⌘n` hints go from 12px at 50% opacity to 12px at 70% with tabular numerals, and they only render from `xl` (a touch drawer has no keyboard). Links carry `aria-label` and `title` so the icon rail stays usable with a screen reader and on hover. The nav landmark is labelled "Primary".

## Verification (Playwright, DEMO_MODE rig on a worktree of this branch)

- 1440×900: sidebar 224px wide, main padding-left 224px, labels and hints visible.
- 1280×800: same as 1440 (the `xl` step).
- 1024×768: icon rail 64px wide, main padding-left 64px, active item highlighted, sync button centred.
- 390×844: sidebar off-screen (x = -224), main padding 0; the drawer opens from the hamburger with full labels and no hints.
- Computed styles read back: label 15px/20px, hint 12px at 0.7 alpha, wordmark 16px/600 in the foreground colour.
- `web`: tsc clean, vitest passing.

Closes #797
Closes #363
