### PR TITLE
Keep a Postgres restart from taking the host down

### DIFF
--- a/bridge/src/db.ts
+++ b/bridge/src/db.ts
@@ -63,6 +63,9 @@ export function openDb(url: string): Db {
   }
   if (host.startsWith("pg.")) return httpDb(url);
   const pool = new Pool({ connectionString: url });
+  // An idle client emitting error with no listener takes the process down, and idle clients emit
+  // on any backend restart. The bridge is short-lived, but it runs unattended.
+  pool.on("error", (err) => console.error("[bridge] idle client error:", err.message));
   return {
     // pg types rowCount as nullable; the callers here only ever read rows, so normalise it.
     query: async (text, params) => {

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -17,7 +17,9 @@ function isNeon(url: string): boolean {
   try {
     return new URL(url).hostname.endsWith(".neon.tech");
   } catch {
-    return false;
+    // A DATABASE_URL that will not parse is a configuration mistake, not a hint to try the other
+    // driver: falling through to pg turns a typo into a confusing connection error much later.
+    throw new Error("DATABASE_URL is not a valid connection string");
   }
 }
 
@@ -31,7 +33,14 @@ let pool: Pool | null = null;
  * tell the difference and no query text changes.
  */
 function localDb(url: string): QueryFn {
-  pool ??= new Pool({ connectionString: url, max: 8, idleTimeoutMillis: 30_000 });
+  if (!pool) {
+    pool = new Pool({ connectionString: url, max: 8, idleTimeoutMillis: 30_000 });
+    // ⛔ AN IDLE CLIENT EMITTING error WITH NO LISTENER TAKES THE PROCESS DOWN. pg is explicit
+    // about this, and idle clients emit on any backend restart, so one `brew services restart
+    // postgresql` would kill the pinned host. This never mattered against Neon because the HTTP
+    // driver holds no pool; `next start` is long-lived and does.
+    pool.on("error", (err) => console.error("[db] idle client error:", err.message));
+  }
   const tagged = async (strings: TemplateStringsArray, ...values: unknown[]) => {
     let text = "";
     strings.forEach((s, i) => {
@@ -58,15 +67,30 @@ function localDb(url: string): QueryFn {
  * empty array. This lets ISR create placeholder pages during `next build`;
  * the first real request after deploy triggers regeneration with real data.
  */
+/**
+ * True while `next build` is prerendering, when there is legitimately no database.
+ * Anywhere else a missing DATABASE_URL is a fault, not a reason to render empty pages.
+ */
+function isBuildPhase(): boolean {
+  return process.env.NEXT_PHASE === "phase-production-build" || process.env.npm_lifecycle_event === "build";
+}
+
 export function getDb(): QueryFn {
   const url = process.env.DATABASE_URL;
   if (!url) {
-    return (_strings, ..._values) => Promise.resolve([]);
+    // ⚠️ THE STUB USED TO APPLY AT RUNTIME TOO, so an unset variable in production rendered every
+    // page as "no data" and looked like a quiet day rather than a broken deployment. That is
+    // exactly how a missing key on the portfolio went unnoticed through three builds.
+    if (isBuildPhase()) {
+      return (_strings, ..._values) => Promise.resolve([]);
+    }
+    throw new Error("DATABASE_URL is not set");
   }
   return isNeon(url) ? (neon(url) as QueryFn) : localDb(url);
 }
 
-/** Retry once on Neon cold-start "fetch failed" errors (free tier goes idle). */
+/** Retry once on a transport hiccup: a Neon cold start, or the gateway between a request
+ * and a Postgres that is restarting underneath it. */
 export async function withDbRetry<T>(fn: () => Promise<T>, retries = 1): Promise<T> {
   try {
     return await fn();


### PR DESCRIPTION
Three faults that only became reachable once the database stopped being an HTTP service and
became a socket on this machine.

**An idle client emitting `error` with no listener takes the process down.** pg documents this,
and idle clients emit on any backend restart. Neon's driver holds no pool, so it never applied;
`next start` is long-lived and does, which means a single `brew services restart postgresql`
could kill the pinned host, and the same for the bridge on a runner. One handler per pool.

Verified on the gateway, which had the same fault: with the handler in place I restarted
Postgres underneath it and the process stayed up and answered the next query.

**`getDb()` rendered empty pages instead of failing.** With `DATABASE_URL` unset it returned a
stub resolving every query to `[]`. That is correct while `next build` prerenders and wrong at
runtime, where a missing variable in production renders every page as "no data" and reads as a
quiet day. It now applies only during the build and throws otherwise. This is not hypothetical:
a missing key on the portfolio produced empty results through three builds before anyone noticed.

**A malformed `DATABASE_URL` fell through to the pg driver**, turning a typo into a confusing
connection error much later instead of failing where the mistake is.

Checked all three: during the build phase with no variable it still returns `[]`; at runtime it
throws "DATABASE_URL is not set"; a malformed value throws "DATABASE_URL is not a valid
connection string". `tsc --noEmit` clean.
