### PR TITLE
fix(deps): take garmin-auth 0.5.0 in web and bridge

### DIFF
--- a/bridge/package-lock.json
+++ b/bridge/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "adm-zip": "^0.6.0",
-        "garmin-auth": "^0.4.1",
+        "garmin-auth": "^0.5.0",
         "oauth-1.0a": "^2.2.6",
         "pg": "^8.11.0",
         "playwright": "^1.48.0"
@@ -1126,17 +1126,12 @@
       }
     },
     "node_modules/garmin-auth": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.4.1.tgz",
-      "integrity": "sha512-Z3Nlh3UpoilqWpjrY4jfgQ8DImzD5vJ4yOdi5Gui3m0w7mc8ReoNESUp6GoKZD9RDzuwsekZuuqAeImTtI7ytw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.5.0.tgz",
+      "integrity": "sha512-YP3waRjxHIrXMz1/6vpTZDEsGU7bg5GUMidNmNK78Iod8q/VYX1kT+rKDNuHY5RTWwVP/kaTHopC+nRKz57BDA==",
       "license": "MIT",
-      "peerDependencies": {
+      "dependencies": {
         "pg": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "pg": {
-          "optional": true
-        }
       }
     },
     "node_modules/loupe": {

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.6.0",
-    "garmin-auth": "^0.4.1",
+    "garmin-auth": "^0.5.0",
     "oauth-1.0a": "^2.2.6",
     "pg": "^8.11.0",
     "playwright": "^1.48.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "fflate": "^0.8.3",
-        "garmin-auth": "^0.4.1",
+        "garmin-auth": "^0.5.0",
         "hevy2garmin": "^0.2.0",
         "lucide-react": "^0.575.0",
         "macro-engine-core": "^0.1.1",
@@ -10414,17 +10414,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/garmin-auth": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.4.1.tgz",
-      "integrity": "sha512-Z3Nlh3UpoilqWpjrY4jfgQ8DImzD5vJ4yOdi5Gui3m0w7mc8ReoNESUp6GoKZD9RDzuwsekZuuqAeImTtI7ytw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.5.0.tgz",
+      "integrity": "sha512-YP3waRjxHIrXMz1/6vpTZDEsGU7bg5GUMidNmNK78Iod8q/VYX1kT+rKDNuHY5RTWwVP/kaTHopC+nRKz57BDA==",
       "license": "MIT",
-      "peerDependencies": {
+      "dependencies": {
         "pg": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "pg": {
-          "optional": true
-        }
       }
     },
     "node_modules/generator-function": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "fflate": "^0.8.3",
-    "garmin-auth": "^0.4.1",
+    "garmin-auth": "^0.5.0",
     "hevy2garmin": "^0.2.0",
     "lucide-react": "^0.575.0",
     "macro-engine-core": "^0.1.1",


### PR DESCRIPTION
garmin-auth 0.5.0 is on npm. Both workspaces pinned `^0.4.1`, and a caret on a 0.x version does not accept 0.5.0, so neither moved on its own.

## Why take it

This is the upstream fix for the failure that cost two sessions on 9 September. The bridge ran against a `DATABASE_URL` naming a host with no DNS record, `DBTokenStore.load()` caught the resolution error and returned null, and every run reported `Login needs MFA / fresh SSO`. That reads as a dead credential, so the investigation went at the credential, which was the one thing that was fine. It survived a real re-auth before the cause was found.

Reproduced that exact shape against 0.5.0:

```
message: getaddrinfo ENOTFOUND pg.gkos.dev.invalid
GOOD: reported as the infrastructure failure it is
```

`bridge/src/token-store.ts` already worked around this by throwing on anything except a genuinely missing row. Upstream now does the same, so the local store and the library finally agree.

Also in 0.5.0: token persistence stops swallowing and runs outside the block that catches authentication errors, so a storage fault can no longer surface as `needs_mfa`; the upsert restores `status`, `auth_type` and `connected_at` on re-login; and `pg` is a regular dependency rather than an optional peer npm never installs.

## No source changes

`auth.client()` already throws today when the store returns null, since that becomes `NEEDS_MFA` and `client()` raises on it. What changes is the message, not whether an exception happens. All five construction sites already catch and report:

- `web/lib/garmin-ingest.ts`, through its cron route's try/catch
- `web/scripts/sync-pipeline.mts`, which catches and degrades by skipping plan-push and enrich
- `web/app/api/cron/plan-push/route.ts`, `web/app/api/admin/plan/route.ts`, `web/lib/dj-daemon.ts`

`bridge/src/token-store.ts` keeps its deliberate no-op `delete()`. That matters more now, not less: garmin-auth calls `store.delete()` when Garmin rejects a token, the bridge runs on a cloud IP where Garmin refuses SSO, and upstream's `delete()` would now throw rather than fail quietly.

The one real behaviour change is that a failed write of a refreshed DI token fails the run instead of continuing with a stale row. A row going stale unnoticed is what produces the rejection-and-delete cascade in the first place, so failing at the write is the better end of that trade.

## Verified

web: 382 tests pass, `tsc --noEmit` clean. bridge: 12 tests pass, `tsc --noEmit` clean.

Checked against the installed package rather than the lockfile in both workspaces. An `npm install` after editing package.json left the previous version on disk earlier today while the lockfile already read 0.5.0, so the installed `dist/storage.js` was grepped directly for the new upsert.

Closes #828
Closes #829
Closes #830
