### PR TITLE
feat(sync): write the strength load into Garmin uploads, opt-in

### DIFF
--- a/web/lib/hevy-upload.test.ts
+++ b/web/lib/hevy-upload.test.ts
@@ -1,40 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { isUploadCandidate, filterUploadCandidates } from "./hevy-upload";
+import { trainingLoadForUpload } from "./hevy-upload";
 
-describe("upload dedup — isUploadCandidate (the never-duplicate guard)", () => {
-  const sent = new Set<string>(["already-sent"]);
-
-  it("only 'enriched' status is eligible", () => {
-    expect(isUploadCandidate("enriched", "w1", sent)).toBe(true);
-    expect(isUploadCandidate("uploaded", "w1", sent)).toBe(false); // matched to existing → excluded
-    expect(isUploadCandidate("pending", "w1", sent)).toBe(false);
+describe("trainingLoadForUpload", () => {
+  it("is undefined unless HEVY2GARMIN_WRITE_TRAINING_LOAD=1", () => {
+    expect(trainingLoadForUpload({ load_value: 62.4 }, { HEVY2GARMIN_WRITE_TRAINING_LOAD: "" })).toBeUndefined();
+    expect(trainingLoadForUpload({ load_value: 62.4 }, { HEVY2GARMIN_WRITE_TRAINING_LOAD: "1" })).toBe(62.4);
   });
-
-  it("anything already in the sent ledger is excluded even if 'enriched'", () => {
-    expect(isUploadCandidate("enriched", "already-sent", sent)).toBe(false);
-  });
-});
-
-describe("filterUploadCandidates — combined dedup", () => {
-  it("keeps only fresh enriched, unsent workouts", () => {
-    const rows = [
-      { hevy_id: "fresh", status: "enriched" },       // upload
-      { hevy_id: "onGarmin", status: "uploaded" },    // already matched → skip
-      { hevy_id: "sent", status: "enriched" },        // in ledger → skip
-      { hevy_id: "fresh2", status: "enriched" },      // upload
-    ];
-    expect(filterUploadCandidates(rows, new Set(["sent"]))).toEqual(["fresh", "fresh2"]);
-  });
-
-  it("empty when everything is matched or sent", () => {
-    const rows = [
-      { hevy_id: "a", status: "uploaded" },
-      { hevy_id: "b", status: "enriched" },
-    ];
-    expect(filterUploadCandidates(rows, new Set(["b"]))).toEqual([]);
-  });
-
-  it("empty input → empty output", () => {
-    expect(filterUploadCandidates([], new Set())).toEqual([]);
+  it("never writes a zero or missing load", () => {
+    expect(trainingLoadForUpload(null, { HEVY2GARMIN_WRITE_TRAINING_LOAD: "1" })).toBeUndefined();
+    expect(trainingLoadForUpload({ load_value: 0 }, { HEVY2GARMIN_WRITE_TRAINING_LOAD: "1" })).toBeUndefined();
   });
 });

--- a/web/lib/hevy-upload.ts
+++ b/web/lib/hevy-upload.ts
@@ -28,6 +28,8 @@ export interface UploadCandidate {
   hrSamples: number[];
   hrSource: string;
   workoutDate: string | null;
+  /** training_load.details.raw_load for this workout, when computed (hevy2garmin#523). */
+  strengthLoad?: { load_value: number } | null;
 }
 
 /**
@@ -72,7 +74,9 @@ export async function logActivitySync(
  */
 export async function getWorkoutsToUpload(sql: QueryFn): Promise<UploadCandidate[]> {
   const rows = await sql`
-    SELECT we.hevy_id, we.hevy_title, h.raw_json, we.hr_samples, we.hr_source, we.workout_date
+    SELECT we.hevy_id, we.hevy_title, h.raw_json, we.hr_samples, we.hr_source, we.workout_date,
+           (SELECT (tl.details->>'raw_load')::float FROM training_load tl
+             WHERE tl.hevy_id = we.hevy_id AND tl.source = 'hevy' ORDER BY tl.computed_at DESC LIMIT 1) AS raw_load
     FROM workout_enrichment we
     JOIN hevy_raw_data h ON h.hevy_id = we.hevy_id AND h.endpoint_name = 'workout'
     WHERE we.status = 'enriched'
@@ -88,7 +92,21 @@ export async function getWorkoutsToUpload(sql: QueryFn): Promise<UploadCandidate
     hrSamples: typeof r.hr_samples === "string" ? JSON.parse(r.hr_samples) : (r.hr_samples ?? []),
     hrSource: r.hr_source ?? "unknown",
     workoutDate: r.workout_date ? String(r.workout_date) : null,
+    strengthLoad: r.raw_load != null ? { load_value: Number(r.raw_load) } : null,
   }));
+}
+
+/** The load written into the FIT session (hevy2garmin#523). banister's computeStrengthLoad already
+ *  produces a session load for every gym session (training_load.details.raw_load); Garmin shows it
+ *  as Training Load. Off unless HEVY2GARMIN_WRITE_TRAINING_LOAD=1, because it feeds Garmin's
+ *  acute load and training status. */
+export function trainingLoadForUpload(
+  load: { load_value: number } | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+): number | undefined {
+  if (env.HEVY2GARMIN_WRITE_TRAINING_LOAD !== "1") return undefined;
+  const v = Number(load?.load_value);
+  return v > 0 ? v : undefined;
 }
 
 export interface UploadOutcome { hevyId: string; status: "uploaded" | "error"; activityId?: number | null; error?: string; }
@@ -100,6 +118,7 @@ export async function processWorkout(client: GarminClient, c: UploadCandidate): 
     // the FIT so Garmin forwards the correct local time to Strava. Empty = raw UTC.
     const { fit } = generateFit(c.workout, c.hrSamples.length ? c.hrSamples : null, {
       profile: { timezone: process.env.HEVY2GARMIN_TIMEZONE ?? "" },
+      trainingLoad: trainingLoadForUpload(c.strengthLoad),
     });
     const start = c.workout?.start_time;
     const { activityId } = await uploadFit(client, fit, start);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,7 @@
         "date-fns": "^4.1.0",
         "fflate": "^0.8.3",
         "garmin-auth": "^0.6.0",
-        "hevy2garmin": "^0.5.0",
+        "hevy2garmin": "^0.6.0",
         "lucide-react": "^0.575.0",
         "macro-engine-core": "^0.2.0",
         "maplibre-gl": "^5.19.0",
@@ -10868,9 +10868,9 @@
       }
     },
     "node_modules/hevy2garmin": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.5.0.tgz",
-      "integrity": "sha512-mrj0a3xO+hY6srm7hGVWaVvd3GIXlloN6SgMxLz3pPxFYKa7+LzoIT4VUIded4hdmF/6RHM3ZNOyWmdEz0Tsew==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.6.0.tgz",
+      "integrity": "sha512-hJ98BwDjt5hdnJB4VvBUtoLSXtaoF8tCoHWROKIkXSB+BD6mrHo65GmaMJHnhfVZEquEly4+Trckpe+oSE8DEg==",
       "license": "MIT",
       "dependencies": {
         "@garmin/fitsdk": "^21.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "date-fns": "^4.1.0",
     "fflate": "^0.8.3",
     "garmin-auth": "^0.6.0",
-    "hevy2garmin": "^0.5.0",
+    "hevy2garmin": "^0.6.0",
     "lucide-react": "^0.575.0",
     "macro-engine-core": "^0.2.0",
     "maplibre-gl": "^5.19.0",


### PR DESCRIPTION
hevy2garmin 0.6.0 lets `generateFit` write `training_load_peak`, which Garmin Connect shows as the activity's Training Load for uploads (hevy2garmin#522 proved it, #523 shipped the option). soma already computes a session load for every gym workout (banister's `computeStrengthLoad`, stored in `training_load` with the raw session load in `details.raw_load`).

## What changed

- `trainingLoadForUpload(load, env)`: undefined unless `HEVY2GARMIN_WRITE_TRAINING_LOAD=1`, undefined for a missing or non-positive load, else the number.
- `getWorkoutsToUpload` carries the latest `training_load.details.raw_load` for the workout as `strengthLoad`; `processWorkout` passes it to `generateFit` as `trainingLoad`.
- `hevy2garmin` pinned to `^0.6.0` (34 files on npm, same shape as 0.5.0).

The flag is set nowhere. With it off every upload is byte-identical to before; Kostas turns it on when he wants Garmin to carry the load, on the live host's `.env.local`.

## Verified

- `vitest run lib/hevy-upload.test.ts`: the three cases (off by default, on with the flag, never zero or missing); full suite (277 tests) and `tsc --noEmit` clean.
- The candidate query run against `verify_soma` returns `raw_load` for recent workouts (numbers in the PR comments).
- No live upload was made for this PR: the field's effect on Garmin was proven once in hevy2garmin#522 with the same encoder and endpoint, and with the flag off there is nothing new to prove on the account.

Closes #897
Closes #898
Closes #899
