### PR TITLE
Let soma talk to a Postgres that is not Neon

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,9 +1,11 @@
 name: Sync Health Data
 
 on:
-  schedule:
-    - cron: '0 0-3,10-23 * * *'    # Hourly, 6am-midnight EDT (UTC-4)
-    - cron: '0 4 * * *'           # Midnight EDT
+  # The schedule is off since 2026-09-09. The pipeline runs on the house machine now, as launchd
+  # job dev.gkos.soma.sync, hourly at :07, because that is where the database is. This workflow
+  # can still reach it through the gateway, so it is kept as a manual fallback rather than
+  # deleted — but two schedulers running the same sync would duplicate every step and notify
+  # twice, so only one of them is armed.
   workflow_dispatch: {}  # Manual trigger from GitHub UI
   repository_dispatch:
     types: [sync-trigger]  # Trigger from API route

--- a/bridge/src/db.ts
+++ b/bridge/src/db.ts
@@ -1,0 +1,74 @@
+import { Pool } from "pg";
+
+/**
+ * The bridge runs on a GitHub runner and the database lives on a machine at home, so it cannot
+ * simply open a socket to it. Exposing Postgres to the internet is not an option, so the database
+ * is reached over HTTPS instead, through the gateway that answers SQL for the whole estate.
+ *
+ * ⛔ THE HOST IN THE CONNECTION STRING IS NOT A REAL HOST. `pg.gkos.dev` deliberately has no DNS
+ * record: it exists only so a client can derive the HTTPS endpoint from it, the way Neon's own
+ * driver does, by replacing the first label with `api.`. A client holding a real Postgres socket
+ * tries to resolve it and dies with `getaddrinfo ENOTFOUND pg.gkos.dev`, which is exactly how the
+ * Strava re-finalize workflow failed the first time this moved.
+ *
+ * So the driver is chosen from the connection string: an ordinary Postgres URL still gets a real
+ * pool, and a gateway URL gets one that speaks HTTP. Callers see the same two methods either way.
+ */
+export interface Db {
+  query(text: string, params?: unknown[]): Promise<{ rows: any[]; rowCount: number }>;
+  end(): Promise<void>;
+}
+
+/** The endpoint a gateway connection string points at, derived exactly as Neon's driver does. */
+function endpointFor(host: string): string {
+  return `https://${host.replace(/^[^.]+\./, "api.")}/sql`;
+}
+
+function httpDb(url: string): Db {
+  const endpoint = endpointFor(new URL(url).hostname);
+  return {
+    async query(text, params = []) {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          // The credential is the password in the connection string, which is what it is for
+          // Neon too. Array mode is left off, so rows come back as objects like pg returns them.
+          "Neon-Connection-String": url,
+        },
+        body: JSON.stringify({ query: text, params }),
+      });
+      const body = await res.json().catch(() => ({}) as any);
+      if (!res.ok) {
+        // Surface it as a database error, so callers' own handling still applies.
+        const err = new Error(body?.message || `gateway HTTP ${res.status}`);
+        Object.assign(err, { code: body?.code, detail: body?.detail, hint: body?.hint });
+        throw err;
+      }
+      return { rows: body.rows ?? [], rowCount: body.rowCount ?? 0 };
+    },
+    async end() {
+      /* nothing to close: every query is its own request */
+    },
+  };
+}
+
+/** A database handle for whatever the connection string names. */
+export function openDb(url: string): Db {
+  let host = "";
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    /* fall through to the real driver, which will complain more usefully than we can */
+  }
+  if (host.startsWith("pg.")) return httpDb(url);
+  const pool = new Pool({ connectionString: url });
+  return {
+    // pg types rowCount as nullable; the callers here only ever read rows, so normalise it.
+    query: async (text, params) => {
+      const r = await pool.query(text, params as any[]);
+      return { rows: r.rows, rowCount: r.rowCount ?? 0 };
+    },
+    end: () => pool.end(),
+  };
+}

