### PR TITLE
ci(universal): lint config and a CI lint step with a warning baseline

### DIFF
--- a/.github/workflows/universal-ci.yml
+++ b/.github/workflows/universal-ci.yml
@@ -26,5 +26,8 @@ jobs:
         run: npm ci || npm install
       - name: Typecheck
         run: npm run typecheck
+      - name: Lint
+        working-directory: universal
+        run: npx eslint . --max-warnings 86
       - name: Unit tests
         run: npm test

--- a/universal/eslint.config.js
+++ b/universal/eslint.config.js
@@ -1,0 +1,33 @@
+// https://docs.expo.dev/guides/using-eslint/
+// Baseline (T6, 2026-09-11): the rules that flagged existing screens are warnings until each is
+// fixed on its own. CI fails on any error and on the warning count growing past the baseline.
+const { defineConfig } = require("eslint/config");
+const expoConfig = require("eslint-config-expo/flat");
+
+const baseline = {
+  "react-hooks/set-state-in-effect": "warn",
+  "react-hooks/immutability": "warn",
+  "react-hooks/exhaustive-deps": "warn",
+  "react-hooks/static-components": "warn",
+  "react-hooks/purity": "warn",
+  "react-hooks/refs": "warn",
+  "react/display-name": "warn",
+  "react/no-unescaped-entities": "warn",
+  "@typescript-eslint/no-unused-vars": "warn",
+  "@typescript-eslint/array-type": "warn",
+  "import/no-duplicates": "warn",
+};
+
+// A rule may only be tuned inside a config object that registers its plugin, so the overrides
+// are merged into the Expo objects that own them instead of appended as a new object.
+const tuned = (Array.isArray(expoConfig) ? expoConfig : [expoConfig]).map((o) => {
+  if (!o.plugins) return o;
+  const rules = { ...(o.rules ?? {}) };
+  for (const [rule, level] of Object.entries(baseline)) {
+    const prefix = rule.slice(0, rule.lastIndexOf("/"));
+    if (prefix in o.plugins) rules[rule] = level;
+  }
+  return { ...o, rules };
+});
+
+module.exports = defineConfig([...tuned, { ignores: ["dist/*", "android/*", ".expo/*"] }]);


### PR DESCRIPTION
T6 of the months plan, the lint half (#886). `universal/` had `eslint` and `eslint-config-expo` installed and a `lint` script, but no config file, so `expo lint` and `npx eslint .` both stopped before reading a file and CI never linted the app.

## What changed

- `universal/eslint.config.js`: Expo's flat config. The rules that flag existing screens (react-hooks purity, refs, set-state-in-effect, immutability, exhaustive-deps, static-components; unused vars; duplicate imports; unescaped entities; display-name; array-type) are tuned to warn inside the Expo objects that register their plugins, because a flat config refuses to tune a rule outside the object that owns the plugin.
- `.github/workflows/universal-ci.yml`: a Lint step after Typecheck, `npx eslint . --max-warnings 86`, so any error and any new warning fails the build while the existing 86 are worked down in #888.

## Verified

- `npx eslint .` in `universal/`: 0 errors, 86 warnings. `tsc --noEmit` clean, `vitest run` 44 tests.

Closes #887
