### PR TITLE
chore: drop the session link from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,5 +44,3 @@ universal/scripts/verify-device.sh <screen> [--marker "<live value>"]
 ## Links
 
 Closes #<issue>
-
-


### PR DESCRIPTION
## What

Removes the hardcoded session URL from the Links section of `.github/pull_request_template.md`.

## Why

The template shipped a fixed assistant session identifier, so every PR opened from it republished that identifier into a public repository. It is a pointer into a private conversation and has no place here. Deleting it from the template also stops it seeding new PRs.

Note that this only fixes the source. The identifier is still present in this repository's existing commit history and in already-opened PR bodies; clearing those is separate work.

## Risk

None to the build. The Links section keeps its `Closes #<issue>` line, which is what it is for.
