### PR TITLE
fix(nutrition): API and web defects from the walkthrough

### DIFF
--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -462,7 +462,9 @@ export async function GET(req: NextRequest) {
 
     // ── Write-back: sync computed values to DB so stored matches dynamic ──
     // Only for current day, non-manual days, when values differ
-    if (date === todayStr && !manualOverride && breakdown) {
+    // Today and future days: the row now exists from the first read, so write the computed targets
+    // back for them too (a future day's row otherwise sat with null targets). Past days are history.
+    if (date >= todayStr && !manualOverride && breakdown) {
       const computedTarget = dayTargets.calories;
       const storedTarget = Number(plan.target_calories) || 0;
       if (Math.abs(computedTarget - storedTarget) > 10 || !plan.target_calories) {

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -76,9 +76,17 @@ function redistributeRemaining(
 
 export async function GET(req: NextRequest) {
   const sql = getDb();
-  const date =
-    req.nextUrl.searchParams.get("date") ??
-    new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const todayStr = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const date = req.nextUrl.searchParams.get("date") ?? todayStr;
+
+  // Nothing else creates the day's row before something is logged, so the first view of a new
+  // day had no plan on either client and the web told the user to run a generator that does not
+  // exist (soma#867). Today and future days get their row on first read; the targets are then
+  // computed below and written back. Past days stay as they are: a day that was never opened
+  // cannot be planned after the fact.
+  if (date >= todayStr) {
+    await sql`INSERT INTO nutrition_day (date) VALUES (${date}) ON CONFLICT (date) DO NOTHING`;
+  }
 
   const [planRows, mealRows, drinkRows] = await Promise.all([
     sql`SELECT * FROM nutrition_day WHERE date = ${date}`,
@@ -454,7 +462,6 @@ export async function GET(req: NextRequest) {
 
     // ── Write-back: sync computed values to DB so stored matches dynamic ──
     // Only for current day, non-manual days, when values differ
-    const todayStr = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
     if (date === todayStr && !manualOverride && breakdown) {
       const computedTarget = dayTargets.calories;
       const storedTarget = Number(plan.target_calories) || 0;

--- a/web/app/api/nutrition/skip-slot/route.ts
+++ b/web/app/api/nutrition/skip-slot/route.ts
@@ -36,15 +36,23 @@ export async function POST(req: NextRequest) {
       WHERE date = ${date}
     `;
   } else {
-    // Skip: add slot to array AND delete any meals logged for that slot
+    // Skip means "I did not eat this slot". A slot with logged meals is the opposite claim, and
+    // the old behaviour here deleted those meals to make the two agree (one tap on the app removed
+    // a 650 kcal lunch with no confirmation, soma#866). Refuse instead: deleting a meal stays an
+    // explicit action on the meal itself.
+    const logged = await sql`
+      SELECT count(*)::int AS n FROM meal_log WHERE date = ${date} AND meal_slot = ${slot}
+    `;
+    if ((logged[0]?.n ?? 0) > 0) {
+      return NextResponse.json(
+        { error: "This slot has logged meals. Delete them before skipping it.", slot, meals: logged[0].n },
+        { status: 409 },
+      );
+    }
     await sql`
       UPDATE nutrition_day
       SET skipped_slots = array_append(skipped_slots, ${slot})
       WHERE date = ${date}
-    `;
-    await sql`
-      DELETE FROM meal_log
-      WHERE date = ${date} AND meal_slot = ${slot}
     `;
   }
 

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -529,7 +529,7 @@ export function MealCard({
         <CardContent className="pt-0 space-y-2">
           {/* Logged meals */}
           {meals.map((meal) => {
-            const itemsList: { ingredient_id?: string; grams?: number; cooked_grams?: number }[] =
+            const itemsList: { ingredient_id?: string; grams?: number; cooked_grams?: number; name?: string }[] =
               Array.isArray(meal.items) ? meal.items : (meal.items?.items ?? []);
             const ingLookup = new Map(
               ((ingredients ?? []) as Ingredient[]).map((i) => [i.id, i]),
@@ -582,8 +582,11 @@ export function MealCard({
                       });
                       return sortedItems.map((item, idx) => {
                         const ing = ingLookup.get(item.ingredient_id ?? "");
-                        const name = ing?.name ?? item.ingredient_id ?? "?";
+                        // A quick-add item has no catalog entry: its name lives on the item and it
+                        // carries no weight, so show the name and no "0g" (soma#868).
+                        const name = ing?.name ?? item.name ?? item.ingredient_id ?? "?";
                         const rawG = item.grams ?? 0;
+                        const weightless = !ing && !(rawG > 0);
                         const ratio = ing?.raw_to_cooked_ratio;
                         const isRaw = ing?.is_raw && ratio && ratio > 0 && ratio !== 1;
                         const cookedG = item.cooked_grams ?? (isRaw ? Math.round(rawG * (ratio as number)) : 0);
@@ -596,9 +599,11 @@ export function MealCard({
                               )}
                             </span>
                             <span className="tabular-nums">
-                              {isRaw
-                                ? `${cookedG}g cooked (${rawG}g raw)`
-                                : `${rawG}g`}
+                              {weightless
+                                ? ""
+                                : isRaw
+                                  ? `${cookedG}g cooked (${rawG}g raw)`
+                                  : `${rawG}g`}
                             </span>
                           </div>
                         );

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -651,7 +651,8 @@ export function NutritionDashboard({
               {/* Burn-based bar with goal marker */}
               {dataReady && breakdown && (() => {
                 const totalBurn = breakdown.totalBurn || 0;
-                const goalIntake = breakdown.targetIntake || 0;
+                // A closed day's breakdown carries no target, which read as "0 goal" (soma#869).
+                const goalIntake = breakdown.targetIntake || Number(plan?.target_calories) || 0;
                 const deficit = breakdown.deficit || 0;
                 const eatPct = totalBurn > 0 ? Math.min(100, (consumedCal / totalBurn) * 100) : 0;
                 const goalPct = totalBurn > 0 ? Math.min(100, (goalIntake / totalBurn) * 100) : 0;
@@ -1065,8 +1066,8 @@ export function NutritionDashboard({
         ) : (
           <Card>
             <CardContent className="pt-4 text-center text-sm text-muted-foreground">
-              No nutrition plan generated for today. Run the daily plan generator
-              to get started.
+              No plan for this day. Targets are computed the first time today or a future day is
+              opened, so a past day that was never opened stays without one.
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
The API and web defects from the nutrition walkthrough on 2026-09-11 (parent #865). Found by logging a full day on the Android emulator against the `verify_soma` snapshot with the web dashboard rendered side by side.

## What changed

- **skip-slot no longer deletes food.** Skipping a slot that has logged meals returns 409 with a message; the row deletion is gone. Skipping an empty slot and un-skipping work as before. On the app one tap on Skip removed a 650 kcal lunch with no confirmation (#856 hides the button there).
- **The first view of a day has a plan.** `GET /api/nutrition/plan` inserts the `nutrition_day` row for today and future dates before reading, so the targets are computed and written back on the first request instead of after the first log. Past days without a row still return `plan: null`; nothing is created for them.
- **Web no-plan message** says what is true: targets exist from the first time today or a future day is opened, and a past day that was never opened stays unplanned. The old text told the user to run a daily plan generator that does not exist.
- **Web meal card**: a quick-add item shows its name (it has no catalog entry) and no "0g"; the closed-day hero takes the goal from the day's stored target when the breakdown carries none, instead of "0 goal".

## Verified

- `npx tsc --noEmit` and `vitest run` in `web/` (277 tests) pass.
- Against `verify_soma` through a dev server of this branch: skip on a slot with meals returns 409 and the meals stay; skip and un-skip on an empty slot return 200; `GET plan?date=<tomorrow>` with no row returns a plan with targets and the row now exists; `GET plan?date=<past day>` with no row returns null and creates nothing.
- Web renders of the closed-day hero, a quick-add item and the no-plan message: screenshots in the PR comments.

Closes #865
Closes #866
Closes #867
Closes #868
Closes #869
Closes #870
