### PR TITLE
fix(app): clear react-native-web 0.21 warnings on Expo web (#812)

### DIFF
--- a/universal/.maestro/verify-sleep-tails.yaml
+++ b/universal/.maestro/verify-sleep-tails.yaml
@@ -9,6 +9,12 @@ tags:
 - openLink: universal://sleep
 - waitForAnimationToEnd:
     timeout: 10000
+# The range is shared and persisted (soma#754); the marker is derived for the default 6M, so
+# select it explicitly rather than inheriting whatever a previous flow left behind.
+- tapOn:
+    text: "6M"
+- waitForAnimationToEnd:
+    timeout: 5000
 # Loaded state first (header stat), so the scroll does not start on the skeleton.
 - extendedWaitUntil:
     visible:

--- a/universal/scripts/verify-device.sh
+++ b/universal/scripts/verify-device.sh
@@ -128,7 +128,10 @@ S = {
   "nutrition":        ("/api/nutrition/plan?date=" + TODAY,    lambda d: "Copy yesterday" if d.get("plan") is None else fmt_int(d["remaining"]["calories"])),
   "running":          ("/api/running/stats?range=6m",          lambda d: "{} runs · {} km".format(d["stats"]["total_runs"], fixed(d["stats"]["total_km"], 0))),
   "workouts":         ("/api/workouts/insights?range=6m",      lambda d: "{} workouts logged".format(len(d["calendar"]))),
-  "sleep":            ("/api/stats/sleep?range=90d",           lambda d: "{}h–{}h".format(fixed(d["summary"]["current_min"], 1), fixed(d["summary"]["current_max"], 1))),
+  # range=6m matches DEFAULT_RANGE in lib/time-range, and the screen honours the persisted range
+  # (soma#754); a 90d marker disagreed with a 6M screen and failed a healthy sleep screen.
+  # (No apostrophes or backticks in this block: it lives inside a single-quoted shell string.)
+  "sleep":            ("/api/stats/sleep?range=6m",            lambda d: "{}h–{}h".format(fixed(d["summary"]["current_min"], 1), fixed(d["summary"]["current_max"], 1))),
   "activities":       ("/api/activities/summary?range=6m",     lambda d: fmt_int(jsround(d["totals"]["cal"]))),
   "training":         ("/api/training/breakdown?date=" + TODAY, lambda d: "Readiness {}".format(d["readiness"]["traffic_light"])),
   "connections":      ("/api/sync/status",                     sync_records),

--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -197,7 +197,7 @@ function ShareTab({ activityId, title, stravaId }: { activityId: string; title: 
       <View style={{ width: "100%", aspectRatio: 4 / 3, borderRadius: 12, backgroundColor: "#0e1a22", overflow: "hidden" }}>
         <Image key={img.uri} source={img} style={{ width: "100%", height: "100%" }} resizeMode="contain" onLoadStart={() => setImgState("loading")} onLoad={() => setImgState("ready")} onError={() => setImgState("error")} />
         {imgState !== "ready" ? (
-          <View className="absolute inset-0 items-center justify-center" pointerEvents="none">
+          <View className="absolute inset-0 items-center justify-center" style={{ pointerEvents: "none" }}>
             <Text variant="caption" className="text-text-muted">{imgState === "error" ? "The card could not be rendered." : "Rendering the card…"}</Text>
           </View>
         ) : null}

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState, type ReactNode } from "react";
-import { View, Pressable, type LayoutChangeEvent, type GestureResponderEvent } from "react-native";
+import { View, Pressable, type LayoutChangeEvent, type GestureResponderEvent, Platform, type ViewProps, type PointerEvent } from "react-native";
 import Svg, { Polyline, Polygon, Line, Circle, Rect, Text as SvgText } from "react-native-svg";
 import { Text, Modal } from "soma-style";
 
@@ -134,9 +134,8 @@ export function LineChart(props: LineChartProps) {
     ? (tickCount <= 2 ? [0, n - 1] : Array.from({ length: tickCount }, (_, k) => Math.round((k / (tickCount - 1)) * (n - 1))))
     : [];
 
-  const onTouch = (e: GestureResponderEvent) => {
+  const onTouchAt = (x: number) => {
     if (!interactive || plotW <= 0 || n <= 1) return;
-    const x = e.nativeEvent.locationX;
     const i = Math.max(0, Math.min(n - 1, Math.round((x / plotW) * (n - 1))));
     setActive(i);
   };
@@ -144,6 +143,25 @@ export function LineChart(props: LineChartProps) {
   // SVG text is invisible to the accessibility tree; expose the reference labels so a
   // screen reader (and the Maestro device flow) can read "10K goal", "avg 52", … (soma#756).
   const refLabels = [...(refLine ? [refLine] : []), ...(refLines ?? [])].map((r) => r.label).filter((l): l is string => !!l);
+  // Native drives the cursor through the responder system; react-native-web 0.20+ dropped that
+  // system, so on web the same View takes pointer events instead (the responder props would
+  // otherwise land on the DOM node as unknown handlers). `accessible` is native-only too.
+  const touchHandlers: ViewProps = Platform.OS === "web"
+    ? {
+        onPointerDown: (e: PointerEvent) => onTouchAt(e.nativeEvent.offsetX),
+        onPointerMove: (e: PointerEvent) => (e.nativeEvent.buttons ?? 1) > 0 && onTouchAt(e.nativeEvent.offsetX),
+        onPointerUp: () => interactive && setActive(null),
+        onPointerLeave: () => interactive && setActive(null),
+      }
+    : {
+        accessible: refLabels.length > 0,
+        onStartShouldSetResponder: () => !!interactive,
+        onMoveShouldSetResponder: () => !!interactive,
+        onResponderGrant: (e: GestureResponderEvent) => onTouchAt(e.nativeEvent.locationX),
+        onResponderMove: (e: GestureResponderEvent) => onTouchAt(e.nativeEvent.locationX),
+        onResponderRelease: () => interactive && setActive(null),
+        onResponderTerminate: () => interactive && setActive(null),
+      };
 
   // Active-point callout data
   const callout = active != null
@@ -172,14 +190,8 @@ export function LineChart(props: LineChartProps) {
         <View
           className="flex-1"
           onLayout={onLayout}
-          accessible={refLabels.length > 0}
           accessibilityLabel={refLabels.length ? `reference lines: ${refLabels.join(", ")}` : undefined}
-          onStartShouldSetResponder={() => !!interactive}
-          onMoveShouldSetResponder={() => !!interactive}
-          onResponderGrant={onTouch}
-          onResponderMove={onTouch}
-          onResponderRelease={() => interactive && setActive(null)}
-          onResponderTerminate={() => interactive && setActive(null)}
+          {...touchHandlers}
         >
           <Svg width="100%" height={height} viewBox={`0 0 ${VBW} ${height}`}>
             {/* reference bands (drawn under everything) */}
@@ -302,7 +314,7 @@ export function LineChart(props: LineChartProps) {
 
           {/* right axis labels */}
           {rightS.length ? (
-            <View className="absolute right-0 top-0 items-end justify-between" style={{ height, paddingVertical: padTop }} pointerEvents="none">
+            <View className="absolute right-0 top-0 items-end justify-between" style={{ height, paddingVertical: padTop, pointerEvents: "none" }}>
               <Text variant="micro" className="text-text-muted tabular-nums">{fmtR(hiR)}</Text>
               <Text variant="micro" className="text-text-muted tabular-nums">{fmtR(loR)}</Text>
             </View>
@@ -310,7 +322,7 @@ export function LineChart(props: LineChartProps) {
 
           {/* interactive callout box */}
           {callout != null ? (
-            <View pointerEvents="none" className="absolute top-0 rounded-md px-2 py-1" style={{ left: `${Math.max(0, Math.min(70, callout.leftPct - 15))}%`, backgroundColor: "#152028", borderWidth: 1, borderColor: "#2a3a48" }}>
+            <View className="absolute top-0 rounded-md px-2 py-1" style={{ left: `${Math.max(0, Math.min(70, callout.leftPct - 15))}%`, backgroundColor: "#152028", borderWidth: 1, borderColor: "#2a3a48", pointerEvents: "none" }}>
               {callout.label ? <Text variant="micro" className="text-text-muted">{callout.label}</Text> : null}
               {callout.rows.map((r, ri) => (
                 <View key={ri} className="flex-row items-center gap-1">

--- a/universal/src/components/macro-goal-bar.tsx
+++ b/universal/src/components/macro-goal-bar.tsx
@@ -152,7 +152,7 @@ export function MacroGoalBar({
                 <View
                   key={i}
                   className="absolute top-0 h-full"
-                  style={{ left: `${pct}%`, width: 2, backgroundColor: base, opacity: crossed ? 0.4 : 1, shadowColor: "#000", shadowOpacity: 0.7, shadowRadius: 0.5, shadowOffset: { width: 0, height: 0 }, elevation: 2 }}
+                  style={{ left: `${pct}%`, width: 2, backgroundColor: base, opacity: crossed ? 0.4 : 1, boxShadow: "0 0 0.5px rgba(0,0,0,0.7)", elevation: 2 }}
                 />
               );
             })

--- a/universal/src/components/muscle-body-map.tsx
+++ b/universal/src/components/muscle-body-map.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { View } from "react-native";
+import { View, Platform } from "react-native";
 import { Text } from "soma-style";
 import Body, { type ExtendedBodyPart, type Slug } from "react-native-body-highlighter";
 import {
@@ -45,16 +45,21 @@ export function MuscleBodyMap({ volumes, selected, onSelect, scale = 1 }: {
     const mg = b.slug ? SLUG_TO_MUSCLE[b.slug] : undefined;
     if (mg) onSelect(selected === mg ? null : mg);
   };
+  // On web, react-native-svg wraps a pressable <Path> in react-native-web's deprecated Touchable
+  // mixin and spreads responder props onto the DOM node (six "unknown event handler" errors and
+  // a TouchableMixin warning per figure). The web build keeps the figures static; the muscle
+  // chips beside them select a group there. Native keeps tap-to-select on the figure.
+  const onBodyPartPress = Platform.OS === "web" ? undefined : onPress;
 
   return (
     <View className="flex-row items-start justify-center gap-4">
       <View className="items-center">
         <Text variant="micro" className="text-text-muted mb-1">Front</Text>
-        <Body data={data} side="front" scale={scale} defaultFill="#2a2a2e" border="none" onBodyPartPress={onPress} />
+        <Body data={data} side="front" scale={scale} defaultFill="#2a2a2e" border="none" onBodyPartPress={onBodyPartPress} />
       </View>
       <View className="items-center">
         <Text variant="micro" className="text-text-muted mb-1">Back</Text>
-        <Body data={data} side="back" scale={scale} defaultFill="#2a2a2e" border="none" onBodyPartPress={onPress} />
+        <Body data={data} side="back" scale={scale} defaultFill="#2a2a2e" border="none" onBodyPartPress={onBodyPartPress} />
       </View>
     </View>
   );

--- a/universal/src/components/route-thumb.native.tsx
+++ b/universal/src/components/route-thumb.native.tsx
@@ -22,7 +22,7 @@ export function RouteThumb({ points }: { points: RoutePoint[]; stroke?: number }
   }, [points]);
   if (!geojson || !bounds) return <View className="h-24 rounded-lg bg-surface-subtle" />;
   return (
-    <View className="h-24 rounded-lg overflow-hidden" pointerEvents="none">
+    <View className="h-24 rounded-lg overflow-hidden" style={{ pointerEvents: "none" }}>
       <Map style={{ flex: 1 }} mapStyle={DARK_STYLE} attribution={false} logo={false}
         dragPan={false} touchZoom={false} doubleTapZoom={false} doubleTapHoldZoom={false} touchRotate={false} touchPitch={false}>
         <Camera bounds={bounds} padding={{ top: 10, bottom: 10, left: 10, right: 10 }} />

--- a/universal/src/components/running-hr-pace.tsx
+++ b/universal/src/components/running-hr-pace.tsx
@@ -90,7 +90,7 @@ export function RunningHrPace({ data }: { data: { points: HrPacePoint[] } | null
           })}
         </Svg>
         {/* Transparent tap targets over each dot (Circle onPress is unreliable on RN-web-svg). */}
-        <View style={{ position: "absolute", left: 0, right: 0, top: 0, height: H }} pointerEvents="box-none">
+        <View style={{ position: "absolute", left: 0, right: 0, top: 0, height: H, pointerEvents: "box-none" }}>
           {visible.map((p, i) => {
             const cx = ((p.pace as number) - minP) / rP * 96 + 2;
             const cy = H - (((p.hr as number) - minH) / rH) * (H - 8) - 4;

--- a/universal/src/components/sleep-dashboard.tsx
+++ b/universal/src/components/sleep-dashboard.tsx
@@ -63,7 +63,7 @@ function StagesTrend({ nights, height = 112 }: { nights: SleepNight[]; height?: 
       {SLEEP_GUIDES.map((g) => {
         const pct = ((g.h * 3600) / maxTotal) * 100;
         return pct > 0 && pct < 100 ? (
-          <View key={g.label} pointerEvents="none" className="absolute left-0 right-0 items-end" style={{ bottom: `${pct}%`, borderTopWidth: 1, borderColor: g.color, borderStyle: "dashed", opacity: 0.85, zIndex: 1 }}>
+          <View key={g.label} className="absolute left-0 right-0 items-end" style={{ bottom: `${pct}%`, borderTopWidth: 1, borderColor: g.color, borderStyle: "dashed", opacity: 0.85, zIndex: 1, pointerEvents: "none" }}>
             <Text variant="micro" style={{ color: g.color, fontSize: 8, lineHeight: 10, marginTop: -11 }}>{g.label}</Text>
           </View>
         ) : null;

--- a/universal/src/components/workout-detail-modal.tsx
+++ b/universal/src/components/workout-detail-modal.tsx
@@ -321,7 +321,7 @@ export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | 
                   <View style={{ width: "100%", aspectRatio: 4 / 3, borderRadius: 12, backgroundColor: "#0e1a22", overflow: "hidden" }}>
                     <Image source={img} style={{ width: "100%", height: "100%" }} resizeMode="contain" onLoadStart={() => setImgState("loading")} onLoad={() => setImgState("ready")} onError={() => setImgState("error")} />
                     {imgState !== "ready" ? (
-                      <View className="absolute inset-0 items-center justify-center" pointerEvents="none">
+                      <View className="absolute inset-0 items-center justify-center" style={{ pointerEvents: "none" }}>
                         <Text variant="caption" className="text-text-muted">{imgState === "error" ? "The card could not be rendered." : "Rendering the card…"}</Text>
                       </View>
                     ) : null}


### PR DESCRIPTION
## Summary

Item 4 of the Phase 5 hygiene sweep (#808): the T6 "RN-web svg warnings" line. A console sweep of the twelve app screens on Expo web (react-native-web 0.21) against the working-tree server surfaced five sources; all fixed at the source.

- **line-chart**: react-native-web 0.20+ dropped the responder system, so the six `onResponder*` props on the chart's touch view reached the DOM as unknown event handlers. The view now takes pointer events on web and responder events on native; `accessible` is native-only (it printed "non-boolean attribute" on the DOM). Cursor behaviour is unchanged on both.
- **pointerEvents** moved from the deprecated prop to `style.pointerEvents` at seven sites (route thumb, HR/pace overlay, chart axis and callout, sleep dashboard guide lines, activity and workout modal overlays).
- **macro-goal-bar** markers: `shadow*` props to `boxShadow`, which React Native 0.76+ and react-native-web both take.
- **muscle-body-map**: on web, react-native-svg wraps a pressable `<Path>` in react-native-web's deprecated Touchable mixin and spreads responder props onto the DOM (six errors and a TouchableMixin warning per figure). The web build keeps the figures static; the muscle chips beside them select a group there. Native keeps tap-to-select on the figure.

## Also in this PR: the sleep marker the verification harness derives

The harness derived the sleep screen's marker from `/api/stats/sleep?range=90d` while the screen honours the persisted shared range, whose default is 6m (#754). The two disagreed (2.5h–9.0h against the rendered 1.3h–10.0h) and failed a healthy sleep screen. The marker now uses `range=6m`, and the sleep flow selects the 6M chip explicitly instead of inheriting whatever a previous flow left behind.

## Verification

- Expo web sweep of all twelve screens with real data: the only remaining console lines are the chat sheet's probe of `/api/chat/session` on the working-tree server, which serves the chat routes as redirects without CORS headers (not a rendering issue; chat runs over the tailnet daemon).
- `universal`: tsc clean, vitest 44 passing.
- Device (emulator-5556, real account, branch APK against 10.0.2.2:3457), five flows green: nutrition trend tails, chart fidelity and activity detail on running, workout detail, sleep tails. Screenshots read back: the muscle map still colours and selects on native, the expanded chart keeps its cursor, the macro bar keeps its optimal and ceiling markers.

Closes #812
