### PR TITLE
feat: one athlete timezone for today

### DIFF
--- a/web/app/api/nutrition/body-comp/route.ts
+++ b/web/app/api/nutrition/body-comp/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { deficitWindow, countsForDeficit, windowLabel } from "@/lib/deficit-window";
+import { todayAthlete } from "@/lib/athlete-tz";
 
 
 export async function GET() {
@@ -73,7 +74,7 @@ export async function GET() {
   const targetWeight = Math.round((ffm / (1 - targetBf / 100)) * 10) / 10;
   const fatToLose = Math.max(0, currentFat - (targetWeight * targetBf / 100));
   const totalDeficitNeeded = fatToLose * 7700;
-  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const today = todayAthlete();
   // Use T12:00 to avoid timezone-related off-by-one when parsing date strings
   const daysRemaining = Math.max(1, Math.round((new Date(targetDate + "T12:00").getTime() - new Date(today + "T12:00").getTime()) / 86400000));
   const weeksRemaining = Math.max(1, daysRemaining / 7);
@@ -194,7 +195,7 @@ export async function GET() {
     ORDER BY n.date
   `;
 
-  const todayStr = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const todayStr = todayAthlete();
   const todayMealRows = await sql`
     SELECT COALESCE(SUM(calories), 0) AS total FROM meal_log WHERE date = ${todayStr}
   `;

--- a/web/app/api/nutrition/onboard/route.ts
+++ b/web/app/api/nutrition/onboard/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { todayAthlete } from "@/lib/athlete-tz";
 
 
 /**
@@ -255,7 +256,7 @@ export async function POST(req: NextRequest) {
   `;
 
   // Generate today's plan immediately
-  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const today = todayAthlete();
   try {
     const baseUrl = process.env.SOMA_WEB_URL || process.env.VERCEL_URL
       ? `https://${process.env.VERCEL_URL}`

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -10,6 +10,7 @@ import { nutritionEngagement, WEEK_ENGAGEMENT_FLOOR_DAYS } from "@/lib/engagemen
 import { getWeightTrend } from "@/lib/weight-trend";
 import { trendAte } from "@/lib/trend-ate";
 import { computeAlcoholDisplacement } from "macro-engine-core";
+import { todayAthlete } from "@/lib/athlete-tz";
 
 
 const VALID_MODES: readonly Mode[] = [
@@ -76,7 +77,7 @@ function redistributeRemaining(
 
 export async function GET(req: NextRequest) {
   const sql = getDb();
-  const todayStr = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const todayStr = todayAthlete();
   const date = req.nextUrl.searchParams.get("date") ?? todayStr;
 
   // Nothing else creates the day's row before something is logged, so the first view of a new
@@ -260,7 +261,7 @@ export async function GET(req: NextRequest) {
     // Recompute step calories from scratch using weight-based formula
     const calPerStep = 0.000423 * weightKg; // conservative: ~-50 kcal/day vs Garmin
     const isClosed = plan?.status === "closed";
-    const isPast = date < new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+    const isPast = date < todayAthlete();
     const stepsForCalc = (isClosed || isPast) && actualSteps !== null ? actualSteps : expectedSteps;
     const rawStepCalories = Math.round(stepsForCalc * calPerStep);
 

--- a/web/app/api/training/forward-sim/route.ts
+++ b/web/app/api/training/forward-sim/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { getLivePlan, getTrailingLoad } from "@/lib/live-plan";
+import { todayAthlete } from "@/lib/athlete-tz";
 
 export const dynamic = "force-dynamic";
 
@@ -18,7 +19,7 @@ export const dynamic = "force-dynamic";
  */
 export async function GET() {
   const sql = getDb();
-  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const today = todayAthlete();
 
   const [
     pmcRows,

--- a/web/app/api/training/graph/route.ts
+++ b/web/app/api/training/graph/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/training-engine";
 import { getBasePace } from "banister";
 import { hmSecondsFromVdot } from "banister";
+import { todayAthlete } from "@/lib/athlete-tz";
 
 
 /**
@@ -27,7 +28,7 @@ import { hmSecondsFromVdot } from "banister";
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const date = searchParams.get("date") ?? new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const date = searchParams.get("date") ?? todayAthlete();
 
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
     return NextResponse.json({ error: "Invalid date format. Use YYYY-MM-DD." }, { status: 400 });
@@ -148,7 +149,7 @@ export async function GET(request: Request) {
   // Today's prescribed run type, but only from a LIVE plan. A dormant plan's
   // day (if one even coincides) is not today's prescription (#701). With no
   // live plan the pace node defaults to "easy", which is the honest neutral.
-  const todayStr = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const todayStr = todayAthlete();
   const livePlan = await getLivePlan(sql, todayStr);
   const todayPlanDay = livePlan.days.find((d) => d.day_date === todayStr);
   const runType = todayPlanDay?.run_type || "easy";

--- a/web/app/api/workouts/insights/route.ts
+++ b/web/app/api/workouts/insights/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { parseRangeDays } from "@/lib/time-ranges";
 import { getDb } from "@/lib/db";
+import { athleteTz } from "@/lib/athlete-tz";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -99,7 +100,7 @@ export async function GET(request: Request) {
     // Monthly volume by muscle group (6 groups via ILIKE CASE)
     sql`
       WITH exercise_muscles AS (
-        SELECT TO_CHAR((raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York', 'YYYY-MM') as month,
+        SELECT TO_CHAR((raw_json->>'start_time')::timestamptz AT TIME ZONE ${athleteTz()}, 'YYYY-MM') as month,
           CASE
             WHEN e->>'title' ILIKE '%bench%' OR e->>'title' ILIKE '%chest%' OR e->>'title' ILIKE '%dip%' THEN 'Chest'
             WHEN e->>'title' ILIKE '%row%' OR e->>'title' ILIKE '%pull up%' OR e->>'title' ILIKE '%lat %' OR e->>'title' ILIKE '%deadlift%' OR e->>'title' ILIKE '%back extension%' THEN 'Back'
@@ -116,7 +117,7 @@ export async function GET(request: Request) {
           jsonb_array_elements(raw_json->'exercises') as e,
           jsonb_array_elements(e->'sets') as s
         WHERE endpoint_name = 'workout'
-          AND (raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York' >= ${cutoff}::date
+          AND (raw_json->>'start_time')::timestamptz AT TIME ZONE ${athleteTz()} >= ${cutoff}::date
           AND s->>'type' = 'normal' AND (s->>'weight_kg')::float > 0 AND (s->>'reps')::int > 0
       )
       SELECT month, muscle_group, ROUND(SUM(volume)::numeric) as volume
@@ -125,7 +126,7 @@ export async function GET(request: Request) {
     `,
     // Training calendar — all workout days (all-time; drives heatmap + frequency + span)
     sql`
-      SELECT ((raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York')::date as day,
+      SELECT ((raw_json->>'start_time')::timestamptz AT TIME ZONE ${athleteTz()})::date as day,
         raw_json->>'title' as program
       FROM hevy_raw_data WHERE endpoint_name = 'workout' ORDER BY day ASC
     `,

--- a/web/app/nutrition/page.tsx
+++ b/web/app/nutrition/page.tsx
@@ -4,6 +4,7 @@ import { getLivePlan } from "@/lib/live-plan";
 import { NutritionDashboard } from "@/components/nutrition-dashboard";
 import { NutritionOnboarding } from "@/components/nutrition-onboarding";
 import { BodyCompChart } from "@/components/body-comp-chart";
+import { todayAthlete } from "@/lib/athlete-tz";
 
 export const metadata: Metadata = { title: "Nutrition" };
 export const revalidate = 60;
@@ -227,7 +228,7 @@ async function getSleepDetail(date: string) {
 
 export default async function NutritionPage({ searchParams }: { searchParams: Promise<{ date?: string; view?: string }> }) {
   const params = await searchParams;
-  const today = params.date || new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const today = params.date || todayAthlete();
   const view = params.view || "day";
 
   // Check if onboarding is needed (no nutrition_profile)

--- a/web/app/training/page.tsx
+++ b/web/app/training/page.tsx
@@ -7,6 +7,7 @@ import { Target } from "lucide-react";
 import { TrainingControls } from "@/components/training-controls";
 import { projectVdotSeries, DEFAULT_BANISTER, type DatedLoad } from "banister";
 import { vdotFromHmSeconds } from "banister";
+import { todayAthlete } from "@/lib/athlete-tz";
 
 export const metadata: Metadata = { title: "Training" };
 export const revalidate = 300;
@@ -51,7 +52,7 @@ async function getReadiness() {
   const sql = getDb();
   // Today's row only: readiness is about last night, so an older row is not a
   // fallback — with no row the card says "No readiness data" (#647).
-  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const today = todayAthlete();
   const rows = await safeQuery(
     () => sql`
       SELECT r.composite_score, r.traffic_light,
@@ -351,7 +352,7 @@ async function getTrajectoryData(
 }
 
 export default async function TrainingPage() {
-  const today = new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const today = todayAthlete();
   const [planForPage, readiness, pmcLatest, fitnessLatest, referenceData, banisterParams, trailingLoad] = await Promise.all([
     getPlanForPage(),
     getReadiness(),

--- a/web/app/workouts/page.tsx
+++ b/web/app/workouts/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { athleteTz } from "@/lib/athlete-tz";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ExpandableChartCard } from "@/components/expandable-chart-card";
 import { getDb } from "@/lib/db";
@@ -422,7 +423,7 @@ async function getMonthlyMuscleVolume(cutoff: string) {
   const rows = await sql`
     WITH exercise_muscles AS (
       SELECT
-        TO_CHAR((raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York', 'YYYY-MM') as month,
+        TO_CHAR((raw_json->>'start_time')::timestamptz AT TIME ZONE ${athleteTz()}, 'YYYY-MM') as month,
         CASE
           WHEN e->>'title' ILIKE '%bench%' OR e->>'title' ILIKE '%chest%' OR e->>'title' ILIKE '%dip%' THEN 'Chest'
           WHEN e->>'title' ILIKE '%row%' OR e->>'title' ILIKE '%pull up%' OR e->>'title' ILIKE '%lat %' OR e->>'title' ILIKE '%deadlift%' OR e->>'title' ILIKE '%back extension%' THEN 'Back'
@@ -439,7 +440,7 @@ async function getMonthlyMuscleVolume(cutoff: string) {
         jsonb_array_elements(raw_json->'exercises') as e,
         jsonb_array_elements(e->'sets') as s
       WHERE endpoint_name = 'workout'
-        AND (raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York' >= ${cutoff}::date
+        AND (raw_json->>'start_time')::timestamptz AT TIME ZONE ${athleteTz()} >= ${cutoff}::date
         AND s->>'type' = 'normal'
         AND (s->>'weight_kg')::float > 0
         AND (s->>'reps')::int > 0
@@ -461,7 +462,7 @@ async function getTrainingCalendar() {
   // Fetch all workout dates (no cutoff) so the calendar can navigate to any period
   const rows = await sql`
     SELECT
-      ((raw_json->>'start_time')::timestamptz AT TIME ZONE 'America/New_York')::date as day,
+      ((raw_json->>'start_time')::timestamptz AT TIME ZONE ${athleteTz()})::date as day,
       raw_json->>'title' as program,
       raw_json->>'id' as hevy_id
     FROM hevy_raw_data

--- a/web/lib/athlete-tz.test.ts
+++ b/web/lib/athlete-tz.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { athleteTz, todayAthlete, dateInAthleteTz } from "./athlete-tz";
+
+describe("athlete timezone (#872)", () => {
+  it("defaults to Europe/Athens and honours SOMA_TZ", () => {
+    expect(athleteTz({})).toBe("Europe/Athens");
+    expect(athleteTz({ SOMA_TZ: "America/New_York" })).toBe("America/New_York");
+  });
+  it("gives the calendar date in that zone", () => {
+    const t = new Date("2026-09-11T22:30:00Z"); // 01:30 next day in Athens, 18:30 same day in New York
+    expect(dateInAthleteTz(t, "Europe/Athens")).toBe("2026-09-12");
+    expect(dateInAthleteTz(t, "America/New_York")).toBe("2026-09-11");
+    expect(todayAthlete({ SOMA_TZ: "Europe/Athens" })).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/web/lib/athlete-tz.ts
+++ b/web/lib/athlete-tz.ts
@@ -1,0 +1,11 @@
+/** The one timezone that defines the athlete's "today" (soma#872). Every route and lib that used
+ *  to hardcode America/New_York reads this instead; the database session timezone is untouched. */
+export function athleteTz(env: Record<string, string | undefined> = process.env): string {
+  return env.SOMA_TZ?.trim() || "Europe/Athens";
+}
+export function dateInAthleteTz(d: Date, tz: string = athleteTz()): string {
+  return d.toLocaleDateString("en-CA", { timeZone: tz });
+}
+export function todayAthlete(env: Record<string, string | undefined> = process.env): string {
+  return dateInAthleteTz(new Date(), athleteTz(env));
+}

--- a/web/lib/banister.ts
+++ b/web/lib/banister.ts
@@ -15,13 +15,14 @@ import { banisterPredict, fitBanister, DEFAULT_PARAMS, type BanisterParams, type
 import type { QueryFn } from "./db";
 import { vdotFromRace } from "./vdot";
 import { crossModalScale } from "./pmc-stream";
+import { dateInAthleteTz } from "./athlete-tz";
 
 export type { BanisterParams };
 export { banisterPredict, DEFAULT_PARAMS };
 
-/** Today (YYYY-MM-DD) in America/New_York — mirrors config.today_nyc. */
+/** Today (YYYY-MM-DD) in the athlete's timezone (soma#872). */
 function todayNyc(now: Date = new Date()): string {
-  return now.toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  return dateInAthleteTz(now);
 }
 
 function daysBetween(a: string, b: string): number {

--- a/web/lib/dj-daemon.ts
+++ b/web/lib/dj-daemon.ts
@@ -6,6 +6,7 @@
  * and Neon. Stage: sync cutover (#187).
  */
 import { writeFileSync, renameSync, readFileSync, unlinkSync } from "fs";
+import { todayAthlete } from "./athlete-tz";
 import { ensureDjPaths } from "./dj-paths";
 import { GarminAuth, DBTokenStore } from "garmin-auth";
 import { healGarminTokenRow } from "./garmin-token-heal";
@@ -181,7 +182,7 @@ export async function runDaemon(opts: DaemonOpts): Promise<void> {
 
   writeStatus(statusFile, { state: "starting", hr: null, target_bpm: null });
 
-  const todayNyc = () => new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  const todayNyc = () => todayAthlete();
 
   while (!stop) {
     try {

--- a/web/lib/garmin-ingest.test.ts
+++ b/web/lib/garmin-ingest.test.ts
@@ -14,9 +14,9 @@ describe("toPath — connectapi query serialization", () => {
 });
 
 describe("todayNyc", () => {
-  it("returns YYYY-MM-DD in America/New_York", () => {
-    // 2026-07-13 03:30 UTC is still 2026-07-12 in New York (EDT, -4).
-    expect(todayNyc(new Date("2026-07-13T03:30:00Z"))).toBe("2026-07-12");
+  it("returns YYYY-MM-DD in the athlete's timezone, Athens by default (soma#872)", () => {
+    // 2026-07-12 21:30 UTC is already 2026-07-13 in Athens (EEST, +3); New York would still say the 12th.
+    expect(todayNyc(new Date("2026-07-12T21:30:00Z"))).toBe("2026-07-13");
     expect(todayNyc(new Date("2026-07-13T12:00:00Z"))).toBe("2026-07-13");
   });
 });

--- a/web/lib/garmin-ingest.ts
+++ b/web/lib/garmin-ingest.ts
@@ -20,6 +20,7 @@ import { updateFitnessTrajectory } from "./fitness-stream";
 import { computeDailyReadiness } from "./readiness-stream";
 import { updateBodyComp } from "./body-comp-stream";
 import { extractKiteJumpsForActivity } from "./kite-jumps";
+import { dateInAthleteTz } from "./athlete-tz";
 
 const MIN_COMPLETE_HR_POINTS = 650;
 // DI-token API profile path (returns displayName). garth's web API uses
@@ -27,9 +28,9 @@ const MIN_COMPLETE_HR_POINTS = 650;
 // is the DI-compatible path (same one garmin-auth's own refresh() uses).
 const PROFILE_URL = "/userprofile-service/socialProfile";
 
-/** Today's date (YYYY-MM-DD) in America/New_York — mirrors config.today_nyc. */
+/** Today's date (YYYY-MM-DD) in the athlete's timezone (soma#872). */
 export function todayNyc(now: Date = new Date()): string {
-  return now.toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  return dateInAthleteTz(now);
 }
 
 /** Serialize a GarminRequest into a connectapi path with an inline query string. */

--- a/web/lib/live-plan.ts
+++ b/web/lib/live-plan.ts
@@ -13,6 +13,7 @@
  * back to what Garmin actually observed instead of a phantom script.
  */
 import type { QueryFn } from "@/lib/db";
+import { todayAthlete } from "./athlete-tz";
 import { trainingEngagement, type PlanInput, type TrainingEngagement } from "@/lib/engagement";
 
 export interface PlanRow {
@@ -52,7 +53,7 @@ export interface LivePlan {
 
 /** Today in the athlete's timezone as YYYY-MM-DD; matches graph/route.ts. */
 export function todayLocal(): string {
-  return new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+  return todayAthlete();
 }
 
 /**


### PR DESCRIPTION
The plan route defined "today" in America/New_York (three places) and so did seven other routes, two pages, `lib/live-plan.ts`, `lib/banister.ts`, `lib/garmin-ingest.ts` and the DJ daemon, while the health routes used Athens and the phone sends its own local date. Between 00:00 and 07:00 Athens the server and the phone disagreed on what day it was, and the plan write-back only ran for the server's day. Decided on 2026-09-11: one athlete timezone.

## What changed

- `web/lib/athlete-tz.ts`: `athleteTz()` (env `SOMA_TZ`, default `Europe/Athens`), `todayAthlete()`, `dateInAthleteTz(d, tz)`.
- Sixteen JavaScript sites now call `todayAthlete()`; `todayNyc` in `banister.ts` and `garmin-ingest.ts` keep their names and delegate to `dateInAthleteTz`, so nothing else moves. The six SQL sites (`app/workouts/page.tsx`, `app/api/workouts/insights/route.ts`) pass the zone as a query parameter instead of the literal.
- The database session timezone is untouched; this is about which calendar day the code means.

No environment change is needed anywhere: the default is Athens. `SOMA_TZ` exists for a fork elsewhere.

## Verified

- `lib/athlete-tz.test.ts`: the default, the override, and 22:30 UTC mapping to the next day in Athens but the same day in New York. `lib/garmin-ingest.test.ts` now pins the Athens boundary. Full suite 282 tests, `tsc --noEmit` clean.
- `grep America/New_York` across `web/app`, `web/lib`, `web/scripts`: only the helper and its test remain.
- A dev server of this branch with `SOMA_TZ=Europe/Athens` and again with `America/New_York` created today's `nutrition_day` row for the date the shell reports in that zone (both the same calendar day at the hour of the check; the boundary is covered by the unit tests).

Closes #872
