### PR TITLE
chore(universal): clear the mechanical lint rules, budget 86 to 46 (#918)

### DIFF
--- a/.github/workflows/universal-ci.yml
+++ b/.github/workflows/universal-ci.yml
@@ -28,6 +28,6 @@ jobs:
         run: npm run typecheck
       - name: Lint
         working-directory: universal
-        run: npx eslint . --max-warnings 86
+        run: npx eslint . --max-warnings 46
       - name: Unit tests
         run: npm test

--- a/universal/eslint.config.js
+++ b/universal/eslint.config.js
@@ -13,7 +13,7 @@ const baseline = {
   "react-hooks/refs": "warn",
   "react/display-name": "warn",
   "react/no-unescaped-entities": "warn",
-  "@typescript-eslint/no-unused-vars": "warn",
+  "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_", ignoreRestSiblings: true }],
   "@typescript-eslint/array-type": "warn",
   "import/no-duplicates": "warn",
 };

--- a/universal/src/app/(main)/_layout.tsx
+++ b/universal/src/app/(main)/_layout.tsx
@@ -7,11 +7,11 @@ import { ChatProvider, useChat } from "../../components/ChatContext";
 import { ChatSheet } from "../../components/ChatSheet";
 
 type IconName = React.ComponentProps<typeof Ionicons>["name"];
-const tabIcon =
-  (name: IconName) =>
-  ({ color, size }: { color: ColorValue; size: number }) => (
-    <Ionicons name={name} size={size} color={color as string} />
-  );
+function tabIcon(name: IconName) {
+  return function TabIcon({ color, size }: { color: ColorValue; size: number }) {
+    return <Ionicons name={name} size={size} color={color as string} />;
+  };
+}
 
 /** Center ⊕ — opens the Claude chat as a quick log/ask action (not a route).
     Uses the shared soma-style CenterTabButton, wired to the chat context. */

--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -102,18 +102,6 @@ const CAT_COLOR: Record<string, string> = {
   Other: "#b17bd4",
 };
 
