### PR TITLE
Make the scheduled-sync skip actually skip

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,22 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    steps:
-      # This repository runs the pipeline on its own machine instead, as a launchd job, because
-      # that is where its database lives. Two schedulers running the same sync would duplicate
-      # every step and notify twice.
-      #
-      # ⭐ THE SCHEDULE STAYS IN THE FILE ON PURPOSE. A fork is meant to deploy on Vercel with a
-      # hosted database and rely on exactly this workflow, so removing the cron would quietly
-      # break the path this project documents. The skip is a repository variable that only this
-      # instance sets; a fork has no such variable and runs normally.
-      - name: Skip when this instance runs the pipeline elsewhere
-        if: github.event_name == 'schedule' && vars.PIPELINE_RUNS_LOCALLY == 'true'
-        run: |
-          echo "PIPELINE_RUNS_LOCALLY is set: this instance syncs from its own machine."
-          echo "Nothing to do here. A fork without this variable runs the pipeline normally."
-          exit 0
+    # This repository runs the pipeline on its own machine instead, as a launchd job, because that
+    # is where its database lives. Two schedulers running the same sync would duplicate every step
+    # and notify twice.
+    #
+    # ⭐ THE SCHEDULE STAYS IN THE FILE ON PURPOSE. A fork is meant to deploy on Vercel with a
+    # hosted database and rely on exactly this workflow, so removing the cron would quietly break
+    # the path this project documents. The skip is a repository variable that only this instance
+    # sets; a fork has no such variable and runs normally. Manual and API triggers always run,
+    # here as well, because those are someone asking for it deliberately.
+    #
+    # ⛔ THIS GUARD BELONGS ON THE JOB, NOT ON A STEP. It was first written as a step that echoed
+    # and called `exit 0`, which ends that STEP successfully and does nothing to the ones after it
+    # — checkout, install and the pipeline itself all still ran, so the skip skipped nothing and
+    # both schedulers would have synced the same database. A step cannot end its job.
+    if: >-
+      !(github.event_name == 'schedule' && vars.PIPELINE_RUNS_LOCALLY == 'true')
 
+    steps:
       - name: Additive backoff — skip if too soon after a failure
         if: github.event_name == 'schedule'
         env:


### PR DESCRIPTION
The skip I added in #824 does not skip. It is a step that echoes and calls `exit 0`:

```yaml
- name: Skip when this instance runs the pipeline elsewhere
  if: github.event_name == 'schedule' && vars.PIPELINE_RUNS_LOCALLY == 'true'
  run: |
    echo "..."
    exit 0
```

`exit 0` ends **that step**, successfully. Every step after it — checkout, setup-node, the
dependency install, and the pipeline itself — has no matching condition and still runs. So on
schedule this instance would have kept syncing from a GitHub runner while its launchd job synced
the same database from the machine that database lives on. Two schedulers, one database, duplicate
work and duplicate notifications, which is exactly what the comment above the step claimed to
prevent.

No scheduled run has fired since #824 merged at 12:20Z, so this is caught before it did damage
rather than after.

**The fix is to put the condition where it can end a job.** A step cannot. It now sits on the job,
inverted, and the no-op step is removed:

```yaml
if: >-
  !(github.event_name == 'schedule' && vars.PIPELINE_RUNS_LOCALLY == 'true')
```

Unchanged, and deliberately: the cron stays in the file, because a fork is meant to deploy on
Vercel with a hosted database and rely on this workflow. A fork sets no `PIPELINE_RUNS_LOCALLY`
variable and runs normally. Manual and API triggers still run here as well, since those are
someone asking for it rather than a timer.
