### PR TITLE
feat(nutrition): plan tomorrow on the phone (#873)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -79,6 +79,11 @@ function shiftDate(iso: string, days: number): string {
 export default function NutritionScreen() {
   const [DATE, setDATE] = useState(todayLocal());
   const isToday = DATE === todayLocal();
+  // Plan ahead one day, not seven: decided 2026-09-11 (#873). Tomorrow's meals are
+  // plans (meal_log.planned) until the day comes.
+  const MAX_AHEAD_DAYS = 1;
+  const isFuture = DATE > todayLocal();
+  const isTomorrow = DATE === shiftDate(todayLocal(), 1);
   const { data, loading, error, refetch } = useSomaPlan(DATE);
   // Reset per-day transient UI when the viewed day changes, and load that
   // day's locked slots from storage (guarded — no-ops on native).
@@ -227,7 +232,8 @@ export default function NutritionScreen() {
     });
     setQBusy(false);
     if (ok) {
-      setLogMode("preset");
+      // The preset and compose paths close the modal on success; quick add now does too (#859).
+      closeLog();
       setQName(""); setQCal(""); setQP(""); setQC(""); setQF("");
       refetch();
       doRebalance(slot);
@@ -248,6 +254,12 @@ export default function NutritionScreen() {
   async function onCopyYesterday() {
     setCopyBusy(true);
     const ok = await copyDay(shiftDate(DATE, -1), DATE);
+    setCopyBusy(false);
+    if (ok) refetch();
+  }
+  async function onCopyToday() {
+    setCopyBusy(true);
+    const ok = await copyDay(todayLocal(), DATE);
     setCopyBusy(false);
     if (ok) refetch();
   }
@@ -366,10 +378,10 @@ export default function NutritionScreen() {
         <View className="w-full flex-row items-center justify-between">
           <Button label="‹" variant="ghost" size="sm" onPress={() => setDATE((d) => shiftDate(d, -1))} />
           <View className="flex-row items-center gap-2">
-            <Text variant="title">{isToday ? "Today" : niceDate(DATE)}</Text>
+            <Text variant="title">{isToday ? "Today" : isTomorrow ? "Tomorrow" : niceDate(DATE)}</Text>
             {dayClosed ? <Badge label="Closed" tone="success" /> : <Badge label="Nutrition" tone="teal" />}
           </View>
-          <Button label="›" variant="ghost" size="sm" disabled={isToday} onPress={() => setDATE((d) => shiftDate(d, 1))} />
+          <Button label="›" variant="ghost" size="sm" disabled={DATE >= shiftDate(todayLocal(), MAX_AHEAD_DAYS)} onPress={() => setDATE((d) => shiftDate(d, 1))} testID="day-next" />
         </View>
         {(!isToday || dayClosed || (meals.length === 0 && !dayClosed)) ? (
           <View className="flex-row flex-wrap items-center justify-center gap-2">
@@ -379,8 +391,11 @@ export default function NutritionScreen() {
             {dayClosed ? (
               <Button label={reopenBusy ? "…" : "Reopen day"} variant="ghost" size="sm" disabled={reopenBusy} onPress={onReopen} />
             ) : null}
-            {meals.length === 0 && !dayClosed ? (
+            {meals.length === 0 && !dayClosed && !isFuture ? (
               <Button label={copyBusy ? "…" : "Copy yesterday"} variant="ghost" size="sm" disabled={copyBusy} onPress={onCopyYesterday} />
+            ) : null}
+            {isFuture && !dayClosed ? (
+              <Button label={copyBusy ? "…" : "Copy today"} variant="ghost" size="sm" disabled={copyBusy} onPress={onCopyToday} testID="copy-today" />
             ) : null}
           </View>
         ) : null}
@@ -647,6 +662,7 @@ export default function NutritionScreen() {
                           <View className="flex-1">
                             <View className="flex-row items-center gap-1.5">
                               <Text variant="body" className="text-text" numberOfLines={1} style={{ flexShrink: 1 }}>{mealName(m, presets)}</Text>
+                              {m.planned ? <Badge label="planned" tone="neutral" /> : null}
                               <ProteinQualityPill grams={m.protein} weightKg={bd?.weightKg} />
                             </View>
                             <Text variant="micro" className="tabular-nums">

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -111,6 +111,8 @@ export interface SomaMealItem { name?: string; grams?: number; ingredient_id?: s
 export interface SomaMeal {
   id: number;
   meal_slot: string;
+  /** Logged on a future date: a plan, not a record (soma#873). */
+  planned?: boolean;
   source?: string | null;
   preset_meal_id?: string | null;
   calories: number; protein: number; carbs: number; fat: number; fiber: number;

--- a/web/app/api/nutrition/copy-day/route.ts
+++ b/web/app/api/nutrition/copy-day/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { isPlannedDate } from "@/lib/planned-meal";
 
 
 export async function POST(req: NextRequest) {
@@ -43,7 +44,7 @@ export async function POST(req: NextRequest) {
   for (const m of sourceMeals) {
     await sql`
       INSERT INTO meal_log (date, meal_slot, source, preset_meal_id, portion_multiplier,
-                            items, calories, protein, carbs, fat, fiber, notes)
+                            items, calories, protein, carbs, fat, fiber, notes, planned)
       VALUES (
         ${to_date},
         ${m.meal_slot},
@@ -56,7 +57,8 @@ export async function POST(req: NextRequest) {
         ${m.carbs},
         ${m.fat},
         ${m.fiber},
-        ${m.notes}
+        ${m.notes},
+        ${isPlannedDate(to_date)}
       )
     `;
     copied++;

--- a/web/app/api/nutrition/log-meal/route.ts
+++ b/web/app/api/nutrition/log-meal/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { isPlannedDate } from "@/lib/planned-meal";
 
 
 interface MealItem {
@@ -74,7 +75,7 @@ export async function POST(req: NextRequest) {
   const source = preset_meal_id ? "preset" : null;
 
   const result = await sql`
-    INSERT INTO meal_log (date, meal_slot, source, preset_meal_id, portion_multiplier, items, calories, protein, carbs, fat, fiber)
+    INSERT INTO meal_log (date, meal_slot, source, preset_meal_id, portion_multiplier, items, calories, protein, carbs, fat, fiber, planned)
     VALUES (
       ${date},
       ${meal_slot},
@@ -86,7 +87,8 @@ export async function POST(req: NextRequest) {
       ${Math.round(protein)},
       ${Math.round(carbs)},
       ${Math.round(fat)},
-      ${Math.round(fiber)}
+      ${Math.round(fiber)},
+      ${isPlannedDate(date)}
     )
     RETURNING id
   `;

--- a/web/components/meal-card.tsx
+++ b/web/components/meal-card.tsx
@@ -84,6 +84,8 @@ interface Meal {
   source: string | null;
   preset_meal_id: string | null;
   preset_name: string | null;
+  /** Logged on a future date: a plan, not a record (soma#873). */
+  planned?: boolean;
   portion_multiplier: number;
   items: any;
   calories: number;
@@ -544,6 +546,9 @@ export function MealCard({
                   <div className="min-w-0">
                     <div className="font-medium truncate">
                       {meal.preset_name || autoMealName(meal.items)}
+                      {meal.planned && (
+                        <span className="ml-1.5 align-middle text-[9px] px-1.5 py-0.5 rounded-full bg-white/10 text-muted-foreground font-normal" data-testid="planned-pill">planned</span>
+                      )}
                       {meal.portion_multiplier !== 1 && (
                         <span className="text-muted-foreground ml-1">
                           ({meal.portion_multiplier}x)

--- a/web/lib/planned-meal.test.ts
+++ b/web/lib/planned-meal.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { isPlannedDate } from "./planned-meal";
+
+describe("isPlannedDate (#873)", () => {
+  it("is true only for dates after today", () => {
+    expect(isPlannedDate("2026-09-12", "2026-09-11")).toBe(true);
+    expect(isPlannedDate("2026-09-11", "2026-09-11")).toBe(false);
+    expect(isPlannedDate("2026-09-10", "2026-09-11")).toBe(false);
+  });
+});

--- a/web/lib/planned-meal.ts
+++ b/web/lib/planned-meal.ts
@@ -1,0 +1,6 @@
+import { todayAthlete } from "./athlete-tz";
+
+/** A meal logged on a future date is a plan, not a record (soma#873). */
+export function isPlannedDate(date: string, today: string = todayAthlete()): boolean {
+  return date > today;
+}


### PR DESCRIPTION
Plan tomorrow on the phone, decided on 2026-09-11 as one day ahead, not seven (Q3). Also closes the log modal after a quick add (#859).

API (#910)

- `lib/planned-meal.ts`: `isPlannedDate(date, today)` is true only for a date after today in the athlete's timezone. Test added.
- `log-meal` and `copy-day` write `meal_log.planned` with it. A meal logged on tomorrow's date is a plan; the same meal on today is a record.

App (#911, #912, #859)

- The next-day arrow is enabled up to tomorrow (`MAX_AHEAD_DAYS = 1`); the header reads "Tomorrow" on that day.
- On a future day the actions row offers "Copy today" (`copyDay(today, date)`); "Copy yesterday" no longer shows there.
- A meal with `planned = true` carries a "planned" badge next to its name in the slot card.
- Quick add closes the modal on success, like the preset and compose paths did.

Web (#912)

- The meal card shows the same "planned" pill next to the meal name.

Verified against `verify_soma`:

- API on a dev server of this branch: a quick meal logged on 2026-09-12 has `planned = t`, the same meal on 2026-09-11 has `planned = f`; `copy-day` today to tomorrow copies four meals, all `planned = t`; the plan route returns `planned` on each meal.
- Web: `/nutrition?date=2026-09-12` shows the four copied meals with the pill (`evidence/P7-web-tomorrow.png`).
- Android release build on emulator-5556 with the real account, pointed at that server: the arrow opens "Tomorrow" with "Copy today" (`evidence/P7-app-tomorrow-empty.png`); after the tap the day carries today's meals with the badge (`evidence/P7-app-tomorrow-planned.png`); a quick add on Pre Sleep closes the modal and the card shows the meal (`evidence/P7-app-quick-add-closed.png`).
- web tsc and vitest (288), universal tsc, vitest (44) and eslint (86 warnings, the baseline) all pass.

Closes #873
Closes #910
Closes #911
Closes #912
Closes #859
