### PR TITLE
feat(nutrition): mark the days estimated from the scale on web and app (#895, #896)

### DIFF
--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -52,6 +52,11 @@ function mealName(m: SomaMeal, presets: Preset[] = []): string {
   return m.source ? slotLabel(m.source) : "Meal";
 }
 
+function shortMD(iso: string | null | undefined): string {
+  if (!iso) return "?";
+  const [y, mo, d] = iso.split("-").map(Number);
+  return new Date(y, (mo ?? 1) - 1, d ?? 1).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
 function niceDate(iso: string): string {
   const [y, mo, d] = iso.split("-").map(Number);
   const dt = new Date(y, (mo ?? 1) - 1, d ?? 1);
@@ -456,7 +461,9 @@ export default function NutritionScreen() {
                   const loggedSlotCount = ["breakfast", "lunch", "dinner", "pre_sleep"].filter(
                     (s) => logged.has(s) || skippedSlots.includes(s),
                   ).length;
-                  const todayObserved = dayClosed || loggedSlotCount >= 3;
+                  // Observed = closed by hand or every slot logged or skipped (soma#891);
+                  // the route says which. Without it, the older three-slot floor.
+                  const todayObserved = dayClosed || (data?.deficitEstimate ? data.deficitEstimate.source === "observed" : loggedSlotCount >= 3);
                   if (todayObserved) {
                     return (
                       <Text variant="micro" style={{ color: currentDeficit <= 0 ? "#6ad4a0" : "#f2868c" }} testID="hero-deficit">
@@ -464,6 +471,21 @@ export default function NutritionScreen() {
                           ? `${Math.abs(Math.round(currentDeficit)).toLocaleString()} kcal current deficit`
                           : `+${Math.round(currentDeficit).toLocaleString()} kcal surplus`}
                       </Text>
+                    );
+                  }
+                  // Not observed, but the scale knows the rate: say the estimate, marked
+                  // as one, and between which weigh-ins it comes from (soma#891).
+                  const est = data?.deficitEstimate && (data.deficitEstimate.source === "partial" || data.deficitEstimate.source === "extrapolated") ? data.deficitEstimate : null;
+                  if (est) {
+                    return (
+                      <View testID="hero-deficit-estimate">
+                        <Text variant="micro" style={{ color: est.deficit <= 0 ? "#6ad4a0cc" : "#f2868ccc" }}>
+                          ~{Math.abs(Math.round(est.deficit)).toLocaleString()} kcal estimated {est.deficit <= 0 ? "deficit" : "surplus"}
+                        </Text>
+                        <Text variant="micro" className="text-text-muted">
+                          {loggedSlotCount === 0 ? "nothing logged yet" : `${loggedSlotCount} of 4 meals logged`} · rest extrapolated between {shortMD(est.intervalStart)} and {shortMD(est.intervalEnd)}
+                        </Text>
+                      </View>
                     );
                   }
                   return (
@@ -744,14 +766,20 @@ export default function NutritionScreen() {
                     // Same three readings as the web table (#703/#717/#721): a day with
                     // nothing logged shows "–"; an open day (today or never closed) shows
                     // its running log in parentheses; only a counted day earns a colour.
-                    const unobserved = (d.coverage ?? 0) === 0 && !(d.ate > 0);
+                    // Since soma#891 a day that was not fully logged is estimated from the
+                    // scale: "~" marks it and the row is greyed; only a day nothing can be
+                    // said about shows a dash.
+                    const src = d.source ?? (d.counted ? "observed" : "unknown");
+                    const est = src === "extrapolated" || src === "partial";
+                    const unobserved = src === "unknown" && (d.coverage ?? 0) === 0 && !(d.ate > 0);
                     const open = !d.closed;
-                    const counted = d.counted === true;
-                    const ateText = unobserved ? "–" : open ? `(${Math.round(d.ate)})` : String(Math.round(d.ate));
-                    const defText = unobserved ? "–" : `${open ? "(" : ""}${d.deficit > 0 ? "+" : ""}${Math.round(d.deficit)}${open ? ")" : ""}`;
+                    const counted = d.counted === true && !est;
+                    const sign = d.deficit > 0 ? "+" : "";
+                    const ateText = unobserved ? "–" : est ? `~${Math.round(d.ate)}` : open ? `(${Math.round(d.ate)})` : String(Math.round(d.ate));
+                    const defText = unobserved ? "–" : est ? `~${sign}${Math.round(d.deficit)}` : `${open ? "(" : ""}${sign}${Math.round(d.deficit)}${open ? ")" : ""}`;
                     return (
                       <View key={d.date} className="flex-row items-center justify-between border-b border-border-subtle py-1.5" testID={`trend-row-${d.date}`}>
-                        <Text variant="caption" className={d.isToday ? "font-semibold text-teal" : "text-text-secondary"}>
+                        <Text variant="caption" className={d.isToday ? "font-semibold text-teal" : est ? "text-text-muted" : "text-text-secondary"}>
                           {niceDate(d.date).replace(/,.*/, "").slice(0, 3)} {d.date.slice(8)}
                         </Text>
                         <Text variant="caption" className="tabular-nums text-text-muted">{ateText} / {Math.round(d.burn)}</Text>
@@ -762,9 +790,9 @@ export default function NutritionScreen() {
                     );
                   })}
                   {/* A total over a partly logged week is not a week's deficit (#699/#703). */}
-                  {data?.engagement?.state === "complete" && (data?.trend7d?.closedDays ?? 0) > 0 ? (
+                  {(data?.engagement?.state === "complete" || days.every((d) => d.counted)) && (data?.trend7d?.closedDays ?? 0) > 0 ? (
                     <View className="flex-row items-center justify-between pt-1.5">
-                      <Text variant="caption" className="font-semibold text-text">Total ({data?.trend7d?.closedDays}d)</Text>
+                      <Text variant="caption" className="font-semibold text-text">Total ({data?.trend7d?.closedDays}d{days.some((d) => d.source === "extrapolated" || d.source === "partial") ? " ~" : ""})</Text>
                       <Text variant="caption" className="tabular-nums text-text-muted">{Math.round(sumAte)} / {Math.round(sumBurn)}</Text>
                       <Text variant="caption" className="w-16 text-right font-semibold tabular-nums" style={{ color: deficitTone(totalActual, goalTotal) }}>
                         {totalActual > 0 ? "+" : ""}{Math.round(totalActual)}
@@ -775,6 +803,14 @@ export default function NutritionScreen() {
                       Weekly total shows after {data?.engagement?.weekFloorDays ?? 3} full days.
                     </Text>
                   )}
+                  {(() => {
+                    const e = days.find((d) => d.source === "extrapolated" || d.source === "partial");
+                    return e ? (
+                      <Text variant="micro" className="pt-1 text-text-muted" testID="trend-estimate-note">
+                        ~ estimated from the scale between {shortMD(e.intervalStart)} and {shortMD(e.intervalEnd)}
+                      </Text>
+                    ) : null;
+                  })()}
                 </Card>
               );
             })() : (

--- a/universal/src/components/body-comp-chart.tsx
+++ b/universal/src/components/body-comp-chart.tsx
@@ -207,6 +207,12 @@ export function BodyCompChart({ visible }: { visible: boolean }) {
   const cLabels = cAxis.map(shortLabel);
   const cumulative = alignBy(cAxis, dailyDeficits.filter((d) => d.cumulative != null), "cumulative");
   const countedDays = profile.window?.countedDays ?? counted.length;
+  // Points estimated from the scale (soma#891) are drawn hollow over the line.
+  const srcByDate = new Map(dailyDeficits.map((d) => [d.date, d.source]));
+  const estimated = cAxis.map((d, i) => {
+    const src = srcByDate.get(d);
+    return cumulative[i] != null && (src === "extrapolated" || src === "partial") ? cumulative[i] : null;
+  });
   const cumulativeChart: LineChartProps = {
     labels: cLabels,
     xTicks: 4,
@@ -214,6 +220,7 @@ export function BodyCompChart({ visible }: { visible: boolean }) {
     series: [
       { values: goalPace, color: C.pace, dashed: true, width: 1.5, label: "Goal pace" },
       { values: cumulative, color: C.deficit, width: 2.2, label: "Actual" },
+      { values: estimated, color: C.deficit, mode: "dots", hollow: true, sizes: estimated.map(() => 3) },
     ],
   };
 

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -24,6 +24,8 @@ export interface ChartSeries {
   stack?: string;
   /** Per-index fill opacity for bars (web fades days outside the current window, soma#782). */
   opacities?: (number | null)[];
+  /** dots mode: ring instead of disc, for a value that is an estimate (soma#891). */
+  hollow?: boolean;
 }
 
 export interface LineChartProps {
@@ -267,7 +269,7 @@ export function LineChart(props: LineChartProps) {
               if (s.mode === "dots") {
                 return s.values.map((v, i) =>
                   v == null || !isFinite(v) ? null : (
-                    <Circle key={`${si}-${i}`} cx={xAt(i)} cy={yOf(s, v)} r={s.sizes?.[i] != null ? Math.max(1.4, Number(s.sizes[i])) : 2.6} fill={s.color} fillOpacity={s.sizes ? 0.55 : 1} />
+                    <Circle key={`${si}-${i}`} cx={xAt(i)} cy={yOf(s, v)} r={s.sizes?.[i] != null ? Math.max(1.4, Number(s.sizes[i])) : 2.6} fill={s.hollow ? "#0c1519" : s.color} stroke={s.hollow ? s.color : undefined} strokeWidth={s.hollow ? 1.4 : 0} fillOpacity={s.hollow ? 1 : s.sizes ? 0.55 : 1} />
                   ),
                 );
               }

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -130,7 +130,13 @@ export interface SomaBreakdown {
   adjustedTargets?: { calories?: number; protein?: number; carbs?: number; fat?: number; fiber?: number };
 }
 /** One 7-day trend row. `counted` = closed AND over the coverage floor (#699); only those feed totals or earn a colour. */
-export interface TrendDay { date: string; ate: number; burn: number; deficit: number; closed: boolean; isToday: boolean; coverage?: number | null; counted?: boolean }
+export type DaySource = "observed" | "partial" | "extrapolated" | "unknown";
+/** `source` (soma#891): observed = logged or closed by hand; partial/extrapolated = filled from the scale
+ *  between `intervalStart` and `intervalEnd`; unknown = nothing to say. `counted` = not unknown. */
+export interface TrendDay {
+  date: string; ate: number; burn: number; deficit: number; closed: boolean; isToday: boolean; coverage?: number | null; counted?: boolean;
+  source?: DaySource; intervalStart?: string | null; intervalEnd?: string | null;
+}
 export interface LoggedDrink {
   id: number; name: string; drink_type: string; quantity: number;
   calories: number; carbs?: number; alcohol_grams?: number; fat_oxidation_pause_hours?: number;
@@ -152,6 +158,8 @@ export interface SomaPlan {
     days?: TrendDay[];
     totalDeficit?: number; goalDeficit?: number; closedDays?: number;
   };
+  /** Today's own estimate: logged so far plus the unlogged share at the current interval's rate (soma#891). */
+  deficitEstimate?: { ate: number; burn: number; deficit: number; source: DaySource; intervalStart: string | null; intervalEnd: string | null } | null;
   /** Is nutrition in use this week (#698/#714). Gate the log-derived numbers on state === "complete". */
   engagement?: { state: "absent" | "partial" | "complete"; coverage: number; basis: string; weekFloorDays?: number };
   /** The scale: OLS over 14 days, null slope until 3 weigh-ins. Leads when weightTrendPrimary. */
@@ -1266,6 +1274,7 @@ export interface BodyComp {
     date: string; deficit: number; cumulative: number | null; goalPace: number | null; closed: boolean; isToday: boolean;
     bmr?: number; dailyActivity?: number; runCal?: number; gymCal?: number; totalBurn?: number; consumed?: number;
     coverage?: number | null; counted?: boolean; inWindow?: boolean;
+    source?: DaySource; intervalStart?: string | null; intervalEnd?: string | null;
   }[];
   goalDeficit: number;
 }

--- a/web/app/api/nutrition/body-comp/route.ts
+++ b/web/app/api/nutrition/body-comp/route.ts
@@ -174,7 +174,20 @@ export async function GET() {
   // lib/adaptive-tdee stays on observed days only: an extrapolated day is
   // derived from the scale, and feeding it back into a TDEE fit would be circular.
   const firstWeighIn = weightRows.length ? String((weightRows[0] as Record<string, unknown>).date) : "9999-12-31";
+  // Activity per day is aggregated once (a CTE), not four correlated scans of
+  // garmin_activity_raw per row: with every day since the first weigh-in in
+  // the result that was the whole cost of this route.
   const deficitRows = await sql`
+    WITH act AS (
+      SELECT (raw_json->>'startTimeLocal')::date AS d,
+             SUM((raw_json->>'calories')::float) FILTER (WHERE raw_json->'activityType'->>'typeKey' = 'running') AS run_cal,
+             SUM((raw_json->>'distance')::float) FILTER (WHERE raw_json->'activityType'->>'typeKey' = 'running') AS run_dist,
+             SUM((raw_json->>'calories')::float) FILTER (WHERE raw_json->'activityType'->>'typeKey' = 'strength_training') AS gym_cal,
+             MIN(raw_json->>'activityName') FILTER (WHERE raw_json->'activityType'->>'typeKey' = 'strength_training') AS gym_title
+      FROM garmin_activity_raw
+      WHERE endpoint_name = 'summary'
+      GROUP BY 1
+    )
     SELECT n.date::text AS date, n.target_calories, n.actual_calories, n.deficit_used, n.status, n.closed_by,
            h.total_kilocalories AS garmin_burn, h.bmr_kilocalories AS bmr, h.total_steps,
            (
@@ -186,18 +199,8 @@ export async function GET() {
              ) u
              WHERE u.s IN ('breakfast', 'lunch', 'dinner', 'pre_sleep')
            ) AS coverage,
-           COALESCE((SELECT SUM((raw_json->>'calories')::float) FROM garmin_activity_raw
-             WHERE endpoint_name = 'summary' AND raw_json->'activityType'->>'typeKey' = 'running'
-             AND (raw_json->>'startTimeLocal')::date = n.date), 0) AS run_cal,
-           COALESCE((SELECT SUM((raw_json->>'distance')::float) FROM garmin_activity_raw
-             WHERE endpoint_name = 'summary' AND raw_json->'activityType'->>'typeKey' = 'running'
-             AND (raw_json->>'startTimeLocal')::date = n.date), 0) AS run_dist,
-           COALESCE((SELECT SUM((raw_json->>'calories')::float) FROM garmin_activity_raw
-             WHERE endpoint_name = 'summary' AND raw_json->'activityType'->>'typeKey' = 'strength_training'
-             AND (raw_json->>'startTimeLocal')::date = n.date), 0) AS gym_cal,
-           (SELECT raw_json->>'activityName' FROM garmin_activity_raw
-             WHERE endpoint_name = 'summary' AND raw_json->'activityType'->>'typeKey' = 'strength_training'
-             AND (raw_json->>'startTimeLocal')::date = n.date LIMIT 1) AS gym_title
+           COALESCE(a.run_cal, 0) AS run_cal, COALESCE(a.run_dist, 0) AS run_dist,
+           COALESCE(a.gym_cal, 0) AS gym_cal, a.gym_title
 ,
            (
              SELECT COALESCE((SELECT SUM(m.calories) FROM meal_log m WHERE m.date = n.date), 0)
@@ -205,6 +208,7 @@ export async function GET() {
            ) AS logged_calories
     FROM nutrition_day n
     LEFT JOIN daily_health_summary h ON h.date = n.date
+    LEFT JOIN act a ON a.d = n.date
     WHERE n.actual_calories > 0 OR n.status = 'active' OR n.date >= ${firstWeighIn}::date
     ORDER BY n.date
   `;

--- a/web/components/body-comp-chart.tsx
+++ b/web/components/body-comp-chart.tsx
@@ -46,6 +46,8 @@ interface BodyCompData {
     gymCal: number; gymTitle: string; totalBurn: number; consumed: number;
     deficit: number; cumulative: number | null; goalPace: number | null; closed: boolean; isToday: boolean;
     coverage?: number | null; counted?: boolean; inWindow?: boolean;
+    /** observed | partial | extrapolated | unknown (soma#891) and the weigh-in interval an estimate came from. */
+    source?: string; intervalStart?: string | null; intervalEnd?: string | null;
   }[];
   goalDeficit: number;
 }
@@ -442,7 +444,7 @@ export function BodyCompChart() {
                         }}>
                           <div style={{ fontWeight: "bold", marginBottom: 6, display: "flex", justifyContent: "space-between" }}>
                             <span>{dayLabel}</span>
-                            <span style={{ fontSize: 10, opacity: 0.5 }}>{day.isToday ? "IN PROGRESS" : day.closed ? "CLOSED" : "OPEN"}</span>
+                            <span style={{ fontSize: 10, opacity: 0.5 }}>{day.source === "extrapolated" ? "ESTIMATED" : day.source === "partial" ? "PARTLY LOGGED" : day.isToday ? "IN PROGRESS" : day.closed ? "CLOSED" : "OPEN"}</span>
                           </div>
                           <div style={{ borderBottom: "1px solid rgba(255,255,255,0.1)", paddingBottom: 4, marginBottom: 4 }}>
                             <div style={{ display: "flex", justifyContent: "space-between" }}>
@@ -510,7 +512,9 @@ export function BodyCompChart() {
                     if (payload.eatenDot == null || payload.eatenDot === 0) return <></>;
                     const deficit = payload.deficit;
                     const fill = deficit <= -goalDeficit ? "#22c55e" : deficit < 0 ? "#f59e0b" : "#ef4444";
-                    return <circle cx={cx} cy={cy} r={5} fill={fill} stroke="rgba(0,0,0,0.5)" strokeWidth={1.5} />;
+                    // An estimated day (soma#891) is a hollow dot: the value is the scale's, not a log.
+                    const est = payload.source === "extrapolated" || payload.source === "partial";
+                    return <circle cx={cx} cy={cy} r={5} fill={est ? "none" : fill} stroke={est ? fill : "rgba(0,0,0,0.5)"} strokeWidth={1.5} />;
                   }} connectNulls={false} />
                 </ComposedChart>
               </ResponsiveContainer>
@@ -542,10 +546,10 @@ export function BodyCompChart() {
                 <ComposedChart data={(() => {
                   // Build cumulative data matching weight chart X-axis range
                   const totalDeficitNeeded = -Math.round((profile.fatToLose || 5.5) * 7700);
-                  const deficitData: { date: string; cumulative: number | null; goalPace: number | null }[] = [];
+                  const deficitData: { date: string; cumulative: number | null; goalPace: number | null; source?: string }[] = [];
                   // Add actual deficit data points
                   for (const d of dailyDeficits) {
-                    deficitData.push({ date: d.date, cumulative: d.cumulative, goalPace: null });
+                    deficitData.push({ date: d.date, cumulative: d.cumulative, goalPace: null, source: d.source });
                   }
                   // Add goal pace line: daily samples so it renders as a smooth straight line
                   // Goal pace runs over the current window only: from its first counted
@@ -608,7 +612,13 @@ export function BodyCompChart() {
                   />
                   <ReferenceLine y={0} stroke="rgba(255,255,255,0.2)" strokeDasharray="4 4" />
                   <Line type="linear" dataKey="goalPace" stroke="#f97316" strokeWidth={2} dot={false} connectNulls isAnimationActive={false} />
-                  <Line type="monotone" dataKey="cumulative" stroke="#3b82f6" strokeWidth={2} dot={{ r: 3, fill: "#3b82f6" }} connectNulls={false} />
+                  <Line type="monotone" dataKey="cumulative" stroke="#3b82f6" strokeWidth={2} dot={(props: any) => {
+                    const { cx, cy, payload, key } = props;
+                    if (payload.cumulative == null) return <g key={key} />;
+                    // Hollow where the day was estimated from the scale (soma#891).
+                    const est = payload.source === "extrapolated" || payload.source === "partial";
+                    return <circle key={key} cx={cx} cy={cy} r={3} fill={est ? "#0b1220" : "#3b82f6"} stroke="#3b82f6" strokeWidth={1.5} />;
+                  }} connectNulls={false} />
                 </ComposedChart>
               </ResponsiveContainer>
             </div>

--- a/web/components/nutrition-dashboard.tsx
+++ b/web/components/nutrition-dashboard.tsx
@@ -335,6 +335,9 @@ export function NutritionDashboard({
   const [budgetExpanded, setBudgetExpanded] = useState(false);
   const [breakdown, setBreakdown] = useState<any>(null);
   const [trend7d, setTrend7d] = useState<any>(null);
+  // Today's estimate from the scale when the day is not fully logged (soma#891).
+  const [deficitEstimate, setDeficitEstimate] = useState<any>(null);
+  const fmtShort = (d: string | null | undefined) => d ? new Date(d + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" }) : "?";
   const [adaptive, setAdaptive] = useState<any>(null);
   // Engagement-aware rendering (#698): is nutrition actually in use this
   // week, and what does the scale say regardless of logging.
@@ -366,6 +369,7 @@ export function NutritionDashboard({
         if (data.slotBudgets) setSlotBudgets(data.slotBudgets);
         if (data.breakdown) setBreakdown(data.breakdown);
         if (data.trend7d) setTrend7d(data.trend7d);
+        setDeficitEstimate(data.deficitEstimate ?? null);
         setAdaptive(data.adaptive ?? null);
         setEngagement(data.engagement ?? null);
         setWeightTrend(data.weightTrend ?? null);
@@ -703,11 +707,26 @@ export function NutritionDashboard({
                         Below the coverage floor, say what is true instead. */}
                     {(() => {
                       const loggedSlotCount = 4 - unloggedSlots.length;
-                      const todayObserved = isClosed || loggedSlotCount >= 3;
+                      // Observed = closed by hand or every slot logged or skipped (soma#891);
+                      // the route says which. Without it, the older three-slot floor.
+                      const todayObserved = isClosed || (deficitEstimate ? deficitEstimate.source === "observed" : loggedSlotCount >= 3);
                       if (todayObserved) {
                         return (
                           <div className="text-xs text-center" data-testid="hero-deficit">
                             <span className={currentDeficit < 0 ? "text-green-500" : "text-rose-500"}>{currentDeficit > 0 ? "+" : ""}{Math.round(currentDeficit)} current deficit</span>
+                          </div>
+                        );
+                      }
+                      // Not observed, but the scale knows the rate: say the estimate,
+                      // marked as one, and between which weigh-ins it comes from (soma#891).
+                      const est = deficitEstimate && (deficitEstimate.source === "partial" || deficitEstimate.source === "extrapolated") ? deficitEstimate : null;
+                      if (est) {
+                        return (
+                          <div className="text-xs text-center text-muted-foreground" data-testid="hero-deficit-estimate">
+                            <span className={est.deficit <= 0 ? "text-green-500/80" : "text-rose-500/80"}>~{est.deficit > 0 ? "+" : ""}{est.deficit} estimated deficit</span>
+                            <span className="block text-[10px] text-muted-foreground/70">
+                              {loggedSlotCount === 0 ? "nothing logged yet" : `${loggedSlotCount} of 4 meals logged`} · rest extrapolated between {fmtShort(est.intervalStart)} and {fmtShort(est.intervalEnd)}
+                            </span>
                           </div>
                         );
                       }
@@ -895,42 +914,42 @@ export function NutritionDashboard({
                             // closed: its ate is the running log (#717), so it reads
                             // parenthesised and muted, never as a settled deficit.
                             const isInProgress = !d.closed;
-                            // A day with nothing logged has no deficit to show, in
-                            // progress or not: "(−2363)" for an unlogged today is the
-                            // same fabrication the hero no longer makes (#703).
-                            const unobserved = (d.coverage ?? 0) === 0 && !(d.ate > 0);
-                            // Colour is a verdict; only a counted day earns one (#699).
-                            const tone = d.counted ? deficitColor : "text-muted-foreground";
+                            // Since soma#891 a day that was not fully logged is estimated from
+                            // the scale: "~" marks it and the row is greyed. Only a day nothing
+                            // can be said about (no plan, or no scale) shows a dash.
+                            const src: string = d.source ?? (d.counted ? "observed" : "unknown");
+                            const est = src === "extrapolated" || src === "partial";
+                            const unobserved = src === "unknown" && (d.coverage ?? 0) === 0 && !(d.ate > 0);
+                            // Colour is a verdict; only an observed, counted day earns one (#699).
+                            const tone = est ? "text-muted-foreground" : d.counted ? deficitColor : "text-muted-foreground";
+                            const sign = d.deficit > 0 ? "+" : "";
+                            const ateText = unobserved ? "\u2013" : est ? `~${d.ate}` : isInProgress ? `(${d.ate})` : d.ate || "\u2013";
+                            const defText = unobserved ? "\u2013" : est ? `~${sign}${d.deficit}` : isInProgress ? `(${sign}${d.deficit})` : d.ate > 0 ? `${sign}${d.deficit}` : "\u2013";
                             return (
                               <React.Fragment key={d.date}>
-                                <span>
+                                <span className={est ? "text-muted-foreground" : ""}>
                                   {dayLabel}
                                   <span className="block sm:hidden text-[9px] text-muted-foreground/60">
-                                    ate {unobserved ? "–" : isInProgress ? `(${d.ate})` : d.ate} · burn {d.burn}
+                                    ate {ateText} · burn {d.burn}
                                   </span>
                                 </span>
-                                <span className={`tabular-nums text-right hidden sm:block ${isInProgress ? "text-muted-foreground" : ""}`} data-testid={`trend-ate-${d.date}`}>
-                                  {unobserved ? "\u2013" : isInProgress ? `(${d.ate})` : d.ate || "\u2013"} / {d.burn || "\u2013"}
+                                <span className={`tabular-nums text-right hidden sm:block ${isInProgress || est ? "text-muted-foreground" : ""}`} data-testid={`trend-ate-${d.date}`}>
+                                  {ateText} / {d.burn || "\u2013"}
                                 </span>
-                                <span className={`tabular-nums text-right font-medium ${tone}`} data-testid={`trend-deficit-${d.date}`} data-counted={d.counted ? "1" : "0"}>
-                                  {unobserved
-                                    ? "\u2013"
-                                    : isInProgress
-                                      ? `(${d.deficit > 0 ? "+" : ""}${d.deficit})`
-                                      : d.ate > 0 ? `${d.deficit > 0 ? "+" : ""}${d.deficit}` : "\u2013"
-                                  } / &minus;{trend7d.goalDeficit}
+                                <span className={`tabular-nums text-right font-medium ${tone}`} data-testid={`trend-deficit-${d.date}`} data-counted={d.counted ? "1" : "0"} data-source={src}>
+                                  {defText} / &minus;{trend7d.goalDeficit}
                                 </span>
                               </React.Fragment>
                             );
                           })}
                           {/* Total — only over a fully engaged week. A total over
                               two closed days is not a week's deficit (#699, #703). */}
-                          {trend7d.closedDays > 0 && engagement?.state === "complete" && (() => {
+                          {trend7d.closedDays > 0 && (engagement?.state === "complete" || trend7d.days.every((d: any) => d.counted)) && (() => {
                             const total = trend7d.totalDeficit; // negative = deficit
                             const goal = -(trend7d.closedDays * trend7d.goalDeficit); // negative target
                             return (
                               <React.Fragment key="trend-total">
-                                <span className="font-medium border-t pt-1">Total ({trend7d.closedDays}d)</span>
+                                <span className="font-medium border-t pt-1">Total ({trend7d.closedDays}d{trend7d.days.some((d: any) => d.source === "extrapolated" || d.source === "partial") ? " ~" : ""})</span>
                                 <span className="border-t pt-1 hidden sm:block" />
                                 <span className={`tabular-nums text-right font-bold border-t pt-1 ${total <= goal ? "text-green-500" : "text-amber-500"}`}>
                                   {total > 0 ? "+" : ""}{Math.round(total)} / {goal}
@@ -939,7 +958,7 @@ export function NutritionDashboard({
                             );
                           })()}
                         </div>
-                        {trend7d.adherence && engagement?.state === "complete" && (() => {
+                        {trend7d.adherence && (engagement?.state === "complete" || trend7d.days.every((d: any) => d.counted)) && (() => {
                           const a = trend7d.adherence;
                           const label = a.status === "on_track" ? "on track" : a.status === "under" ? "under goal" : "over goal";
                           const color = a.status === "on_track" ? "text-green-500" : "text-amber-400";
@@ -949,6 +968,12 @@ export function NutritionDashboard({
                               <span className={`${color} tabular-nums`}>{label} · {Math.round(a.ratio * 100)}%</span>
                             </div>
                           );
+                        })()}
+                        {(() => {
+                          const e = trend7d.days.find((d: any) => d.source === "extrapolated" || d.source === "partial");
+                          return e ? (
+                            <div className="text-[9px] text-muted-foreground/60" data-testid="trend-estimate-note">~ estimated from the scale between {fmtShort(e.intervalStart)} and {fmtShort(e.intervalEnd)}</div>
+                          ) : null;
                         })()}
                         {trend7d.days.some((d: any) => d.manual) && (
                           <div className="text-[9px] text-muted-foreground/60">* offset target in parentheses · +/− vs {trend7d.goalDeficit}/day goal</div>


### PR DESCRIPTION
Web and app mark the days that were estimated from the scale (soma#891, Tasks 12.4 and 12.5), on top of the routes from #909.

Web (`nutrition-dashboard.tsx`, `body-comp-chart.tsx`)

- 7-day trend: an extrapolated or partly logged day prints `~` before its ate and its deficit and the row is greyed; a day nothing can be said about (no plan, or no scale) keeps the dash. A note under the table says "~ estimated from the scale between May 12 and Aug 26" with the weigh-in interval the rate came from.
- Hero: when today is not observed but the route has an estimate, it says "~+34 estimated deficit" with "3 of 4 meals logged · rest extrapolated between May 12 and Aug 26" under it, instead of "deficit unknown". Observed now comes from the route (`deficitEstimate.source`), so the old three-slot floor only applies to a server without it.
- Weekly total and adherence show when the week is engaged or when every day in the window is counted; the label carries `~` when any counted day is an estimate.
- Burn vs Eaten: the eaten dot of an estimated day is hollow; the tooltip says ESTIMATED or PARTLY LOGGED. Cumulative deficit: hollow points where the day was estimated.

App (`nutrition.tsx`, `body-comp-chart.tsx`, `line-chart.tsx`, `api.ts`)

- Same three readings in the hero and the 7-day table, with the same note; `TrendDay` and `dailyDeficits` carry `source` and the interval; `SomaPlan` carries `deficitEstimate`.
- The cumulative deficit chart draws estimated points as rings (`hollow` on a dots series, new in `line-chart`).

Also in this PR, from the route work: the body-comp query aggregates the day's Garmin activity once in a CTE instead of four correlated scans per row. With every day since the first weigh-in in the result that was the whole cost of the route: 9 s to 0.07 s warm on `verify_soma`, byte-identical output on all 145 days.

Verified against `verify_soma` on a dev server of this branch:

- Web desktop 1440 and mobile 390: hero estimate, the `~` rows, the dash on the day without a plan, the note, the trajectory charts.
- Android release build on emulator-5556 with the real account pointed at that server: Food tab hero "~34 kcal estimated surplus · 3 of 4 meals logged · rest extrapolated between May 12 and Aug 26"; Trend tab table with the `~` rows and the note; cumulative deficit rings. Screenshots on the evidence branch: `evidence/P12-web-day-desktop.png`, `evidence/P12-web-day-mobile.png`, `evidence/P12-web-trajectory-desktop.png`, `evidence/P12-app-food.png`, `evidence/P12-app-trend.png`.
- web tsc and vitest (287), universal tsc, vitest (44) and eslint (86 warnings, the baseline) all pass.

Closes #895
Closes #896
Closes #891
