### PR TITLE
feat(nutrition): reconcile unlogged days against the scale in the routes (#894)

### DIFF
--- a/web/app/api/nutrition/body-comp/route.ts
+++ b/web/app/api/nutrition/body-comp/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import { deficitWindow, countsForDeficit, windowLabel } from "@/lib/deficit-window";
+import { deficitWindow, windowLabel } from "@/lib/deficit-window";
 import { todayAthlete } from "@/lib/athlete-tz";
+import { isObservedDay } from "@/lib/observed-day";
+import { reconcile, type DayIn, type DaySource } from "@/lib/energy-reconcile";
 
 
 export async function GET() {
@@ -164,9 +166,16 @@ export async function GET() {
     trendTargetDate = trendPrediction.find(p => p.weight <= targetWeight)?.date || null;
   }
 
-  // Burn breakdown per day — stacked bar data
+  // Burn breakdown per day — stacked bar data. Since soma#891 every day from
+  // the first weigh-in on is returned: an observed day (closed by a person, or
+  // every slot logged or skipped) carries what was logged; any other day is
+  // reconciled against the scale (lib/energy-reconcile), so an auto-closed
+  // empty day is an estimate between two weigh-ins, not a zero and not a gap.
+  // lib/adaptive-tdee stays on observed days only: an extrapolated day is
+  // derived from the scale, and feeding it back into a TDEE fit would be circular.
+  const firstWeighIn = weightRows.length ? String((weightRows[0] as Record<string, unknown>).date) : "9999-12-31";
   const deficitRows = await sql`
-    SELECT n.date::text AS date, n.target_calories, n.actual_calories, n.deficit_used, n.status,
+    SELECT n.date::text AS date, n.target_calories, n.actual_calories, n.deficit_used, n.status, n.closed_by,
            h.total_kilocalories AS garmin_burn, h.bmr_kilocalories AS bmr, h.total_steps,
            (
              SELECT COUNT(DISTINCT s)::float / 4
@@ -189,9 +198,14 @@ export async function GET() {
            (SELECT raw_json->>'activityName' FROM garmin_activity_raw
              WHERE endpoint_name = 'summary' AND raw_json->'activityType'->>'typeKey' = 'strength_training'
              AND (raw_json->>'startTimeLocal')::date = n.date LIMIT 1) AS gym_title
+,
+           (
+             SELECT COALESCE((SELECT SUM(m.calories) FROM meal_log m WHERE m.date = n.date), 0)
+                  + COALESCE((SELECT SUM(d.calories) FROM drink_log d WHERE d.date = n.date), 0)
+           ) AS logged_calories
     FROM nutrition_day n
     LEFT JOIN daily_health_summary h ON h.date = n.date
-    WHERE n.actual_calories > 0 OR n.status = 'active'
+    WHERE n.actual_calories > 0 OR n.status = 'active' OR n.date >= ${firstWeighIn}::date
     ORDER BY n.date
   `;
 
@@ -205,28 +219,36 @@ export async function GET() {
   const todayConsumed = Number(todayMealRows[0]?.total || 0) + Number(todayDrinkRows[0]?.total || 0);
 
   // Per-day rows first; the cumulative/goal-pace series is filled afterwards
-  // over the CURRENT window only (#728): a day counts when it is closed and its
-  // coverage clears the floor, and a window breaks at a gap of more than seven
-  // days. Days outside the window are still returned for the charts, with
+  // over the CURRENT window only (#728): a day counts when it is observed or
+  // reconciled, and a window breaks at a gap of more than seven days. Days
+  // outside the window are still returned for the charts, with
   // cumulative/goalPace null, so they render as context, never as a sum.
   const dailyDeficits: {
     date: string; bmr: number; dailyActivity: number; runCal: number; runDistKm: number;
     gymCal: number; gymTitle: string; totalBurn: number; consumed: number;
     deficit: number; cumulative: number | null; goalPace: number | null; closed: boolean; isToday: boolean;
     coverage: number | null; counted: boolean; inWindow: boolean;
+    /** observed | partial | extrapolated | unknown, and the weigh-in interval an estimate came from. */
+    source: DaySource; intervalStart: string | null; intervalEnd: string | null;
   }[] = [];
 
+  const prepared: {
+    date: string; bmr: number; dailyActivity: number; runCal: number; runDistKm: number; gymCal: number;
+    gymTitle: string; totalBurn: number; closed: boolean; isToday: boolean; coverage: number | null;
+  }[] = [];
+  const dayIns: DayIn[] = [];
   for (let i = 0; i < deficitRows.length; i++) {
     const r = deficitRows[i] as Record<string, unknown>;
     const dateStr = String(r.date).slice(0, 10);
     const isClosed = r.status === "closed";
     const isToday = dateStr === todayStr;
+    if (dateStr > todayStr) continue; // a planned-ahead day is not history
     const storedTarget = Number(r.target_calories) || 0;
 
-    if (storedTarget === 0 && !isToday && !isClosed) continue;
-
-    // Burn breakdown
+    // Burn breakdown. A day with no plan and no watch reading has no burn,
+    // and without a burn there is nothing to reconcile.
     const garminTotal = Number(r.garmin_burn) || 0;
+    if (storedTarget === 0 && garminTotal <= 1500 && !isToday) continue;
     const defUsed = Number(r.deficit_used) || goalDeficit;
     const totalBurn = garminTotal > 1500 ? garminTotal : storedTarget + defUsed;
     const bmr = Number(r.bmr) || 0;
@@ -236,44 +258,41 @@ export async function GET() {
     const runDistKm = Math.round((Number(r.run_dist) || 0) / 1000 * 10) / 10;
     const gymTitle = String(r.gym_title || "");
 
-    // Consumed
-    let consumed: number;
-    if (isClosed) {
-      consumed = Number(r.actual_calories) || 0;
-    } else if (isToday) {
-      consumed = todayConsumed;
-    } else {
-      const pastMeals = await sql`SELECT COALESCE(SUM(calories), 0) AS total FROM meal_log WHERE date = ${dateStr}`;
-      const pastDrinks = await sql`SELECT COALESCE(SUM(calories), 0) AS total FROM drink_log WHERE date = ${dateStr}`;
-      consumed = Number(pastMeals[0]?.total || 0) + Number(pastDrinks[0]?.total || 0);
-      if (consumed === 0) continue;
-    }
-
-    const deficit = consumed - totalBurn; // negative = deficit (good)
     const coverage = typeof r.coverage === "number" ? r.coverage : r.coverage != null ? Number(r.coverage) : null;
+    const observed = isObservedDay({
+      status: (r.status as string | null) ?? null,
+      closedBy: (r.closed_by as "user" | "auto" | null) ?? null,
+      coverage,
+    });
+    // Logged intake: an observed closed day keeps actual_calories (close-day
+    // reconciled it); today reads its live logs; anything else its raw logs.
+    const loggedKcal = isClosed && observed
+      ? Number(r.actual_calories) || 0
+      : isToday ? todayConsumed : Number(r.logged_calories) || 0;
 
+    prepared.push({ date: dateStr, bmr: Math.round(bmr), dailyActivity, runCal, runDistKm, gymCal, gymTitle, totalBurn: Math.round(totalBurn), closed: isClosed, isToday, coverage });
+    dayIns.push({ date: dateStr, observed, loggedKcal, loggedShare: observed ? 1 : Math.min(1, coverage ?? 0), burn: Math.round(totalBurn) });
+  }
+  const weighIns = weightRows.map((w: Record<string, unknown>) => ({ date: String(w.date).slice(0, 10), weightKg: Number(w.weight_kg) }));
+  const reconciled = reconcile(weighIns, dayIns);
+  for (let i = 0; i < prepared.length; i++) {
+    const p = prepared[i];
+    const o = reconciled[i];
     dailyDeficits.push({
-      date: dateStr,
-      bmr: Math.round(bmr),
-      dailyActivity,
-      runCal,
-      runDistKm,
-      gymCal,
-      gymTitle,
-      totalBurn: Math.round(totalBurn),
-      consumed: Math.round(consumed),
-      deficit: Math.round(deficit),
+      ...p,
+      consumed: Math.round(o.ate),
+      deficit: Math.round(o.deficit), // negative = deficit (good)
       cumulative: null,
       goalPace: null,
-      closed: isClosed,
-      isToday,
-      coverage,
-      counted: countsForDeficit({ date: dateStr, closed: isClosed, coverage, deficit }),
+      counted: o.source !== "unknown",
       inWindow: false,
+      source: o.source,
+      intervalStart: o.intervalStart,
+      intervalEnd: o.intervalEnd,
     });
   }
   // The current window: cumulative and goal pace run over its counted days only.
-  const win = deficitWindow(dailyDeficits.map(d => ({ date: d.date, closed: d.closed, coverage: d.coverage, deficit: d.deficit })), todayStr);
+  const win = deficitWindow(dailyDeficits.map(d => ({ date: d.date, closed: d.closed, coverage: d.coverage, deficit: d.deficit, counted: d.counted })), todayStr);
   let cumulativeDeficit = 0;
   let windowIndex = 0;
   for (const d of dailyDeficits) {

--- a/web/app/api/nutrition/plan/route.ts
+++ b/web/app/api/nutrition/plan/route.ts
@@ -5,7 +5,8 @@ import type { Mode } from "@/lib/mode-engine";
 import type { SlotBudgets } from "@/lib/nutrition-types";
 import { computeAdaptiveContext } from "@/lib/adaptive-tdee";
 import { computeWeeklyAdherence } from "@/lib/adherence";
-import { meetsCoverageFloor } from "@/lib/coverage";
+import { isObservedDay } from "@/lib/observed-day";
+import { reconcile, type DayIn } from "@/lib/energy-reconcile";
 import { nutritionEngagement, WEEK_ENGAGEMENT_FLOOR_DAYS } from "@/lib/engagement";
 import { getWeightTrend } from "@/lib/weight-trend";
 import { trendAte } from "@/lib/trend-ate";
@@ -487,14 +488,39 @@ export async function GET(req: NextRequest) {
 
   // ── 7-day rolling trend ──
   // `coverage` = (distinct slots with logged kcal ∪ explicitly skipped) / 4,
-  // the same definition lib/adaptive-tdee uses, so a closed-but-empty day is
-  // treated identically everywhere (#699).
-  const trendRows = await sql`
+  // the same definition lib/adaptive-tdee uses (#699). Since soma#891 a day is
+  // OBSERVED when a person closed it or every slot was logged or skipped; any
+  // other day is reconciled against the scale: the weight change between two
+  // weigh-ins, at 7700 kcal/kg, is spread over the unobserved share of the
+  // days between them (lib/energy-reconcile). For that the query spans back to
+  // the last weigh-in before the window, not just seven days. lib/adaptive-tdee
+  // stays on observed days only: an extrapolated day is derived from the scale,
+  // and feeding it back into a TDEE fit would be circular.
+  const shiftDate = (d: string, n: number) => {
+    const t = new Date(`${d}T00:00:00Z`);
+    t.setUTCDate(t.getUTCDate() + n);
+    return t.toISOString().slice(0, 10);
+  };
+  const weighIns = (
+    await sql`
+      SELECT date::text AS date, weight_grams / 1000.0 AS weight_kg
+      FROM weight_log WHERE weight_grams IS NOT NULL AND date <= ${date}::date ORDER BY date
+    `
+  ).map((w: Record<string, unknown>) => ({ date: String(w.date), weightKg: Number(w.weight_kg) }));
+  const windowStart = shiftDate(date, -6);
+  // The span starts at the beginning of the last complete weigh-in interval
+  // before the window: the rate that fills the window's unlogged days is that
+  // interval's, and it needs every day of the interval to be computed.
+  const before = weighIns.filter((w: { date: string }) => w.date <= windowStart);
+  const intervalStart = before.length >= 2 ? before[before.length - 2] : before[0] ?? weighIns[0];
+  const spanStart = intervalStart && intervalStart.date < windowStart ? intervalStart.date : windowStart;
+  const spanRows = await sql`
     SELECT
       n.date::text AS date,
       n.target_calories,
       n.actual_calories,
       n.status,
+      n.closed_by,
       n.manual_override,
       n.deficit_used,
       (
@@ -514,10 +540,12 @@ export async function GET(req: NextRequest) {
              + COALESCE((SELECT SUM(d.calories) FROM drink_log d WHERE d.date = n.date), 0)
       ) AS logged_calories
     FROM nutrition_day n
-    WHERE n.date >= ${date}::date - interval '6 days'
+    WHERE n.date >= ${spanStart}::date
       AND n.date <= ${date}::date
     ORDER BY n.date
   `;
+  // The seven days the trend shows; the rows before them only feed the reconciliation.
+  const trendRows = spanRows.filter((r: Record<string, unknown>) => String(r.date) >= windowStart);
 
   // Goal deficit from profile (the user's real target, e.g. 800/day)
   let goalDeficit = 800;
@@ -535,59 +563,102 @@ export async function GET(req: NextRequest) {
     return target + defUsed;
   };
 
-  // A day feeds the cumulative deficit and weekly adherence only when it is
-  // closed AND its logging coverage clears the floor. A closed day with one
-  // meal logged is absent data, not a 600-kcal day; counting it is how the
-  // week reads as a huge deficit the user never had (#699).
-  const counts = (r: Record<string, unknown>) =>
-    r.status === "closed" && meetsCoverageFloor(r.coverage as number | null);
-  const counted = trendRows.filter(counts);
+  const coverageOf = (r: Record<string, unknown>) =>
+    typeof r.coverage === "number" ? r.coverage : r.coverage != null ? Number(r.coverage) : null;
+  // A day with no plan has no burn (target 0 + deficit is not one), and
+  // without a burn there is nothing to reconcile: it stays unknown.
+  const hasBurn = (r: Record<string, unknown>) => String(r.date) === date || Number(r.target_calories) > 0;
+  const spanDays: DayIn[] = spanRows.filter(hasBurn).map((r: Record<string, unknown>) => {
+    const d = String(r.date);
+    const isCurrentDay = d === date;
+    const coverage = coverageOf(r);
+    const observed = isObservedDay({
+      status: (r.status as string | null) ?? null,
+      closedBy: (r.closed_by as "user" | "auto" | null) ?? null,
+      coverage,
+    });
+    // An observed closed day keeps actual_calories (close-day reconciled it);
+    // an auto-closed day is read from its raw logs like an open one.
+    const loggedKcal = trendAte({
+      isToday: isCurrentDay,
+      closed: observed && r.status === "closed",
+      actualCalories: r.actual_calories as number | null,
+      loggedCalories: r.logged_calories as number | null,
+      todayConsumed: consumed.calories,
+    });
+    return {
+      date: d,
+      observed,
+      loggedKcal,
+      // The share of the day that was logged or skipped; the rest is estimated.
+      loggedShare: observed ? 1 : Math.min(1, coverage ?? 0),
+      burn: Math.round(computeBurn(r, isCurrentDay)),
+    };
+  });
+  const reconciled = new Map(reconcile(weighIns, spanDays).map((o) => [o.date, o]));
+  const windowOut = trendRows.map((r: Record<string, unknown>) => {
+    const o = reconciled.get(String(r.date));
+    if (o) return o;
+    // Unknown day: the legacy numbers, for display only, never summed.
+    const isCurrentDay = String(r.date) === date;
+    const ate = trendAte({
+      isToday: isCurrentDay,
+      closed: r.status === "closed",
+      actualCalories: r.actual_calories as number | null,
+      loggedCalories: r.logged_calories as number | null,
+      todayConsumed: consumed.calories,
+    });
+    const burn = Math.round(computeBurn(r, isCurrentDay));
+    return { date: String(r.date), ate, burn, deficit: ate - burn, source: "unknown" as const, intervalStart: null, intervalEnd: null };
+  });
+  // A day feeds the cumulative deficit and weekly adherence when it is observed
+  // or reconciled; only a day nothing can say anything about is left out.
+  const counted = windowOut.filter((o) => o.source !== "unknown");
 
   const trend7d = {
     goalDeficit,
-    days: trendRows.map((r: Record<string, unknown>) => {
-      const isCurrentDay = String(r.date) === date;
-      const ate = trendAte({
-        isToday: isCurrentDay,
-        closed: r.status === "closed",
-        actualCalories: r.actual_calories as number | null,
-        loggedCalories: r.logged_calories as number | null,
-        todayConsumed: consumed.calories,
-      });
-      const burn = Math.round(computeBurn(r, isCurrentDay));
-      const deficit = ate - burn; // negative = deficit (good), positive = surplus (bad)
+    days: trendRows.map((r: Record<string, unknown>, i: number) => {
+      const o = windowOut[i];
       return {
         date: r.date,
-        ate,
-        burn,
-        deficit,
+        ate: Math.round(o.ate),
+        burn: o.burn,
+        deficit: Math.round(o.deficit), // negative = deficit (good), positive = surplus (bad)
         closed: r.status === "closed",
-        // Surfaced so the UI can distinguish "closed and complete" from
-        // "closed but barely logged" instead of painting both the same.
-        coverage: typeof r.coverage === "number" ? r.coverage : null,
-        counted: counts(r),
-        isToday: isCurrentDay,
+        coverage: coverageOf(r),
+        counted: o.source !== "unknown",
+        isToday: String(r.date) === date,
+        // observed | partial | extrapolated | unknown, and the weigh-in interval
+        // the estimate came from, so the UI can say "~" and between which dates.
+        source: o.source,
+        intervalStart: o.intervalStart,
+        intervalEnd: o.intervalEnd,
       };
     }),
-    // Cumulative deficit: sum of (ate - burn) over counted days only
-    totalDeficit: counted.reduce((sum: number, r: Record<string, unknown>) => {
-      const ate = Number(r.actual_calories) || 0;
-      const burn = Math.round(computeBurn(r, false));
-      return sum + (ate - burn);
-    }, 0),
+    // Cumulative deficit: sum of (ate - burn) over counted days
+    totalDeficit: Math.round(counted.reduce((sum, o) => sum + o.deficit, 0)),
     closedDays: counted.length,
     goalExpectedDeficit: counted.length * goalDeficit,
     // Weekly adherence (±10% band). Achieved deficit = burn − ate, summed over
     // counted days (positive = in deficit); goal = counted days × goal/day.
-    adherence: (() => {
-      const weeklyActual = counted.reduce((s: number, r: Record<string, unknown>) => {
-        const ate = Number(r.actual_calories) || 0;
-        const burn = Math.round(computeBurn(r, false));
-        return s + (burn - ate);
-      }, 0);
-      return computeWeeklyAdherence(weeklyActual, counted.length * goalDeficit);
-    })(),
+    adherence: computeWeeklyAdherence(
+      Math.round(counted.reduce((s, o) => s + (o.burn - o.ate), 0)),
+      counted.length * goalDeficit,
+    ),
   };
+  // Today's own estimate for the hero: what the day will have come to once the
+  // unlogged share is filled at the current interval's rate.
+  const todayOut = reconciled.get(date);
+  const deficitEstimate = todayOut
+    ? {
+        ate: Math.round(todayOut.ate),
+        burn: todayOut.burn,
+        deficit: Math.round(todayOut.deficit),
+        source: todayOut.source,
+        intervalStart: todayOut.intervalStart,
+        intervalEnd: todayOut.intervalEnd,
+      }
+    : null;
 
   // Adaptive TDEE + deficit-duration (display-only — never changes targets).
   const adaptive = await computeAdaptiveContext(sql).catch(() => null);
@@ -622,6 +693,7 @@ export async function GET(req: NextRequest) {
     gymCalories,
     breakdown,
     trend7d,
+    deficitEstimate,
     // Only meaningful when the week is engaged; the UI hides it otherwise
     // rather than showing a drift computed from nothing.
     adaptive: engagement.state === "complete" ? adaptive : null,

--- a/web/lib/deficit-window.ts
+++ b/web/lib/deficit-window.ts
@@ -17,6 +17,9 @@ export interface WindowDay {
   coverage: number | null;
   /** consumed − burn for the day; negative is a deficit. */
   deficit: number;
+  /** When set, decides whether the day counts (soma#891: a reconciled day counts
+   *  whether or not it was closed). Absent, the #699 rule applies. */
+  counted?: boolean;
 }
 
 export interface DeficitWindow {
@@ -36,6 +39,7 @@ export interface DeficitWindow {
 }
 
 export function countsForDeficit(d: WindowDay): boolean {
+  if (typeof d.counted === "boolean") return d.counted;
   return d.closed && meetsCoverageFloor(d.coverage);
 }
 

--- a/web/lib/energy-reconcile.test.ts
+++ b/web/lib/energy-reconcile.test.ts
@@ -32,9 +32,13 @@ describe("reconcile", () => {
     );
     expect(out[2].source).toBe("extrapolated"); expect(out[2].ate).toBeCloseTo(2400, 0); expect(out[2].intervalEnd).toBe("2026-09-03");
   });
-  it("leaves every day unknown with fewer than two weigh-ins", () => {
-    const out = reconcile([{ date: "2026-09-01", weightKg: 75 }], [day("2026-09-01"), day("2026-09-02")]);
-    expect(out.every((d) => d.source === "unknown")).toBe(true);
+  it("leaves unobserved days unknown with fewer than two weigh-ins, observed ones observed", () => {
+    const out = reconcile(
+      [{ date: "2026-09-01", weightKg: 75 }],
+      [day("2026-09-01"), day("2026-09-02", { observed: true, loggedKcal: 2000, loggedShare: 1 })],
+    );
+    expect(out.map((d) => d.source)).toEqual(["unknown", "observed"]);
+    expect(out[1].deficit).toBe(2000 - 2400);
   });
   it("keeps observed days untouched when every day is observed", () => {
     const out = reconcile(

--- a/web/lib/energy-reconcile.ts
+++ b/web/lib/energy-reconcile.ts
@@ -35,7 +35,9 @@ export function reconcile(weighIns: { date: string; weightKg: number }[], days: 
   const unknown = (d: DayIn): DayOut => ({
     date: d.date, ate: d.loggedKcal, burn: d.burn, deficit: d.loggedKcal - d.burn, source: "unknown", intervalStart: null, intervalEnd: null,
   });
-  if (w.length < 2) return days.map(unknown);
+  // With fewer than two weigh-ins nothing can be extrapolated, but an observed
+  // day is still observed: its intake was logged, no scale needed.
+  if (w.length < 2) return days.map((d) => (d.observed ? { ...unknown(d), source: "observed" as const } : unknown(d)));
 
   const out = new Map<string, DayOut>();
   const rates: { start: string; end: string; A: number }[] = [];


### PR DESCRIPTION
The nutrition routes reconcile unlogged days against the scale (soma#891, Task 12.3).

Rule, as decided on 2026-09-11: a day is observed when a person closed it or every slot was logged or skipped. Any other day is not a zero and not a gap: the weight change between two weigh-ins, at 7700 kcal/kg, is spread over the unobserved share of the days between them, and a partially logged day keeps what was logged and gets the rest at that rate. `lib/energy-reconcile` (merged in #900) does the arithmetic; this PR wires it into the two routes.

`GET /api/nutrition/plan`

- The 7-day trend query now spans back to the start of the last complete weigh-in interval before the window, because the rate that fills the window's unlogged days is that interval's and it needs every day of the interval.
- Every `trend7d.days[]` entry carries `source` (`observed`, `partial`, `extrapolated`, `unknown`) and the weigh-in interval the estimate came from (`intervalStart`, `intervalEnd`). `counted` is now "not unknown": an auto-closed day counts through its estimate. `totalDeficit`, `closedDays` and `adherence` sum the counted days.
- A day with no plan has no burn and stays `unknown`; its legacy numbers are returned for display and never summed.
- New top-level `deficitEstimate`: today's own estimate for the hero (logged so far plus the unlogged share at the current rate), with its source and interval.

`GET /api/nutrition/body-comp`

- `dailyDeficits[]` covers every day from the first weigh-in on, not only days with something logged, and each entry carries `source` and the interval. The `if (consumed === 0) continue` gate is gone, as are the two queries per past day (the logged calories come from the main query now).
- `counted` is "not unknown"; `lib/deficit-window` accepts that from the caller (a `counted` override on `WindowDay`), so the window and the cumulative line run over reconciled days. Planned-ahead days are skipped.
- `lib/adaptive-tdee` is unchanged on purpose: it fits on observed days, and an extrapolated day is derived from the scale, so feeding it back would be circular.

`lib/energy-reconcile`: with fewer than two weigh-ins an observed day is still `observed` (its intake was logged; no scale needed). Test updated.

Proof on a dev server of this branch against `verify_soma`:

- `trend7d.days` shows `extrapolated` days at 2569 kcal (burn 2363 plus the interval's surplus rate) where the old route showed 0, one `unknown` day with no plan, and today `partial` at 2652 (2010 logged over 0.75 of the day). `deficitEstimate` is that partial day.
- `body-comp`: 145 days, 45 observed, 96 extrapolated, 4 partial, none with `consumed` 0. Over the last complete interval (2026-05-12 to 2026-08-26, weight 73.2 to 73.2) the reconciled deficits sum to -9 kcal against an implied 0: the identity holds within rounding.
- `tsc` clean; vitest on the three lib tests passes.

The two routes estimate burn differently on days with a watch reading (body-comp prefers the Garmin total), as they did before, so their extrapolated values can differ by that much. The web and app marking of these days is #895 and #896, next.

Closes #894
