### PR TITLE
fix(verify): snapshot database for the verification server

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ everything alive across Mac sleep/wake/reboot:
 
 | Plist | Purpose |
 |---|---|
-| `dev.gkos.soma.web.plist` | Runs `npm run dev` from `web/` on :3456, KeepAlive on crash |
+| `dev.gkos.soma.web.plist` | The verification server: `npm run dev` from `web/` on 127.0.0.1:3457 with `DATABASE_URL` set in the plist environment to `verify_soma`, so Maestro and Playwright runs never write into the live data (refresh the copy with `scripts/verify-db-refresh.sh`). KeepAlive on crash |
 | `dev.gkos.soma.tunnel.plist` | Runs the cloudflared named tunnel (`tunnel run --token <connector>`), KeepAlive |
 
 Logs land in `~/Library/Logs/soma/`. Manage with

--- a/scripts/verify-db-refresh.sh
+++ b/scripts/verify-db-refresh.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# verify-db-refresh.sh: snapshot the live local database into verify_soma.
+#
+# The verification server (port 3457, launchd dev.gkos.soma.web) reads verify_soma so that
+# Maestro and Playwright runs never write into the real data. This refreshes that copy.
+#
+#   scripts/verify-db-refresh.sh            # soma -> verify_soma
+#   SOMA_DB=soma_other scripts/verify-db-refresh.sh
+#
+# What it does, in order: dump the source, terminate whatever is connected to verify_soma
+# (the 3457 server's pool reconnects on its next query), drop and recreate verify_soma,
+# restore, ANALYZE (statistics do not come back with the data), then compare table and row
+# counts against the source so the run proves what it did. The only database it ever drops
+# is verify_soma; the source is read once and never written.
+set -euo pipefail
+SRC=${SOMA_DB:-soma}
+DST=verify_soma
+export PGHOST=${PGHOST:-127.0.0.1} PGPORT=${PGPORT:-5432}
+[ "$SRC" != "$DST" ] || { echo "refusing: source and target are both $DST" >&2; exit 2; }
+psql -Atc "select 1" "$SRC" >/dev/null || { echo "refusing: cannot read source $SRC" >&2; exit 2; }
+
+count_tables() { psql -Atc "select count(*) from information_schema.tables where table_schema='public'" "$1" 2>/dev/null || echo 0; }
+count_rows()   { psql -Atc "select count(*) from garmin_raw_data" "$1" 2>/dev/null || echo 0; }
+newest()       { psql -Atc "select coalesce(max(date)::text,'none') from garmin_raw_data" "$1" 2>/dev/null || echo none; }
+
+echo "before  $DST: $(count_tables "$DST") tables, $(count_rows "$DST") garmin rows, newest $(newest "$DST")"
+echo "source  $SRC: $(count_tables "$SRC") tables, $(count_rows "$SRC") garmin rows, newest $(newest "$SRC")"
+
+DUMP=$(mktemp -t verify_soma).dump
+trap 'rm -f "$DUMP"' EXIT
+pg_dump -Fc -f "$DUMP" "$SRC"
+echo "dumped  $SRC -> $DUMP ($(du -h "$DUMP" | cut -f1))"
+
+psql -qc "select pg_terminate_backend(pid) from pg_stat_activity where datname='$DST' and pid<>pg_backend_pid()" postgres >/dev/null
+dropdb --if-exists "$DST"
+createdb "$DST"
+# pg_restore exits non-zero on harmless ownership notices; the comparison below is the gate.
+pg_restore -d "$DST" --no-owner --no-acl "$DUMP" || true
+psql -qc "ANALYZE" "$DST"
+
+ST=$(count_tables "$SRC"); DT=$(count_tables "$DST"); SR=$(count_rows "$SRC"); DR=$(count_rows "$DST")
+echo "after   $DST: $DT tables, $DR garmin rows, newest $(newest "$DST")"
+if [ "$ST" != "$DT" ] || [ "$SR" != "$DR" ]; then
+  echo "MISMATCH: source $ST tables/$SR rows, copy $DT tables/$DR rows" >&2; exit 1
+fi
+echo "ok      $DST matches $SRC"

