### PR TITLE
fix(app): nutrition logging defects from the walkthrough

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -43,9 +43,12 @@ const SLOT_ICONS: Record<string, string> = {
   breakfast: "☀️", lunch: "🌤️", dinner: "🌙", pre_sleep: "🌙", during_workout: "🏃",
 };
 
-function mealName(m: SomaMeal): string {
+function mealName(m: SomaMeal, presets: Preset[] = []): string {
   const names = (m.items ?? []).map((i) => i.name).filter(Boolean) as string[];
   if (names.length) return names.slice(0, 3).join(", ") + (names.length > 3 ? "…" : "");
+  // Rows logged before soma#857 carry no items; the preset they came from still has the name.
+  const preset = m.preset_meal_id ? presets.find((p) => p.id === m.preset_meal_id) : undefined;
+  if (preset?.name) return preset.name;
   return m.source ? slotLabel(m.source) : "Meal";
 }
 
@@ -173,6 +176,9 @@ export default function NutritionScreen() {
     setEditMeal(null); setSelectedPreset(null); setPresetSeed(null); setComposePreview(null); setPresetMult(1);
   }
   function closeLog() { setLogOpen(false); resetLogState(); }
+  // Open the log modal for a slot from a clean Presets tab. Without this the modal reopened in
+  // whatever mode the last log used, with the previous compose still in it (soma#858).
+  function openLog(s: string) { resetLogState(); setLogMode("preset"); setSlot(s); setLogOpen(true); }
   // Switch log mode from the tab buttons — clears any in-flight preview/preset.
   function setMode(m: "preset" | "quick" | "compose") { resetLogState(); setLogMode(m); }
 
@@ -640,7 +646,7 @@ export default function NutritionScreen() {
                         <Pressable key={m.id} onPress={() => setDetailMeal(m)} className="flex-row items-center gap-2 border-b border-border-subtle py-1.5">
                           <View className="flex-1">
                             <View className="flex-row items-center gap-1.5">
-                              <Text variant="body" className="text-text" numberOfLines={1} style={{ flexShrink: 1 }}>{mealName(m)}</Text>
+                              <Text variant="body" className="text-text" numberOfLines={1} style={{ flexShrink: 1 }}>{mealName(m, presets)}</Text>
                               <ProteinQualityPill grams={m.protein} weightKg={bd?.weightKg} />
                             </View>
                             <Text variant="micro" className="tabular-nums">
@@ -652,8 +658,10 @@ export default function NutritionScreen() {
                       ))}
                       {!dayClosed ? (
                         <View className="flex-row gap-2 self-start">
-                          <Button label={`+ Log ${slotLabel(s)}`} variant="secondary" size="sm" onPress={() => { setSlot(s); setLogOpen(true); }} />
-                          <Button label={skipBusy === s ? "…" : "Skip"} variant="ghost" size="sm" disabled={skipBusy != null} onPress={() => onSkip(s)} />
+                          <Button label={`+ Log ${slotLabel(s)}`} variant="secondary" size="sm" onPress={() => openLog(s)} />
+                          {slotMeals.length === 0 ? (
+                            <Button label={skipBusy === s ? "…" : "Skip"} variant="ghost" size="sm" disabled={skipBusy != null} onPress={() => onSkip(s)} />
+                          ) : null}
                         </View>
                       ) : null}
                     </>
@@ -867,7 +875,7 @@ export default function NutritionScreen() {
       {/* Logged-meal detail — tap a meal to see macros + ingredients, edit or delete */}
       <MealDetailModal
         meal={detailMeal}
-        name={detailMeal ? mealName(detailMeal) : ""}
+        name={detailMeal ? mealName(detailMeal, presets) : ""}
         slotLabel={slotLabel}
         deleting={delId != null}
         onClose={() => setDetailMeal(null)}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -1374,7 +1374,9 @@ export async function logPresetMeal(
       meal_slot: slot,
       preset_meal_id: preset.id,
       portion_multiplier: portion,
-      items: [],
+      // The web sends the preset's items too; without them the row cannot be named and the prep
+      // list cannot count its raw ingredients (soma#857).
+      items: presetItems(preset),
       preset_macros: {
         calories: preset.total_calories,
         protein: preset.total_protein,


### PR DESCRIPTION
Three of the app defects from the nutrition walkthrough on 2026-09-11 (parent #855). Found by logging a full day on the Android emulator against the `verify_soma` snapshot with the web dashboard rendered side by side.

## What changed

- **Skip only on empty slots.** The slot card no longer renders "Skip" when the slot has a logged meal. The API's skip deleted every meal in the slot, so on the app one tap removed a logged lunch with no confirmation; the web never offered it. The server-side refusal is #866 in the API PR.
- **Preset meals carry their items.** `logPresetMeal` sent `items: []` with only the macros, so the stored row could not be named (app: "Preset", web: "Custom meal") and the prep list could not count its raw ingredients. It now sends `presetItems(preset)` like the web. Rows logged before this fall back to the preset's name through `preset_meal_id`.
- **The log modal opens clean.** `openLog(slot)` resets the transient state and the mode to Presets. Before, "+ Log Pre Sleep" opened in Compose with the previous dinner's chicken still in the meal.

## Verified

- `npx tsc --noEmit` and `vitest run` in `universal/` (44 tests) pass.
- Release APK built from this branch and the three scenarios re-run on the emulator against `verify_soma`; screenshots in the PR comments.

Closes #855
Closes #856
Closes #857
Closes #858
