### PR TITLE
fix(bridge): refinalize picks the same share card as the bridge (#804)

### DIFF
--- a/bridge/src/main.ts
+++ b/bridge/src/main.ts
@@ -17,6 +17,7 @@ import { findMissed, lookbackStart, type GarminActivitySummary } from "./dedup";
 import { mainGarminClient, getActivitiesByDate, getActivity, downloadFit } from "./garmin";
 import { parseGarthDump, serializeGarthDump, isOauth2Expired, refreshOauth2, uploadFit } from "./facterino";
 import { stravaCreds, loadSession, saveSession, sessionValid, login, ownActivityIds, setActivityDetails } from "./strava-web";
+import { imagePathFor } from "./share-image";
 
 const FORWARD_POLL_MS = 15_000;
 const FORWARD_TRIES = 48; // ~12 min for Garmin→Strava forward
@@ -46,35 +47,6 @@ async function missed(db: Pool, activities: GarminActivitySummary[]): Promise<Ga
   const extRows = await db.query("SELECT raw_json->>'external_id' AS e FROM strava_raw_data WHERE jsonb_typeof(raw_json)='object' AND raw_json->>'external_id' IS NOT NULL");
   const externalIdsJoined = extRows.rows.map((r: any) => r.e).filter(Boolean).join(" ");
   return findMissed(activities, bridged, externalIdsJoined);
-}
-
-/** The workout card (Hevy-enriched) or the activity card for the Strava photo. A miss used to
- *  be silent — the 2026-09-07 "Upper" push reached Strava without its photo and the log said
- *  only "pushed". Now: three attempts (the card render on Vercel can cold-start past a single
- *  fetch), and the outcome is logged and surfaced in the RESULT line as NO_PHOTO. */
-async function imagePathFor(db: Pool, gid: number): Promise<{ path: string | null; note: string }> {
-  const r = await db.query("SELECT hevy_id FROM workout_enrichment WHERE garmin_activity_id=$1 ORDER BY processed_at DESC LIMIT 1", [gid]);
-  const url = r.rows[0]?.hevy_id ? `${SOMA}/api/workout/${r.rows[0].hevy_id}/image` : `${SOMA}/api/activity/${gid}/image`;
-  let note = "";
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      const resp = await fetch(url, { signal: AbortSignal.timeout(60_000) });
-      if (!resp.ok) { note = `image http ${resp.status}`; }
-      else {
-        const buf = Buffer.from(await resp.arrayBuffer());
-        if (buf.length < 1000) { note = `image too small (${buf.length} B)`; }
-        else {
-          const path = `/tmp/bridge_${gid}.png`;
-          await require("node:fs/promises").writeFile(path, buf);
-          console.log(`image ok for ${gid}: ${buf.length} B from ${url} (attempt ${attempt})`);
-          return { path, note: "" };
-        }
-      }
-    } catch (e) { note = `image fetch failed: ${(e as Error).message.slice(0, 60)}`; }
-    console.log(`image attempt ${attempt} for ${gid}: ${note}`);
-    if (attempt < 3) await new Promise((r) => setTimeout(r, 5000 * attempt));
-  }
-  return { path: null, note };
 }
 
 async function recordUpload(db: Pool, gid: number, sid: number): Promise<void> {

--- a/bridge/src/refinalize.ts
+++ b/bridge/src/refinalize.ts
@@ -8,13 +8,12 @@
  *
  * Run: node dist/refinalize.js <garmin_id> [<garmin_id> ...]   (DRY unless STRAVA creds)
  */
-import { writeFile } from "node:fs/promises";
 import { chromium } from "playwright";
 import { Pool } from "pg";
 import { stravaCreds, loadSession, saveSession, sessionValid, login, setActivityDetails } from "./strava-web";
 import { kiteActivityName, generateKiteStravaDescription } from "./kite-description";
+import { imagePathFor } from "./share-image";
 
-const SOMA = process.env.SOMA_WEB_URL || process.env.SOMA_BASE_URL || "https://soma.gkos.dev";
 
 async function stravaIdFor(db: Pool, gid: number): Promise<number | null> {
   const r = await db.query("SELECT strava_activity_id FROM strava_bridge_uploads WHERE garmin_activity_id=$1", [gid]);
@@ -30,16 +29,6 @@ async function kitePayloadFor(db: Pool, gid: number): Promise<any | null> {
   const j = r.rows[0]?.raw_json;
   return j == null ? null : (typeof j === "string" ? JSON.parse(j) : j);
 }
-async function imagePathFor(gid: number): Promise<string | null> {
-  try {
-    const resp = await fetch(`${SOMA}/api/activity/${gid}/image`);
-    if (!resp.ok) return null;
-    const path = `/tmp/refinalize_${gid}.png`;
-    await writeFile(path, Buffer.from(await resp.arrayBuffer()));
-    return path;
-  } catch { return null; }
-}
-
 async function main(): Promise<void> {
   const ids = process.argv.slice(2).map((s) => parseInt(s, 10)).filter((n) => !isNaN(n));
   if (!ids.length) { console.log("usage: refinalize <garmin_id> ..."); return; }
@@ -58,9 +47,9 @@ async function main(): Promise<void> {
     const isKite = kite && (kite.summary?.jump_count || 0) > 0;
     const title = isKite ? kiteActivityName(summary, kite) : (summary.activityName || "Activity");
     const description = isKite ? generateKiteStravaDescription(summary, kite) : String(summary.description || "");
-    const imagePath = await imagePathFor(gid);
+    const { path: imagePath, note: imageNote, kind } = await imagePathFor(db, gid, "refinalize");
     jobs.push({ gid, stravaId, title, description, imagePath });
-    console.log(`  prepared ${gid} -> strava/${stravaId}: "${title}" (image=${imagePath ? "yes" : "no"})`);
+    console.log(`  prepared ${gid} -> strava/${stravaId}: "${title}" (image=${imagePath ? `${kind} card` : `no: ${imageNote}`})`);
   }
   if (!jobs.length) { console.log("RESULT: nothing to re-finalize"); await db.end(); return; }
 

--- a/bridge/src/share-image.ts
+++ b/bridge/src/share-image.ts
@@ -1,0 +1,48 @@
+/**
+ * The Strava photo for a bridged Garmin activity: the Hevy-enriched workout card when
+ * workout_enrichment links the activity to a Hevy workout, else the generic activity card.
+ * Shared by the bridge (main.ts) and the re-finalize entrypoint (refinalize.ts) so both pick
+ * the same card — refinalize used to fetch the activity card unconditionally and replaced a
+ * strength workout's gym card with a run-style card (soma#804).
+ *
+ * A miss used to be silent: the 2026-09-07 "Upper" push reached Strava without its photo and
+ * the log said only "pushed". Now: three attempts (the card render on Vercel can cold-start
+ * past a single fetch), a 60 s timeout each, and the outcome is returned as a note the caller
+ * logs and surfaces (NO_PHOTO in the bridge RESULT line).
+ */
+import { writeFile } from "node:fs/promises";
+import type { Pool } from "pg";
+
+const SOMA = process.env.SOMA_WEB_URL || process.env.SOMA_BASE_URL || "https://soma.gkos.dev";
+
+export async function shareImageUrl(db: Pool, gid: number): Promise<{ url: string; kind: "workout" | "activity" }> {
+  const r = await db.query("SELECT hevy_id FROM workout_enrichment WHERE garmin_activity_id=$1 ORDER BY processed_at DESC LIMIT 1", [gid]);
+  const hevyId = r.rows[0]?.hevy_id as string | undefined;
+  return hevyId
+    ? { url: `${SOMA}/api/workout/${hevyId}/image`, kind: "workout" }
+    : { url: `${SOMA}/api/activity/${gid}/image`, kind: "activity" };
+}
+
+export async function imagePathFor(db: Pool, gid: number, prefix = "bridge"): Promise<{ path: string | null; note: string; kind: "workout" | "activity" }> {
+  const { url, kind } = await shareImageUrl(db, gid);
+  let note = "";
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const resp = await fetch(url, { signal: AbortSignal.timeout(60_000) });
+      if (!resp.ok) { note = `image http ${resp.status}`; }
+      else {
+        const buf = Buffer.from(await resp.arrayBuffer());
+        if (buf.length < 1000) { note = `image too small (${buf.length} B)`; }
+        else {
+          const path = `/tmp/${prefix}_${gid}.png`;
+          await writeFile(path, buf);
+          console.log(`image ok for ${gid}: ${buf.length} B from ${url} (attempt ${attempt})`);
+          return { path, note: "", kind };
+        }
+      }
+    } catch (e) { note = `image fetch failed: ${(e as Error).message.slice(0, 60)}`; }
+    console.log(`image attempt ${attempt} for ${gid}: ${note}`);
+    if (attempt < 3) await new Promise((r) => setTimeout(r, 5000 * attempt));
+  }
+  return { path: null, note, kind };
+}


### PR DESCRIPTION
## Summary

`bridge/src/refinalize.ts` fetched `/api/activity/<garmin id>/image` unconditionally, the generic activity card, while the bridge (`main.ts`) picks the Hevy-enriched workout card `/api/workout/<hevy id>/image` whenever `workout_enrichment` links the activity. Re-finalizing a strength workout therefore replaced its gym card with a run-style card: empty route panel with a Slow/Fast legend, empty Pace, Elev and Cadence tiles. That is what happened to the 2026-09-07 "Upper" push after the photo miss that #798 addressed.

- New `bridge/src/share-image.ts` with the one selector both entrypoints use: `hevy_id` lookup, three attempts with a 60 s timeout each, size sanity, and a note the caller logs.
- `main.ts` imports it (behaviour unchanged, the `NO_PHOTO` reporting from #798 stays).
- `refinalize.ts` uses it and logs which card it fetched (`image=workout card` / `activity card` / `no: <reason>`).

## Why the automatic photo was missed on Sep 7

The enrichment row for "Upper" existed at 19:36 UTC and the bridge ran at 21:51 UTC, so the bridge asked for the workout card. Its single fetch had no retry and no logging, so the reason is not recorded; the endpoint answers in one to four seconds today, both with and without auth (the image routes are public in the middleware), and Vercel lists no runtime error on either image route in the last seven days. The retries and logging from #798 will name it next time.

## Verification

- `bridge`: tsc clean, vitest passing.
- After merge: dispatch `refinalize-strava.yml` with `ids=24276081336` (#806) and confirm the log shows `image ok … from /api/workout/8e4db067-…/image` and "re-finalized".

Closes #804
Closes #805