-function fmtDuration(mins: number): string {
-  const h = Math.floor(mins / 60);
-  const m = Math.round(mins % 60);
-  return h > 0 ? `${h}h ${m}m` : `${m}m`;
-}
-
-function fmtDate(iso: string): string {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "2-digit" });
-}
-
 export default function ActivitiesScreen() {
   const [range, setRange] = useRangePref();
   const { data, loading, error, refetch } = useActivities(range);

--- a/universal/src/app/(main)/overview.tsx
+++ b/universal/src/app/(main)/overview.tsx
@@ -25,8 +25,7 @@ import {
   todayLocal,
   type ActivityRow,
 } from "../../lib/api";
-import { readinessScore } from "banister";
-import { freshness, staleShort, todayKey } from "banister";
+import { readinessScore, freshness, staleShort, todayKey } from "banister";
 
 interface OverviewTrends {
   steps: number[];
@@ -444,7 +443,7 @@ export default function OverviewScreen() {
         ) : null}
 
         {/* Today's health KPIs */}
-        <Text variant="eyebrow" className="text-text-muted mt-1">Today's metrics</Text>
+        <Text variant="eyebrow" className="text-text-muted mt-1">Today&apos;s metrics</Text>
         <View className="flex-row flex-wrap gap-3">
           {stats.map((s) => (
             <Pressable key={s.label} className="min-w-[46%] flex-1" onPress={() => setStatDetail(s)}>

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -19,8 +19,6 @@ import { SleepScheduleChart } from "../../components/sleep-schedule-chart";
 /** Value series from a StatSeries.current, dropping nulls (for sparklines). */
 const seriesVals = (pts?: { value: number | null }[]) =>
   (pts ?? []).map((p) => Number(p.value)).filter((v) => isFinite(v));
-const series2Vals = (pts?: { value2?: number | null }[]) =>
-  (pts ?? []).map((p) => Number(p.value2)).filter((v) => isFinite(v));
 const chartLabel = (iso: string) => {
   const [, m, d] = iso.slice(0, 10).split("-").map(Number);
   return `${["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][(m ?? 1) - 1]} ${d}`;

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -58,18 +58,6 @@ function localDayOf(iso: string): string {
 }
 export { localDayOf };
 
-function formatDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  if (Number.isNaN(d.getTime())) return dateStr;
-  const now = new Date();
-  const sameYear = d.getFullYear() === now.getFullYear();
-  return d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    ...(sameYear ? {} : { year: "2-digit" }),
-  });
-}
-
 export default function WorkoutsScreen() {
   const { data, error, refetch } = useWorkouts();
   const [range, setRange] = useRangePref();
@@ -112,12 +100,6 @@ export default function WorkoutsScreen() {
     if (withKcal.length === 0) return null;
     return Math.round(withKcal.reduce((s, w) => s + w.kcal, 0) / withKcal.length);
   })();
-  const avgExercises = (() => {
-    const withEx = recent.filter((w) => w.exercises > 0);
-    if (withEx.length === 0) return null;
-    return Math.round(withEx.reduce((s, w) => s + w.exercises, 0) / withEx.length);
-  })();
-
   // Per-session calories, oldest→newest, for the Avg-Calories trend sparkline.
   const kcalTrend = recent
     .map((w) => w.kcal)

--- a/universal/src/components/ChatSheet.tsx
+++ b/universal/src/components/ChatSheet.tsx
@@ -165,14 +165,14 @@ function useChatStream() {
       }
     };
 
-    const onUser = (m: { content?: Array<{ type?: string; tool_use_id?: string; content?: unknown; is_error?: boolean }> }) => {
+    const onUser = (m: { content?: { type?: string; tool_use_id?: string; content?: unknown; is_error?: boolean }[] }) => {
       if (!Array.isArray(m.content)) return;
       for (const item of m.content) {
         if (item.type !== "tool_result" || !item.tool_use_id) continue;
         let raw2 = "";
         if (typeof item.content === "string") raw2 = item.content;
         else if (Array.isArray(item.content))
-          raw2 = (item.content as Array<{ type?: string; text?: string }>)
+          raw2 = (item.content as { type?: string; text?: string }[])
             .filter((c) => c.type === "text" && typeof c.text === "string")
             .map((c) => c.text as string)
             .join("\n");

--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { View, ScrollView, Image, Pressable, Platform, Share } from "react-native";
+import { View, ScrollView, Image, Platform, Share } from "react-native";
 import * as FileSystem from "expo-file-system/legacy";
 import * as Sharing from "expo-sharing";
 import { Text, Modal, Badge, Button, Sparkline } from "soma-style";

--- a/universal/src/components/compose-meal-view.tsx
+++ b/universal/src/components/compose-meal-view.tsx
@@ -122,7 +122,7 @@ export function ComposeMealView({
   const setG = (id: string, v: number) => setGrams((g) => ({ ...g, [id]: Math.max(0, Math.round(v)) }));
   const remove = (id: string) => setGrams((g) => { const n = { ...g }; delete n[id]; return n; });
   const toggleSet = (setter: React.Dispatch<React.SetStateAction<Set<string>>>) => (id: string) =>
-    setter((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+    setter((s) => { const n = new Set(s); if (n.has(id)) n.delete(id); else n.add(id); return n; });
   const toggleCooked = toggleSet(setCookedMode);
   const toggleGramMode = toggleSet(setGramMode);
 

--- a/universal/src/components/credentials-dialog.tsx
+++ b/universal/src/components/credentials-dialog.tsx
@@ -70,7 +70,7 @@ export function CredentialsDialog({ platform, onClose, onSaved }: { platform: st
         ) : (
           <>
             <Text variant="body" className="text-text-secondary">
-              {LABEL[platform] ?? platform} uses a {platform === "strava" ? "one-tap OAuth" : "browser-based"} sign-in that's handled on the soma web dashboard.
+              {LABEL[platform] ?? platform} uses a {platform === "strava" ? "one-tap OAuth" : "browser-based"} sign-in that&apos;s handled on the soma web dashboard.
             </Text>
             <Text variant="micro" className="text-text-muted">Open soma on the web to connect {LABEL[platform] ?? platform}, then pull-to-refresh here.</Text>
           </>

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -261,7 +261,7 @@ export function LineChart(props: LineChartProps) {
                 if (s.stack) for (let k = 0; k < si; k++) { const o = series[k]; if (o.mode === "bars" && o.stack === s.stack) o.values.forEach((v, i) => { base[i] = (base[i] ?? 0) + (v != null && isFinite(v) ? v : 0); }); }
                 return s.values.map((v, i) => {
                   if (v == null || !isFinite(v) || v <= 0) return null;
-                  const b = base[i] ?? 0; const y0 = yOf(s, b + (s.stack ? 0 : 0)); const yTop = yOf(s, b + v);
+                  const b = base[i] ?? 0; const yTop = yOf(s, b + v);
                   const bottom = s.stack ? yOf(s, b) : floorY;
                   return <Rect key={`${si}-${i}`} x={xAt(i) - bw / 2} y={Math.min(yTop, bottom)} width={bw} height={Math.max(0.5, Math.abs(bottom - yTop))} fill={s.color} fillOpacity={s.opacities?.[i] ?? 0.85} rx={s.stack ? 0 : 1} />;
                 });

--- a/universal/src/components/macro-goal-bar.tsx
+++ b/universal/src/components/macro-goal-bar.tsx
@@ -9,7 +9,6 @@ import { Text } from "soma-style";
 export type PerMealProteinLevel = "red" | "amber" | "yellow" | "green" | "plenty";
 const MPS_G_PER_KG = 0.4;
 const PLENTY_G_PER_KG = 0.55;
-const FALLBACK_MPS_G = 30;
 
 function proteinThresholds(weightKg: number | null | undefined) {
   if (!weightKg || weightKg <= 0) return { red: 15, amber: 25, yellow: 30, plenty: 55 };
@@ -109,7 +108,6 @@ export function MacroGoalBar({
 
   const displayRef = useMulti ? (softCeiling?.value ?? hardCeiling?.value ?? highest) : target;
   const floorPct = !useMulti && target > 0 ? Math.min(100, (target / maxVal) * 100) : null;
-  const underFloor = current < (useMulti ? (markers!.find((m) => m.optimal)?.value ?? 0) : target);
 
   const valueTone = pastHard ? "text-danger" : pastSoft ? "text-warm" : "text-text-muted";
 

--- a/universal/src/components/matched-activity-panel.tsx
+++ b/universal/src/components/matched-activity-panel.tsx
@@ -28,7 +28,7 @@ function ScoreRing({ score }: { score: number }) {
   );
 }
 
-function Bar({ label, plan, actual, unit, invert }: { label: string; plan: number; actual: number; unit: string; invert?: boolean }) {
+function Bar({ label, plan, actual, unit }: { label: string; plan: number; actual: number; unit: string; invert?: boolean }) {
   const ratio = plan > 0 ? actual / plan : 0;
   // compliance: 1.0 = on target; color by closeness
   const off = Math.abs(1 - ratio);

--- a/universal/src/components/race-header.tsx
+++ b/universal/src/components/race-header.tsx
@@ -1,5 +1,5 @@
 import { View } from "react-native";
-import { Text, Badge } from "soma-style";
+import { Badge } from "soma-style";
 import type { PlanDay } from "../lib/api";
 
 function daysBetween(a: string, b: string): number {

--- a/universal/src/components/running-routes.tsx
+++ b/universal/src/components/running-routes.tsx
@@ -3,7 +3,7 @@ import { View, Pressable } from "react-native";
 import { Text, Card } from "soma-style";
 import { RouteThumb } from "./route-thumb";
 import { ActivityDetailModal } from "./activity-detail-modal";
-import type { RouteItem, RoutePoint, ActivityRow } from "../lib/api";
+import type { RouteItem, ActivityRow } from "../lib/api";
 
 /** Web's gallery caption pace (mm:ss /km from distance + duration). */
 function formatPace(distanceKm: number | null, durationS: number | null): string {

--- a/universal/src/components/running-splits.tsx
+++ b/universal/src/components/running-splits.tsx
@@ -1,6 +1,6 @@
 import { View } from "react-native";
 import { Text, Card } from "soma-style";
-import type { RunningSplits } from "../lib/api";
+import type { RunningSplits as RunningSplitsData } from "../lib/api";
 
 /** Decimal minutes → "M:SS". */
 function pace(mins: number | null | undefined): string {
@@ -17,7 +17,7 @@ function shortDate(iso: string): string {
 const MEDAL = ["#e0c458", "#c0c0c8", "#b17850"]; // gold / silver / bronze
 
 /** Per-km pace bars + fastest single-km splits, fed by /api/running/splits. */
-export function RunningSplits({ data }: { data: RunningSplits | null | undefined }) {
+export function RunningSplits({ data }: { data: RunningSplitsData | null | undefined }) {
   if (!data) return null;
   const perKm = data.perKm.filter((k) => k.avg_pace != null);
   const paces = perKm.map((k) => Number(k.avg_pace));

--- a/universal/src/components/sleep-dashboard.tsx
+++ b/universal/src/components/sleep-dashboard.tsx
@@ -158,7 +158,7 @@ export function SleepDashboard({ summary }: { summary: SleepSummary | null | und
             chart={{ series: [{ values: scoreVals, color: "#a5b4fc", width: 2.2 }], labels: scoreLabels, refLine: { y: 80, color: "#6ad4a0" }, yMin: 0, yMax: 100, yFormat: (v) => String(Math.round(v)) }}
           >
             <Text variant="micro" className="tabular-nums text-text-muted">
-              avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"} · "Excellent" ≥ 80
+              avg {summary.stats.avg_score != null ? Math.round(summary.stats.avg_score) : "—"} · &quot;Excellent&quot; ≥ 80
             </Text>
             <LineChart height={120} interactive labels={scoreLabels} xTicks={4} yMin={0} yMax={100} refLine={{ y: 80, color: "#6ad4a0" }} yFormat={(v) => String(Math.round(v))} series={[{ values: scoreVals, color: "#a5b4fc", width: 2.2 }]} />
           </ExpandableChart>

--- a/universal/src/components/sleep-schedule-chart.tsx
+++ b/universal/src/components/sleep-schedule-chart.tsx
@@ -1,4 +1,3 @@
-import { View } from "react-native";
 import { Text, Card } from "soma-style";
 import { LineChart, ChartLegend, ExpandableChart, type LineChartProps } from "./line-chart";
 import type { SchedulePoint } from "../lib/api";

--- a/universal/src/components/training-schedule.tsx
+++ b/universal/src/components/training-schedule.tsx
@@ -282,7 +282,7 @@ export function TrainingSchedule({
   const toggleWeek = (w: number) =>
     setExpanded((prev) => {
       const next = new Set(prev);
-      next.has(w) ? next.delete(w) : next.add(w);
+      if (next.has(w)) next.delete(w); else next.add(w);
       return next;
     });
 

--- a/universal/src/components/training-trends.tsx
+++ b/universal/src/components/training-trends.tsx
@@ -2,8 +2,7 @@ import { View } from "react-native";
 import Svg, { Polyline } from "react-native-svg";
 import { Text, Card } from "soma-style";
 import type { ComparisonPoint } from "../lib/api";
-import { pacesForVdot, timeStr } from "banister";
-import { readinessScore } from "banister";
+import { pacesForVdot, timeStr, readinessScore } from "banister";
 
 /** Two lines on a SHARED y-scale (so the comparison is honest), scaled to width. */
 function DualLine({

--- a/universal/src/components/trajectory-chart.tsx
+++ b/universal/src/components/trajectory-chart.tsx
@@ -2,9 +2,8 @@ import { useState, useMemo } from "react";
 import { View, Pressable } from "react-native";
 import { Text, Card, SegmentedControl } from "soma-style";
 import { LineChart, ChartLegend, ExpandableChart, chartDateLabel, type LineChartProps } from "./line-chart";
-import { todayKey } from "banister";
+import { todayKey, getHMPrediction, timeStr } from "banister";
 import { trajectoryAnnotations } from "../lib/trajectory-annotations";
-import { getHMPrediction, timeStr } from "banister";
 import type { ForwardSim, TrajectoryData } from "../lib/api";
 
 function raceDateLabel(iso: string): string {

--- a/universal/src/components/whatif-slider.tsx
+++ b/universal/src/components/whatif-slider.tsx
@@ -91,7 +91,7 @@ export function WhatIfSlider({ planDays, onApply, onPreview }: { planDays: PlanD
         label={state === "saving" ? "Saving…" : state === "saved" ? "Saved" : state === "error" ? "Retry" : `Apply changes (${upcoming.length} workouts)`}
         onPress={apply}
       />
-      {state === "error" ? <Text variant="micro" className="text-danger">Couldn't save — the plan adjust flow may be web-only.</Text> : null}
+      {state === "error" ? <Text variant="micro" className="text-danger">Couldn&apos;t save — the plan adjust flow may be web-only.</Text> : null}
     </Card>
   );
 }

--- a/universal/src/lib/engine.test.ts
+++ b/universal/src/lib/engine.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { readinessFactorCalc, fatigueFactorCalc, DEFAULT_BASE_PACE } from "banister";
-import { getHMPrediction, getBasePace, getHRZone } from "banister";
-import { vdotFromHmSeconds } from "banister";
-import { projectVdotSeries, projectVdotAt, DEFAULT_BANISTER, type DatedLoad } from "banister";
+import {
+  readinessFactorCalc, fatigueFactorCalc, DEFAULT_BASE_PACE, getHMPrediction, getBasePace, getHRZone,
+  vdotFromHmSeconds, projectVdotSeries, projectVdotAt, DEFAULT_BANISTER, type DatedLoad,
+} from "banister";
 import { ALL_MUSCLE_GROUPS, MUSCLE_COLORS, MUSCLE_TO_SLUGS, SLUG_TO_MUSCLE, hexToRgba } from "./muscle-groups";
 
 /**

--- a/universal/src/lib/time-range.test.ts
+++ b/universal/src/lib/time-range.test.ts
@@ -8,7 +8,10 @@ vi.mock("@react-native-async-storage/async-storage", () => ({
   },
 }));
 
+// The mock above must be declared before the modules it replaces are imported.
+// eslint-disable-next-line import/first
 import AsyncStorage from "@react-native-async-storage/async-storage";
+// eslint-disable-next-line import/first
 import {
   RANGES, rangeToDays, rangeLabel, isRangeKey, getRangePref, setRangePref, hydrateRangePref,
   isRangeHydrated, __resetRangePrefForTests, DEFAULT_RANGE,


### PR DESCRIPTION
First of three PRs for #888. Baseline on main: 86 warnings, 0 errors. This one clears the rules that change no behaviour, 40 warnings, and lowers the CI budget from 86 to 46.

- `@typescript-eslint/no-unused-vars` (18): dead helpers and imports removed (`fmtDuration`, `fmtDate`, `formatDate`, `avgExercises`, `series2Vals`, `FALLBACK_MPS_G`, `underFloor`, `y0`, unused `Pressable`, `Text`, `View`, `RoutePoint`), one prop left in the type but no longer destructured. The rule now ignores `_`-prefixed names and rest siblings, which is what `playlist.ts` and `themed-view.tsx` use on purpose.
- `import/no-duplicates` (9): the split `banister` imports merged in overview, training-trends, trajectory-chart and engine.test.
- `react/no-unescaped-entities` (5): apostrophes and quotes in JSX text escaped; rendered text unchanged.
- `import/first` (2): the two imports that must follow a `vi.mock` in `time-range.test.ts` carry a line-level disable with the reason.
- `@typescript-eslint/array-type` (2), `no-unused-expressions` (2), `@typescript-eslint/no-redeclare` (1), `react/display-name` (1): `T[]` syntax, `if/else` instead of a ternary used for effect, the `RunningSplits` type aliased, the tab icon factory returns a named component.

Verified in the worktree: `npx eslint . --max-warnings 46` passes (46 left, all `react-hooks/*`), `npx tsc --noEmit` clean, vitest 44 passed. Device check of the tab bar and the Overview screen on emulator-5556 in the PR thread.

Closes #918
