### PR TITLE
Keep the sync schedule for forks, and skip it only on this instance

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,11 +1,9 @@
 name: Sync Health Data
 
 on:
-  # The schedule is off since 2026-09-09. The pipeline runs on the house machine now, as launchd
-  # job dev.gkos.soma.sync, hourly at :07, because that is where the database is. This workflow
-  # can still reach it through the gateway, so it is kept as a manual fallback rather than
-  # deleted — but two schedulers running the same sync would duplicate every step and notify
-  # twice, so only one of them is armed.
+  schedule:
+    - cron: '0 0-3,10-23 * * *'    # Hourly, 6am-midnight EDT (UTC-4)
+    - cron: '0 4 * * *'           # Midnight EDT
   workflow_dispatch: {}  # Manual trigger from GitHub UI
   repository_dispatch:
     types: [sync-trigger]  # Trigger from API route
@@ -20,6 +18,21 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # This repository runs the pipeline on its own machine instead, as a launchd job, because
+      # that is where its database lives. Two schedulers running the same sync would duplicate
+      # every step and notify twice.
+      #
+      # ⭐ THE SCHEDULE STAYS IN THE FILE ON PURPOSE. A fork is meant to deploy on Vercel with a
+      # hosted database and rely on exactly this workflow, so removing the cron would quietly
+      # break the path this project documents. The skip is a repository variable that only this
+      # instance sets; a fork has no such variable and runs normally.
+      - name: Skip when this instance runs the pipeline elsewhere
+        if: github.event_name == 'schedule' && vars.PIPELINE_RUNS_LOCALLY == 'true'
+        run: |
+          echo "PIPELINE_RUNS_LOCALLY is set: this instance syncs from its own machine."
+          echo "Nothing to do here. A fork without this variable runs the pipeline normally."
+          exit 0
+
       - name: Additive backoff — skip if too soon after a failure
         if: github.event_name == 'schedule'
         env:


### PR DESCRIPTION
Turning off the cron broke the path this project documents.

A fork is meant to deploy on Vercel with a hosted database and rely on this workflow. A fork of a repository whose schedule has been deleted gets a pipeline that never runs, and nothing to explain why.

The schedule is restored. This instance skips scheduled runs through a repository variable, `PIPELINE_RUNS_LOCALLY`, because it runs the pipeline on its own machine where its database now lives, and two schedulers would duplicate every step and notify twice. A fork has no such variable and runs normally.

The same principle already holds in the data layer: `getDb()` picks the serverless driver for a hosted connection string and a pool for a local one, so the self-hosted path is an alternative alongside the documented one, never a replacement for it.