### PR TITLE
web: bump hevy2garmin to 0.3.0 (#836)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,7 @@
         "date-fns": "^4.1.0",
         "fflate": "^0.8.3",
         "garmin-auth": "^0.5.0",
-        "hevy2garmin": "^0.2.0",
+        "hevy2garmin": "^0.3.0",
         "lucide-react": "^0.575.0",
         "macro-engine-core": "^0.1.1",
         "maplibre-gl": "^5.19.0",
@@ -10868,9 +10868,9 @@
       }
     },
     "node_modules/hevy2garmin": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.2.0.tgz",
-      "integrity": "sha512-QZe8eeSd4Ilw8+2SVPItYz7VkHA4LJcyZYJH0aDOqexQRwr/rDxX/E35DvhPy8KNWKJf2ZwOaUskd4uyyyW51g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.3.0.tgz",
+      "integrity": "sha512-YO6LX6yoHfmLXgVYoIGwOOsZdKPKGGXo2ZVvKY9xiIB5mVs1Qj/X9K/OYd8TxQ4u46qlhQ2wdLuTg5S40UJ1Ww==",
       "license": "MIT",
       "dependencies": {
         "@garmin/fitsdk": "^21.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "date-fns": "^4.1.0",
     "fflate": "^0.8.3",
     "garmin-auth": "^0.5.0",
-    "hevy2garmin": "^0.2.0",
+    "hevy2garmin": "^0.3.0",
     "lucide-react": "^0.575.0",
     "macro-engine-core": "^0.1.1",
     "maplibre-gl": "^5.19.0",
@@ -47,6 +47,7 @@
     "web-push": "^3.6.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/pg": "^8.20.0",
@@ -55,7 +56,6 @@
     "@types/react-dom": "^19",
     "@types/spotify-web-playback-sdk": "^0.1.19",
     "@types/web-push": "^3.6.4",
-    "@playwright/test": "^1.59.1",
     "@vitest/ui": "^4.1.5",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",


### PR DESCRIPTION
Bumps `web/` from `hevy2garmin@^0.2.0` to `^0.3.0`, the release that moves the sync orchestration into the package (hevy2garmin#500, merged in hevy2garmin#503). soma and the hevy2garmin web dashboard now resolve the same published engine, which is the prerequisite for moving `web/lib/hevy-match.ts` next to it (#835).

0.3.0 is additive (new exports only); none of soma's six `hevy2garmin` imports changed.

Verification in a clean worktree off `main`: `npm ci`, `npm i hevy2garmin@^0.3.0`, `npx tsc --noEmit` clean, `npx vitest run` 382 passing across 49 files, `npm ls hevy2garmin` prints 0.3.0.

Closes #836
