### PR TITLE
web: ingredient research from macro-engine-core 0.2.0 (#841)

### DIFF
--- a/web/lib/ingredient-research.ts
+++ b/web/lib/ingredient-research.ts
@@ -1,56 +1,19 @@
 /**
  * T3a — ingredient research (soma#678). Two sources, one shape, no LLM:
  *   usda: the local `usda_foods` table (USDA FoodData Central foundation + SR legacy
- *         rows, per 100 g, full-text indexed) — no API key needed.
- *   off:  Open Food Facts search (branded/packaged items, per 100 g, community data).
- * Every candidate carries source, source_id, source_url, confidence and flags.
+ *         rows, per 100 g, full-text indexed) — soma's own table, searched here.
+ *   off:  Open Food Facts, searched by macro-engine-core (re-exported below).
+ * The proposal shape, the picker categories and the macro sanity flags live in
+ * macro-engine-core too, so every consumer judges a candidate the same way.
  * An unknown macro stays null — never 0.
  */
 import type { QueryFn } from "./db";
+import { num, sanityFlags, type Proposal } from "macro-engine-core/ingredient-research";
 
-/** The picker's categories; shrink priority for auto-rebalance per docs/plans/2026-03-16 (carb 1, fat 2, protein 3, vegetable 999).
- *  (Kept here, not in the route file: a Next.js route may only export HTTP handlers.) */
-export const CATEGORIES = ["carbs", "condiment", "dairy", "dessert", "drink", "fat", "fruit", "grain", "protein", "restaurant", "sauce", "snack", "supplement", "treat", "vegetable"] as const;
-export const SHRINK_BY_CATEGORY: Record<string, number> = {
-  carbs: 1, grain: 1, fruit: 1, fat: 2, condiment: 2, sauce: 2, dairy: 2, dessert: 2, drink: 2, snack: 2, treat: 2, restaurant: 2,
-  protein: 3, supplement: 3, vegetable: 999,
-};
-
-export interface Proposal {
-  name: string;
-  brand?: string | null;
-  calories_per_100g: number | null;
-  protein_per_100g: number | null;
-  carbs_per_100g: number | null;
-  fat_per_100g: number | null;
-  fiber_per_100g: number | null;
-  source: "usda" | "off";
-  source_id: string;
-  source_url: string;
-  confidence: number;
-  rationale: string;
-  flags: string[];
-}
+export { CATEGORIES, SHRINK_BY_CATEGORY, sanityFlags, searchOpenFoodFacts } from "macro-engine-core/ingredient-research";
+export type { Proposal } from "macro-engine-core/ingredient-research";
 
 const USDA_CONF: Record<string, number> = { foundation: 0.9, sr_legacy: 0.85, survey_fndds: 0.7, branded: 0.6 };
-
-function num(v: unknown): number | null {
-  const n = typeof v === "string" ? Number(v) : (v as number);
-  return typeof n === "number" && Number.isFinite(n) ? Math.round(n * 100) / 100 : null;
-}
-
-/** Flags a candidate whose macros don't add up: per-serving values filed as per-100 g, or holes. */
-export function sanityFlags(p: { calories_per_100g: number | null; protein_per_100g: number | null; carbs_per_100g: number | null; fat_per_100g: number | null; fiber_per_100g: number | null }): string[] {
-  const flags: string[] = [];
-  for (const k of ["calories_per_100g", "protein_per_100g", "carbs_per_100g", "fat_per_100g", "fiber_per_100g"] as const) {
-    if (p[k] == null) flags.push(`missing:${k.replace("_per_100g", "")}`);
-  }
-  if (p.calories_per_100g != null && p.protein_per_100g != null && p.carbs_per_100g != null && p.fat_per_100g != null) {
-    const est = 4 * p.protein_per_100g + 4 * p.carbs_per_100g + 9 * p.fat_per_100g;
-    if (Math.abs(est - p.calories_per_100g) > 0.2 * Math.max(p.calories_per_100g, 20)) flags.push("kcal_macro_mismatch");
-  }
-  return flags;
-}
 
 export async function searchUsda(sql: QueryFn, query: string, limit = 8): Promise<Proposal[]> {
   let rows = (await sql`
@@ -84,49 +47,4 @@ export async function searchUsda(sql: QueryFn, query: string, limit = 8): Promis
       flags: sanityFlags(p),
     };
   });
-}
-
-interface OffProduct { code?: string; product_name?: string; brands?: string | string[]; nutriments?: Record<string, unknown> }
-const OFF_UA = "soma/1.0 (https://github.com/drkostas/soma; ingredient research)";
-
-/** Open Food Facts: the search-a-licious service first (fast, reliable), the legacy cgi search as fallback (it 503s under load). */
-async function offProducts(query: string, limit: number, timeoutMs: number): Promise<OffProduct[]> {
-  const fields = "code,product_name,brands,nutriments";
-  try {
-    const r = await fetch(`https://search.openfoodfacts.org/search?q=${encodeURIComponent(query)}&page_size=${limit}&fields=${fields}`,
-      { headers: { "User-Agent": OFF_UA }, signal: AbortSignal.timeout(timeoutMs) });
-    if (r.ok) { const d = (await r.json()) as { hits?: OffProduct[] }; if (d.hits?.length) return d.hits; }
-  } catch { /* fall through to the legacy endpoint */ }
-  const r = await fetch(`https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=${limit}&fields=${fields}`,
-    { headers: { "User-Agent": OFF_UA }, signal: AbortSignal.timeout(timeoutMs) });
-  if (!r.ok) throw new Error(`Open Food Facts HTTP ${r.status}`);
-  return ((await r.json()) as { products?: OffProduct[] }).products ?? [];
-}
-
-export async function searchOpenFoodFacts(query: string, limit = 6, timeoutMs = 8000): Promise<Proposal[]> {
-  const out: Proposal[] = [];
-  for (const pr of await offProducts(query, limit, timeoutMs)) {
-    const n = pr.nutriments ?? {};
-    const name = (pr.product_name ?? "").trim();
-    const kcal = num(n["energy-kcal_100g"]);
-    if (!name || !pr.code || kcal == null) continue;   // nameless or kcal-less rows are not candidates
-    const brand = Array.isArray(pr.brands) ? pr.brands.filter(Boolean).join(", ") : pr.brands ? String(pr.brands) : null;
-    const p = {
-      name, brand: brand || null,
-      calories_per_100g: kcal, protein_per_100g: num(n["proteins_100g"]), carbs_per_100g: num(n["carbohydrates_100g"]),
-      fat_per_100g: num(n["fat_100g"]), fiber_per_100g: num(n["fiber_100g"]),
-    };
-    const flags = sanityFlags(p);
-    const complete = !flags.some((f) => f.startsWith("missing:"));
-    out.push({
-      ...p,
-      source: "off",
-      source_id: String(pr.code),
-      source_url: `https://world.openfoodfacts.org/product/${pr.code}`,
-      confidence: complete ? 0.6 : 0.45,
-      rationale: `Open Food Facts${p.brand ? ` (${p.brand})` : ""}, community-entered label data per 100 g`,
-      flags,
-    });
-  }
-  return out;
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,7 +19,7 @@
         "garmin-auth": "^0.5.0",
         "hevy2garmin": "^0.4.1",
         "lucide-react": "^0.575.0",
-        "macro-engine-core": "^0.1.1",
+        "macro-engine-core": "^0.2.0",
         "maplibre-gl": "^5.19.0",
         "motion": "^12.34.3",
         "nanoid": "^5.1.6",
@@ -12613,9 +12613,9 @@
       }
     },
     "node_modules/macro-engine-core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/macro-engine-core/-/macro-engine-core-0.1.1.tgz",
