### PR TITLE
feat(web): dev session for the local verification server

### DIFF
--- a/web/lib/dev-session.test.ts
+++ b/web/lib/dev-session.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { devSessionAllowed } from "./dev-session";
+
+const req = (host: string) => ({ headers: new Headers({ host }) });
+
+describe("devSessionAllowed", () => {
+  it("is off unless SOMA_DEV_SESSION=1", () => {
+    expect(devSessionAllowed(req("127.0.0.1:3457"), { SOMA_DEV_SESSION: "", NODE_ENV: "development" })).toBe(false);
+  });
+  it("is on for a loopback host in a non-production build", () => {
+    expect(devSessionAllowed(req("127.0.0.1:3457"), { SOMA_DEV_SESSION: "1", NODE_ENV: "development" })).toBe(true);
+    expect(devSessionAllowed(req("localhost:3457"), { SOMA_DEV_SESSION: "1", NODE_ENV: "development" })).toBe(true);
+  });
+  it("never applies in production or to a non-loopback host", () => {
+    expect(devSessionAllowed(req("127.0.0.1:3457"), { SOMA_DEV_SESSION: "1", NODE_ENV: "production" })).toBe(false);
+    expect(devSessionAllowed(req("soma.gkos.dev"), { SOMA_DEV_SESSION: "1", NODE_ENV: "development" })).toBe(false);
+  });
+});

--- a/web/lib/dev-session.ts
+++ b/web/lib/dev-session.ts
@@ -1,0 +1,12 @@
+/** A signed-in session for the local verification server only (soma#854).
+ *  Three conditions, all required: SOMA_DEV_SESSION=1 in the job environment, the request
+ *  host is loopback, and the build is not production. Vercel and the live host never see it. */
+export function devSessionAllowed(
+  req: { headers: Headers },
+  env: { SOMA_DEV_SESSION?: string; NODE_ENV?: string } = process.env,
+): boolean {
+  if (env.SOMA_DEV_SESSION !== "1") return false;
+  if (env.NODE_ENV === "production") return false;
+  const host = (req.headers.get("host") ?? "").split(":")[0];
+  return host === "127.0.0.1" || host === "localhost" || host === "::1";
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,6 +1,7 @@
 import { auth } from "@/auth";
 import { NextResponse } from "next/server";
 import { tailnetIdentityOk } from "@/lib/chat-transport";
+import { devSessionAllowed } from "@/lib/dev-session";
 
 const isDev = process.env.NODE_ENV !== "production";
 
@@ -88,8 +89,9 @@ export default auth((req) => {
     return NextResponse.next();
   }
 
-  // Require session for everything else
-  if (!req.auth) {
+  // Require session for everything else. The local verification server may stand in for one
+  // (soma#854): SOMA_DEV_SESSION=1, loopback host, non-production build, all three.
+  if (!req.auth && !devSessionAllowed(req)) {
     const loginUrl = new URL("/login", req.url);
     return NextResponse.redirect(loginUrl);
   }

--- a/web/tests/e2e/README.md
+++ b/web/tests/e2e/README.md
@@ -16,6 +16,10 @@ The verification server is the launchd job `dev.gkos.soma.web`. Its plist sets
 does not override with `web/.env.local`, so the same working tree serves the live
 database on 3456 and the snapshot on 3457.
 
+The 3457 job runs with `SOMA_DEV_SESSION=1`, so pages render there without a GitHub
+session. The flag only works for loopback hosts in non-production builds; Vercel and the
+live host on 3456 never see it.
+
 Refresh the snapshot with `scripts/verify-db-refresh.sh` (about 40 seconds for
 the current database). It drops and recreates only `verify_soma`, restores from a
 fresh dump of `soma`, runs `ANALYZE`, and fails loudly if the table or row counts


### PR DESCRIPTION
The local verification server (launchd `dev.gkos.soma.web`, port 3457, database `verify_soma`) could not render a page: every page redirected to `/login`, and `/login` calls `signIn("github")` with no OAuth app behind it (#852). Playwright flows that need a page had nowhere to run. Decided on 2026-09-11: a dev session, not an OAuth app.

## What changed

- `web/lib/dev-session.ts`: `devSessionAllowed(req)` is true only when all three hold: `SOMA_DEV_SESSION=1` in the process environment, the request host is loopback (`127.0.0.1`, `localhost`, `::1`), and `NODE_ENV` is not `production`.
- `web/middleware.ts`: the session requirement becomes `!req.auth && !devSessionAllowed(req)`. Everything else in the middleware is unchanged: the API token path, the chat tokens, demo mode.
- `web/tests/e2e/README.md` says the 3457 job runs with the flag and what the flag refuses.

The flag is set in the 3457 job's launchd plist only. Vercel and the live host on 3456 do not set it, and even if someone did, a request for `soma.gkos.dev` is not a loopback host.

## Verified

- `vitest run lib/dev-session.test.ts`: 3 tests (off by default, on for loopback in dev, never in production or for a public host). `tsc --noEmit` clean.
- A dev server of this branch on 3459 with the flag: `GET /nutrition` as `127.0.0.1` answers 200 and renders the dashboard (screenshot in the comments); the same request with `Host: soma.gkos.dev` answers 307 to `/login`.

Closes #852
Closes #854
