### PR TITLE
Let the bridge run under a role that cannot create tables

### DIFF
--- a/bridge/src/main.ts
+++ b/bridge/src/main.ts
@@ -40,9 +40,30 @@ async function facterinoAccessToken(db: Db): Promise<string> {
 
 /** Recent Garmin activities not yet on Strava. */
 async function missed(db: Db, activities: GarminActivitySummary[]): Promise<GarminActivitySummary[]> {
-  await db.query(
-    "CREATE TABLE IF NOT EXISTS strava_bridge_uploads (garmin_activity_id BIGINT PRIMARY KEY, strava_activity_id BIGINT, uploaded_at TIMESTAMPTZ DEFAULT NOW())",
-  );
+  // Bootstrap for a fresh database. A forker deploying this against an empty Postgres needs the
+  // ledger created on first run, so the statement stays.
+  //
+  // ⛔ BUT IT CANNOT BE FATAL, BECAUSE `IF NOT EXISTS` DOES NOT MEAN "SKIP THE PERMISSION CHECK".
+  // Postgres tests CREATE on the schema before it looks to see whether the table is already there,
+  // so a least-privilege application role is refused with 42501 even when the table exists and
+  // nothing needs creating. This estate's roles hold exactly the SELECT/INSERT they use and no
+  // DDL, which is the point of them, and that turned a no-op bootstrap line into a hard failure
+  // of every bridge run.
+  //
+  // Swallowing 42501 here hides nothing: the very next statement selects from this table, so a
+  // table that genuinely does not exist still fails immediately, with `relation does not exist`,
+  // which is the honest error for that condition. Any other error still throws.
+  try {
+    await db.query(
+      "CREATE TABLE IF NOT EXISTS strava_bridge_uploads (garmin_activity_id BIGINT PRIMARY KEY, strava_activity_id BIGINT, uploaded_at TIMESTAMPTZ DEFAULT NOW())",
+    );
+  } catch (err) {
+    if ((err as { code?: string })?.code !== "42501") throw err;
+    console.warn(
+      "[bridge] no CREATE privilege on the schema, so the ledger bootstrap was skipped. " +
+        "That is expected under a least-privilege role; the table must already exist.",
+    );
+  }
   const bridged = new Set<number>((await db.query("SELECT garmin_activity_id FROM strava_bridge_uploads")).rows.map((r: any) => Number(r.garmin_activity_id)));
   const extRows = await db.query("SELECT raw_json->>'external_id' AS e FROM strava_raw_data WHERE jsonb_typeof(raw_json)='object' AND raw_json->>'external_id' IS NOT NULL");
   const externalIdsJoined = extRows.rows.map((r: any) => r.e).filter(Boolean).join(" ");


### PR DESCRIPTION
With #826 merged the bridge reaches the database, and the next error is real rather than
misleading:

```
bridge failed: Error: permission denied for schema public
  at Object.query (bridge/dist/db.js:26)
  at async missed (bridge/dist/main.js:40)
  code: '42501'
```

It is the bridge's own bootstrap line, and it fails before any work is done.

**`CREATE TABLE IF NOT EXISTS` does not mean "skip the permission check".** Postgres tests CREATE
on the schema *before* it checks whether the table is already there, so a least-privilege role is
refused even when the table exists and nothing needs creating. Verified against the live gateway:

```
soma_ro   CREATE TABLE IF NOT EXISTS   permission denied for schema public
soma_app  CREATE TABLE IF NOT EXISTS   permission denied for schema public
```

Both, because neither application role holds DDL — which is the point of them. Meanwhile the work
the bridge actually does is all permitted:

```
soma_app  SELECT strava_bridge_uploads    38 rows
soma_app  SELECT strava_raw_data        3174 rows
soma_app  INSERT ledger                 ok
soma_app  DELETE ledger                 ok
```

So the only thing standing between the bridge and a working run was a no-op bootstrap.

**The statement stays**, because a fork deploying against an empty database needs the ledger
created on first run and would otherwise get `relation does not exist` with no explanation. It is
simply no longer fatal, and **only 42501 is tolerated** — every other error still throws.

Swallowing that one code hides nothing, which is the part I checked rather than assumed: the very
next statement selects from this table, so a genuinely missing table still fails immediately with
`relation does not exist`. The tolerated case and the hidden case cannot be confused.