-      "integrity": "sha512-rCKqje5PQ0C/EtwSFccn0lgiRFdosEfTx1xk031fY5ROM7WuJEyuCObDi+JsEJ9B2v/11iCAuAK85hHlSTo3FQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/macro-engine-core/-/macro-engine-core-0.2.0.tgz",
+      "integrity": "sha512-I0+wQBW2PD8xyaPzG5tC4OZnwyMT+9MSvdwrgQ1hXOtZXO71mF59GaG4qYrUgeeDe/T5kukdDTZWNKFn6zkihQ==",
       "license": "MIT"
     },
     "node_modules/magic-string": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
     "garmin-auth": "^0.5.0",
     "hevy2garmin": "^0.4.1",
     "lucide-react": "^0.575.0",
-    "macro-engine-core": "^0.1.1",
+    "macro-engine-core": "^0.2.0",
     "maplibre-gl": "^5.19.0",
     "motion": "^12.34.3",
     "nanoid": "^5.1.6",


### PR DESCRIPTION
Ingredient research's source-independent half now comes from `macro-engine-core` 0.2.0 (drkostas/macro-engine#230, closes macro-engine#227).

- `web/lib/ingredient-research.ts` keeps `searchUsda` (soma's own `usda_foods` table) and re-exports `CATEGORIES`, `SHRINK_BY_CATEGORY`, `sanityFlags`, `searchOpenFoodFacts` and the `Proposal` type from `macro-engine-core/ingredient-research`, so the research and confirm routes are unchanged. 131 lines to 50.
- `macro-engine-core` pinned `^0.2.0`.

Verified: `tsc --noEmit` clean, 371 tests, `next build` clean.

Part of #841.
