### PR TITLE
fix(api): heatmap drops force-dynamic so revalidate 300 applies (#816)

### DIFF
--- a/web/app/api/running/heatmap/route.ts
+++ b/web/app/api/running/heatmap/route.ts
@@ -3,7 +3,6 @@ import { getDb } from "@/lib/db";
 import { getRouteSamples, thinSamples } from "@/lib/activity-routes";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
 export const revalidate = 300;
 
 export async function GET() {


### PR DESCRIPTION
Follow-up to #818 (#816). The heatmap route declared `dynamic = "force-dynamic"`, which overrides `revalidate = 300`: production answered with `x-vercel-cache: BYPASS` on consecutive calls after the merge. Its siblings (recent-routes, stats, activities/summary, overview/trends) never set it. This removes the line so the 5-minute route cache serves repeat opens with no database transfer.

Verification after deploy: two calls to `/api/running/heatmap` on production, the second with `x-vercel-cache: HIT`, JSON unchanged.