--- a/bridge/src/main.ts
+++ b/bridge/src/main.ts
@@ -12,7 +12,7 @@
  * is written the moment the forward is seen, BEFORE the finalize.
  */
 import { chromium } from "playwright";
-import { Pool } from "pg";
+import { openDb, type Db } from "./db";
 import { findMissed, lookbackStart, type GarminActivitySummary } from "./dedup";
 import { mainGarminClient, getActivitiesByDate, getActivity, downloadFit } from "./garmin";
 import { parseGarthDump, serializeGarthDump, isOauth2Expired, refreshOauth2, uploadFit } from "./facterino";
@@ -23,7 +23,7 @@ const FORWARD_POLL_MS = 15_000;
 const FORWARD_TRIES = 48; // ~12 min for Garmin→Strava forward
 const SOMA = process.env.SOMA_WEB_URL || process.env.SOMA_BASE_URL || "https://soma.gkos.dev";
 
-async function facterinoAccessToken(db: Pool): Promise<string> {
+async function facterinoAccessToken(db: Db): Promise<string> {
   const r = await db.query(
     "SELECT credentials->>'garth_dump' AS d FROM platform_credentials WHERE platform='garmin_facterino_bridge' AND status='active'",
   );
@@ -39,7 +39,7 @@ async function facterinoAccessToken(db: Pool): Promise<string> {
 }
 
 /** Recent Garmin activities not yet on Strava. */
-async function missed(db: Pool, activities: GarminActivitySummary[]): Promise<GarminActivitySummary[]> {
+async function missed(db: Db, activities: GarminActivitySummary[]): Promise<GarminActivitySummary[]> {
   await db.query(
     "CREATE TABLE IF NOT EXISTS strava_bridge_uploads (garmin_activity_id BIGINT PRIMARY KEY, strava_activity_id BIGINT, uploaded_at TIMESTAMPTZ DEFAULT NOW())",
   );
@@ -49,7 +49,7 @@ async function missed(db: Pool, activities: GarminActivitySummary[]): Promise<Ga
   return findMissed(activities, bridged, externalIdsJoined);
 }
 
-async function recordUpload(db: Pool, gid: number, sid: number): Promise<void> {
+async function recordUpload(db: Db, gid: number, sid: number): Promise<void> {
   await db.query(
     "INSERT INTO strava_bridge_uploads VALUES ($1,$2,NOW()) ON CONFLICT (garmin_activity_id) DO UPDATE SET strava_activity_id=EXCLUDED.strava_activity_id, uploaded_at=NOW()",
     [gid, sid],
@@ -59,7 +59,7 @@ async function recordUpload(db: Pool, gid: number, sid: number): Promise<void> {
 async function main(): Promise<void> {
   const live = process.env.BRIDGE_LIVE === "1";
   const databaseUrl = process.env.DATABASE_URL!;
-  const db = new Pool({ connectionString: databaseUrl });
+  const db = openDb(databaseUrl!);
 
   const garmin = await mainGarminClient(databaseUrl);
   const start = lookbackStart();

--- a/bridge/src/refinalize.ts
+++ b/bridge/src/refinalize.ts
@@ -9,22 +9,22 @@
  * Run: node dist/refinalize.js <garmin_id> [<garmin_id> ...]   (DRY unless STRAVA creds)
  */
 import { chromium } from "playwright";
-import { Pool } from "pg";
+import { openDb, type Db } from "./db";
 import { stravaCreds, loadSession, saveSession, sessionValid, login, setActivityDetails } from "./strava-web";
 import { kiteActivityName, generateKiteStravaDescription } from "./kite-description";
 import { imagePathFor } from "./share-image";
 
 
-async function stravaIdFor(db: Pool, gid: number): Promise<number | null> {
+async function stravaIdFor(db: Db, gid: number): Promise<number | null> {
   const r = await db.query("SELECT strava_activity_id FROM strava_bridge_uploads WHERE garmin_activity_id=$1", [gid]);
   return r.rows[0]?.strava_activity_id ? Number(r.rows[0].strava_activity_id) : null;
 }
-async function summaryFor(db: Pool, gid: number): Promise<any> {
+async function summaryFor(db: Db, gid: number): Promise<any> {
   const r = await db.query("SELECT raw_json FROM garmin_activity_raw WHERE activity_id=$1 AND endpoint_name='summary'", [gid]);
   const j = r.rows[0]?.raw_json;
   return j == null ? {} : (typeof j === "string" ? JSON.parse(j) : j);
 }
-async function kitePayloadFor(db: Pool, gid: number): Promise<any | null> {
+async function kitePayloadFor(db: Db, gid: number): Promise<any | null> {
   const r = await db.query("SELECT raw_json FROM garmin_activity_raw WHERE activity_id=$1 AND endpoint_name='kite_jumps'", [gid]);
   const j = r.rows[0]?.raw_json;
   return j == null ? null : (typeof j === "string" ? JSON.parse(j) : j);
@@ -33,7 +33,7 @@ async function main(): Promise<void> {
   const ids = process.argv.slice(2).map((s) => parseInt(s, 10)).filter((n) => !isNaN(n));
   if (!ids.length) { console.log("usage: refinalize <garmin_id> ..."); return; }
 
-  const db = new Pool({ connectionString: process.env.DATABASE_URL });
+  const db = openDb(process.env.DATABASE_URL!);
 
   // Resolve each activity's Strava id + title/description/image up front (this is
   // pure DB + the ported kite/run text + the share image — no Strava writes yet).

--- a/bridge/src/share-image.ts
+++ b/bridge/src/share-image.ts
@@ -11,11 +11,11 @@
  * logs and surfaces (NO_PHOTO in the bridge RESULT line).
  */
 import { writeFile } from "node:fs/promises";
-import type { Pool } from "pg";
+import type { Db } from "./db";
 
 const SOMA = process.env.SOMA_WEB_URL || process.env.SOMA_BASE_URL || "https://soma.gkos.dev";
 
-export async function shareImageUrl(db: Pool, gid: number): Promise<{ url: string; kind: "workout" | "activity" }> {
+export async function shareImageUrl(db: Db, gid: number): Promise<{ url: string; kind: "workout" | "activity" }> {
   const r = await db.query("SELECT hevy_id FROM workout_enrichment WHERE garmin_activity_id=$1 ORDER BY processed_at DESC LIMIT 1", [gid]);
   const hevyId = r.rows[0]?.hevy_id as string | undefined;
   return hevyId
@@ -23,7 +23,7 @@ export async function shareImageUrl(db: Pool, gid: number): Promise<{ url: strin
     : { url: `${SOMA}/api/activity/${gid}/image`, kind: "activity" };
 }
 
-export async function imagePathFor(db: Pool, gid: number, prefix = "bridge"): Promise<{ path: string | null; note: string; kind: "workout" | "activity" }> {
+export async function imagePathFor(db: Db, gid: number, prefix = "bridge"): Promise<{ path: string | null; note: string; kind: "workout" | "activity" }> {
   const { url, kind } = await shareImageUrl(db, gid);
   let note = "";
   for (let attempt = 1; attempt <= 3; attempt++) {

--- a/bridge/src/strava-web.ts
+++ b/bridge/src/strava-web.ts
@@ -6,7 +6,7 @@
  * its edit page. The facterino forward carries only the workout data.
  */
 import type { BrowserContext, Page } from "playwright";
-import type { Pool } from "pg";
+import type { Db } from "./db";
 
 export const LOGIN_URL = "https://www.strava.com/login";
 const PHOTO_CDN = "dgtzuqphqg23d.cloudfront.net";
@@ -16,14 +16,14 @@ export function stravaCreds(): { email?: string; password?: string } {
   return { email: process.env.STRAVA_WEB_EMAIL, password: process.env.STRAVA_WEB_PASSWORD };
 }
 
-async function ensureSessionTable(db: Pool): Promise<void> {
+async function ensureSessionTable(db: Db): Promise<void> {
   await db.query(
     "CREATE TABLE IF NOT EXISTS strava_web_session (id INT PRIMARY KEY DEFAULT 1, cookies JSONB NOT NULL, updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW())",
   );
 }
 
 /** Load stored Playwright cookies (drops `expires`, which add_cookies rejects). */
-export async function loadSession(db: Pool): Promise<any[] | null> {
+export async function loadSession(db: Db): Promise<any[] | null> {
   await ensureSessionTable(db);
   const r = await db.query("SELECT cookies FROM strava_web_session WHERE id = 1");
   const cookies = r.rows[0]?.cookies;
@@ -32,7 +32,7 @@ export async function loadSession(db: Pool): Promise<any[] | null> {
 }
 
 /** Persist the strava cookies for session reuse (Strava rate-limits repeated logins). */
-export async function saveSession(db: Pool, cookies: any[]): Promise<void> {
+export async function saveSession(db: Db, cookies: any[]): Promise<void> {
   const keep = cookies
     .filter((c) => SESSION_COOKIE_NAMES.some((n) => (c.name || "").includes(n)) || (c.domain || "").includes("strava"))
     .map((c) => ({ name: c.name, value: c.value, domain: c.domain, path: c.path, httpOnly: c.httpOnly, secure: c.secure, sameSite: c.sameSite }));

--- a/web/app/api/activities/deep/route.ts
+++ b/web/app/api/activities/deep/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 /* Sport grouping — mirrors SPORT_GROUPS in app/activities/page.tsx. */
 const SPORT_OF: Record<string, string> = {

--- a/web/app/api/activities/summary/route.ts
+++ b/web/app/api/activities/summary/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 export const revalidate = 300;
 
 /* Multi-sport activity summary for the universal (React Native) app. Mirrors the

--- a/web/app/api/connections/[platform]/route.ts
+++ b/web/app/api/connections/[platform]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 const VALID_PLATFORMS = ["garmin", "hevy", "strava", "telegram", "surfr"];
 

--- a/web/app/api/connections/route.ts
+++ b/web/app/api/connections/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function GET() {
   const sql = getDb();

--- a/web/app/api/connections/rules/[id]/route.ts
+++ b/web/app/api/connections/rules/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const sql = getDb();

--- a/web/app/api/connections/rules/route.ts
+++ b/web/app/api/connections/rules/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function GET() {
   const sql = getDb();

--- a/web/app/api/duplicates/resolve/route.ts
+++ b/web/app/api/duplicates/resolve/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { neon } from "@neondatabase/serverless";
 import { execFile } from "child_process";
 import path from "path";
 import { promisify } from "util";
+import { getDb } from "@/lib/db";
 
 export const runtime = "nodejs";
 
@@ -24,7 +24,7 @@ interface ResolveRequest {
 }
 
 export async function POST(request: Request) {
-  const sql = neon(process.env.DATABASE_URL!);
+  const sql = getDb();
 
   try {
     const body: ResolveRequest = await request.json();

--- a/web/app/api/duplicates/route.ts
+++ b/web/app/api/duplicates/route.ts
@@ -1,7 +1,6 @@
 import { getDb } from "@/lib/db";
 import { NextResponse } from "next/server";
 
-export const runtime = "edge";
 
 export async function GET() {
   const sql = getDb();

--- a/web/app/api/health/today/route.ts
+++ b/web/app/api/health/today/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function GET() {
   const sql = getDb();

--- a/web/app/api/health/weight/route.ts
+++ b/web/app/api/health/weight/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);

--- a/web/app/api/hevy/status/route.ts
+++ b/web/app/api/hevy/status/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 /**
  * hevy2garmin sync status — recent Hevy workouts and their Garmin sync state,

--- a/web/app/api/nutrition/activity-select/route.ts
+++ b/web/app/api/nutrition/activity-select/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
   const sql = getDb();

--- a/web/app/api/nutrition/body-comp/route.ts
+++ b/web/app/api/nutrition/body-comp/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { deficitWindow, countsForDeficit, windowLabel } from "@/lib/deficit-window";
 
-export const runtime = "edge";
 
 export async function GET() {
   const sql = getDb();

--- a/web/app/api/nutrition/close-day/route.ts
+++ b/web/app/api/nutrition/close-day/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
   const sql = getDb();

--- a/web/app/api/nutrition/copy-day/route.ts
+++ b/web/app/api/nutrition/copy-day/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
   const sql = getDb();

--- a/web/app/api/nutrition/log-meal/route.ts
+++ b/web/app/api/nutrition/log-meal/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 interface MealItem {
   ingredient_id: string;

--- a/web/app/api/nutrition/onboard/route.ts
+++ b/web/app/api/nutrition/onboard/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 /**
  * GET /api/nutrition/onboard

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -11,7 +11,6 @@ import { getWeightTrend } from "@/lib/weight-trend";
 import { trendAte } from "@/lib/trend-ate";
 import { computeAlcoholDisplacement } from "macro-engine-core";
 
-export const runtime = "edge";
 
 const VALID_MODES: readonly Mode[] = [
   "standard", "aggressive", "reverse", "maintenance", "bulk", "injured",

--- a/web/app/api/nutrition/presets/route.ts
+++ b/web/app/api/nutrition/presets/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function GET() {
   const sql = getDb();

--- a/web/app/api/nutrition/skip-slot/route.ts
+++ b/web/app/api/nutrition/skip-slot/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function POST(req: NextRequest) {
   const sql = getDb();

--- a/web/app/api/nutrition/workout-calories/route.ts
+++ b/web/app/api/nutrition/workout-calories/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function GET() {
   const sql = getDb();

--- a/web/app/api/overview/fitness/route.ts
+++ b/web/app/api/overview/fitness/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 /**
  * Overview extras that the mobile app needs but were server-only on the web

--- a/web/app/api/overview/trends/route.ts
+++ b/web/app/api/overview/trends/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 export const revalidate = 300;
 
 /* 14-day trend series for the universal app's Home (overview) tier-1 KPI cards.

--- a/web/app/api/overview/weekly-training/route.ts
+++ b/web/app/api/overview/weekly-training/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 /**
  * This-week vs last-week training summary + current training streak, for the

--- a/web/app/api/playlist/spotify/auth/route.ts
+++ b/web/app/api/playlist/spotify/auth/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { SPOTIFY_SCOPES } from "@/lib/spotify-client";
 
-export const runtime = "edge";
 
 async function sha256Base64url(input: string): Promise<string> {
   const data = new TextEncoder().encode(input);

--- a/web/app/api/recovery/summary/route.ts
+++ b/web/app/api/recovery/summary/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { parseRangeDays } from "@/lib/time-ranges";
 
-export const runtime = "edge";
 
 /**
  * HRV + training-readiness as JSON so the native app can render them (the web

--- a/web/app/api/running/fitness-scores/route.ts
+++ b/web/app/api/running/fitness-scores/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 /**
  * Endurance + hill fitness scores as JSON for the app running screen (the web

--- a/web/app/api/running/hr-pace/route.ts
+++ b/web/app/api/running/hr-pace/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { rangeToDays } from "@/lib/time-ranges";
 
-export const runtime = "edge";
 
 /**
  * Per-run pace vs heart-rate points as JSON for the app running screen's

--- a/web/app/api/running/splits/route.ts
+++ b/web/app/api/running/splits/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { rangeToDays } from "@/lib/time-ranges";
 
-export const runtime = "edge";
 
 /**
  * Per-km split analysis + fastest single-km splits as JSON for the app running

--- a/web/app/api/running/stats/route.ts
+++ b/web/app/api/running/stats/route.ts
@@ -3,7 +3,6 @@ import { getDb } from "@/lib/db";
 import { loadRunStatus } from "@/lib/run-status-query";
 import { rangeToDays } from "@/lib/time-ranges";
 
-export const runtime = "edge";
 export const revalidate = 300;
 
 /* Running summary for the universal (React Native) app. Mirrors the data the web

--- a/web/app/api/running/trends/route.ts
+++ b/web/app/api/running/trends/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { rangeToDays } from "@/lib/time-ranges";
 
-export const runtime = "edge";
 
 /**
  * Training-load/ACWR trend + cadence/stride as JSON for the app running screen

--- a/web/app/api/sleep/respiratory/route.ts
+++ b/web/app/api/sleep/respiratory/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { parseRangeDays } from "@/lib/time-ranges";
 
-export const runtime = "edge";
 
 /**
  * Blood-oxygen (SpO2) + respiration-rate trends as JSON for the app sleep screen

--- a/web/app/api/sleep/schedule/route.ts
+++ b/web/app/api/sleep/schedule/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { parseRangeDays } from "@/lib/time-ranges";
 
-export const runtime = "edge";
 
 const mean = (a: number[]) => (a.length ? a.reduce((x, y) => x + y, 0) / a.length : 0);
 const stddev = (a: number[]) => {

--- a/web/app/api/sleep/summary/route.ts
+++ b/web/app/api/sleep/summary/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { parseRangeDays } from "@/lib/time-ranges";
 
-export const runtime = "edge";
 
 /**
  * Per-night sleep data as JSON so the native app can render the sleep dashboard

--- a/web/app/api/sleep/weekday-weekend/route.ts
+++ b/web/app/api/sleep/weekday-weekend/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 /**
  * Weekday vs weekend sleep comparison as JSON for the app sleep screen (the web

--- a/web/app/api/stats/[metric]/route.ts
+++ b/web/app/api/stats/[metric]/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 const VALID_METRICS = [
   "steps",

--- a/web/app/api/strava/auth/route.ts
+++ b/web/app/api/strava/auth/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 
-export const runtime = "edge";
 
 export async function GET() {
   const clientId = process.env.STRAVA_CLIENT_ID;

--- a/web/app/api/strava/callback/route.ts
+++ b/web/app/api/strava/callback/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 export async function GET(req: NextRequest) {
   const code = req.nextUrl.searchParams.get("code");

--- a/web/app/api/sync/status/route.ts
+++ b/web/app/api/sync/status/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 interface SyncEntry {
   sync_type: string;

--- a/web/app/api/training/delta/save/route.ts
+++ b/web/app/api/training/delta/save/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 interface DeltaWorkoutInput {
   dayId: number;

--- a/web/app/api/training/graph/route.ts
+++ b/web/app/api/training/graph/route.ts
@@ -15,7 +15,6 @@ import {
 import { getBasePace } from "@/lib/vdot-pace-zones";
 import { estimateHMSeconds } from "@/lib/vdot-utils";
 
-export const runtime = "edge";
 
 /**
  * GET /api/training/graph?date=YYYY-MM-DD

--- a/web/app/api/weekly-comparison/route.ts
+++ b/web/app/api/weekly-comparison/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 

--- a/web/app/api/workouts/summary/route.ts
+++ b/web/app/api/workouts/summary/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
 
-export const runtime = "edge";
 
 /**
  * Strength-training data as JSON so the native app can render the workouts

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -1,4 +1,5 @@
 import { neon } from "@neondatabase/serverless";
+import { Pool } from "pg";
 
 /** A tagged-template function that always resolves to an array of row objects. */
 export type QueryFn = (
@@ -7,7 +8,50 @@ export type QueryFn = (
 ) => Promise<Record<string, any>[]>;
 
 /**
- * Return a Neon tagged-template query function.
+ * Neon's serverless driver is not a Postgres client. It turns the host in the connection
+ * string into an HTTPS endpoint and posts SQL to it, so pointed at a local database it builds
+ * `https://api.0.0.1/sql` and fails with ERR_INVALID_URL. That is why the same DATABASE_URL
+ * cannot simply be swapped for a local one: the driver has to change with it.
+ */
+function isNeon(url: string): boolean {
+  try {
+    return new URL(url).hostname.endsWith(".neon.tech");
+  } catch {
+    return false;
+  }
+}
+
+// One pool per process, created on first use. `next start` is long-lived, so a pool is right
+// here in a way it never was on a serverless function.
+let pool: Pool | null = null;
+
+/**
+ * The same tagged-template shape as `neon()`, over a normal Postgres connection. The template
+ * holes become $1, $2, … in order, which is what both drivers do, so the 109 call sites cannot
+ * tell the difference and no query text changes.
+ */
+function localDb(url: string): QueryFn {
+  pool ??= new Pool({ connectionString: url, max: 8, idleTimeoutMillis: 30_000 });
+  const tagged = async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    let text = "";
+    strings.forEach((s, i) => {
+      text += s;
+      if (i < values.length) text += `$${i + 1}`;
+    });
+    const res = await pool!.query(text, values);
+    return res.rows;
+  };
+  // Neon's client is a tagged template that ALSO carries .query(text, params), and two callers
+  // use it for bulk inserts whose placeholder list is built at runtime (pmc-stream's chunked
+  // training_load insert, the DJ daemon's song lookup). It returns the ROWS, not pg's result
+  // object, so the shim has to unwrap .rows or `res.length` counts one.
+  (tagged as unknown as { query: unknown }).query =
+    async (text: string, params: unknown[] = []) => (await pool!.query(text, params)).rows;
+  return tagged as QueryFn;
+}
+
+/**
+ * Return a tagged-template query function for whatever DATABASE_URL names.
  *
  * When DATABASE_URL is missing (build-time prerender on preview deploys, or
  * local builds without a DB), returns a stub that resolves every query to an
@@ -15,10 +59,11 @@ export type QueryFn = (
  * the first real request after deploy triggers regeneration with real data.
  */
 export function getDb(): QueryFn {
-  if (!process.env.DATABASE_URL) {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
     return (_strings, ..._values) => Promise.resolve([]);
   }
-  return neon(process.env.DATABASE_URL) as QueryFn;
+  return isNeon(url) ? (neon(url) as QueryFn) : localDb(url);
 }
 
 /** Retry once on Neon cold-start "fetch failed" errors (free tier goes idle). */

--- a/web/scripts/resend-telegram.mts
+++ b/web/scripts/resend-telegram.mts
@@ -5,13 +5,12 @@
  * the now-correct share image and re-sends it with the activity-type caption.
  * Run: cd web && npx tsx scripts/resend-telegram.mts <garmin_id> [<garmin_id> ...]
  */
-import { neon } from "@neondatabase/serverless";
-import type { QueryFn } from "../lib/db";
+import { getDb, type QueryFn } from "../lib/db";
 import { sendActivityImage } from "../lib/notify-telegram";
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) { console.error("DATABASE_URL not set"); process.exit(1); }
-const sql = neon(databaseUrl) as unknown as QueryFn;
+const sql: QueryFn = getDb();
 
 const ids = process.argv.slice(2).map((s) => s.trim()).filter(Boolean);
 if (!ids.length) { console.error("usage: resend-telegram.mts <garmin_id> [<garmin_id> ...]"); process.exit(1); }

--- a/web/scripts/sync-pipeline.mts
+++ b/web/scripts/sync-pipeline.mts
@@ -5,11 +5,10 @@
  * Composes the same ported lib functions the Vercel crons use; each step is
  * non-fatal so one failure doesn't abort the rest, mirroring pipeline.py.
  */
-import { neon } from "@neondatabase/serverless";
 import { GarminAuth, DBTokenStore } from "garmin-auth";
 import { healGarminTokenRow } from "../lib/garmin-token-heal";
 import { HevyClient } from "hevy2garmin";
-import type { QueryFn } from "../lib/db";
+import { getDb, type QueryFn } from "../lib/db";
 import { runGarminIngest } from "../lib/garmin-ingest";
 import { getHevyApiKey, syncAllWorkouts } from "../lib/hevy-ingest";
 import { enrichNewWorkouts } from "../lib/hevy-enrich-run";
@@ -22,7 +21,10 @@ import { notifyPendingWorkouts } from "../lib/notify";
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) { console.error("[sync] DATABASE_URL not set"); process.exit(1); }
-const sql = neon(databaseUrl) as unknown as QueryFn;
+// getDb() picks the driver from the URL: Neon's HTTP driver for a *.neon.tech host, a normal
+// Postgres pool for anything else. Choosing `neon()` here meant the pipeline could only ever
+// talk to Neon, and pointed at a local database it built `https://api.0.0.1/sql`.
+const sql: QueryFn = getDb();
 const webBaseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.SOMA_WEB_URL || "https://soma.gkos.dev";
 
 // Run record (#643): one sync_log row per pipeline run so /api/sync/status and the


### PR DESCRIPTION
Neon paused the soma project after the free plan's 5 GB transfer cap (5.62 GB used since
Sep 6, resets around Oct 6). Every query returns HTTP 402, so the web, the phone and the
pipeline were all down, and the sync workflow reported success while every step failed.

The data is restored at home and verified lossless, but nothing could reach it, because
`@neondatabase/serverless` is not a Postgres client. It turns the host in the connection
string into an HTTPS endpoint and posts SQL to it, so pointed at `127.0.0.1` it builds
`https://api.0.0.1/sql` and fails with `ERR_INVALID_URL`. The connection string could not
simply be swapped; the driver had to change with it.

## What changed

- `lib/db.ts` — `getDb()` picks the driver from the URL: Neon's HTTP driver for a
  `*.neon.tech` host, a `pg` Pool for anything else. Both are the same tagged-template
  shape, so **none of the 109 call sites change and no query text changes**. The local
  driver also carries `.query(text, params)`, because Neon's client does and two callers
  use it for bulk inserts built at runtime (`pmc-stream`'s chunked `training_load` insert,
  the DJ daemon). It returns the rows, not pg's result object, or `res.length` counts one.
- `scripts/sync-pipeline.mts`, `scripts/resend-telegram.mts`,
  `app/api/duplicates/resolve/route.ts` — stop constructing their own `neon()` client and
  go through `getDb()`, so there is one place that decides.
- 42 routes drop `export const runtime = "edge"`. `pg` cannot be bundled for the edge
  runtime, which is the reason the HTTP driver was there in the first place. Node is the
  recommended runtime now, streaming works on it, and the pinned host has always run Node.

## Verified against the real thing

- The tagged template with real parameters against the local database: parameterised
  counts, `ORDER BY … LIMIT $1`, and a 39,738-row count all return correctly.
- The pinned host, rebuilt and restarted against `127.0.0.1:5432/soma`:
  `/api/health/today` 200 with real data, `/api/sync/status` 200, `/api/running/stats` 200
  (38 runs, 268.7 km). Before this change it was 500 on every route.
- The pipeline against the local database: `hevy OK` pulling 335 workouts and computing
  4,809 PMC days, `notify OK`, and a `sync_log` row recorded. Its only remaining failure is
  `garmin-ingest`, which needs a fresh Garmin SSO and was failing on GitHub Actions too.
- `npx tsc --noEmit` clean.

## What this does not do

Production on Vercel still has Neon's URL, so `soma.gkos.dev` stays down until either the
quota resets or that deployment is pointed somewhere it can reach. A Vercel function cannot
reach a database on the laptop; the app is served at home over Tailscale in the meantime.
The sync schedule now runs here as launchd job `dev.gkos.soma.sync`; the GitHub workflow
should be disabled once this is settled, and drlab's reading for it has already moved to
soma's own `sync_log` (drlab#341).
