### PR TITLE
Give the bridge a token store that can reach the database

### DIFF
--- a/bridge/src/garmin.ts
+++ b/bridge/src/garmin.ts
@@ -4,7 +4,8 @@
  * The FIT is what gets forwarded to facterino.
  */
 import AdmZip from "adm-zip";
-import { GarminAuth, DBTokenStore, type GarminClient } from "garmin-auth";
+import { GarminAuth, type GarminClient } from "garmin-auth";
+import { GatewayTokenStore } from "./token-store";
 
 const CONNECTAPI = "https://connectapi.garmin.com";
 const NATIVE_UA = "GCM-Android-5.23";
@@ -14,7 +15,7 @@ export interface GarminActivity { activityId: number; activityName?: string; sta
 
 /** Authenticated main-account Garmin client (DI token from the DB). */
 export async function mainGarminClient(databaseUrl: string): Promise<GarminClient> {
-  return new GarminAuth({ store: new DBTokenStore(databaseUrl) }).client();
+  return new GarminAuth({ store: new GatewayTokenStore(databaseUrl) }).client();
 }
 
 /** Recent activities in [start, end] (YYYY-MM-DD). */

--- a/bridge/src/token-store.ts
+++ b/bridge/src/token-store.ts
@@ -1,0 +1,81 @@
+import { openDb } from "./db";
+
+/**
+ * A garmin-auth TokenStore that reads the credential row through whatever `openDb` speaks.
+ *
+ * ⛔ WHY THIS EXISTS RATHER THAN garmin-auth's OWN DBTokenStore. That one takes the connection
+ * string and opens a real Postgres socket. This estate's DATABASE_URL names `pg.gkos.dev`, a host
+ * that deliberately has no DNS record, so the socket attempt dies with `getaddrinfo ENOTFOUND` —
+ * and `DBTokenStore.load()` ends in a bare `catch { return null; }`, which turns "I could not
+ * reach the database" into "there are no tokens". The caller then reports
+ * `Login needs MFA / fresh SSO`, which is a true-sounding sentence about the wrong subject and
+ * sent two people looking at the Garmin account while the actual fault was the connection string.
+ *
+ * So this store goes through `openDb`, which picks a driver from the URL, and — the part that
+ * matters more than the transport — it DOES NOT SWALLOW FAILURES. A missing row returns null
+ * because that is a real answer. Anything else throws, so an unreachable store is reported as an
+ * unreachable store.
+ */
+const PLATFORM = "garmin_tokens";
+
+export class GatewayTokenStore {
+  constructor(private readonly databaseUrl: string) {}
+
+  async load(): Promise<string | null> {
+    const db = openDb(this.databaseUrl);
+    try {
+      const { rows } = await db.query(
+        "SELECT credentials FROM platform_credentials WHERE platform = $1 LIMIT 1",
+        [PLATFORM],
+      );
+      if (!rows.length || !rows[0].credentials) return null;
+      const raw = rows[0].credentials;
+      const creds = typeof raw === "string" ? JSON.parse(raw) : raw;
+      // garmin-auth 0.3+ writes the payload nested under `garmin_tokens` on both stacks.
+      const payload = creds?.garmin_tokens;
+      if (!payload || typeof payload !== "object") return null;
+      if (!("di_token" in payload)) return null;
+      return JSON.stringify(payload);
+    } finally {
+      await db.end().catch(() => {});
+    }
+  }
+
+  async save(tokens: string | Record<string, unknown>): Promise<void> {
+    const payload = typeof tokens === "string" ? JSON.parse(tokens) : tokens;
+    const wrapped = JSON.stringify({ garmin_tokens: payload });
+    const db = openDb(this.databaseUrl);
+    try {
+      await db.query(
+        `INSERT INTO platform_credentials (platform, auth_type, credentials, status, connected_at)
+         VALUES ($1, 'oauth', $2::jsonb, 'active', NOW())
+         ON CONFLICT (platform) DO UPDATE SET credentials = EXCLUDED.credentials`,
+        [PLATFORM, wrapped],
+      );
+    } finally {
+      await db.end().catch(() => {});
+    }
+  }
+
+  /**
+   * ⛔ DELIBERATELY DOES NOT DELETE, AND THAT IS THE WHOLE POINT OF IT.
+   *
+   * garmin-auth clears the store when Garmin rejects a token (`auth.ts`: `store.delete()` on a
+   * stale credential). That is reasonable where the caller can recover by logging in again. This
+   * caller cannot: it runs on a GitHub runner, and Garmin refuses SSO from cloud IPs, which is why
+   * the whole CF-Worker path exists. So a rejection here would delete a credential this process
+   * has no way to recreate — one shared with the hourly sync on the machine at home, which would
+   * then fail too, with `Login needs MFA` and no trace of what removed the row.
+   *
+   * That is not hypothetical. On 9 September a dead refresh token caused exactly that deletion,
+   * and the missing row sent two people looking at a migration instead of at the credential.
+   * The bridge is a consumer of this credential, not its owner, so it declines.
+   */
+  async delete(): Promise<void> {
+    console.warn(
+      "[bridge] garmin-auth asked to clear the shared garmin_tokens row; refusing. " +
+        "This process cannot re-authenticate (Garmin blocks SSO from cloud IPs), so deleting it " +
+        "would break the hourly sync as well. Re-auth at soma.gkos.dev/connections instead.",
+    );
+  }
+}


### PR DESCRIPTION
The Strava bridge has failed **every run since the database moved home**, always with:

```
bridge failed: GarminAuthenticationError: Login needs MFA / fresh SSO — provide tokens via the CF Worker path.
```

The Garmin credential was not the problem. It survived a real re-auth this morning that fixed the
hourly sync and changed nothing here, and the bridge kept failing 40 minutes later at 14:52Z.

**It could not read the database, and was told to say something else.**

`mainGarminClient` passed `DATABASE_URL` straight to garmin-auth's `DBTokenStore`, which opens a
real Postgres socket. That URL names `pg.gkos.dev`, a host with deliberately no DNS record — it
exists only so a client can derive the HTTPS endpoint from it. The socket attempt dies with
`getaddrinfo ENOTFOUND`, and `DBTokenStore.load()` ends in:

```js
catch { return null; }
```

so "I could not reach the database" becomes "there are no tokens", and the caller reports a
credential problem. The whole failure takes 0.5s, which is a DNS answer, not a login attempt.

The bridge already solved this for its own queries — `openDb` picks a driver from the connection
string, and `src/db.ts` documents this exact trap. garmin-auth simply never got the benefit.

**This adds a `TokenStore` over `openDb` and uses it.** It returns `null` only for a genuinely
missing row and **throws for everything else**, so an unreachable store reads as unreachable.

Verified against the live gateway:

```
load(): got a payload, fields = di_client_id,di_refresh_token,di_token
bad credential load(): threw as it should — unauthorised
```

**`delete()` deliberately does nothing, and that is the more important half.** garmin-auth clears
the store when Garmin rejects a token, which is right where the caller can log in again. This one
cannot: it runs on a GitHub runner, and Garmin refuses SSO from cloud IPs — the reason the CF
Worker path exists at all. So a rejection here would delete a credential shared with the hourly
sync on the machine at home, which would then fail the same way, with nothing recording what
removed the row.

That is not hypothetical. It is what happened on 9 September: a dead refresh token triggered that
deletion, and the missing row sent two people looking at the migration instead of at the
credential. Verified that the row survives:

```
row present before delete(): true
row present after  delete(): true
```

`tsc --noEmit` clean, `npm run build` clean.
