### PR TITLE
feat(nutrition): closed_by tells a hand-close from an auto-close

### DIFF
--- a/web/app/api/nutrition/close-day/route.ts
+++ b/web/app/api/nutrition/close-day/route.ts
@@ -104,7 +104,8 @@ export async function POST(req: NextRequest) {
       actual_fat      = ${actual.fat},
       actual_fiber    = ${actual.fiber},
       plan            = ${JSON.stringify(reconciledPlan)},
-      status          = 'closed'
+      status          = 'closed',
+      closed_by       = 'user'
     WHERE date = ${date}
   `;
 

--- a/web/app/api/nutrition/reopen-day/route.ts
+++ b/web/app/api/nutrition/reopen-day/route.ts
@@ -4,6 +4,6 @@ import { getDb } from "@/lib/db";
 export async function POST(req: NextRequest) {
   const { date } = await req.json();
   const sql = getDb();
-  await sql`UPDATE nutrition_day SET status = 'active' WHERE date = ${date}`;
+  await sql`UPDATE nutrition_day SET status = 'active', closed_by = NULL WHERE date = ${date}`;
   return NextResponse.json({ ok: true });
 }

--- a/web/lib/db/migrations/2026-09-11-closed-by.sql
+++ b/web/lib/db/migrations/2026-09-11-closed-by.sql
@@ -1,0 +1,9 @@
+-- Who closed the day (soma#893). Additive; applied by hand to verify_soma first, then to soma.
+-- A day is observed only when a person closed it or every slot was logged (soma#891). The old
+-- auto-close left closed rows with no meal_log rows and no skipped slots; those are 'auto'.
+ALTER TABLE nutrition_day ADD COLUMN IF NOT EXISTS closed_by TEXT CHECK (closed_by IN ('user', 'auto'));
+UPDATE nutrition_day d SET closed_by = CASE
+  WHEN NOT EXISTS (SELECT 1 FROM meal_log m WHERE m.date = d.date)
+   AND COALESCE(array_length(d.skipped_slots, 1), 0) = 0 THEN 'auto'
+  ELSE 'user' END
+WHERE status = 'closed' AND closed_by IS NULL;

--- a/web/lib/observed-day.test.ts
+++ b/web/lib/observed-day.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { isObservedDay } from "./observed-day";
+
+describe("isObservedDay", () => {
+  it("is true for a hand-closed day whatever was logged", () => {
+    expect(isObservedDay({ status: "closed", closedBy: "user", coverage: 0.25 })).toBe(true);
+  });
+  it("is true for a fully logged open day", () => {
+    expect(isObservedDay({ status: "active", closedBy: null, coverage: 1 })).toBe(true);
+  });
+  it("is false for an auto-closed day and for a partial open day", () => {
+    expect(isObservedDay({ status: "closed", closedBy: "auto", coverage: 0 })).toBe(false);
+    expect(isObservedDay({ status: "active", closedBy: null, coverage: 0.5 })).toBe(false);
+    expect(isObservedDay({ status: "closed", closedBy: null, coverage: 0.5 })).toBe(false);
+  });
+});

--- a/web/lib/observed-day.ts
+++ b/web/lib/observed-day.ts
@@ -1,0 +1,6 @@
+/** A day is observed when a person closed it or every slot was logged or skipped (soma#891).
+ *  An auto-closed day is not: the old auto-close produced 77 closed days with nothing logged. */
+export function isObservedDay(d: { status: string | null; closedBy: "user" | "auto" | null; coverage: number | null }): boolean {
+  if (d.status === "closed" && d.closedBy === "user") return true;
+  return typeof d.coverage === "number" && d.coverage >= 1;
+}


### PR DESCRIPTION
Part of #891: the rule that a day counts as observed only when a person closed it or every slot was logged. The 77 closed days with nothing logged were the old auto-close, not Kostas, so the record has to say who closed a day.

## What changed

- `lib/db/migrations/2026-09-11-closed-by.sql`: `nutrition_day.closed_by` ('user' | 'auto'), backfilled once: a closed row with no `meal_log` rows and no skipped slots is 'auto', every other closed row is 'user'. Applied by hand to `verify_soma`; applied to `soma` after this merges.
- `close-day` writes `closed_by = 'user'`; `reopen-day` clears it.
- `lib/observed-day.ts`: `isObservedDay({ status, closedBy, coverage })`. The routes switch to it in the next PR (#894); nothing reads it yet.

## Verified

- `vitest run lib/observed-day.test.ts`: hand-closed with partial logging is observed, fully logged open day is observed, auto-closed and partial open days are not. `tsc --noEmit` clean.
- Migration on `verify_soma`: closed rows split into auto and user (counts in the PR comments); close then reopen of a scratch day through a dev server of this branch sets and clears the column.

Closes #893
