### PR TITLE
refactor(nutrition): remove the Offset Plan feature (#874)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -3,7 +3,7 @@ import { ScrollView, View, RefreshControl, TextInput, Pressable } from "react-na
 import { Text, Card, Badge, SegmentedControl, ProgressBar, Button, Modal, Pill, PillGroup, Sparkline } from "soma-style";
 import {
   useSomaPlan, usePresets, logPresetMeal, deleteMeal, quickAddMeal, skipSlot, useDrinks, logDrink, deleteDrink, closeDay,
-  reopenDay, copyDay, setManualOverride, rebalanceMeals, presetItems, presetBaseMacros, useOnboard,
+  reopenDay, copyDay, rebalanceMeals, presetItems, presetBaseMacros, useOnboard,
   fetchJson, usePullRefresh, todayLocal, type Preset, type SomaMeal,
 } from "../../lib/api";
 import { NutritionOnboarding } from "../../components/nutrition-onboarding";
@@ -116,7 +116,6 @@ export default function NutritionScreen() {
   const [skipBusy, setSkipBusy] = useState<string | null>(null);
   const [reopenBusy, setReopenBusy] = useState(false);
   const [copyBusy, setCopyBusy] = useState(false);
-  const [unlockBusy, setUnlockBusy] = useState(false);
   const [delDrinkId, setDelDrinkId] = useState<number | null>(null);
   const [detailMeal, setDetailMeal] = useState<SomaMeal | null>(null);
   const [editMeal, setEditMeal] = useState<{ id: number; grams: Record<string, number> } | null>(null);
@@ -142,7 +141,6 @@ export default function NutritionScreen() {
   const skippedSlots = data?.skippedSlots ?? [];
   const loggedDrinks = data?.drinks ?? [];
   const dayClosed = closeStatus === "closed" || plan?.status === "closed";
-  const manualOverride = (bd?.manualOverride ?? false) && !dayClosed;
   const caloriesTrend = useCaloriesTrend();
   const targetCal = bd?.adjustedTargets?.calories ?? (Number(plan?.target_calories) || 0);
 
@@ -251,12 +249,6 @@ export default function NutritionScreen() {
     setCopyBusy(true);
     const ok = await copyDay(shiftDate(DATE, -1), DATE);
     setCopyBusy(false);
-    if (ok) refetch();
-  }
-  async function onUnlock() {
-    setUnlockBusy(true);
-    const ok = await setManualOverride(DATE, false);
-    setUnlockBusy(false);
     if (ok) refetch();
   }
   async function onLogDrink(key: string) {
@@ -376,11 +368,10 @@ export default function NutritionScreen() {
           <View className="flex-row items-center gap-2">
             <Text variant="title">{isToday ? "Today" : niceDate(DATE)}</Text>
             {dayClosed ? <Badge label="Closed" tone="success" /> : <Badge label="Nutrition" tone="teal" />}
-            {manualOverride ? <Badge label="Offset Plan" tone="warm" /> : null}
           </View>
           <Button label="›" variant="ghost" size="sm" disabled={isToday} onPress={() => setDATE((d) => shiftDate(d, 1))} />
         </View>
-        {(!isToday || dayClosed || manualOverride || (meals.length === 0 && !dayClosed)) ? (
+        {(!isToday || dayClosed || (meals.length === 0 && !dayClosed)) ? (
           <View className="flex-row flex-wrap items-center justify-center gap-2">
             {!isToday ? (
               <Button label="Jump to today" variant="ghost" size="sm" onPress={() => setDATE(todayLocal())} />
@@ -390,9 +381,6 @@ export default function NutritionScreen() {
             ) : null}
             {meals.length === 0 && !dayClosed ? (
               <Button label={copyBusy ? "…" : "Copy yesterday"} variant="ghost" size="sm" disabled={copyBusy} onPress={onCopyYesterday} />
-            ) : null}
-            {manualOverride ? (
-              <Button label={unlockBusy ? "…" : "✕ Unlock plan"} variant="ghost" size="sm" disabled={unlockBusy} onPress={onUnlock} />
             ) : null}
           </View>
         ) : null}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -122,7 +122,7 @@ export interface SomaBreakdown {
   stepCalories?: number; stepCaloriesPredicted?: number; expectedSteps?: number; actualSteps?: number;
   runCalories?: number; runActual?: number; runPredicted?: number; runEnabled?: boolean; runActualDistKm?: number; runDistanceKm?: number;
   gymCalories?: number; gymBreakdown?: { title: string; calories: number; predicted?: number; actual?: boolean }[];
-  drinkCalories?: number; deficit?: number; manualOverride?: boolean;
+  drinkCalories?: number; deficit?: number;
   weightKg?: number;
   // Dynamically recomputed targets for the day (run/gym/drink/macro-floor adjusted).
   // Web reads these; the app must too, or it shows stale stored plan.target_* goals.
@@ -1317,15 +1317,6 @@ export async function copyDay(fromDate: string, toDate: string): Promise<boolean
   return res.ok;
 }
 
-/** Toggle the manual activity-plan override (unlock an Offset Plan). */
-export async function setManualOverride(date: string, on: boolean): Promise<boolean> {
-  const res = await fetch(`${API_BASE}/api/nutrition/activity-select`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
-    body: JSON.stringify({ date, manual_override: on }),
-  });
-  return res.ok;
-}
 
 /** Update the day's activity plan (drives the burn calc): run on/off + which
  *  gym workouts count + expected steps + ad-hoc planned-run km. */

--- a/web/app/api/nutrition/activity-select/route.ts
+++ b/web/app/api/nutrition/activity-select/route.ts
@@ -12,7 +12,6 @@ export async function POST(req: NextRequest) {
     /** Ad-hoc planned run distance in km. NULL clears the override and falls back
      *  to training_plan_day.target_distance_km in the plan API read path. */
     planned_run_km?: number | null;
-    manual_override?: boolean;
   };
   const { date, run_enabled, selected_workouts, expected_steps, planned_run_km } = body;
 
@@ -26,17 +25,6 @@ export async function POST(req: NextRequest) {
     VALUES (${date})
     ON CONFLICT (date) DO NOTHING
   `;
-
-  // Handle manual_override toggle
-  if (body.manual_override !== undefined) {
-    await sql`UPDATE nutrition_day SET manual_override = ${body.manual_override} WHERE date = ${date}`;
-    // When unlocking, reset stale offset values so the plan API recomputes correctly
-    if (body.manual_override === false) {
-      const profRows = await sql`SELECT daily_deficit FROM nutrition_profile WHERE id = 1`;
-      const defaultDeficit = profRows[0]?.daily_deficit != null ? Number(profRows[0].daily_deficit) : 800;
-      await sql`UPDATE nutrition_day SET target_calories = NULL, deficit_used = ${defaultDeficit} WHERE date = ${date}`;
-    }
-  }
 
   // Handle activity selection updates (only if fields provided)
   if (run_enabled !== undefined && selected_workouts !== undefined) {

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -487,23 +487,6 @@ export function NutritionDashboard({
     ? [...MEAL_SLOTS, "during_workout" as const]
     : [...MEAL_SLOTS];
 
-  // Unlock manual override handler
-  const handleUnlock = async () => {
-    try {
-      const res = await fetch("/api/nutrition/activity-select", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ date, manual_override: false }),
-      });
-      if (!res.ok) {
-        console.error("Unlock failed:", res.status);
-        return;
-      }
-      await refreshData();
-    } catch (err) {
-      console.error("Unlock error:", err);
-    }
-  };
 
   // Slots that are neither logged with calories nor explicitly skipped. These
   // are ABSENT, not zero: closing over them silently would turn a
@@ -608,15 +591,6 @@ export function NutritionDashboard({
               >
                 reopen
               </button>
-            )}
-            {breakdown?.manualOverride && !isClosed && (
-              <Badge variant="secondary" className="gap-1 text-amber-500 border-amber-500/30">
-                <Lock className="h-3 w-3" />
-                Offset Plan
-                <button onClick={handleUnlock} className="ml-1 hover:text-foreground">
-                  <X className="h-3 w-3" />
-                </button>
-              </Badge>
             )}
           </div>
           <a href={`/nutrition?date=${(() => { const d = new Date(date + "T12:00:00"); d.setDate(d.getDate() + 1); return d.toISOString().slice(0, 10); })()}`}>
@@ -1132,13 +1106,9 @@ export function NutritionDashboard({
           disabled={(() => {
             const isPast = date < new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
             const hasActuals = breakdown?.runActual || breakdown?.gymBreakdown?.some((w: any) => w.actual);
-            return breakdown?.manualOverride || (isPast && hasActuals) || isClosed;
+            return (isPast && hasActuals) || isClosed;
           })()}
-          disabledReason={
-            breakdown?.manualOverride ? "Target locked — offset plan"
-            : isClosed ? "Day is closed"
-            : "Activities finalized"
-          }
+          disabledReason={isClosed ? "Day is closed" : "Activities finalized"}
         />
 
         <div className="hidden lg:block">


### PR DESCRIPTION
Removes the Offset Plan feature, as decided on 2026-09-11 (Q4 in the nutrition product decisions).

What goes:

- The `manual_override` toggle in `POST /api/nutrition/activity-select`: selecting activities no longer locks or unlocks the plan.
- The lock badge, the Unlock action and their state in `web/components/nutrition-dashboard.tsx`; the same in the app's `nutrition.tsx`, and `setManualOverride` in `universal/src/lib/api.ts`.
- The activity controls stay and are disabled only when the day is closed or the activities are finalized.

What stays: the `manual_override` column, which two historical rows still carry, and the plan route, which does not read it for anything the user can see.

Verified: web on a dev server of this branch renders `/nutrition` with no "Offset Plan" or "Unlock" text and the activity section intact; the route call with `manual_override` returns 200 and leaves the column false; the app on emulator-5556 with the real account shows the Food tab without the badge and with Today's Activity (screenshot `/tmp/soma/t3b/60-phase8-food.png`, in the evidence branch). web vitest, universal tsc, vitest and eslint all pass.

Closes #874
