### PR TITLE
feat(ops): soma reports its facts to drlab

### DIFF
--- a/scripts/report-to-drlab.sh
+++ b/scripts/report-to-drlab.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# report-to-drlab.sh: one fact about soma into the estate record (soma T7, soma#903).
+#
+#   scripts/report-to-drlab.sh sync_green true
+#   scripts/report-to-drlab.sh deployed_commit 262b84e
+#   scripts/report-to-drlab.sh verify_db_age_hours 0
+#
+# Never a notification: drlab decides what is notable. Silent when drlab is not reachable or the
+# token is missing (a report is never worth failing the caller), one stderr line when the record
+# refuses the name, which means it was not declared (drlab kernel/soma_facts.sql).
+set -u
+NAME=${1:?fact name}; VALUE=${2:?fact value}
+TOK=$(python3 -c "import json;print(json.load(open('$HOME/.config/drlab/secrets.json'))['drlab://api-token'])" 2>/dev/null) || exit 0
+case "$VALUE" in true|false) JSON="$VALUE" ;; ''|*[!0-9.]*) JSON="\"$VALUE\"" ;; *) JSON="$VALUE" ;; esac
+OUT=$(curl -s -m 5 -X POST -H "Authorization: Bearer $TOK" -H 'content-type: application/json' \
+  -d "{\"project\":\"soma\",\"facts\":{\"$NAME\":$JSON}}" http://localhost:8787/observe 2>/dev/null) || exit 0
+printf '%s' "$OUT" | /usr/bin/grep -q '"ok": true' || echo "report-to-drlab: $NAME not recorded: ${OUT:0:160}" >&2
+exit 0

--- a/scripts/verify-db-refresh.sh
+++ b/scripts/verify-db-refresh.sh
@@ -44,3 +44,4 @@ if [ "$ST" != "$DT" ] || [ "$SR" != "$DR" ]; then
   echo "MISMATCH: source $ST tables/$SR rows, copy $DT tables/$DR rows" >&2; exit 1
 fi
 echo "ok      $DST matches $SRC"
+"$(dirname "$0")/report-to-drlab.sh" verify_db_age_hours 0


### PR DESCRIPTION
Part of T7 (#903): soma tells drlab the three facts only soma knows.

## What changed

- `scripts/report-to-drlab.sh NAME VALUE`: one POST to `http://localhost:8787/observe` for project soma with the token from `~/.config/drlab/secrets.json`. Exit 0 always: silent when drlab or the token is absent, one stderr line when the record refuses the name (which means the kind is not declared; the declaration is drlab#904's `kernel/soma_facts.sql`).
- `scripts/verify-db-refresh.sh` reports `verify_db_age_hours 0` after a good refresh.
- Outside the repo, on the Mac: `~/.config/soma/deploy-main.sh` reports `deployed_commit` after a restart and `~/bin/soma-sync.sh` reports `sync_green` after each run (edited alongside this PR).

## Verified

- `bash -n` on the script; a run against production drlab before the kinds exist there prints the expected refusal on stderr and exits 0 (so a caller never fails on a missing declaration).
- After drlab merges the kinds: `sync_green` reads back on `scope://project/soma` (proof in the comments once the other side lands).

Closes #905
