### PR TITLE
fix(health): judge the sync pipeline where it actually runs

### DIFF
--- a/scripts/sync-health.sh
+++ b/scripts/sync-health.sh
@@ -12,6 +12,7 @@ GH=${GH:-/opt/homebrew/bin/gh}
 REPO=drkostas/soma
 SYNC_MAX_AGE_H="${SYNC_MAX_AGE_H:-6}"      # sync.yml: observed ~3 h between successes
 BRIDGE_MAX_AGE_H="${BRIDGE_MAX_AGE_H:-18}" # strava-bridge-ts.yml runs 11/15/19 UTC → the overnight gap is 16 h; 12 h false-alarmed every morning
+SYNC_LOCAL_LOG="${SYNC_LOCAL_LOG:-$HOME/Library/Logs/soma/sync-local.log}"
 
 check() { # name workflow max_age_h
   local name="$1" wf="$2" max="$3" json
@@ -36,7 +37,54 @@ print(f"OK {name}: last success {age_h:.1f} h ago (limit {max_h:g} h){extra}"); 
 PY
 }
 
+check_local_sync() { # name max_age_h
+  # The pipeline's own record of what it did, judged by the status it recorded and NOT by the
+  # exit code: it has written thousands of records and exited 0 while garmin-ingest had been
+  # dead for 38 hours, and only the recorded status showed `partial`. Counting `success` alone
+  # means a `partial` that never recovers ages into a failure on its own.
+  local name="$1" max="$2"
+  [ -r "$SYNC_LOCAL_LOG" ] || { echo "UNKNOWN $name: local run log $SYNC_LOCAL_LOG is missing or unreadable"; return 2; }
+  python3 - "$name" "$max" "$SYNC_LOCAL_LOG" <<'PY'
+import re,sys,datetime as dt
+name,max_h,path=sys.argv[1],float(sys.argv[2]),sys.argv[3]
+START=re.compile(r'^=== (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \S+ sync starting ===')
+REC=re.compile(r'^\[sync\] run recorded: (\w+)')
+runs, started = [], None      # runs: [(started_at, status)] in file order
+for line in open(path, errors="replace"):
+    m = START.match(line)
+    if m:
+        started = dt.datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S").astimezone()
+        continue
+    m = REC.match(line)
+    if m and started is not None:
+        runs.append((started, m.group(1))); started = None
+if not runs:
+    print(f"UNKNOWN {name}: no completed run found in {path}"); sys.exit(2)
+recent = runs[-8:]
+ok = [r for r in recent if r[1] == "success"]
+bad = [r for r in recent if r[1] != "success"]
+if not ok:
+    print(f"UNHEALTHY {name}: no successful run in the last {len(recent)} (local)"); sys.exit(1)
+age_h = (dt.datetime.now().astimezone() - ok[-1][0]).total_seconds() / 3600
+if age_h > max_h:
+    print(f"UNHEALTHY {name}: last success {age_h:.1f} h ago (> {max_h:g} h); last run recorded {recent[-1][1]} (local)"); sys.exit(1)
+extra = f"; {len(bad)} non-success in last {len(recent)}" if bad else ""
+print(f"OK {name}: last success {age_h:.1f} h ago (limit {max_h:g} h){extra} (local)"); sys.exit(0)
+PY
+}
+
+# Where the pipeline runs decides where its health can be read. sync.yml keeps its schedule so
+# forks still work, but skips the job on this instance when PIPELINE_RUNS_LOCALLY is set, because
+# two schedulers against one database would duplicate every step. Checking Actions here anyway
+# reported "last success 23.5 h ago" and grew by an hour every hour, with no state the pipeline
+# could reach that would clear it. Mirror the workflow's own condition rather than restate it.
+PIPELINE_RUNS_LOCALLY="$($GH variable get PIPELINE_RUNS_LOCALLY --repo "$REPO" 2>/dev/null || true)"
+
 rc=0
-check "sync-pipeline"  "sync.yml"             "$SYNC_MAX_AGE_H";   r=$?; [ $r -gt $rc ] && rc=$r
+if [ "$PIPELINE_RUNS_LOCALLY" = "true" ]; then
+  check_local_sync "sync-pipeline" "$SYNC_MAX_AGE_H"; r=$?; [ $r -gt $rc ] && rc=$r
+else
+  check "sync-pipeline" "sync.yml" "$SYNC_MAX_AGE_H"; r=$?; [ $r -gt $rc ] && rc=$r
+fi
 check "strava-bridge"  "strava-bridge-ts.yml" "$BRIDGE_MAX_AGE_H"; r=$?; [ $r -gt $rc ] && rc=$r
 exit $rc


### PR DESCRIPTION
The 11am check reported `UNHEALTHY sync-pipeline: last success 23.5 h ago (> 6 h); latest run completed/skipped`. The pipeline was fine. It ran at 09:07 and 10:07 and recorded `success, 5257 records, 0/6 steps failed` both times.

## Why the alarm could never clear

`sync-health.sh` judged the pipeline by `gh run list --workflow sync.yml`. Since #824 and #825 the scheduled job is guarded by `!(github.event_name == 'schedule' && vars.PIPELINE_RUNS_LOCALLY == 'true')`, and that variable is set on this repo, so every scheduled run now completes with the job skipped:

```
  4.1h ago  schedule   completed/skipped
  9.0h ago  schedule   completed/skipped
 11.3h ago  schedule   completed/skipped
 14.9h ago  schedule   completed/skipped
 23.5h ago  schedule   completed/success   <- the guard merged here
```

The last Actions success is pinned to the moment the guard merged, so the reported age grows by an hour every hour and no state the pipeline can reach clears it. That is the same failure the retired chat tunnel caused for drlab, described in this repo's own CLAUDE.md, and it had happened again inside soma's own checker. An alarm that cannot be cleared teaches you to ignore the channel.

## The change

The check mirrors the workflow's condition rather than restating it. `PIPELINE_RUNS_LOCALLY=true` means read the local run record, since launchd `dev.gkos.soma.sync` runs the pipeline hourly at :07 from `~/srv/soma/web`. Anything else keeps the Actions check, which is what a fork gets.

A local run is judged by the status it recorded, never by its exit code: the pipeline has written thousands of records and exited 0 while garmin-ingest had been dead for 38 hours, and only the recorded status showed `partial`. Counting only `success` makes a `partial` that never recovers age into a failure on its own.

## Verified

A checker that only ever says OK is the failure this is meant to fix, so every path was exercised:

| state | result |
| --- | --- |
| live, as it stands | `OK sync-pipeline: last success 0.9 h ago (limit 6 h) (local)`, rc 0 |
| last success 30 h ago | `UNHEALTHY … last success 30.0 h ago`, rc 1 |
| recent run recorded `partial` | `UNHEALTHY … no successful run in the last 1 (local)`, rc 1 |
| log missing | `UNKNOWN … missing or unreadable`, rc 2 |
| log with no completed run | `UNKNOWN … no completed run found`, rc 2 |
| `PIPELINE_RUNS_LOCALLY` unset (fork) | falls through to the Actions check |

Ran the full 11am wrapper end to end afterwards. It went from injecting the alarm at 11:00 to `green (silent)` at 11:03.

The wrapper at `~/bin/soma-health-check.sh` lives outside this repo and was updated in place: its injected prompt told the maintainer to go read failing Actions runs, which is the wrong place to look when the pipeline runs on this Mac. It now names where each thing runs and says to judge a sync run by its recorded status.

Closes #833
