### PR TITLE
feat(nutrition): energy reconciliation between weigh-ins

### DIFF
--- a/web/lib/energy-reconcile.test.ts
+++ b/web/lib/energy-reconcile.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { reconcile, KCAL_PER_KG } from "./energy-reconcile";
+
+const day = (date: string, o: Partial<{ observed: boolean; loggedKcal: number; loggedShare: number; burn: number }> = {}) =>
+  ({ date, observed: false, loggedKcal: 0, loggedShare: 0, burn: 2400, ...o });
+
+describe("reconcile", () => {
+  it("spreads the weight change over unobserved days", () => {
+    // 1 kg lost over 4 days = 7700 kcal deficit; day 2 observed at a 700 deficit; 3 unknown days share 7000.
+    const out = reconcile(
+      [{ date: "2026-09-01", weightKg: 75 }, { date: "2026-09-05", weightKg: 74 }],
+      [day("2026-09-01"), day("2026-09-02", { observed: true, loggedKcal: 1700, loggedShare: 1 }), day("2026-09-03"), day("2026-09-04")],
+    );
+    expect(out.map((d) => d.source)).toEqual(["extrapolated", "observed", "extrapolated", "extrapolated"]);
+    expect(out[1].deficit).toBe(-700);
+    expect(out[0].deficit).toBeCloseTo(-7000 / 3, 0);
+    expect(out.reduce((s, d) => s + d.deficit, 0)).toBeCloseTo(-KCAL_PER_KG, 0);
+  });
+  it("fills only the missing share of a partial day", () => {
+    const out = reconcile(
+      [{ date: "2026-09-01", weightKg: 75 }, { date: "2026-09-03", weightKg: 75 }],
+      [day("2026-09-01", { loggedKcal: 1200, loggedShare: 0.5 }), day("2026-09-02")],
+    );
+    // no weight change: 1200 + 0.5A - 2400 + A - 2400 = 0 -> A = 2400
+    expect(out[0].source).toBe("partial"); expect(out[0].ate).toBeCloseTo(2400, 0);
+    expect(out[1].ate).toBeCloseTo(2400, 0);
+  });
+  it("borrows the nearest interval after the last weigh-in", () => {
+    const out = reconcile(
+      [{ date: "2026-09-01", weightKg: 75 }, { date: "2026-09-03", weightKg: 75 }],
+      [day("2026-09-01"), day("2026-09-02"), day("2026-09-05")],
+    );
+    expect(out[2].source).toBe("extrapolated"); expect(out[2].ate).toBeCloseTo(2400, 0); expect(out[2].intervalEnd).toBe("2026-09-03");
+  });
+  it("leaves every day unknown with fewer than two weigh-ins", () => {
+    const out = reconcile([{ date: "2026-09-01", weightKg: 75 }], [day("2026-09-01"), day("2026-09-02")]);
+    expect(out.every((d) => d.source === "unknown")).toBe(true);
+  });
+  it("keeps observed days untouched when every day is observed", () => {
+    const out = reconcile(
+      [{ date: "2026-09-01", weightKg: 75 }, { date: "2026-09-02", weightKg: 75 }],
+      [day("2026-09-01", { observed: true, loggedKcal: 2000, loggedShare: 1 })],
+    );
+    expect(out[0]).toMatchObject({ source: "observed", ate: 2000, deficit: -400 });
+  });
+});

--- a/web/lib/energy-reconcile.ts
+++ b/web/lib/energy-reconcile.ts
@@ -1,0 +1,69 @@
+/** Energy reconciliation between weigh-ins (soma#891). Kostas's rule: a day is observed only when a
+ *  person closed it or every slot was logged; everything else is extrapolated. Between two
+ *  weigh-ins the weight change fixes the interval's total energy balance; observed days contribute
+ *  what was logged; one intake rate A closes the interval: an unlogged day eats A, a partly logged
+ *  day eats its logged kcal plus A times the share of the day it did not log. Days before the
+ *  first or after the last weigh-in borrow the nearest interval's A. With fewer than two weigh-ins
+ *  nothing is solved and every day is unknown. */
+export const KCAL_PER_KG = 7700; // the constant body-comp already uses
+
+export interface DayIn {
+  date: string;
+  /** hand-closed or fully logged: ate is what was logged, nothing is filled */
+  observed: boolean;
+  loggedKcal: number;
+  /** share of the day's budget covered by logged or skipped slots, 0..1 */
+  loggedShare: number;
+  burn: number;
+}
+
+export type DaySource = "observed" | "partial" | "extrapolated" | "unknown";
+
+export interface DayOut {
+  date: string;
+  ate: number;
+  burn: number;
+  /** ate minus burn: negative is a deficit */
+  deficit: number;
+  source: DaySource;
+  intervalStart: string | null;
+  intervalEnd: string | null;
+}
+
+export function reconcile(weighIns: { date: string; weightKg: number }[], days: DayIn[]): DayOut[] {
+  const w = [...weighIns].filter((x) => x.weightKg > 0).sort((a, b) => a.date.localeCompare(b.date));
+  const unknown = (d: DayIn): DayOut => ({
+    date: d.date, ate: d.loggedKcal, burn: d.burn, deficit: d.loggedKcal - d.burn, source: "unknown", intervalStart: null, intervalEnd: null,
+  });
+  if (w.length < 2) return days.map(unknown);
+
+  const out = new Map<string, DayOut>();
+  const rates: { start: string; end: string; A: number }[] = [];
+  for (let i = 0; i + 1 < w.length; i++) {
+    const start = w[i].date, end = w[i + 1].date;
+    const inRange = days.filter((d) => d.date >= start && d.date < end);
+    const implied = (w[i + 1].weightKg - w[i].weightKg) * KCAL_PER_KG;
+    let known = 0, unknownShare = 0, partialFixed = 0;
+    for (const d of inRange) {
+      if (d.observed) known += d.loggedKcal - d.burn;
+      else { unknownShare += Math.max(0, 1 - d.loggedShare); partialFixed += d.loggedKcal - d.burn; }
+    }
+    const A = unknownShare > 0 ? (implied - known - partialFixed) / unknownShare : 0;
+    rates.push({ start, end, A });
+    for (const d of inRange) out.set(d.date, fill(d, A, start, end));
+  }
+  for (const d of days) {
+    if (out.has(d.date)) continue;
+    const r = d.date < rates[0].start ? rates[0] : rates[rates.length - 1];
+    out.set(d.date, fill(d, r.A, r.start, r.end));
+  }
+  return days.map((d) => out.get(d.date)!);
+}
+
+function fill(d: DayIn, A: number, start: string, end: string): DayOut {
+  if (d.observed) {
+    return { date: d.date, ate: d.loggedKcal, burn: d.burn, deficit: d.loggedKcal - d.burn, source: "observed", intervalStart: start, intervalEnd: end };
+  }
+  const ate = d.loggedKcal + A * Math.max(0, 1 - d.loggedShare);
+  return { date: d.date, ate, burn: d.burn, deficit: ate - d.burn, source: d.loggedShare > 0 ? "partial" : "extrapolated", intervalStart: start, intervalEnd: end };
+}


### PR DESCRIPTION
The pure half of #891: `web/lib/energy-reconcile.ts` with five fixture tests (a 1 kg loss spread over three unknown days around one observed day; a partial day taking only its missing share; the nearest interval borrowed after the last weigh-in; fewer than two weigh-ins leaves everything unknown; an all-observed interval untouched). No route or client reads it yet; those are #894, #895 and #896.

Closes #892
