### PR TITLE
fix(app): nutrition dashboard defects from the walkthrough

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -404,17 +404,25 @@ export default function NutritionScreen() {
         <Card variant="glow" className="gap-4">
           <SegmentedControl options={["Day", "Trend"] as const} value={tab} onChange={setTab} />
           <View className="items-center gap-1">
-            {plan ? (
-              <>
-                <Text variant="display">{loading ? "…" : (remaining?.calories ?? 0).toLocaleString()}</Text>
-                <Text variant="caption" className="text-text-muted">
-                  kcal left · {(consumed?.calories ?? 0).toLocaleString()} of {targetCal.toLocaleString()} eaten
-                </Text>
-              </>
-            ) : (
+            {plan ? (() => {
+              const left = remaining?.calories ?? 0;
+              const over = left < 0;
+              return (
+                <>
+                  <Text variant="display" style={over ? { color: "#e06060" } : undefined}>
+                    {loading ? "…" : over ? `+${Math.abs(Math.round(left)).toLocaleString()}` : Math.round(left).toLocaleString()}
+                  </Text>
+                  <Text variant="caption" className="text-text-muted">
+                    {over ? "over goal" : "kcal left"} · {(consumed?.calories ?? 0).toLocaleString()} of {targetCal.toLocaleString()} eaten
+                  </Text>
+                </>
+              );
+            })() : (
               <>
                 <Text variant="display">{loading ? "…" : (consumed?.calories ?? 0).toLocaleString()}</Text>
-                <Text variant="caption" className="text-text-muted">kcal eaten today</Text>
+                <Text variant="caption" className="text-text-muted">
+                  {loading ? "" : "No plan for this day. Targets exist from the first time today or a future day is opened; a past day that was never opened stays without one."}
+                </Text>
               </>
             )}
           </View>
@@ -476,14 +484,16 @@ export default function NutritionScreen() {
             );
           })() : null}
 
-          <View className="gap-2.5">
-            {renderMacroBars()}
-            <Text variant="micro" className="text-text-muted">
-              {(bd?.weightKg ?? 0) > 0
-                ? "Protein & fat ticks are g/kg tiers · green = optimal · red = ceiling"
-                : "green = optimal target · red = ceiling"}
-            </Text>
-          </View>
+          {plan ? (
+            <View className="gap-2.5">
+              {renderMacroBars()}
+              <Text variant="micro" className="text-text-muted">
+                {(bd?.weightKg ?? 0) > 0
+                  ? "Protein & fat ticks are g/kg tiers · green = optimal · red = ceiling"
+                  : "green = optimal target · red = ceiling"}
+              </Text>
+            </View>
+          ) : null}
         </Card>
 
         {tab === "Day" && isToday ? <NutritionContextStrip /> : null}
@@ -530,8 +540,9 @@ export default function NutritionScreen() {
                     <View key={i}>
                       {burnRow(
                         `🏋 ${g.title}`,
-                        g.actual ?? g.calories ?? g.predicted,
-                        { note: g.actual == null && g.predicted != null ? `~${Math.round(g.predicted)} kcal predicted` : undefined },
+                        // `actual` is a flag, not a number: a predicted workout used to render as 0 kcal (soma#861)
+                        g.calories ?? g.predicted ?? 0,
+                        { note: !g.actual && g.predicted != null ? `~${Math.round(g.predicted)} kcal predicted` : undefined },
                       )}
                     </View>
                   ))
@@ -613,7 +624,8 @@ export default function NutritionScreen() {
               const budget = data?.slotBudgets?.[s]?.calories ?? 0;
               const eatenInSlot = slotMeals.reduce((sum, m) => sum + (m.calories ?? 0), 0);
               const isSkipped = skippedSlots.includes(s);
-              if (budget <= 0 && slotMeals.length === 0 && !isSkipped) return null;
+              // Every slot stays on screen: hiding a slot with no budget left meant its meal could not be
+              // logged on the phone at all (soma#877). The web shows a zero budget instead.
               return (
                 <Card key={s} className="gap-2">
                   <View className="flex-row items-center justify-between">
@@ -633,7 +645,7 @@ export default function NutritionScreen() {
                       <Badge label="Skipped" tone="neutral" />
                     ) : (
                       <Text variant="caption" className="tabular-nums text-text-muted">
-                        {Math.round(eatenInSlot)}{budget > 0 ? ` / ${Math.round(budget)}` : ""} kcal
+                        {budget > 0 ? `${Math.round(eatenInSlot)} / ${Math.round(budget)} kcal` : `${Math.round(eatenInSlot)} kcal · no budget left`}
                       </Text>
                     )}
                   </View>
@@ -656,6 +668,9 @@ export default function NutritionScreen() {
                           <Text variant="body" className="text-text-muted">›</Text>
                         </Pressable>
                       ))}
+                      {!dayClosed && slotMeals.length === 0 ? (
+                        <Text variant="micro" className="text-center" style={{ color: "#60a5fa" }}>Drink 500ml water 30 min before eating</Text>
+                      ) : null}
                       {!dayClosed ? (
                         <View className="flex-row gap-2 self-start">
                           <Button label={`+ Log ${slotLabel(s)}`} variant="secondary" size="sm" onPress={() => openLog(s)} />

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -121,7 +121,7 @@ export interface SomaBreakdown {
   totalBurn?: number; bmr?: number;
   stepCalories?: number; stepCaloriesPredicted?: number; expectedSteps?: number; actualSteps?: number;
   runCalories?: number; runActual?: number; runPredicted?: number; runEnabled?: boolean; runActualDistKm?: number; runDistanceKm?: number;
-  gymCalories?: number; gymBreakdown?: { title: string; calories: number; predicted?: number; actual?: number }[];
+  gymCalories?: number; gymBreakdown?: { title: string; calories: number; predicted?: number; actual?: boolean }[];
   drinkCalories?: number; deficit?: number; manualOverride?: boolean;
   weightKg?: number;
   // Dynamically recomputed targets for the day (run/gym/drink/macro-floor adjusted).


### PR DESCRIPTION
The dashboard defects from the nutrition walkthrough on 2026-09-11 (parent #860), plus the slot card that disappeared (#877). Found by logging a full day on the Android emulator against the `verify_soma` snapshot with the web dashboard rendered side by side. Builds on #875.

## What changed

- **Gym burn row shows the workout's calories.** The API's `gymBreakdown[].actual` is a boolean flag; the app rendered `actual ?? calories`, so a predicted workout showed 0 kcal while the total included it. Now `calories` with the "predicted" note when `actual` is false; the type says boolean.
- **Over goal reads like the web.** Positive number, "over goal", danger colour, instead of "-357 kcal left".
- **A day without a plan says so.** One line ("No plan for this day…") instead of a hero with 0/0g macro goals. The API now creates today's row on first read (#876), so this is the past-day case.
- **Water hint** on empty, unskipped slots, as on the web.
- **Every slot card stays on screen.** A slot with no budget left and no meal returned null, so its meal could not be logged on the phone; it now shows "0 kcal · no budget left".

## Verified

- `npx tsc --noEmit` and `vitest run` in `universal/` (44 tests) pass.
- Release APK of this branch on the emulator against `verify_soma`: over-goal hero, gym row with "Upper" selected, Sep 8 (no row), and the slot cards on an over-budget day; screenshots in the PR comments.

Closes #860
Closes #861
Closes #862
Closes #863
Closes #864
Closes #877
