### PR TITLE
chore(universal): no setState inside effects, memoised derived arrays (#919)

### DIFF
--- a/universal/src/app/(main)/activities.tsx
+++ b/universal/src/app/(main)/activities.tsx
@@ -72,20 +72,23 @@ interface ActivitiesSummary {
  */
 function useActivities(range: string) {
   const [data, setData] = useState<ActivitiesSummary | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reload, setReload] = useState(0);
+  // Loading is "the latest request has not settled": derived from a request key
+  // rather than set inside the effect (react-hooks/set-state-in-effect).
+  const key = `${range}|${reload}`;
+  const [settled, setSettled] = useState<string | null>(null);
+  const loading = settled !== key;
   useEffect(() => {
     let alive = true;
-    setLoading(true);
     fetchJson<ActivitiesSummary>(`/api/activities/summary?range=${range}`)
       .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)))
-      .finally(() => alive && setLoading(false));
+      .finally(() => alive && setSettled(key));
     return () => {
       alive = false;
     };
-  }, [range, reload]);
+  }, [range, key]);
   return { data, loading, error, refetch: () => setReload((n) => n + 1) };
 }
 

--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -339,9 +339,12 @@ function SourcesModal({ visible, onClose, selected, onChange }: { visible: boole
 
 /* Pump-up Bank modal (mirrors web pump-up-modal.tsx). */
 function BankModal({ visible, onClose, refreshKey }: { visible: boolean; onClose: () => void; refreshKey: number }) {
-  const [songs, setSongs] = useState<PumpUpSong[] | null>(null);
-  useEffect(() => { if (!visible) return; setSongs(null); fetchPumpUp().then(setSongs).catch(() => setSongs([])); }, [visible, refreshKey]);
-  async function remove(id: string) { setSongs((p) => (p ? p.filter((s) => s.track_id !== id) : p)); await removePumpUp(id); }
+  // The list is tagged with the open and refresh it answers; a fresh open reads as loading (null).
+  const key = `${visible}|${refreshKey}`;
+  const [fetched, setFetched] = useState<{ key: string; songs: PumpUpSong[] } | null>(null);
+  const songs = fetched?.key === key ? fetched.songs : null;
+  useEffect(() => { if (!visible) return; fetchPumpUp().then((s) => setFetched({ key, songs: s })).catch(() => setFetched({ key, songs: [] })); }, [visible, key]);
+  async function remove(id: string) { setFetched((p) => (p ? { ...p, songs: p.songs.filter((s) => s.track_id !== id) } : p)); await removePumpUp(id); }
   return (
     <Modal visible={visible} onClose={onClose} title="⚡ Pump-up Bank">
       <Text variant="micro" className="mb-2 text-text-muted tabular-nums">{songs?.length ?? 0}/10 songs</Text>

--- a/universal/src/app/(main)/playlist.tsx
+++ b/universal/src/app/(main)/playlist.tsx
@@ -40,12 +40,13 @@ interface PlaylistData {
 /** Fetches the three GET surfaces the playlist page reads from soma (:3456). */
 function usePlaylist() {
   const [data, setData] = useState<PlaylistData | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Loading until the one request settles (react-hooks/set-state-in-effect).
+  const [settled, setSettled] = useState(false);
+  const loading = !settled;
 
   useEffect(() => {
     let alive = true;
-    setLoading(true);
 
     const json = (path: string) => fetchJson<unknown>(path);
 
@@ -64,7 +65,7 @@ function usePlaylist() {
         setError(null);
       })
       .catch((e) => alive && setError(String(e.message ?? e)))
-      .finally(() => alive && setLoading(false));
+      .finally(() => alive && setSettled(true));
 
     return () => {
       alive = false;

--- a/universal/src/app/(main)/sleep.tsx
+++ b/universal/src/app/(main)/sleep.tsx
@@ -54,13 +54,15 @@ function useSleepRecovery(range: string) {
   const [stress, setStress] = useState<StatSeries | null>(null);
   const [battery, setBattery] = useState<StatSeries | null>(null);
   const [recovery, setRecovery] = useState<StatSeries | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reload, setReload] = useState(0);
+  // Loading is derived from a request key (react-hooks/set-state-in-effect).
+  const key = `${range}|${reload}`;
+  const [settled, setSettled] = useState<string | null>(null);
+  const loading = settled !== key;
 
   useEffect(() => {
     let alive = true;
-    setLoading(true);
     const get = (m: string) => fetchJson<StatSeries>(`/api/stats/${m}?range=${range}`);
 
     Promise.all([
@@ -80,12 +82,12 @@ function useSleepRecovery(range: string) {
         setError(null);
       })
       .catch((e) => alive && setError(String(e.message ?? e)))
-      .finally(() => alive && setLoading(false));
+      .finally(() => alive && setSettled(key));
 
     return () => {
       alive = false;
     };
-  }, [range, reload]);
+  }, [range, key]);
 
   return { sleep, rhr, stress, battery, recovery, loading, error, refetch: () => setReload((n) => n + 1) };
 }

--- a/universal/src/app/(main)/system.tsx
+++ b/universal/src/app/(main)/system.tsx
@@ -43,17 +43,19 @@ function toneFor(status: string): BadgeTone {
 export default function SystemScreen() {
   const [sync, setSync] = useState<SyncStatusResponse | null>(null);
   const [conn, setConn] = useState<ConnectionsResponse | null>(null);
-  const [health, setHealth] = useState<"checking" | "ok" | "rejected" | "unreachable">("checking");
+  // The health reading is tagged with the reload it answers; a newer reload reads
+  // as "checking" until its own answer lands (react-hooks/set-state-in-effect).
+  const [healthFor, setHealthFor] = useState<{ reload: number; value: "ok" | "rejected" | "unreachable" } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reload, setReload] = useState(0);
+  const health: "checking" | "ok" | "rejected" | "unreachable" = healthFor?.reload === reload ? healthFor.value : "checking";
   const { refreshing, onRefresh } = usePullRefresh(() => setReload((n) => n + 1));
 
   useEffect(() => {
     let alive = true;
-    setHealth("checking");
     fetch(`${API_BASE}/api/health/today`, { headers: { ...AUTH_HEADERS } })
-      .then((r) => { if (!alive) return; setHealth(r.ok && (r.headers.get("content-type") ?? "").includes("json") ? "ok" : "rejected"); })
-      .catch(() => alive && setHealth("unreachable"));
+      .then((r) => { if (!alive) return; setHealthFor({ reload, value: r.ok && (r.headers.get("content-type") ?? "").includes("json") ? "ok" : "rejected" }); })
+      .catch(() => alive && setHealthFor({ reload, value: "unreachable" }));
     fetchJson<SyncStatusResponse>("/api/sync/status").then((d) => alive && setSync(d)).catch((e) => alive && setError(String(e?.message ?? e)));
     fetchJson<ConnectionsResponse>("/api/connections").then((d) => alive && setConn(d)).catch(() => {});
     return () => { alive = false; };

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -80,7 +80,7 @@ export default function WorkoutsScreen() {
     return { count: cal.length, years: days / 365, months, first: cal[0].day, last: cal[cal.length - 1].day };
   })();
 
-  const recent = data?.recent ?? [];
+  const recent = useMemo(() => data?.recent ?? [], [data]);
   // Web's Recent Workouts rows carry Garmin calories and avg HR; the sync list has the kcal and
   // the insights HR trend has the HR, both keyed by local day + title (soma#784).
   const enrich = useMemo(() => {

--- a/universal/src/components/activity-detail-modal.tsx
+++ b/universal/src/components/activity-detail-modal.tsx
@@ -218,25 +218,32 @@ function ShareTab({ activityId, title, stravaId }: { activityId: string; title: 
  * tab. Falls back to the passed-in row's fields for the header while loading.
  */
 export function ActivityDetailModal({ activity, onClose }: { activity: ActivityRow | null; onClose: () => void }) {
-  const [data, setData] = useState<ActivityDetail | null>(null);
-  const [loading, setLoading] = useState(false);
+  // The fetched detail is tagged with the activity it answers: a newly opened
+  // activity reads as loading with no data until its own answer lands, and a
+  // closed modal shows nothing. No setState inside the effect body.
+  const [fetched, setFetched] = useState<{ id: string; detail: ActivityDetail | null } | null>(null);
   const [tab, setTab] = useState<string>("Overview");
+  const activityId = activity?.activity_id ?? null;
+  // The tab resets when another activity opens: adjusted during render, not in an effect.
+  const [tabFor, setTabFor] = useState<string | null>(activityId);
+  if (tabFor !== activityId) { setTabFor(activityId); setTab("Overview"); }
+  const data = activityId != null && fetched?.id === activityId ? fetched.detail : null;
+  const loading = activityId != null && fetched?.id !== activityId;
 
   useEffect(() => {
-    if (!activity) { setData(null); return; }
-    let alive = true; setLoading(true); setTab("Overview");
-    fetchJson<ActivityDetail>(`/api/activity/${activity.activity_id}`)
+    if (!activityId) return;
+    let alive = true;
+    fetchJson<ActivityDetail>(`/api/activity/${activityId}`)
       .then((d) => {
         if (!alive) return;
-        setData(d);
+        setFetched({ id: activityId, detail: d });
         // Web opens on the Map tab when there's a GPS route (defaultValue).
         const rp = (d?.gps_route ?? []).filter((p) => p != null && p.lat != null && p.lng != null);
         if (rp.length > 10) setTab("Map");
       })
-      .catch(() => alive && setData(null))
-      .finally(() => alive && setLoading(false));
+      .catch(() => alive && setFetched({ id: activityId, detail: null }));
     return () => { alive = false; };
-  }, [activity]);
+  }, [activityId]);
 
   if (!activity) return null;
   const s = data?.summary ?? null;

--- a/universal/src/components/activity-selector.tsx
+++ b/universal/src/components/activity-selector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import { Text, Card, Button } from "soma-style";
 import { setActivity, useWorkoutCalories } from "../lib/api";
@@ -46,12 +46,17 @@ export function ActivitySelector({
   const [selected, setSelected] = useState<string[]>(selectedWorkouts);
   const [saving, setSaving] = useState(false);
 
-  // Re-sync from the plan whenever it reloads (after a save/refetch).
-  useEffect(() => { setRun(runEnabled); }, [runEnabled]);
-  useEffect(() => { setKm(plannedRunKm); }, [plannedRunKm]);
-  useEffect(() => { setSteps(expectedSteps); }, [expectedSteps]);
+  // Re-sync from the plan whenever it reloads (after a save/refetch): each local
+  // copy follows the prop it came from, adjusted during render rather than in effects.
   const selKey = selectedWorkouts.join(",");
-  useEffect(() => { setSelected(selectedWorkouts); }, [selKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  const [seen, setSeen] = useState({ runEnabled, plannedRunKm, expectedSteps, selKey });
+  if (seen.runEnabled !== runEnabled || seen.plannedRunKm !== plannedRunKm || seen.expectedSteps !== expectedSteps || seen.selKey !== selKey) {
+    if (seen.runEnabled !== runEnabled) setRun(runEnabled);
+    if (seen.plannedRunKm !== plannedRunKm) setKm(plannedRunKm);
+    if (seen.expectedSteps !== expectedSteps) setSteps(expectedSteps);
+    if (seen.selKey !== selKey) setSelected(selectedWorkouts);
+    setSeen({ runEnabled, plannedRunKm, expectedSteps, selKey });
+  }
 
   async function save(opts: { run_enabled?: boolean; selected_workouts?: string[]; expected_steps?: number; planned_run_km?: number | null }) {
     setSaving(true);

--- a/universal/src/components/compose-meal-view.tsx
+++ b/universal/src/components/compose-meal-view.tsx
@@ -71,7 +71,9 @@ export function ComposeMealView({
   const [saving, setSaving] = useState(false);
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const initKey = initialGrams ? Object.entries(initialGrams).map(([k, v]) => `${k}:${v}`).join(",") : "";
-  useEffect(() => { if (initialGrams) setGrams(initialGrams); }, [initKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  // A new initial set replaces the grams: adjusted during render, not in an effect.
+  const [seenInit, setSeenInit] = useState(initKey);
+  if (seenInit !== initKey) { setSeenInit(initKey); if (initialGrams) setGrams(initialGrams); }
 
   const byId = useMemo(() => new Map(ingredients.map((i) => [i.id, i])), [ingredients]);
   const selectedIds = Object.keys(grams).filter((id) => (grams[id] ?? 0) > 0 && byId.has(id));
@@ -126,13 +128,17 @@ export function ComposeMealView({
   const toggleCooked = toggleSet(setCookedMode);
   const toggleGramMode = toggleSet(setGramMode);
 
-  // Clamp whole-egg grams to the yolk cap when the max changes (mirrors web).
-  useEffect(() => {
+  // Clamp whole-egg grams to the yolk cap when the max changes (mirrors web):
+  // adjusted during render, not in an effect.
+  const [seenMax, setSeenMax] = useState(maxYolks);
+  if (seenMax !== maxYolks) {
+    setSeenMax(maxYolks);
     const ing = byId.get("eggs_whole");
-    if (!ing || !(grams["eggs_whole"] > 0)) return;
-    const maxGrams = (Number(ing.grams_per_unit) || 50) * maxYolks;
-    if (grams["eggs_whole"] > maxGrams) setG("eggs_whole", maxGrams);
-  }, [maxYolks]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (ing && grams["eggs_whole"] > 0) {
+      const maxGrams = (Number(ing.grams_per_unit) || 50) * maxYolks;
+      if (grams["eggs_whole"] > maxGrams) setG("eggs_whole", maxGrams);
+    }
+  }
 
   function buildItems(): ComposeItem[] {
     return selectedIds.map((id) => {

--- a/universal/src/components/exercise-detail-modal.tsx
+++ b/universal/src/components/exercise-detail-modal.tsx
@@ -34,17 +34,17 @@ function shortDate(iso: string | null): string {
  * /api/workouts/exercise?name= on open. Weight unit follows the screen toggle.
  */
 export function ExerciseDetailModal({ name, unit, onClose }: { name: string | null; unit: "kg" | "lb"; onClose: () => void }) {
-  const [data, setData] = useState<ExerciseDetail | null>(null);
-  const [loading, setLoading] = useState(false);
+  // The fetched detail is tagged with the exercise it answers (no setState in the effect body).
+  const [fetched, setFetched] = useState<{ name: string; detail: ExerciseDetail | null } | null>(null);
   const [metric, setMetric] = useState<ProgMetric>("Weight");
+  const data = name && fetched?.name === name ? fetched.detail : null;
+  const loading = !!name && fetched?.name !== name;
   useEffect(() => {
-    if (!name) { setData(null); return; }
+    if (!name) return;
     let alive = true;
-    setLoading(true);
     fetchJson<ExerciseDetail>(`/api/workouts/exercise?name=${encodeURIComponent(name)}`)
-      .then((d) => alive && setData(d))
-      .catch(() => alive && setData(null))
-      .finally(() => alive && setLoading(false));
+      .then((d) => alive && setFetched({ name, detail: d }))
+      .catch(() => alive && setFetched({ name, detail: null }));
     return () => { alive = false; };
   }, [name]);
 

--- a/universal/src/components/stat-detail-modal.tsx
+++ b/universal/src/components/stat-detail-modal.tsx
@@ -58,18 +58,21 @@ const RANGES: readonly Range[] = ["7d", "30d", "90d", "1y"] as const;
  *  avg/min/max + Δ-vs-previous; otherwise shows the card's sparkline trend. */
 export function StatDetailModal({ stat, onClose }: { stat: StatDetail | null; onClose: () => void }) {
   const [range, setRange] = useState<Range>("30d");
-  const [data, setData] = useState<StatSeries | null>(null);
-  const [loading, setLoading] = useState(false);
+  // The series is tagged with the metric and range it answers (no setState in the effect body).
+  const [fetched, setFetched] = useState<{ key: string; series: StatSeries | null } | null>(null);
+  const key = stat?.metric ? `${stat.metric}|${range}` : null;
+  const metric = stat?.metric ?? null;
+  const data = key != null && fetched?.key === key ? fetched.series : null;
+  const loading = key != null && fetched?.key !== key;
 
   useEffect(() => {
-    if (!stat?.metric) { setData(null); return; }
-    let alive = true; setLoading(true);
-    fetchJson<StatSeries>(`/api/stats/${stat.metric}?range=${range}`)
-      .then((d) => alive && setData(d))
-      .catch(() => alive && setData(null))
-      .finally(() => alive && setLoading(false));
+    if (!key || !metric) return;
+    let alive = true;
+    fetchJson<StatSeries>(`/api/stats/${metric}?range=${range}`)
+      .then((d) => alive && setFetched({ key, series: d }))
+      .catch(() => alive && setFetched({ key, series: null }));
     return () => { alive = false; };
-  }, [stat?.metric, range]);
+  }, [key, metric, range]);
 
   if (!stat) return null;
   const unit = stat.unit ? ` ${stat.unit}` : "";

--- a/universal/src/components/step-editor-sheet.tsx
+++ b/universal/src/components/step-editor-sheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { View, Pressable, TextInput, ScrollView } from "react-native";
 import { Text, Modal, Button } from "soma-style";
 import type { PlanDay, WorkoutStep } from "../lib/api";
@@ -21,10 +21,12 @@ function clone(steps: WorkoutStep[] | null | undefined): WorkoutStep[] {
  * does that on its own schedule, as on web) (soma#794).
  */
 export function StepEditorSheet({ day, onClose, onSave }: { day: PlanDay | null; onClose: () => void; onSave: (dayId: number, steps: WorkoutStep[]) => Promise<boolean> }) {
-  const [steps, setSteps] = useState<WorkoutStep[]>([]);
+  const [steps, setSteps] = useState<WorkoutStep[]>(() => clone(day?.workoutSteps));
   const [saving, setSaving] = useState(false);
   const [result, setResult] = useState<"idle" | "saved" | "error">("idle");
-  useEffect(() => { setSteps(clone(day?.workoutSteps)); setResult("idle"); }, [day]);
+  // A different day resets the editor: adjusted during render, not in an effect.
+  const [editing, setEditing] = useState(day);
+  if (editing !== day) { setEditing(day); setSteps(clone(day?.workoutSteps)); setResult("idle"); }
   if (!day) return null;
 
   const update = (i: number, patch: Partial<WorkoutStep>) => setSteps((prev) => prev.map((s, k) => (k === i ? { ...s, ...patch } : s)));

--- a/universal/src/components/workout-detail-modal.tsx
+++ b/universal/src/components/workout-detail-modal.tsx
@@ -83,7 +83,7 @@ function groupBlocks(sets: ExerciseSet[], totalSec: number, timeline: { elapsed_
 }
 
 function HrTab({ g, title }: { g: NonNullable<WorkoutDetail["garmin"]>; title: string }) {
-  const tl = g.hr_timeline ?? [];
+  const tl = useMemo(() => g.hr_timeline ?? [], [g.hr_timeline]);
   const [selected, setSelected] = useState<number | null>(null);
   const total = tl.length ? tl[tl.length - 1].elapsed_sec : 0;
   const blocks = useMemo(() => groupBlocks(g.exercise_sets ?? [], total, tl), [g.exercise_sets, total, tl]);
@@ -181,24 +181,27 @@ function HrTab({ g, title }: { g: NonNullable<WorkoutDetail["garmin"]>; title: s
  * tabs. Fetches /api/workout/[id] on open. Weight unit follows the screen toggle.
  */
 export function WorkoutDetailModal({ id, title, unit, onClose }: { id: string | null; title?: string; unit: "kg" | "lb"; onClose: () => void }) {
-  const [data, setData] = useState<WorkoutDetail | null>(null);
-  const [loading, setLoading] = useState(false);
+  // The fetched detail is tagged with the workout it answers (no setState in the effect body).
+  const [fetched, setFetched] = useState<{ id: string; detail: WorkoutDetail | null } | null>(null);
   const [tab, setTab] = useState<string>("Exercises");
   const [imgState, setImgState] = useState<"loading" | "ready" | "error">("loading");
   const [saving, setSaving] = useState(false);
+  // Tab and image state reset when another workout opens: adjusted during render, not in an effect.
+  const [openedFor, setOpenedFor] = useState<string | null>(id);
+  if (openedFor !== id) { setOpenedFor(id); setTab("Exercises"); setImgState("loading"); }
+  const data = id && fetched?.id === id ? fetched.detail : null;
+  const loading = !!id && fetched?.id !== id;
   useEffect(() => {
-    if (!id) { setData(null); return; }
+    if (!id) return;
     let alive = true;
-    setLoading(true); setTab("Exercises"); setImgState("loading");
     fetchJson<WorkoutDetail>(`/api/workout/${encodeURIComponent(id)}`)
-      .then((d) => alive && setData(d))
-      .catch(() => alive && setData(null))
-      .finally(() => alive && setLoading(false));
+      .then((d) => alive && setFetched({ id, detail: d }))
+      .catch(() => alive && setFetched({ id, detail: null }));
     return () => { alive = false; };
   }, [id]);
 
   // Hooks stay above the early return (a hook after it changes the hook count when `id` flips).
-  const exercises = data?.exercises ?? [];
+  const exercises = useMemo(() => data?.exercises ?? [], [data]);
   const muscles = useMemo(() => aggregateWorkoutMuscles(exercises), [exercises]);
   if (!id) return null;
   const w = (kg: number | null | undefined) => (kg == null ? "—" : `${Math.round((unit === "lb" ? kg * KG_TO_LB : kg) * 10) / 10}`);

--- a/universal/src/components/workout-muscle.tsx
+++ b/universal/src/components/workout-muscle.tsx
@@ -18,7 +18,7 @@ function monthLabel(m: string): string { const [, mm] = m.split("-").map(Number)
  * monthly-volume-by-muscle chart. Fed by /api/workouts/insights.monthlyMuscle.
  */
 export function WorkoutMuscle({ insights }: { insights: WorkoutInsights | null | undefined }) {
-  const rows = insights?.monthlyMuscle ?? [];
+  const rows = useMemo(() => insights?.monthlyMuscle ?? [], [insights]);
   const { totals, grandTotal, months } = useMemo(() => {
     const t: Record<string, number> = {};
     const monthMap = new Map<string, Record<string, number>>();

--- a/universal/src/components/workout-strength.tsx
+++ b/universal/src/components/workout-strength.tsx
@@ -19,15 +19,16 @@ function StrengthProgression({ names, unit }: { names: string[]; unit: "kg" | "l
   const [tracked, setTracked] = useState<string[]>(names.slice(0, 3));
   const [picking, setPicking] = useState(false);
   const [sel, setSel] = useState<string | null>(names[0] ?? null);
-  const [prog, setProg] = useState<ProgResp["progression"]>([]);
-  const [loading, setLoading] = useState(false);
+  // The progression is tagged with the exercise it answers (no setState in the effect body).
+  const [fetched, setFetched] = useState<{ name: string; prog: ProgResp["progression"] } | null>(null);
+  const prog = sel && fetched?.name === sel ? fetched.prog : [];
+  const loading = !!sel && fetched?.name !== sel;
   useEffect(() => {
     if (!sel) return;
-    let alive = true; setLoading(true);
+    let alive = true;
     fetchJson<ProgResp>(`/api/workouts/exercise?name=${encodeURIComponent(sel)}`)
-      .then((d) => alive && setProg(d.progression ?? []))
-      .catch(() => alive && setProg([]))
-      .finally(() => alive && setLoading(false));
+      .then((d) => alive && setFetched({ name: sel, prog: d.progression ?? [] }))
+      .catch(() => alive && setFetched({ name: sel, prog: [] }));
     return () => { alive = false; };
   }, [sel]);
   if (!names.length) return null;

--- a/universal/src/hooks/use-color-scheme.web.ts
+++ b/universal/src/hooks/use-color-scheme.web.ts
@@ -1,15 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { useColorScheme as useRNColorScheme } from 'react-native';
+
+// Hydration flag without an effect: the server snapshot is false, the client's is true.
+const subscribe = () => () => {};
+const useHasHydrated = () => useSyncExternalStore(subscribe, () => true, () => false);
 
 /**
  * To support static rendering, this value needs to be re-calculated on the client side for web
  */
 export function useColorScheme() {
-  const [hasHydrated, setHasHydrated] = useState(false);
-
-  useEffect(() => {
-    setHasHydrated(true);
-  }, []);
+  const hasHydrated = useHasHydrated();
 
   const colorScheme = useRNColorScheme();
 

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -372,18 +372,20 @@ export interface ForwardSim {
 /** The full forward-simulation payload: schedule + PMC + readiness + fitness + comparison. */
 export function useForwardSim(date: string) {
   const [data, setData] = useState<ForwardSim | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reload, setReload] = useState(0);
+  // Loading is derived from a request key (react-hooks/set-state-in-effect).
+  const key = `${date}|${reload}`;
+  const [settled, setSettled] = useState<string | null>(null);
+  const loading = settled !== key;
   useEffect(() => {
     let alive = true;
-    setLoading(true);
     fetchJson<ForwardSim>(`/api/training/forward-sim?date=${date}`)
       .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)))
-      .finally(() => alive && setLoading(false));
+      .finally(() => alive && setSettled(key));
     return () => { alive = false; };
-  }, [date, reload]);
+  }, [date, key]);
   return { data, loading, error, refetch: () => setReload((n) => n + 1) };
 }
 
@@ -508,11 +510,12 @@ export interface DuplicateSide { id: number; name: string; type: string; startTi
 export interface DuplicatePairs { pairs: { a: DuplicateSide; b: DuplicateSide }[]; count: number; error?: string }
 export function useDuplicates(enabled: boolean) {
   const [data, setData] = useState<DuplicatePairs | null>(null);
-  const [loading, setLoading] = useState(false);
+  // Loading while enabled and nothing has arrived (the catch stores an error result).
+  const loading = enabled && data == null;
   useEffect(() => {
     if (!enabled || data) return;
-    let alive = true; setLoading(true);
-    fetchJson<DuplicatePairs>("/api/duplicates").then((d) => alive && setData(d)).catch(() => alive && setData({ pairs: [], count: 0, error: "unavailable" })).finally(() => alive && setLoading(false));
+    let alive = true;
+    fetchJson<DuplicatePairs>("/api/duplicates").then((d) => alive && setData(d)).catch(() => alive && setData({ pairs: [], count: 0, error: "unavailable" }));
     return () => { alive = false; };
   }, [enabled, data]);
   return { data, loading };
@@ -992,18 +995,20 @@ export function useTrainingGraph(date: string) {
 
 export function useSomaPlan(date: string) {
   const [data, setData] = useState<SomaPlan | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reload, setReload] = useState(0);
+  // Loading is derived from a request key (react-hooks/set-state-in-effect).
+  const key = `${date}|${reload}`;
+  const [settled, setSettled] = useState<string | null>(null);
+  const loading = settled !== key;
   useEffect(() => {
     let alive = true;
-    setLoading(true);
     fetchJson<SomaPlan>(`/api/nutrition/plan?date=${date}`)
       .then((d) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)))
-      .finally(() => alive && setLoading(false));
+      .finally(() => alive && setSettled(key));
     return () => { alive = false; };
-  }, [date, reload]);
+  }, [date, key]);
   return { data, loading, error, refetch: () => setReload((n) => n + 1) };
 }
 
@@ -1282,15 +1287,16 @@ export interface BodyComp {
 }
 export function useBodyComp(enabled: boolean) {
   const [data, setData] = useState<BodyComp | null>(null);
-  const [loading, setLoading] = useState(false);
+  // Loading while enabled and the one request has neither answered nor failed.
+  const [settled, setSettled] = useState(false);
+  const loading = enabled && data == null && !settled;
   useEffect(() => {
     if (!enabled || data) return;
     let alive = true;
-    setLoading(true);
     fetchJson<BodyComp>("/api/nutrition/body-comp")
       .then((d) => alive && setData(d))
       .catch(() => {})
-      .finally(() => alive && setLoading(false));
+      .finally(() => alive && setSettled(true));
     return () => { alive = false; };
   }, [enabled, data]);
   return { data, loading };


### PR DESCRIPTION
Second of three PRs for #888, on top of #921. Clears `react-hooks/set-state-in-effect` (22) and `react-hooks/exhaustive-deps` (4): 46 warnings down to 20, all of them in the last PR's rules.

What changed, and why nothing the user sees moves:

- Fetch hooks (`useActivities`, `usePlaylist`, the sleep hook, `useForwardSim`, `useSomaPlan`, `useDuplicates`, `useBodyComp`, the strength progression): `loading` is derived from a request key (or from the id the fetched data answers) instead of being set at the top of the effect. The same requests fire at the same moments; only the bookkeeping moved out of the effect body.
- Detail modals (activity, exercise, stat, workout): the fetched detail is tagged with the id it answers, so a newly opened item reads as loading with no data until its own answer lands and a closed modal shows nothing, which is what `setData(null)` in the effect did. Tab and image-state resets on open happen during render with a "seen id" check.
- Prop re-syncs (`ActivitySelector`, `ComposeMealView`, `StepEditorSheet`): the local copy follows the prop it came from, adjusted during render with a "seen value" check, the pattern the React docs give for derived state. The Pump-up Bank modal tags its list with the open/refresh it answers.
- `useColorScheme` (web): the hydration flag comes from `useSyncExternalStore` (server snapshot false, client true) instead of an effect.
- The four arrays fed to `useMemo` (`recent`, `tl`, `exercises`, `rows`) are memoised themselves, so the memo inputs stop changing every render.
- `system.tsx`: the health reading is tagged with the reload it answers; a newer reload reads as "checking" until its own answer lands.

Verified: `npx eslint . --max-warnings 20` passes, `npx tsc --noEmit` clean, vitest 44 passed. Device tour on emulator-5556 with the real account, before (the Phase 7 build) and after (this branch), same twelve screens: Home, Training, Food, Food's Today's Activity, Activities, Workouts, the Total Synced stat modal, Sleep, Playlist, Playlist builder, Status. Ten of twelve are pixel-identical outside the status bar; the Food pair differs only by the "~336 kcal estimated surplus" hero line that #914 added after the baseline build. The CI budget stays at 46 here and drops to 0 in the last PR.

Closes #919