--- a/universal/.maestro/README.md
+++ b/universal/.maestro/README.md
@@ -61,6 +61,14 @@ App id: `dev.gkos.soma` (both iOS bundle id and Android package).
    `EXPO_PUBLIC_API_URL` at a running soma instance if you want the screens to
    populate with real data.
 
+   For a walkthrough with real data on this machine, point it at the verification
+   server, not the dev server: `EXPO_PUBLIC_API_URL=http://10.0.2.2:3457` from the
+   Android emulator (`10.0.2.2` is the host). Port 3457 is the launchd
+   `dev.gkos.soma.web` server and reads `verify_soma`, a snapshot of the live
+   database, so a day of logging meals in a flow never lands in the real data.
+   Refresh the snapshot with `scripts/verify-db-refresh.sh` before a run when you
+   want today's data in it. The dev server on 3456 reads the live database.
+
 ## Running
 
 From the `universal/` directory:

--- a/web/tests/e2e/README.md
+++ b/web/tests/e2e/README.md
@@ -1,0 +1,27 @@
+# Playwright end-to-end checks
+
+`npx playwright test` from `web/` runs the specs in this directory against
+`BASE_URL`, which defaults to the public demo (`https://soma-demo.gkos.dev`).
+
+## Where to point it
+
+| Target | `BASE_URL` | Database | Use |
+|---|---|---|---|
+| Verification server | `http://127.0.0.1:3457` | `verify_soma`, a snapshot of the live database | any run that clicks around, logs meals, or otherwise writes |
+| Dev server | `http://127.0.0.1:3456` | `soma`, the live database | hands-on development only |
+| Live host or demo | the public address | production | the post-merge check, and nothing else |
+
+The verification server is the launchd job `dev.gkos.soma.web`. Its plist sets
+`DATABASE_URL` to `verify_soma` in the job environment, which Next's env loading
+does not override with `web/.env.local`, so the same working tree serves the live
+database on 3456 and the snapshot on 3457.
+
+Refresh the snapshot with `scripts/verify-db-refresh.sh` (about 40 seconds for
+the current database). It drops and recreates only `verify_soma`, restores from a
+fresh dump of `soma`, runs `ANALYZE`, and fails loudly if the table or row counts
+differ from the source.
+
+```bash
+scripts/verify-db-refresh.sh
+cd web && BASE_URL=http://127.0.0.1:3457 npx playwright test
+```


### PR DESCRIPTION
The 3457 working-tree server (launchd `dev.gkos.soma.web`) read the live database. The issue was written when that database was Neon and the cost was transfer; the database is local now, so the cost is different and worse: every Maestro or Playwright run that logs a meal or clicks through a flow writes into the real data. This gives verification its own copy.

## What changed

- `scripts/verify-db-refresh.sh`: dumps `soma`, drops and recreates `verify_soma` (the only database it will ever drop; the source is read once), restores, runs `ANALYZE`, and compares table and row counts with the source before saying ok. About 40 seconds on the current 174 MB.
- The launchd plist for `dev.gkos.soma.web` now sets `DATABASE_URL` to `verify_soma` in the job environment. The plist lives in `~/Library/LaunchAgents`, outside the repo; the README row for it now says what it is and where it points.
- `universal/.maestro/README.md` and a new `web/tests/e2e/README.md` say which server each kind of run should use: 3457 for anything that writes, 3456 for hands-on development, the live host for the post-merge check only.

## Verified

- Refresh run: before, `verify_soma` had 39786 Garmin rows with newest day 2026-09-09; after, 39834 rows and newest 2026-09-11, matching `soma`, 52 tables both sides. A `pg_dump` of the previous copy was taken first.
- Restarted the launchd job and asked the 3457 server for `/api/health/today` and `/api/activities/summary` (both 200); `pg_stat_activity`, joined on the server's own client ports, shows its connections on `verify_soma` and none on `soma`. Next's env loading does not override a variable that is already in the environment, which is what makes one working tree serve two databases.
- `soma` itself had 48 of 52 tables never analysed since the restore from Neon; `ANALYZE` was run on it while here.

Closes #817
Closes #848
Closes #849
Closes #850
