### PR TITLE
perf(api): derive running routes once instead of shipping details blobs (#814)

### DIFF
--- a/web/app/api/running/heatmap/route.ts
+++ b/web/app/api/running/heatmap/route.ts
@@ -1,43 +1,18 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { getRouteSamples, thinSamples } from "@/lib/activity-routes";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-export const revalidate = 0;
-
-// Extract lat/lng only — heavier thinning for heatmap (many routes on one map)
-function extractLatLng(details: any, thin = 20): Array<[number, number]> {
-  if (!details?.metricDescriptors || !details?.activityDetailMetrics) return [];
-
-  const keyIndex: Record<string, number> = {};
-  for (const desc of details.metricDescriptors as Array<{ key: string; metricsIndex: number }>) {
-    keyIndex[desc.key] = desc.metricsIndex;
-  }
-
-  const latIdx = keyIndex["directLatitude"];
-  const lngIdx = keyIndex["directLongitude"];
-  if (latIdx == null || lngIdx == null) return [];
-
-  const points: Array<[number, number]> = [];
-  const metrics = details.activityDetailMetrics as Array<{ metrics: number[] }>;
-
-  for (let i = 0; i < metrics.length; i += thin) {
-    const m = metrics[i]?.metrics;
-    if (!m) continue;
-    const lat = m[latIdx];
-    const lng = m[lngIdx];
-    if (lat == null || lng == null || (lat === 0 && lng === 0)) continue;
-    points.push([lng, lat]); // GeoJSON is [lng, lat]
-  }
-  return points;
-}
+export const revalidate = 300;
 
 export async function GET() {
   const sql = getDb();
 
+  // Only ids cross the wire here; the GPS samples come from activity_routes (soma#814), derived
+  // once per activity instead of shipping 40 details blobs (7.5 MB) on every call.
   const rows = await sql`
-    SELECT
-      d.raw_json AS details
+    SELECT s.activity_id
     FROM garmin_activity_raw s
     JOIN garmin_activity_raw d
       ON d.activity_id = s.activity_id AND d.endpoint_name = 'details'
@@ -48,9 +23,10 @@ export async function GET() {
     ORDER BY (s.raw_json->>'startTimeLocal')::text DESC
     LIMIT 40
   `;
+  const samples = await getRouteSamples(sql, rows.map((r) => String(r.activity_id)));
 
   const routes = rows
-    .map((row) => extractLatLng(row.details, 20))
+    .map((row) => thinSamples(samples.get(String(row.activity_id)) ?? [], 20).map(([, lat, lng]) => [lng, lat] as [number, number])) // GeoJSON is [lng, lat]
     .filter((pts) => pts.length > 5);
 
   return NextResponse.json({ routes });

--- a/web/app/api/running/recent-routes/route.ts
+++ b/web/app/api/running/recent-routes/route.ts
@@ -1,46 +1,9 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { getRouteSamples, thinSamples } from "@/lib/activity-routes";
 
 export const runtime = "nodejs";
 export const revalidate = 300;
-
-function extractGpsPoints(
-  details: any,
-  thin = 8
-): Array<{ lat: number; lng: number; hr: null; speed: number | null; elev: null; cadence: null; dist_m: null }> {
-  if (!details?.metricDescriptors || !details?.activityDetailMetrics) return [];
-
-  const keyIndex: Record<string, number> = {};
-  for (const desc of details.metricDescriptors as Array<{ key: string; metricsIndex: number }>) {
-    keyIndex[desc.key] = desc.metricsIndex;
-  }
-
-  const latIdx = keyIndex["directLatitude"];
-  const lngIdx = keyIndex["directLongitude"];
-  const speedIdx = keyIndex["directSpeed"];
-  if (latIdx == null || lngIdx == null) return [];
-
-  const points: Array<{ lat: number; lng: number; hr: null; speed: number | null; elev: null; cadence: null; dist_m: null }> = [];
-  const metrics = details.activityDetailMetrics as Array<{ metrics: number[] }>;
-
-  for (let i = 0; i < metrics.length; i += thin) {
-    const m = metrics[i]?.metrics;
-    if (!m) continue;
-    const lat = m[latIdx];
-    const lng = m[lngIdx];
-    if (lat == null || lng == null || (lat === 0 && lng === 0)) continue;
-    points.push({
-      lat,
-      lng,
-      hr: null,
-      speed: speedIdx != null ? (m[speedIdx] ?? null) : null,
-      elev: null,
-      cadence: null,
-      dist_m: null,
-    });
-  }
-  return points;
-}
 
 export async function GET() {
   const sql = getDb();
@@ -48,8 +11,7 @@ export async function GET() {
   const rows = await sql`
     SELECT
       s.activity_id,
-      s.raw_json AS summary,
-      d.raw_json AS details
+      s.raw_json AS summary
     FROM garmin_activity_raw s
     JOIN garmin_activity_raw d
       ON d.activity_id = s.activity_id AND d.endpoint_name = 'details'
@@ -61,9 +23,13 @@ export async function GET() {
     LIMIT 6
   `;
 
+  // GPS samples from activity_routes (soma#814) instead of six details blobs per call.
+  const samples = await getRouteSamples(sql, rows.map((r) => String(r.activity_id)));
   const result = rows.map((row) => {
     const summary = row.summary as any;
-    const gps_points = extractGpsPoints(row.details, 8);
+    const gps_points = thinSamples(samples.get(String(row.activity_id)) ?? [], 8).map(([, lat, lng, speed]) => ({
+      lat, lng, hr: null as null, speed, elev: null as null, cadence: null as null, dist_m: null as null,
+    }));
     return {
       activity_id: String(row.activity_id),
       name: summary.activityName || "Run",

--- a/web/lib/activity-routes.test.ts
+++ b/web/lib/activity-routes.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { deriveRouteSamples, thinSamples } from "./activity-routes";
+
+// The extractors the heatmap and recent-routes routes used before soma#814, kept here as the
+// reference: the cached samples thinned by metric index must reproduce them exactly.
+function legacyHeatmap(details: any, thin = 20): Array<[number, number]> {
+  const keyIndex: Record<string, number> = {};
+  for (const d of details.metricDescriptors) keyIndex[d.key] = d.metricsIndex;
+  const latIdx = keyIndex["directLatitude"], lngIdx = keyIndex["directLongitude"];
+  const points: Array<[number, number]> = [];
+  const metrics = details.activityDetailMetrics;
+  for (let i = 0; i < metrics.length; i += thin) {
+    const m = metrics[i]?.metrics; if (!m) continue;
+    const lat = m[latIdx], lng = m[lngIdx];
+    if (lat == null || lng == null || (lat === 0 && lng === 0)) continue;
+    points.push([lng, lat]);
+  }
+  return points;
+}
+function legacyRecent(details: any, thin = 8) {
+  const keyIndex: Record<string, number> = {};
+  for (const d of details.metricDescriptors) keyIndex[d.key] = d.metricsIndex;
+  const latIdx = keyIndex["directLatitude"], lngIdx = keyIndex["directLongitude"], speedIdx = keyIndex["directSpeed"];
+  const points: any[] = [];
+  const metrics = details.activityDetailMetrics;
+  for (let i = 0; i < metrics.length; i += thin) {
+    const m = metrics[i]?.metrics; if (!m) continue;
+    const lat = m[latIdx], lng = m[lngIdx];
+    if (lat == null || lng == null || (lat === 0 && lng === 0)) continue;
+    points.push({ lat, lng, hr: null, speed: speedIdx != null ? (m[speedIdx] ?? null) : null, elev: null, cadence: null, dist_m: null });
+  }
+  return points;
+}
+
+function fixture(n = 500) {
+  const metrics: Array<{ metrics: number[] } | undefined> = [];
+  for (let i = 0; i < n; i++) {
+    if (i % 37 === 0) { metrics.push(undefined as any); continue; }        // rows without metrics
+    const lat = i % 11 === 0 ? 0 : 37.97 + i / 1e4;                        // (0,0) fixes are skipped
+    const lng = i % 11 === 0 ? 0 : 23.72 + i / 1e4;
+    const speed = i % 5 === 0 ? (null as any) : 2.5 + (i % 7) / 10;
+    metrics.push({ metrics: [speed, lat, lng, 120] });
+  }
+  return {
+    metricDescriptors: [
+      { key: "directSpeed", metricsIndex: 0 },
+      { key: "directLatitude", metricsIndex: 1 },
+      { key: "directLongitude", metricsIndex: 2 },
+      { key: "directHeartRate", metricsIndex: 3 },
+    ],
+    activityDetailMetrics: metrics,
+  };
+}
+
+describe("activity route samples (soma#814)", () => {
+  it("thinned samples reproduce the heatmap extractor byte for byte", () => {
+    const d = fixture();
+    const ours = thinSamples(deriveRouteSamples(d), 20).map(([, lat, lng]) => [lng, lat]);
+    expect(JSON.stringify(ours)).toBe(JSON.stringify(legacyHeatmap(d, 20)));
+    expect(ours.length).toBeGreaterThan(5);
+  });
+  it("thinned samples reproduce the recent-routes extractor byte for byte", () => {
+    const d = fixture();
+    const ours = thinSamples(deriveRouteSamples(d), 8).map(([, lat, lng, speed]) => ({ lat, lng, hr: null, speed, elev: null, cadence: null, dist_m: null }));
+    expect(JSON.stringify(ours)).toBe(JSON.stringify(legacyRecent(d, 8)));
+  });
+  it("stores a quarter of the rows and rejects a thin that is not a multiple of it", () => {
+    const d = fixture();
+    const samples = deriveRouteSamples(d);
+    expect(samples.every((s) => s[0] % 4 === 0)).toBe(true);
+    expect(() => thinSamples(samples, 6)).toThrow();
+  });
+  it("returns nothing without descriptors or a fix", () => {
+    expect(deriveRouteSamples({})).toEqual([]);
+    expect(deriveRouteSamples({ metricDescriptors: [{ key: "directSpeed", metricsIndex: 0 }], activityDetailMetrics: [{ metrics: [1] }] })).toEqual([]);
+  });
+});

--- a/web/lib/activity-routes.ts
+++ b/web/lib/activity-routes.ts
@@ -1,0 +1,97 @@
+/**
+ * Derived GPS samples per Garmin activity (soma#814).
+ *
+ * The running heatmap and the Recent Routes card used to pull the whole `details` blob of every
+ * candidate activity (about 190 KB each, 40 of them for the heatmap) out of Neon on every request,
+ * then keep a few hundred lat/lng pairs. That was 7.5 MB of database transfer per heatmap call and
+ * the largest single consumer of the Free plan's monthly allowance.
+ *
+ * `activity_routes` keeps one sample per `KEEP_EVERY` metric rows: `[metricIndex, lat, lng, speed]`
+ * for every kept row that has a fix. Callers thin by the original metric index (`index % thin
+ * === 0`, with `thin` a multiple of `KEEP_EVERY`), which reproduces the previous extractors byte
+ * for byte, including the rows they skipped for a missing fix. Rows are derived lazily on first
+ * read from `details` and inserted; nothing about ingest changes.
+ */
+import type { QueryFn } from "./db";
+
+/** [metricIndex, lat, lng, speed|null] */
+export type RouteSample = [number, number, number, number | null];
+/** Stored resolution: every 4th metric row. Both readers thin by a multiple of 4 (8 and 20), so
+ *  the stored subset still yields their exact selections at a quarter of the bytes. */
+export const KEEP_EVERY = 4;
+
+let ensured: Promise<void> | null = null;
+/** Additive, idempotent; memoised per process. Never rejects the caller's query on failure. */
+export function ensureActivityRoutesTable(sql: QueryFn): Promise<void> {
+  if (!ensured) {
+    ensured = sql`
+      CREATE TABLE IF NOT EXISTS activity_routes (
+        activity_id BIGINT PRIMARY KEY,
+        samples JSONB NOT NULL,
+        sample_count INT NOT NULL,
+        derived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )`.then(() => undefined).catch(() => { ensured = null; });
+  }
+  return ensured;
+}
+
+/** Full-resolution samples from a Garmin `details` payload, tagged with their metric index. */
+export function deriveRouteSamples(details: any): RouteSample[] {
+  if (!details?.metricDescriptors || !details?.activityDetailMetrics) return [];
+  const keyIndex: Record<string, number> = {};
+  for (const desc of details.metricDescriptors as Array<{ key: string; metricsIndex: number }>) {
+    keyIndex[desc.key] = desc.metricsIndex;
+  }
+  const latIdx = keyIndex["directLatitude"];
+  const lngIdx = keyIndex["directLongitude"];
+  const speedIdx = keyIndex["directSpeed"];
+  if (latIdx == null || lngIdx == null) return [];
+  const metrics = details.activityDetailMetrics as Array<{ metrics: number[] }>;
+  const out: RouteSample[] = [];
+  for (let i = 0; i < metrics.length; i += KEEP_EVERY) {
+    const m = metrics[i]?.metrics;
+    if (!m) continue;
+    const lat = m[latIdx];
+    const lng = m[lngIdx];
+    if (lat == null || lng == null || (lat === 0 && lng === 0)) continue;
+    out.push([i, lat, lng, speedIdx != null ? (m[speedIdx] ?? null) : null]);
+  }
+  return out;
+}
+
+/** Every `thin`-th metric row that had a fix, in metric order: the legacy extractors' selection. */
+export function thinSamples(samples: RouteSample[], thin: number): RouteSample[] {
+  if (thin % KEEP_EVERY !== 0) throw new Error(`thin must be a multiple of ${KEEP_EVERY}, got ${thin}`);
+  return samples.filter((s) => s[0] % thin === 0);
+}
+
+/**
+ * Samples for the given activity ids, from `activity_routes` where present, else derived from
+ * `details` once and stored. Ids without a usable `details` row map to an empty list.
+ */
+export async function getRouteSamples(sql: QueryFn, ids: Array<string | number>): Promise<Map<string, RouteSample[]>> {
+  const out = new Map<string, RouteSample[]>();
+  if (!ids.length) return out;
+  const wanted = ids.map((i) => String(i));
+  await ensureActivityRoutesTable(sql);
+  const cached = await sql`
+    SELECT activity_id, samples FROM activity_routes WHERE activity_id = ANY(${wanted}::bigint[])`.catch(() => []);
+  for (const r of cached) out.set(String(r.activity_id), (typeof r.samples === "string" ? JSON.parse(r.samples) : r.samples) as RouteSample[]);
+  const missing = wanted.filter((id) => !out.has(id));
+  if (!missing.length) return out;
+  // First read of these activities: the only time the blobs cross the wire.
+  const rows = await sql`
+    SELECT activity_id, raw_json FROM garmin_activity_raw
+    WHERE endpoint_name = 'details' AND activity_id = ANY(${missing}::bigint[])`;
+  for (const r of rows) {
+    const id = String(r.activity_id);
+    const samples = deriveRouteSamples(typeof r.raw_json === "string" ? JSON.parse(r.raw_json) : r.raw_json);
+    out.set(id, samples);
+    await sql`
+      INSERT INTO activity_routes (activity_id, samples, sample_count)
+      VALUES (${id}::bigint, ${JSON.stringify(samples)}::jsonb, ${samples.length})
+      ON CONFLICT (activity_id) DO NOTHING`.catch(() => {});
+  }
+  for (const id of missing) if (!out.has(id)) out.set(id, []);
+  return out;
+}


### PR DESCRIPTION
## Summary

Neon warned on 2026-09-08 that the `soma` project had used 96% of the Free plan's 5 GB monthly network transfer. The console shows 4.8 GB "since Sep 6", the day the org went back to Free after the August incident. Most of it is the verification loops of Sep 7 and 8 opening app screens against the real database, and the running screen was the expensive one:

- `GET /api/running/heatmap` joined 40 Garmin `details` blobs (about 190 KB each) to keep a few hundred lat/lng pairs: **7.5 MB of database transfer per call**, measured with `pg_column_size` on the live DB, with `revalidate = 0`.
- `GET /api/running/recent-routes` read 6 more: 0.7 MB per call.

This PR derives the GPS samples once per activity into an additive `activity_routes` table and has both routes read from it.

- `web/lib/activity-routes.ts`: table created on first use (`CREATE TABLE IF NOT EXISTS`, memoised); samples `[metricIndex, lat, lng, speed]` for every 4th metric row that has a fix; readers thin by the original metric index, and 8 and 20 are multiples of 4, so both routes produce byte-identical JSON. Rows are derived lazily from `details` the first time an activity is asked for; ingest is untouched.
- Heatmap and recent-routes now select ids and summaries only. Heatmap gets `revalidate = 300` like recent-routes, stats, activities/summary and overview/trends.

## Verification

- `web`: tsc clean, vitest 382 passing, including a fixture test that checks the cached samples reproduce the two legacy extractors byte for byte (rows without metrics and (0,0) fixes included) and that the stored resolution is every 4th row.
- Working-tree server on 3457 against the real DB: heatmap JSON identical across the first (deriving) call and the cached calls; 40 routes, 6 recent routes; the cache holds about 10 KB per route after the in-place shrink. Database transfer per heatmap call drops from 7.5 MB to about 0.4 MB.

## What this does not fix

About 200 MB of this month's allowance remain and the pipeline alone reads roughly 50 MB a day. Whether to upgrade for the rest of September is the owner's decision; #817 records the local-snapshot recipe so next month's verification runs stop billing Neon at all.

Closes #814
Closes #815
Closes #816
