### PR TITLE
chore(universal): zero lint warnings, CI budget 0 (#920)

### DIFF
--- a/.github/workflows/universal-ci.yml
+++ b/.github/workflows/universal-ci.yml
@@ -28,6 +28,6 @@ jobs:
         run: npm run typecheck
       - name: Lint
         working-directory: universal
-        run: npx eslint . --max-warnings 46
+        run: npx eslint . --max-warnings 0
       - name: Unit tests
         run: npm test

--- a/universal/src/app/(main)/live-dj.tsx
+++ b/universal/src/app/(main)/live-dj.tsx
@@ -55,8 +55,10 @@ export default function LiveDjScreen() {
   const [busy, setBusy] = useState(false);
   const [ctrlErr, setCtrlErr] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const sessionStartRef = useRef<number | null>(null);
-  const [, setTick] = useState(0);
+  // The session start and "now" are state, so render reads no ref and calls no clock:
+  // the 1 s ticker below advances `now` while live.
+  const [sessionStart, setSessionStart] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
 
   const isRunning = status.state === "running";
   const isLive = status.state !== "stopped";
@@ -65,8 +67,8 @@ export default function LiveDjScreen() {
     try {
       const s = await fetchDjStatus();
       setStatus(s);
-      if (s.state === "running" || s.state === "starting") { if (sessionStartRef.current === null) sessionStartRef.current = Date.now(); }
-      else sessionStartRef.current = null;
+      if (s.state === "running" || s.state === "starting") setSessionStart((prev) => prev ?? Date.now());
+      else setSessionStart(null);
       if (s.state === "stopped" && pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
     } catch { /* keep last */ }
   }, []);
@@ -85,7 +87,7 @@ export default function LiveDjScreen() {
   // 1s ticker while live — animates "Session:", "polled Ns ago", and the countdown.
   useEffect(() => {
     if (!isLive) return;
-    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
   }, [isLive]);
 
@@ -108,7 +110,7 @@ export default function LiveDjScreen() {
     const r = await stopDj();
     setBusy(false);
     if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
-    sessionStartRef.current = null;
+    setSessionStart(null);
     if (r.ok || r.status === 403) setStatus({ state: "stopped" });
     else setCtrlErr(r.error || `Couldn't stop the DJ (${r.status}).`);
   }
@@ -120,7 +122,7 @@ export default function LiveDjScreen() {
   const hrs = (status.hr_history ?? []).map((p) => p.hr).filter((h) => h > 0);
   const hrLo = hrs.length ? Math.min(...hrs) : null;
   const hrHi = hrs.length ? Math.max(...hrs) : null;
-  const polledAgo = status.ts ? Math.max(0, Math.floor(Date.now() / 1000 - status.ts)) : null;
+  const polledAgo = status.ts ? Math.max(0, Math.floor(now / 1000 - status.ts)) : null;
 
   const dotColor = status.state === "error" ? "#e06060" : status.state === "starting" ? "#e0c458" : "#6ad4a0";
   const stateLabel = status.state === "error" ? "ERROR" : status.state === "starting" ? "STARTING…" : "LIVE";
@@ -225,7 +227,7 @@ export default function LiveDjScreen() {
               <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: dotColor }} />
               <Text variant="caption" className="font-semibold" style={{ color: dotColor }}>{stateLabel}</Text>
               <View className="ml-auto flex-row items-center gap-2">
-                {sessionStartRef.current !== null ? <Text variant="micro" className="text-text-muted">Session: {formatElapsed(Date.now() - sessionStartRef.current)}</Text> : null}
+                {sessionStart !== null ? <Text variant="micro" className="text-text-muted">Session: {formatElapsed(now - sessionStart)}</Text> : null}
                 {polledAgo != null ? <Text variant="micro" className="text-text-muted">polled {polledAgo < 60 ? `${polledAgo}s ago` : `${Math.floor(polledAgo / 60)}m ago`}</Text> : null}
               </View>
             </View>

--- a/universal/src/app/(main)/nutrition.tsx
+++ b/universal/src/app/(main)/nutrition.tsx
@@ -57,6 +57,13 @@ function shortMD(iso: string | null | undefined): string {
   const [y, mo, d] = iso.split("-").map(Number);
   return new Date(y, (mo ?? 1) - 1, d ?? 1).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
+/** A day's locked slots from storage (guarded: no-ops on native). */
+function readLockedSlots(date: string): string[] {
+  try {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(`locked-slots-${date}`) : null;
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch { return []; }
+}
 function niceDate(iso: string): string {
   const [y, mo, d] = iso.split("-").map(Number);
   const dt = new Date(y, (mo ?? 1) - 1, d ?? 1);
@@ -90,18 +97,6 @@ export default function NutritionScreen() {
   const isFuture = DATE > todayLocal();
   const isTomorrow = DATE === shiftDate(todayLocal(), 1);
   const { data, loading, error, refetch } = useSomaPlan(DATE);
-  // Reset per-day transient UI when the viewed day changes, and load that
-  // day's locked slots from storage (guarded — no-ops on native).
-  useEffect(() => {
-    setCloseStatus(null); setLogMode("preset"); setLogOpen(false); setEditMeal(null); setDetailMeal(null); setRebalanceToast(null);
-    setSelectedPreset(null); setPresetSeed(null); setComposePreview(null); setPresetMult(1);
-    let stored: string[] = [];
-    try {
-      const raw = typeof localStorage !== "undefined" ? localStorage.getItem(`locked-slots-${DATE}`) : null;
-      if (raw) stored = JSON.parse(raw);
-    } catch { /* native / unavailable */ }
-    setLockedSlots(new Set(stored));
-  }, [DATE]);
   const { refreshing, onRefresh } = usePullRefresh(refetch);
   const { presets, ingredients, reload: reloadPresets } = usePresets();
   const { drinks } = useDrinks();
@@ -137,8 +132,18 @@ export default function NutritionScreen() {
   const [composePreview, setComposePreview] = useState<{ calories: number; protein: number; carbs: number; fat: number; fiber: number } | null>(null);
   // Slots the user has locked (won't be rebalanced). Persisted per-date via
   // guarded localStorage (works on Expo web; in-memory fallback on native).
-  const [lockedSlots, setLockedSlots] = useState<Set<string>>(new Set());
+  const [lockedSlots, setLockedSlots] = useState<Set<string>>(() => new Set(readLockedSlots(DATE)));
   const [rebalanceToast, setRebalanceToast] = useState<string | null>(null);
+  // Reset per-day transient UI when the viewed day changes, and load that day's
+  // locked slots from storage: adjusted during render (after every setter it
+  // touches is declared), not in an effect.
+  const [dayShown, setDayShown] = useState(DATE);
+  if (dayShown !== DATE) {
+    setDayShown(DATE);
+    setCloseStatus(null); setLogMode("preset"); setLogOpen(false); setEditMeal(null); setDetailMeal(null); setRebalanceToast(null);
+    setSelectedPreset(null); setPresetSeed(null); setComposePreview(null); setPresetMult(1);
+    setLockedSlots(new Set(readLockedSlots(DATE)));
+  }
 
   const plan = data?.plan;
   const consumed = data?.consumed;

--- a/universal/src/app/(main)/playlist-builder.tsx
+++ b/universal/src/app/(main)/playlist-builder.tsx
@@ -27,6 +27,11 @@ const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
 /* ---- run selector (Past Runs / Saved Plans / History / Manual — mirrors web) ---- */
 type SelTab = "past" | "plans" | "history" | "manual";
+
+/** One selector tab; declared once so it keeps its identity across renders. */
+function TabPill({ id, label, n, tab, onSelect }: { id: SelTab; label: string; n?: number; tab: SelTab; onSelect: (t: SelTab) => void }) {
+  return <Pill label={n != null ? `${label} (${n})` : label} active={tab === id} onPress={() => onSelect(id)} />;
+}
 interface SessionMeta { id: number; workout_name: string | null; garmin_activity_id: string | null; spotify_playlist_url: string | null; song_assignments: Record<string, unknown[]> | null; created_at: string }
 const sessTrackCount = (a: Record<string, unknown[]> | null) => a ? Object.values(a).reduce((s, v) => s + (Array.isArray(v) ? v.length : 0), 0) : 0;
 
@@ -77,17 +82,14 @@ function RunSelector({ onPick }: { onPick: (name: string, garminId: string | nul
     return [...g.values()].sort((a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime());
   })();
 
-  const TabPill = ({ id, label, n }: { id: SelTab; label: string; n?: number }) => (
-    <Pill label={n != null ? `${label} (${n})` : label} active={tab === id} onPress={() => setTab(id)} />
-  );
 
   return (
     <View className="gap-3">
       <View className="flex-row flex-wrap gap-2">
-        <TabPill id="past" label="Past Runs" />
-        <TabPill id="plans" label="Saved Plans" n={plans?.length} />
-        <TabPill id="history" label="History" n={historyRows.length || undefined} />
-        <TabPill id="manual" label="Manual" />
+        <TabPill id="past" label="Past Runs" tab={tab} onSelect={setTab} />
+        <TabPill id="plans" label="Saved Plans" n={plans?.length} tab={tab} onSelect={setTab} />
+        <TabPill id="history" label="History" n={historyRows.length || undefined} tab={tab} onSelect={setTab} />
+        <TabPill id="manual" label="Manual" tab={tab} onSelect={setTab} />
       </View>
       {tab === "past" ? (
         <>

--- a/universal/src/components/line-chart.tsx
+++ b/universal/src/components/line-chart.tsx
@@ -236,14 +236,18 @@ export function LineChart(props: LineChartProps) {
               const labelled = [...(refLine ? [refLine] : []), ...(refLines ?? [])]
                 .filter((r) => r.label && r.y >= loL && r.y <= hiL)
                 .sort((a, b) => yAtL(a.y) - yAtL(b.y));
+              const placed: { r: (typeof labelled)[number]; ly: number; atRight: boolean }[] = [];
               let lastY = -100; let lastRight = rightS.length !== 0;
-              return labelled.map((r, ri) => {
-              const ly = yAtL(r.y);
+              for (const r of labelled) {
+                const ly = yAtL(r.y);
+                let atRight = rightS.length === 0;
+                if (Math.abs(ly - lastY) < 11) atRight = !lastRight;
+                lastY = ly; lastRight = atRight;
+                placed.push({ r, ly, atRight });
+              }
+              return placed.map(({ r, ly, atRight }, ri) => {
               const ty = ly < 14 ? ly + 10 : ly - 3;
               const tw = r.label!.length * 4.4 + 4;
-              let atRight = rightS.length === 0;
-              if (Math.abs(ly - lastY) < 11) atRight = !lastRight;
-              lastY = ly; lastRight = atRight;
               return (
                 <Fragment key={`rt-${ri}`}>
                   <Rect x={atRight ? VBW - 2 - tw : 2} y={ty - 8} width={tw} height={10} rx={2} fill="#0c1519" fillOpacity={0.8} />


### PR DESCRIPTION
Last of three PRs for #888, on top of #924. Clears the remaining `react-hooks/immutability` (12), `react-hooks/static-components` (4), `react-hooks/purity` (2) and `react-hooks/refs` (2): 20 warnings down to 0, and `universal-ci.yml` now runs `npx eslint . --max-warnings 0`.

- Food screen (`nutrition.tsx`): the per-day reset (modal, preset, compose and toast state, the locked slots from storage) ran in an effect declared above the state it reset. It now runs during render, after every setter it touches, keyed on the day shown; the locked slots for the first day are read in the state initialiser.
- `line-chart.tsx`: the reference-label sides ("left or right, alternate when neighbours are closer than a text line") are decided in a loop before the JSX map instead of by reassigning closure variables inside it. Same placement, same labels.
- Playlist builder: the selector tab was a component created inside render; it is one module-level `TabPill` now, so React keeps its identity across renders.
- Live DJ: the session start and the clock are state (the 1 s ticker advances `now` while live) instead of a ref and `Date.now()` read during render; the "Session:" and "polled Ns ago" texts read from them.

Verified: `npx eslint . --max-warnings 0` passes, `npx tsc --noEmit` clean, vitest 44 passed. Device on emulator-5556 with the real account: the twelve-screen tour is pixel-identical to the #924 build outside the status bar (the Today's Activity shot differs only by scroll offset); the Food screen steps to Tomorrow and back to Today with the header, "Copy yesterday" and the hero intact; the playlist builder's Saved Plans tab selects and lists; the Live DJ screen renders in its stopped state.

Closes #920
Closes #888
